### PR TITLE
Fix macOS crash: force load ObjC categories from WebRTC

### DIFF
--- a/src-tauri/.cargo/config.toml
+++ b/src-tauri/.cargo/config.toml
@@ -1,6 +1,14 @@
 [build]
 rustflags = []
 
+[target.aarch64-apple-darwin]
+# Ensure Objective-C categories are loaded from static libs (fixes WebRTC crash)
+rustflags = ["-C", "link-arg=-ObjC"]
+
+[target.x86_64-apple-darwin]
+# Ensure Objective-C categories are loaded from static libs (fixes WebRTC crash)
+rustflags = ["-C", "link-arg=-ObjC"]
+
 [target.x86_64-pc-windows-msvc]
 # Use static CRT to match LiveKit WebRTC libraries (which use /MT)
 rustflags = ["-C", "target-feature=+crt-static"]

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,12 @@
 fn main() {
+    // Fix Objective-C category loading for WebRTC on macOS
+    // webrtc-sys adds -ObjC but it doesn't always propagate to final link
+    // This ensures ObjC categories (like NSString+StdString) are included
+    #[cfg(target_os = "macos")]
+    {
+        // Add ObjC linker flag to ensure categories are loaded
+        println!("cargo:rustc-link-arg=-ObjC");
+    }
+
     tauri_build::build()
 }


### PR DESCRIPTION
  Added -ObjC linker flag to ensure NSString+StdString category methods
  are loaded. Fixes 'stringForAbslStringView: unrecognized selector' crash.