### PR TITLE
⏺ Fix Rust compilation error in voice track unpublish

### DIFF
--- a/src-tauri/src/commands/voice.rs
+++ b/src-tauri/src/commands/voice.rs
@@ -772,7 +772,7 @@ pub async fn leave_voice_channel(state: State<'_, Arc<AppState>>) -> Result<()> 
     // Unpublish the local track before closing the room to release the microphone
     if let Some(room) = &voice.room {
         if let Some(track) = &voice.local_track {
-            let _ = room.local_participant().unpublish_track(track.sid()).await;
+            let _ = room.local_participant().unpublish_track(&track.sid()).await;
         }
     }
 


### PR DESCRIPTION
  Pass reference to track.sid() instead of owned value