### PR TITLE
perf: batch remote one-time prekey inserts into a single transaction

### DIFF
--- a/src-tauri/src/commands/signal.rs
+++ b/src-tauri/src/commands/signal.rs
@@ -131,12 +131,14 @@ pub async fn replenish_one_time_prekeys(
     drop(db);
 
     let conn = state.remote_db.conn().await?;
+    let tx = conn.transaction().await?;
     for (id, pub_key) in &new_opks {
-        conn.execute(
+        tx.execute(
             "INSERT INTO one_time_prekey (user_id, key_id, public_key) VALUES (?1, ?2, ?3)",
             libsql::params![user_id.clone(), *id as i64, hex::encode(pub_key)],
         ).await?;
     }
+    tx.commit().await?;
 
     Ok(count)
 }


### PR DESCRIPTION
Closes #36

## Summary

- `replenish_one_time_prekeys` was calling `conn.execute()` in a loop — 50 sequential remote round-trips to Turso per replenish cycle
- Wraps the loop in a `conn.transaction()` so all 50 inserts commit in a single round-trip

## Test plan

- [ ] Run the app through initial key generation and verify prekeys appear in Turso
- [ ] Confirm `replenish_one_time_prekeys` still returns the correct count (50)
- [ ] Verify no regression in `get_prekey_bundle` (prekeys are claimable after replenish)

🤖 Generated with [Claude Code](https://claude.com/claude-code)