### PR TITLE
fix: prefix keychain/keystore keys with DEV: in debug builds

### DIFF
--- a/src-tauri/src/keystore.rs
+++ b/src-tauri/src/keystore.rs
@@ -4,6 +4,9 @@ use crate::error::{Error, Result};
 /// so multiple instances don't stomp each other's session/identity keys.
 /// Production builds without POLLIS_DATA_DIR are unaffected.
 fn namespaced(key: &str) -> String {
+    #[cfg(debug_assertions)]
+    let key = format!("DEV:{key}");
+
     match std::env::var("POLLIS_DATA_DIR") {
         Ok(dir) => {
             let label = std::path::Path::new(&dir)


### PR DESCRIPTION
Debug builds already use a JSON file instead of the OS keychain, so dev and prod sessions are isolated. This adds an explicit DEV: prefix to all key names in debug builds so entries are clearly distinguishable if the store is ever inspected. Closes #27.