### PR TITLE
perf: add partial index on message_envelope for poll query

### DIFF
--- a/src-tauri/src/db/migrations/000002_envelope_delivered_index.sql
+++ b/src-tauri/src/db/migrations/000002_envelope_delivered_index.sql
@@ -1,0 +1,8 @@
+-- Speed up poll_pending_messages by indexing only undelivered envelopes.
+-- Partial index stays small and shrinks as messages are delivered.
+CREATE INDEX IF NOT EXISTS idx_envelope_undelivered
+    ON message_envelope(conversation_id, delivered)
+    WHERE delivered = 0;
+
+INSERT INTO schema_migrations (version, description) VALUES
+    (2, 'partial index on message_envelope for undelivered polling');


### PR DESCRIPTION
Closes #37

## Summary
- Adds a partial index on `message_envelope(conversation_id, delivered) WHERE delivered = 0` to speed up `poll_pending_messages`
- Only indexes undelivered rows so it stays small and shrinks as messages are delivered
- New migration file only — no changes to frozen `remote_schema.sql`

## Test plan
- [ ] Run `000002_envelope_delivered_index.sql` against Turso staging and verify the index is created
- [ ] Confirm `poll_pending_messages` query uses the new index via `EXPLAIN QUERY PLAN`
- [ ] Verify existing app functionality is unaffected