### PR TITLE
Fix Linux CI build by using GCC-universal warning suppression

### DIFF
--- a/src-tauri/.cargo/config.toml
+++ b/src-tauri/.cargo/config.toml
@@ -2,8 +2,8 @@
 rustflags = []
 
 [env]
-# Force C++17 and add permissive flags to work around WebRTC header issues
+# Force C++17 and suppress warnings to work around WebRTC header issues
 # -std=c++17: Avoids C++20 iterator concepts issues with rust::Slice
+# -w: Suppress all warnings (prevents warning-as-error issues across GCC versions)
 # -fpermissive: Allows method names that shadow class names (Network() returning Network*)
-# -Wno-error=changes-meaning: Treats the specific shadowing warning as non-fatal
-CXXFLAGS = "-std=c++17 -fpermissive -Wno-error=changes-meaning"
+CXXFLAGS = "-std=c++17 -w -fpermissive"


### PR DESCRIPTION
  Replace -Wno-error=changes-meaning (not supported in older GCC) with -w
  (suppress all warnings) to fix WebRTC compilation across different GCC
  versions.