### PR TITLE
Rotate MLS keys and hand off group ownership on account deletion

### DIFF
--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -298,13 +298,138 @@ pub async fn logout(state: State<'_, Arc<AppState>>, delete_data: bool) -> Resul
     Ok(())
 }
 
-/// Permanently delete the account: wipe all remote data, clear keystore, delete local DB.
+/// Permanently delete the account: rotate MLS keys for all groups/DMs the user
+/// belongs to, then wipe all remote data, clear keystore, and delete local DB.
+///
+/// MLS key rotation is done first (while the local DB is still open) so that
+/// remaining group members receive a remove commit and advance their epoch.
+/// This ensures forward secrecy: the deleted user's key material cannot decrypt
+/// any messages sent after the rotation.
+///
+/// See: https://github.com/actuallydan/pollis/issues/103
 #[tauri::command]
 pub async fn delete_account(
     state: State<'_, Arc<AppState>>,
     user_id: String,
 ) -> Result<()> {
     let conn = state.remote_db.conn().await?;
+
+    // ── Phase 1: MLS key rotation ──────────────────────────────────────
+    // Issue remove commits for every group and DM channel the user belongs
+    // to. This must happen while the local DB is open because
+    // remove_member_mls_inner reads the MLS group state from local SQLite.
+    // Failures are non-fatal — we still proceed with account deletion so
+    // the user isn't stuck, but log each error for debugging.
+
+    // Enumerate all groups the user belongs to.
+    {
+        let mut group_rows = conn.query(
+            "SELECT group_id FROM group_member WHERE user_id = ?1",
+            libsql::params![user_id.clone()],
+        ).await?;
+
+        let mut group_ids: Vec<String> = Vec::new();
+        while let Some(row) = group_rows.next().await? {
+            group_ids.push(row.get(0)?);
+        }
+
+        for gid in &group_ids {
+            match crate::commands::mls::remove_member_mls_inner(
+                state.inner(), gid, &user_id, &user_id,
+            ).await {
+                Ok(()) => eprintln!("[account] rotated MLS keys for group {gid}"),
+                Err(e) => eprintln!("[account] MLS remove from group {gid} failed (non-fatal): {e}"),
+            }
+        }
+    }
+
+    // Enumerate all DM channels the user belongs to.
+    {
+        let mut dm_rows = conn.query(
+            "SELECT dm_channel_id FROM dm_channel_member WHERE user_id = ?1",
+            libsql::params![user_id.clone()],
+        ).await?;
+
+        let mut dm_ids: Vec<String> = Vec::new();
+        while let Some(row) = dm_rows.next().await? {
+            dm_ids.push(row.get(0)?);
+        }
+
+        for dm_id in &dm_ids {
+            match crate::commands::mls::remove_member_mls_inner(
+                state.inner(), dm_id, &user_id, &user_id,
+            ).await {
+                Ok(()) => eprintln!("[account] rotated MLS keys for DM {dm_id}"),
+                Err(e) => eprintln!("[account] MLS remove from DM {dm_id} failed (non-fatal): {e}"),
+            }
+        }
+    }
+
+    // ── Phase 2: remote data cleanup ───────────────────────────────────
+
+    // Handle group ownership before removing memberships. For each group
+    // the user belongs to, check whether they're the sole member (delete
+    // the group) or the sole admin (promote another member first).
+    {
+        let mut group_rows = conn.query(
+            "SELECT group_id, role FROM group_member WHERE user_id = ?1",
+            libsql::params![user_id.clone()],
+        ).await?;
+
+        let mut memberships: Vec<(String, String)> = Vec::new();
+        while let Some(row) = group_rows.next().await? {
+            memberships.push((row.get(0)?, row.get(1)?));
+        }
+
+        for (gid, role) in &memberships {
+            // How many members does this group have?
+            let mut count_rows = conn.query(
+                "SELECT COUNT(*) FROM group_member WHERE group_id = ?1",
+                libsql::params![gid.clone()],
+            ).await?;
+            let member_count: i64 = if let Some(row) = count_rows.next().await? {
+                row.get(0)?
+            } else {
+                0
+            };
+
+            if member_count <= 1 {
+                // Sole member — delete the entire group (cascades channels, invites, etc.)
+                let _ = conn.execute(
+                    "DELETE FROM groups WHERE id = ?1",
+                    libsql::params![gid.clone()],
+                ).await;
+                eprintln!("[account] deleted empty group {gid}");
+            } else if role == "admin" {
+                // Check if there are other admins.
+                let mut admin_rows = conn.query(
+                    "SELECT COUNT(*) FROM group_member WHERE group_id = ?1 AND role = 'admin' AND user_id != ?2",
+                    libsql::params![gid.clone(), user_id.clone()],
+                ).await?;
+                let other_admins: i64 = if let Some(row) = admin_rows.next().await? {
+                    row.get(0)?
+                } else {
+                    0
+                };
+
+                if other_admins == 0 {
+                    // Sole admin — promote the first non-admin member.
+                    let mut candidate_rows = conn.query(
+                        "SELECT user_id FROM group_member WHERE group_id = ?1 AND user_id != ?2 LIMIT 1",
+                        libsql::params![gid.clone(), user_id.clone()],
+                    ).await?;
+                    if let Some(row) = candidate_rows.next().await? {
+                        let new_admin: String = row.get(0)?;
+                        let _ = conn.execute(
+                            "UPDATE group_member SET role = 'admin' WHERE group_id = ?1 AND user_id = ?2",
+                            libsql::params![gid.clone(), new_admin.clone()],
+                        ).await;
+                        eprintln!("[account] promoted {new_admin} to admin in group {gid}");
+                    }
+                }
+            }
+        }
+    }
 
     // Remove encrypted message envelopes sent by this user
     let _ = conn.execute(
@@ -318,17 +443,19 @@ pub async fn delete_account(
         libsql::params![user_id.clone()],
     ).await;
 
-    // Remove group memberships
+    // Remove group memberships (for groups that weren't deleted above)
     let _ = conn.execute(
         "DELETE FROM group_member WHERE user_id = ?1",
         libsql::params![user_id.clone()],
     ).await;
 
-    // Remove the user row itself
+    // Remove the user row itself (cascades to dm_channel_member, group_invite, etc.)
     conn.execute(
         "DELETE FROM users WHERE id = ?1",
         libsql::params![user_id.clone()],
     ).await?;
+
+    // ── Phase 3: local cleanup ─────────────────────────────────────────
 
     // Close and delete the per-user local database
     state.unload_user_db().await;
@@ -358,5 +485,288 @@ pub async fn delete_account(
 #[tauri::command]
 pub fn list_known_accounts() -> crate::accounts::AccountsIndex {
     crate::accounts::read_accounts_index()
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::Connection;
+
+    const REMOTE_V001: &str = include_str!("../db/migrations/remote_schema.sql");
+
+    fn db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys=ON;").unwrap();
+        conn.execute_batch(REMOTE_V001).unwrap();
+        conn
+    }
+
+    fn setup_users(conn: &Connection) {
+        conn.execute("INSERT INTO users (id, email, username) VALUES ('alice', 'alice@x.com', 'alice')", []).unwrap();
+        conn.execute("INSERT INTO users (id, email, username) VALUES ('bob',   'bob@x.com',   'bob')", []).unwrap();
+        conn.execute("INSERT INTO users (id, email, username) VALUES ('carol', 'carol@x.com', 'carol')", []).unwrap();
+    }
+
+    // ── sole member: group should be deleted ───────────────────────────
+
+    #[test]
+    fn sole_member_deletion_removes_group() {
+        let conn = db();
+        setup_users(&conn);
+
+        conn.execute("INSERT INTO groups (id, name, owner_id) VALUES ('g1', 'Solo Group', 'alice')", []).unwrap();
+        conn.execute("INSERT INTO group_member (group_id, user_id, role) VALUES ('g1', 'alice', 'admin')", []).unwrap();
+        conn.execute("INSERT INTO channels (id, group_id, name) VALUES ('ch1', 'g1', 'general')", []).unwrap();
+
+        // Simulate Phase 2 logic: check member count
+        let member_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM group_member WHERE group_id = 'g1'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(member_count, 1);
+
+        // Sole member — delete the group
+        conn.execute("DELETE FROM groups WHERE id = 'g1'", []).unwrap();
+
+        let group_exists: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM groups WHERE id = 'g1'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(group_exists, 0);
+
+        // Channels cascade-deleted too
+        let ch_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM channels WHERE group_id = 'g1'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(ch_count, 0);
+    }
+
+    // ── sole admin with other members: promote then leave ──────────────
+
+    #[test]
+    fn sole_admin_promotes_first_member_before_leaving() {
+        let conn = db();
+        setup_users(&conn);
+
+        conn.execute("INSERT INTO groups (id, name, owner_id) VALUES ('g1', 'Team', 'alice')", []).unwrap();
+        conn.execute("INSERT INTO group_member (group_id, user_id, role) VALUES ('g1', 'alice', 'admin')", []).unwrap();
+        conn.execute("INSERT INTO group_member (group_id, user_id, role) VALUES ('g1', 'bob', 'member')", []).unwrap();
+        conn.execute("INSERT INTO group_member (group_id, user_id, role) VALUES ('g1', 'carol', 'member')", []).unwrap();
+
+        let deleting_user = "alice";
+
+        // Simulate Phase 2: check other admins
+        let other_admins: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM group_member WHERE group_id = 'g1' AND role = 'admin' AND user_id != ?1",
+            rusqlite::params![deleting_user],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(other_admins, 0, "alice is the sole admin");
+
+        // Promote first non-admin member
+        let new_admin: String = conn.query_row(
+            "SELECT user_id FROM group_member WHERE group_id = 'g1' AND user_id != ?1 LIMIT 1",
+            rusqlite::params![deleting_user],
+            |row| row.get(0),
+        ).unwrap();
+
+        conn.execute(
+            "UPDATE group_member SET role = 'admin' WHERE group_id = 'g1' AND user_id = ?1",
+            rusqlite::params![new_admin.clone()],
+        ).unwrap();
+
+        // Remove the deleting user
+        conn.execute(
+            "DELETE FROM group_member WHERE group_id = 'g1' AND user_id = ?1",
+            rusqlite::params![deleting_user],
+        ).unwrap();
+
+        // Verify: promoted member is admin, group still exists with 2 members
+        let role: String = conn.query_row(
+            "SELECT role FROM group_member WHERE group_id = 'g1' AND user_id = ?1",
+            rusqlite::params![new_admin],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(role, "admin");
+
+        let remaining: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM group_member WHERE group_id = 'g1'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(remaining, 2);
+
+        let group_exists: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM groups WHERE id = 'g1'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(group_exists, 1, "group should still exist");
+    }
+
+    // ── admin with other admins: no promotion needed ───────────────────
+
+    #[test]
+    fn admin_with_other_admins_no_promotion() {
+        let conn = db();
+        setup_users(&conn);
+
+        conn.execute("INSERT INTO groups (id, name, owner_id) VALUES ('g1', 'Team', 'alice')", []).unwrap();
+        conn.execute("INSERT INTO group_member (group_id, user_id, role) VALUES ('g1', 'alice', 'admin')", []).unwrap();
+        conn.execute("INSERT INTO group_member (group_id, user_id, role) VALUES ('g1', 'bob', 'admin')", []).unwrap();
+        conn.execute("INSERT INTO group_member (group_id, user_id, role) VALUES ('g1', 'carol', 'member')", []).unwrap();
+
+        let deleting_user = "alice";
+
+        let other_admins: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM group_member WHERE group_id = 'g1' AND role = 'admin' AND user_id != ?1",
+            rusqlite::params![deleting_user],
+            |row| row.get(0),
+        ).unwrap();
+        assert!(other_admins > 0, "bob is also an admin — no promotion needed");
+
+        // Just remove alice
+        conn.execute(
+            "DELETE FROM group_member WHERE group_id = 'g1' AND user_id = ?1",
+            rusqlite::params![deleting_user],
+        ).unwrap();
+
+        // bob is still admin
+        let bob_role: String = conn.query_row(
+            "SELECT role FROM group_member WHERE group_id = 'g1' AND user_id = 'bob'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(bob_role, "admin");
+
+        // carol unchanged
+        let carol_role: String = conn.query_row(
+            "SELECT role FROM group_member WHERE group_id = 'g1' AND user_id = 'carol'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(carol_role, "member");
+    }
+
+    // ── regular member deletion: no promotion needed ───────────────────
+
+    #[test]
+    fn regular_member_deletion_no_promotion() {
+        let conn = db();
+        setup_users(&conn);
+
+        conn.execute("INSERT INTO groups (id, name, owner_id) VALUES ('g1', 'Team', 'alice')", []).unwrap();
+        conn.execute("INSERT INTO group_member (group_id, user_id, role) VALUES ('g1', 'alice', 'admin')", []).unwrap();
+        conn.execute("INSERT INTO group_member (group_id, user_id, role) VALUES ('g1', 'bob', 'member')", []).unwrap();
+
+        // bob (member) deletes account — no admin promotion needed
+        conn.execute("DELETE FROM group_member WHERE group_id = 'g1' AND user_id = 'bob'", []).unwrap();
+
+        let alice_role: String = conn.query_row(
+            "SELECT role FROM group_member WHERE group_id = 'g1' AND user_id = 'alice'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(alice_role, "admin", "alice should remain admin");
+
+        let group_exists: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM groups WHERE id = 'g1'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(group_exists, 1);
+    }
+
+    // ── multiple groups: each handled correctly ────────────────────────
+
+    #[test]
+    fn deletion_handles_multiple_groups_independently() {
+        let conn = db();
+        setup_users(&conn);
+
+        // Group 1: alice is sole member → should be deleted
+        conn.execute("INSERT INTO groups (id, name, owner_id) VALUES ('g1', 'Solo', 'alice')", []).unwrap();
+        conn.execute("INSERT INTO group_member (group_id, user_id, role) VALUES ('g1', 'alice', 'admin')", []).unwrap();
+
+        // Group 2: alice is sole admin with bob → bob should be promoted
+        conn.execute("INSERT INTO groups (id, name, owner_id) VALUES ('g2', 'Shared', 'alice')", []).unwrap();
+        conn.execute("INSERT INTO group_member (group_id, user_id, role) VALUES ('g2', 'alice', 'admin')", []).unwrap();
+        conn.execute("INSERT INTO group_member (group_id, user_id, role) VALUES ('g2', 'bob', 'member')", []).unwrap();
+
+        // Group 3: alice is member, carol is admin → just leave
+        conn.execute("INSERT INTO groups (id, name, owner_id) VALUES ('g3', 'Other', 'carol')", []).unwrap();
+        conn.execute("INSERT INTO group_member (group_id, user_id, role) VALUES ('g3', 'carol', 'admin')", []).unwrap();
+        conn.execute("INSERT INTO group_member (group_id, user_id, role) VALUES ('g3', 'alice', 'member')", []).unwrap();
+
+        let deleting_user = "alice";
+
+        // Simulate Phase 2 for each group
+        let memberships: Vec<(String, String)> = conn
+            .prepare("SELECT group_id, role FROM group_member WHERE user_id = ?1")
+            .unwrap()
+            .query_map(rusqlite::params![deleting_user], |row| Ok((row.get(0)?, row.get(1)?)))
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+
+        for (gid, role) in &memberships {
+            let member_count: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM group_member WHERE group_id = ?1",
+                rusqlite::params![gid.as_str()],
+                |row| row.get(0),
+            ).unwrap();
+
+            if member_count <= 1 {
+                conn.execute("DELETE FROM groups WHERE id = ?1", rusqlite::params![gid.as_str()]).unwrap();
+            } else if role == "admin" {
+                let other_admins: i64 = conn.query_row(
+                    "SELECT COUNT(*) FROM group_member WHERE group_id = ?1 AND role = 'admin' AND user_id != ?2",
+                    rusqlite::params![gid.as_str(), deleting_user],
+                    |row| row.get(0),
+                ).unwrap();
+                if other_admins == 0 {
+                    let new_admin: String = conn.query_row(
+                        "SELECT user_id FROM group_member WHERE group_id = ?1 AND user_id != ?2 LIMIT 1",
+                        rusqlite::params![gid.as_str(), deleting_user],
+                        |row| row.get(0),
+                    ).unwrap();
+                    conn.execute(
+                        "UPDATE group_member SET role = 'admin' WHERE group_id = ?1 AND user_id = ?2",
+                        rusqlite::params![gid.as_str(), new_admin],
+                    ).unwrap();
+                }
+            }
+        }
+
+        // Remove alice from all remaining groups
+        conn.execute("DELETE FROM group_member WHERE user_id = ?1", rusqlite::params![deleting_user]).unwrap();
+
+        // g1 should be deleted
+        let g1: i64 = conn.query_row("SELECT COUNT(*) FROM groups WHERE id = 'g1'", [], |row| row.get(0)).unwrap();
+        assert_eq!(g1, 0, "sole-member group should be deleted");
+
+        // g2 should exist, bob is now admin
+        let g2: i64 = conn.query_row("SELECT COUNT(*) FROM groups WHERE id = 'g2'", [], |row| row.get(0)).unwrap();
+        assert_eq!(g2, 1, "shared group should still exist");
+        let bob_role: String = conn.query_row(
+            "SELECT role FROM group_member WHERE group_id = 'g2' AND user_id = 'bob'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(bob_role, "admin", "bob should have been promoted");
+
+        // g3 should exist, carol still admin
+        let g3: i64 = conn.query_row("SELECT COUNT(*) FROM groups WHERE id = 'g3'", [], |row| row.get(0)).unwrap();
+        assert_eq!(g3, 1);
+        let carol_role: String = conn.query_row(
+            "SELECT role FROM group_member WHERE group_id = 'g3' AND user_id = 'carol'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(carol_role, "admin");
+    }
 }
 

--- a/src-tauri/src/commands/dm.rs
+++ b/src-tauri/src/commands/dm.rs
@@ -299,3 +299,397 @@ pub async fn leave_dm_channel(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::Connection;
+
+    const REMOTE_V001: &str = include_str!("../db/migrations/remote_schema.sql");
+
+    const EXTRA_TABLES: &str = "
+        CREATE TABLE IF NOT EXISTS conversation_watermark (
+            conversation_id TEXT NOT NULL,
+            user_id         TEXT NOT NULL,
+            last_fetched_at TEXT NOT NULL,
+            PRIMARY KEY (conversation_id, user_id)
+        );
+    ";
+
+    fn db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys=ON;").unwrap();
+        conn.execute_batch(REMOTE_V001).unwrap();
+        conn.execute_batch(EXTRA_TABLES).unwrap();
+        conn
+    }
+
+    fn setup(conn: &Connection) {
+        conn.execute("INSERT INTO users (id, email, username) VALUES ('alice', 'alice@x.com', 'alice')", []).unwrap();
+        conn.execute("INSERT INTO users (id, email, username) VALUES ('bob',   'bob@x.com',   'bob')", []).unwrap();
+        conn.execute("INSERT INTO users (id, email, username) VALUES ('carol', 'carol@x.com', 'carol')", []).unwrap();
+    }
+
+    fn create_dm(conn: &Connection, id: &str, creator: &str, members: &[&str]) {
+        let now = "2024-01-01T00:00:00Z";
+        conn.execute(
+            "INSERT INTO dm_channel (id, created_by, created_at) VALUES (?1, ?2, ?3)",
+            rusqlite::params![id, creator, now],
+        ).unwrap();
+
+        // Add creator
+        conn.execute(
+            "INSERT INTO dm_channel_member (dm_channel_id, user_id, added_by, added_at) VALUES (?1, ?2, ?3, ?4)",
+            rusqlite::params![id, creator, creator, now],
+        ).unwrap();
+
+        // Add other members
+        for member in members {
+            if *member == creator {
+                continue;
+            }
+            conn.execute(
+                "INSERT OR IGNORE INTO dm_channel_member (dm_channel_id, user_id, added_by, added_at) VALUES (?1, ?2, ?3, ?4)",
+                rusqlite::params![id, member, creator, now],
+            ).unwrap();
+        }
+    }
+
+    // ── DM channel creation ────────────────────────────────────────────────
+
+    #[test]
+    fn create_dm_channel_with_two_members() {
+        let conn = db();
+        setup(&conn);
+        create_dm(&conn, "dm1", "alice", &["alice", "bob"]);
+
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM dm_channel_member WHERE dm_channel_id = 'dm1'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn create_dm_channel_creator_is_member() {
+        let conn = db();
+        setup(&conn);
+        create_dm(&conn, "dm1", "alice", &["alice", "bob"]);
+
+        let exists: bool = conn.query_row(
+            "SELECT COUNT(*) FROM dm_channel_member WHERE dm_channel_id = 'dm1' AND user_id = 'alice'",
+            [],
+            |row| row.get::<_, i64>(0).map(|c| c > 0),
+        ).unwrap();
+        assert!(exists, "creator should be a member");
+    }
+
+    #[test]
+    fn create_dm_channel_duplicate_member_ignored() {
+        let conn = db();
+        setup(&conn);
+        create_dm(&conn, "dm1", "alice", &["alice", "bob"]);
+
+        // Try adding bob again
+        conn.execute(
+            "INSERT OR IGNORE INTO dm_channel_member (dm_channel_id, user_id, added_by, added_at) VALUES ('dm1', 'bob', 'alice', '2024-01-02T00:00:00Z')",
+            [],
+        ).unwrap();
+
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM dm_channel_member WHERE dm_channel_id = 'dm1' AND user_id = 'bob'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(count, 1, "should still be one membership row");
+    }
+
+    // ── list_dm_channels ───────────────────────────────────────────────────
+
+    #[test]
+    fn list_dm_channels_only_returns_user_dms() {
+        let conn = db();
+        setup(&conn);
+        create_dm(&conn, "dm1", "alice", &["alice", "bob"]);
+        create_dm(&conn, "dm2", "alice", &["alice", "carol"]);
+        create_dm(&conn, "dm3", "bob", &["bob", "carol"]); // carol-bob only
+
+        let alice_dms: Vec<String> = conn.prepare(
+            "SELECT dc.id FROM dm_channel dc JOIN dm_channel_member dcm ON dcm.dm_channel_id = dc.id WHERE dcm.user_id = ?1",
+        ).unwrap().query_map(
+            rusqlite::params!["alice"],
+            |row| row.get(0),
+        ).unwrap().map(|r| r.unwrap()).collect();
+
+        assert_eq!(alice_dms.len(), 2);
+        assert!(alice_dms.contains(&"dm1".to_string()));
+        assert!(alice_dms.contains(&"dm2".to_string()));
+        assert!(!alice_dms.contains(&"dm3".to_string()));
+    }
+
+    // ── fetch_dm_members ───────────────────────────────────────────────────
+
+    #[test]
+    fn fetch_dm_members_includes_username() {
+        let conn = db();
+        setup(&conn);
+        create_dm(&conn, "dm1", "alice", &["alice", "bob"]);
+
+        let members: Vec<(String, Option<String>)> = conn.prepare(
+            "SELECT dcm.user_id, u.username
+             FROM dm_channel_member dcm
+             LEFT JOIN users u ON u.id = dcm.user_id
+             WHERE dcm.dm_channel_id = ?1",
+        ).unwrap().query_map(
+            rusqlite::params!["dm1"],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        ).unwrap().map(|r| r.unwrap()).collect();
+
+        assert_eq!(members.len(), 2);
+        assert!(members.contains(&("alice".into(), Some("alice".into()))));
+        assert!(members.contains(&("bob".into(), Some("bob".into()))));
+    }
+
+    // ── get_dm_channel ─────────────────────────────────────────────────────
+
+    #[test]
+    fn get_dm_channel_returns_channel() {
+        let conn = db();
+        setup(&conn);
+        create_dm(&conn, "dm1", "alice", &["alice", "bob"]);
+
+        let (id, created_by): (String, String) = conn.query_row(
+            "SELECT id, created_by FROM dm_channel WHERE id = ?1",
+            rusqlite::params!["dm1"],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        ).unwrap();
+
+        assert_eq!(id, "dm1");
+        assert_eq!(created_by, "alice");
+    }
+
+    #[test]
+    fn get_dm_channel_not_found() {
+        let conn = db();
+        setup(&conn);
+
+        let result = conn.query_row(
+            "SELECT id FROM dm_channel WHERE id = 'nonexistent'",
+            [],
+            |row| row.get::<_, String>(0),
+        );
+        assert!(result.is_err());
+    }
+
+    // ── remove_user_from_dm_channel (authorization) ────────────────────────
+
+    #[test]
+    fn remove_member_by_creator_succeeds() {
+        let conn = db();
+        setup(&conn);
+        create_dm(&conn, "dm1", "alice", &["alice", "bob"]);
+
+        // alice (creator) removes bob
+        let creator: String = conn.query_row(
+            "SELECT created_by FROM dm_channel WHERE id = 'dm1'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(creator, "alice");
+
+        conn.execute(
+            "DELETE FROM dm_channel_member WHERE dm_channel_id = 'dm1' AND user_id = 'bob'",
+            [],
+        ).unwrap();
+
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM dm_channel_member WHERE dm_channel_id = 'dm1' AND user_id = 'bob'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(count, 0);
+    }
+
+    // ── leave_dm_channel: auto-cleanup ─────────────────────────────────────
+
+    #[test]
+    fn leave_dm_last_member_cleans_up_channel() {
+        let conn = db();
+        setup(&conn);
+        create_dm(&conn, "dm1", "alice", &["alice", "bob"]);
+
+        // Add a message to verify cleanup
+        conn.execute(
+            "INSERT INTO message_envelope (id, conversation_id, sender_id, ciphertext, sent_at) VALUES ('m1', 'dm1', 'alice', 'hello', '2024-01-01T10:00:00Z')",
+            [],
+        ).unwrap();
+
+        // Both leave
+        conn.execute("DELETE FROM dm_channel_member WHERE dm_channel_id = 'dm1' AND user_id = 'alice'", []).unwrap();
+        conn.execute("DELETE FROM dm_channel_member WHERE dm_channel_id = 'dm1' AND user_id = 'bob'", []).unwrap();
+
+        let remaining: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM dm_channel_member WHERE dm_channel_id = 'dm1'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(remaining, 0);
+
+        // Simulate cleanup logic from leave_dm_channel
+        conn.execute("DELETE FROM message_envelope WHERE conversation_id = 'dm1'", []).unwrap();
+        conn.execute("DELETE FROM dm_channel WHERE id = 'dm1'", []).unwrap();
+
+        let channel_exists: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM dm_channel WHERE id = 'dm1'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(channel_exists, 0, "channel should be deleted");
+
+        let msg_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM message_envelope WHERE conversation_id = 'dm1'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(msg_count, 0, "messages should be cleaned up");
+    }
+
+    #[test]
+    fn leave_dm_not_last_member_keeps_channel() {
+        let conn = db();
+        setup(&conn);
+        create_dm(&conn, "dm1", "alice", &["alice", "bob"]);
+
+        conn.execute("DELETE FROM dm_channel_member WHERE dm_channel_id = 'dm1' AND user_id = 'alice'", []).unwrap();
+
+        let remaining: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM dm_channel_member WHERE dm_channel_id = 'dm1'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(remaining, 1, "bob is still a member");
+
+        let channel_exists: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM dm_channel WHERE id = 'dm1'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(channel_exists, 1, "channel should still exist");
+    }
+
+    // ── DM cascade deletes ─────────────────────────────────────────────────
+
+    #[test]
+    fn dm_channel_delete_cascades_members() {
+        let conn = db();
+        setup(&conn);
+        create_dm(&conn, "dm1", "alice", &["alice", "bob"]);
+
+        conn.execute("DELETE FROM dm_channel WHERE id = 'dm1'", []).unwrap();
+
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM dm_channel_member WHERE dm_channel_id = 'dm1'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(count, 0, "members should be cascade-deleted");
+    }
+
+    #[test]
+    fn user_delete_cascades_dm_membership() {
+        let conn = db();
+        setup(&conn);
+        create_dm(&conn, "dm1", "alice", &["alice", "bob"]);
+
+        conn.execute("DELETE FROM users WHERE id = 'bob'", []).unwrap();
+
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM dm_channel_member WHERE user_id = 'bob'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(count, 0, "bob's membership should be cascade-deleted");
+    }
+
+    // ── watermark initialization ───────────────────────────────────────────
+
+    #[test]
+    fn watermark_initialized_for_dm_members() {
+        let conn = db();
+        setup(&conn);
+        create_dm(&conn, "dm1", "alice", &["alice", "bob"]);
+
+        // Simulate watermark init
+        for uid in ["alice", "bob"] {
+            conn.execute(
+                "INSERT OR IGNORE INTO conversation_watermark (conversation_id, user_id, last_fetched_at) VALUES (?1, ?2, datetime('now'))",
+                rusqlite::params!["dm1", uid],
+            ).unwrap();
+        }
+
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM conversation_watermark WHERE conversation_id = 'dm1'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn watermark_idempotent() {
+        let conn = db();
+        setup(&conn);
+        create_dm(&conn, "dm1", "alice", &["alice", "bob"]);
+
+        // Insert twice — INSERT OR IGNORE should not error or duplicate
+        for _ in 0..2 {
+            conn.execute(
+                "INSERT OR IGNORE INTO conversation_watermark (conversation_id, user_id, last_fetched_at) VALUES ('dm1', 'alice', datetime('now'))",
+                [],
+            ).unwrap();
+        }
+
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM conversation_watermark WHERE conversation_id = 'dm1' AND user_id = 'alice'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(count, 1);
+    }
+
+    // ── group DM (3+ members) ──────────────────────────────────────────────
+
+    #[test]
+    fn group_dm_three_members() {
+        let conn = db();
+        setup(&conn);
+        create_dm(&conn, "dm1", "alice", &["alice", "bob", "carol"]);
+
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM dm_channel_member WHERE dm_channel_id = 'dm1'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(count, 3);
+    }
+
+    #[test]
+    fn add_user_to_existing_dm() {
+        let conn = db();
+        setup(&conn);
+        create_dm(&conn, "dm1", "alice", &["alice", "bob"]);
+
+        // Add carol to existing DM
+        conn.execute(
+            "INSERT OR IGNORE INTO dm_channel_member (dm_channel_id, user_id, added_by, added_at) VALUES ('dm1', 'carol', 'alice', '2024-01-02T00:00:00Z')",
+            [],
+        ).unwrap();
+
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM dm_channel_member WHERE dm_channel_id = 'dm1'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(count, 3);
+    }
+}

--- a/src-tauri/src/commands/groups.rs
+++ b/src-tauri/src/commands/groups.rs
@@ -1170,3 +1170,839 @@ pub async fn reject_join_request(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::Connection;
+
+    const REMOTE_V001: &str = include_str!("../db/migrations/remote_schema.sql");
+
+    /// Extra tables from numbered migrations that the base schema doesn't include.
+    const EXTRA_TABLES: &str = "
+        CREATE TABLE IF NOT EXISTS conversation_watermark (
+            conversation_id TEXT NOT NULL,
+            user_id         TEXT NOT NULL,
+            last_fetched_at TEXT NOT NULL,
+            PRIMARY KEY (conversation_id, user_id)
+        );
+    ";
+
+    fn db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys=ON;").unwrap();
+        conn.execute_batch(REMOTE_V001).unwrap();
+        conn.execute_batch(EXTRA_TABLES).unwrap();
+        conn
+    }
+
+    fn setup(conn: &Connection) {
+        conn.execute("INSERT INTO users (id, email, username) VALUES ('alice', 'alice@x.com', 'alice')", []).unwrap();
+        conn.execute("INSERT INTO users (id, email, username) VALUES ('bob',   'bob@x.com',   'bob')", []).unwrap();
+        conn.execute("INSERT INTO users (id, email, username) VALUES ('carol', 'carol@x.com', 'carol')", []).unwrap();
+
+        conn.execute("INSERT INTO groups (id, name, description, owner_id) VALUES ('g1', 'Test Group', 'a group', 'alice')", []).unwrap();
+        conn.execute("INSERT INTO group_member (group_id, user_id, role) VALUES ('g1', 'alice', 'admin')", []).unwrap();
+        conn.execute("INSERT INTO group_member (group_id, user_id, role) VALUES ('g1', 'bob', 'member')", []).unwrap();
+
+        conn.execute("INSERT INTO channels (id, group_id, name, channel_type) VALUES ('ch1', 'g1', 'general', 'text')", []).unwrap();
+        conn.execute("INSERT INTO channels (id, group_id, name, channel_type) VALUES ('ch2', 'g1', 'random', 'text')", []).unwrap();
+    }
+
+    // ── derive_slug ────────────────────────────────────────────────────────
+
+    #[test]
+    fn slug_simple_name() {
+        assert_eq!(super::derive_slug("Test Group"), "test-group");
+    }
+
+    #[test]
+    fn slug_special_characters_stripped() {
+        assert_eq!(super::derive_slug("Hello, World!"), "hello-world");
+    }
+
+    #[test]
+    fn slug_multiple_spaces_collapsed() {
+        assert_eq!(super::derive_slug("a   b"), "a-b");
+    }
+
+    #[test]
+    fn slug_leading_trailing_hyphens_trimmed() {
+        assert_eq!(super::derive_slug("-test-"), "test");
+    }
+
+    #[test]
+    fn slug_consecutive_hyphens_collapsed() {
+        assert_eq!(super::derive_slug("a---b"), "a-b");
+    }
+
+    #[test]
+    fn slug_mixed_case_lowered() {
+        assert_eq!(super::derive_slug("My Cool Group"), "my-cool-group");
+    }
+
+    #[test]
+    fn slug_already_clean() {
+        assert_eq!(super::derive_slug("simple"), "simple");
+    }
+
+    #[test]
+    fn slug_unicode_stripped() {
+        assert_eq!(super::derive_slug("café"), "caf");
+    }
+
+    // ── group queries ──────────────────────────────────────────────────────
+
+    #[test]
+    fn list_user_groups_only_returns_member_groups() {
+        let conn = db();
+        setup(&conn);
+
+        // carol's own group
+        conn.execute("INSERT INTO groups (id, name, owner_id) VALUES ('g2', 'Carol Group', 'carol')", []).unwrap();
+        conn.execute("INSERT INTO group_member (group_id, user_id, role) VALUES ('g2', 'carol', 'admin')", []).unwrap();
+
+        let groups: Vec<String> = conn.prepare(
+            "SELECT g.id FROM groups g JOIN group_member gm ON gm.group_id = g.id WHERE gm.user_id = ?1",
+        ).unwrap().query_map(
+            rusqlite::params!["bob"],
+            |row| row.get(0),
+        ).unwrap().map(|r| r.unwrap()).collect();
+
+        assert_eq!(groups, ["g1"]);
+        assert!(!groups.contains(&"g2".to_string()));
+    }
+
+    #[test]
+    fn list_group_channels_returns_all_channels() {
+        let conn = db();
+        setup(&conn);
+
+        let channels: Vec<(String, String)> = conn.prepare(
+            "SELECT id, name FROM channels WHERE group_id = ?1",
+        ).unwrap().query_map(
+            rusqlite::params!["g1"],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        ).unwrap().map(|r| r.unwrap()).collect();
+
+        assert_eq!(channels.len(), 2);
+        let names: Vec<&str> = channels.iter().map(|(_, n)| n.as_str()).collect();
+        assert!(names.contains(&"general"));
+        assert!(names.contains(&"random"));
+    }
+
+    #[test]
+    fn channel_type_defaults_to_text() {
+        let conn = db();
+        setup(&conn);
+
+        // Insert channel without explicit channel_type
+        conn.execute("INSERT INTO channels (id, group_id, name) VALUES ('ch-no-type', 'g1', 'untyped')", []).unwrap();
+
+        let ct: String = conn.query_row(
+            "SELECT channel_type FROM channels WHERE id = 'ch-no-type'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(ct, "text");
+    }
+
+    // ── RBAC: admin-only operations ────────────────────────────────────────
+
+    #[test]
+    fn admin_role_check_returns_admin_for_admin_user() {
+        let conn = db();
+        setup(&conn);
+
+        let role: String = conn.query_row(
+            "SELECT role FROM group_member WHERE group_id = ?1 AND user_id = ?2",
+            rusqlite::params!["g1", "alice"],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(role, "admin");
+    }
+
+    #[test]
+    fn admin_role_check_returns_member_for_regular_user() {
+        let conn = db();
+        setup(&conn);
+
+        let role: String = conn.query_row(
+            "SELECT role FROM group_member WHERE group_id = ?1 AND user_id = ?2",
+            rusqlite::params!["g1", "bob"],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(role, "member");
+    }
+
+    #[test]
+    fn role_check_returns_none_for_non_member() {
+        let conn = db();
+        setup(&conn);
+
+        let result = conn.query_row(
+            "SELECT role FROM group_member WHERE group_id = ?1 AND user_id = ?2",
+            rusqlite::params!["g1", "carol"],
+            |row| row.get::<_, String>(0),
+        );
+        assert!(result.is_err());
+    }
+
+    // ── group update (partial) ─────────────────────────────────────────────
+
+    #[test]
+    fn update_group_name_only() {
+        let conn = db();
+        setup(&conn);
+
+        conn.execute("UPDATE groups SET name = ?1 WHERE id = ?2", rusqlite::params!["New Name", "g1"]).unwrap();
+
+        let (name, desc): (String, Option<String>) = conn.query_row(
+            "SELECT name, description FROM groups WHERE id = 'g1'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        ).unwrap();
+        assert_eq!(name, "New Name");
+        assert_eq!(desc.as_deref(), Some("a group"), "description should be unchanged");
+    }
+
+    #[test]
+    fn update_group_icon_url() {
+        let conn = db();
+        setup(&conn);
+
+        conn.execute("UPDATE groups SET icon_url = ?1 WHERE id = ?2", rusqlite::params!["https://img.example.com/icon.png", "g1"]).unwrap();
+
+        let icon: Option<String> = conn.query_row(
+            "SELECT icon_url FROM groups WHERE id = 'g1'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(icon.as_deref(), Some("https://img.example.com/icon.png"));
+    }
+
+    // ── group deletion cascades ────────────────────────────────────────────
+
+    #[test]
+    fn delete_group_cascades_members_and_channels() {
+        let conn = db();
+        setup(&conn);
+
+        conn.execute("DELETE FROM groups WHERE id = 'g1'", []).unwrap();
+
+        let member_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM group_member WHERE group_id = 'g1'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(member_count, 0, "members should be cascade-deleted");
+
+        let channel_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM channels WHERE group_id = 'g1'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(channel_count, 0, "channels should be cascade-deleted");
+    }
+
+    // ── member removal ─────────────────────────────────────────────────────
+
+    #[test]
+    fn remove_member_deletes_membership_row() {
+        let conn = db();
+        setup(&conn);
+
+        conn.execute(
+            "DELETE FROM group_member WHERE group_id = ?1 AND user_id = ?2",
+            rusqlite::params!["g1", "bob"],
+        ).unwrap();
+
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM group_member WHERE group_id = 'g1' AND user_id = 'bob'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(count, 0);
+    }
+
+    // ── leave group: auto-delete when empty ────────────────────────────────
+
+    #[test]
+    fn leave_group_last_member_deletes_group() {
+        let conn = db();
+        setup(&conn);
+
+        // Remove bob first, then alice (last member)
+        conn.execute("DELETE FROM group_member WHERE group_id = 'g1' AND user_id = 'bob'", []).unwrap();
+        conn.execute("DELETE FROM group_member WHERE group_id = 'g1' AND user_id = 'alice'", []).unwrap();
+
+        let member_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM group_member WHERE group_id = 'g1'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(member_count, 0);
+
+        // Simulate: if member_count <= 1, delete group
+        conn.execute("DELETE FROM groups WHERE id = 'g1'", []).unwrap();
+
+        let group_exists: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM groups WHERE id = 'g1'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(group_exists, 0);
+    }
+
+    // ── set_member_role ────────────────────────────────────────────────────
+
+    #[test]
+    fn set_member_role_promotes_to_admin() {
+        let conn = db();
+        setup(&conn);
+
+        conn.execute(
+            "UPDATE group_member SET role = ?1 WHERE group_id = ?2 AND user_id = ?3",
+            rusqlite::params!["admin", "g1", "bob"],
+        ).unwrap();
+
+        let role: String = conn.query_row(
+            "SELECT role FROM group_member WHERE group_id = 'g1' AND user_id = 'bob'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(role, "admin");
+    }
+
+    #[test]
+    fn set_member_role_demotes_to_member() {
+        let conn = db();
+        setup(&conn);
+
+        // alice starts as admin
+        conn.execute(
+            "UPDATE group_member SET role = 'member' WHERE group_id = 'g1' AND user_id = 'alice'",
+            [],
+        ).unwrap();
+
+        let role: String = conn.query_row(
+            "SELECT role FROM group_member WHERE group_id = 'g1' AND user_id = 'alice'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(role, "member");
+    }
+
+    // ── add_member_to_group (INSERT OR IGNORE) ─────────────────────────────
+
+    #[test]
+    fn add_member_ignores_duplicate() {
+        let conn = db();
+        setup(&conn);
+
+        // bob is already a member — INSERT OR IGNORE should not error
+        conn.execute(
+            "INSERT OR IGNORE INTO group_member (group_id, user_id, role) VALUES ('g1', 'bob', 'member')",
+            [],
+        ).unwrap();
+
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM group_member WHERE group_id = 'g1' AND user_id = 'bob'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(count, 1, "should still be exactly one membership row");
+    }
+
+    #[test]
+    fn add_member_initializes_watermarks_for_existing_channels() {
+        let conn = db();
+        setup(&conn);
+
+        // Simulate add_member_to_group watermark init
+        conn.execute(
+            "INSERT OR IGNORE INTO group_member (group_id, user_id, role) VALUES ('g1', 'carol', 'member')",
+            [],
+        ).unwrap();
+        conn.execute(
+            "INSERT OR IGNORE INTO conversation_watermark (conversation_id, user_id, last_fetched_at)
+             SELECT c.id, ?1, datetime('now')
+             FROM channels c WHERE c.group_id = ?2",
+            rusqlite::params!["carol", "g1"],
+        ).unwrap();
+
+        let watermark_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM conversation_watermark WHERE user_id = 'carol'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(watermark_count, 2, "should have watermarks for ch1 and ch2");
+    }
+
+    // ── get_group_members ──────────────────────────────────────────────────
+
+    #[test]
+    fn get_group_members_returns_all_with_roles() {
+        let conn = db();
+        setup(&conn);
+
+        let members: Vec<(String, String)> = conn.prepare(
+            "SELECT gm.user_id, gm.role FROM group_member gm WHERE gm.group_id = ?1",
+        ).unwrap().query_map(
+            rusqlite::params!["g1"],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        ).unwrap().map(|r| r.unwrap()).collect();
+
+        assert_eq!(members.len(), 2);
+        assert!(members.contains(&("alice".into(), "admin".into())));
+        assert!(members.contains(&("bob".into(), "member".into())));
+    }
+
+    #[test]
+    fn get_group_members_joins_user_profile() {
+        let conn = db();
+        setup(&conn);
+
+        let result: (String, Option<String>) = conn.query_row(
+            "SELECT gm.user_id, u.username
+             FROM group_member gm
+             LEFT JOIN users u ON u.id = gm.user_id
+             WHERE gm.group_id = ?1 AND gm.user_id = ?2",
+            rusqlite::params!["g1", "alice"],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        ).unwrap();
+
+        assert_eq!(result.0, "alice");
+        assert_eq!(result.1.as_deref(), Some("alice"));
+    }
+
+    // ── invites ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn invite_insert_and_query() {
+        let conn = db();
+        setup(&conn);
+
+        conn.execute(
+            "INSERT INTO group_invite (id, group_id, inviter_id, invitee_id) VALUES ('inv1', 'g1', 'alice', 'carol')",
+            [],
+        ).unwrap();
+
+        let (inviter, invitee): (String, String) = conn.query_row(
+            "SELECT inviter_id, invitee_id FROM group_invite WHERE id = 'inv1'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        ).unwrap();
+        assert_eq!(inviter, "alice");
+        assert_eq!(invitee, "carol");
+    }
+
+    #[test]
+    fn invite_existing_member_blocked() {
+        let conn = db();
+        setup(&conn);
+
+        // bob is already a member of g1 — check that a membership check catches it
+        let is_member: bool = conn.query_row(
+            "SELECT COUNT(*) FROM group_member WHERE group_id = ?1 AND user_id = ?2",
+            rusqlite::params!["g1", "bob"],
+            |row| row.get::<_, i64>(0).map(|c| c > 0),
+        ).unwrap();
+        assert!(is_member, "bob should already be a member");
+
+        // In the command, this check prevents the invite from being created.
+        // The INSERT itself would succeed (no DB constraint), so the guard is in app logic.
+    }
+
+    #[test]
+    fn invite_self_blocked() {
+        let conn = db();
+        setup(&conn);
+
+        // The command checks invitee_id == inviter_id before inserting.
+        // Verify the condition that would be checked:
+        let inviter_id = "alice";
+        let invitee_id = "alice";
+        assert_eq!(inviter_id, invitee_id, "self-invite should be caught by app logic");
+    }
+
+    #[test]
+    fn duplicate_pending_invite_blocked() {
+        let conn = db();
+        setup(&conn);
+
+        // First invite
+        conn.execute(
+            "INSERT INTO group_invite (id, group_id, inviter_id, invitee_id) VALUES ('inv1', 'g1', 'alice', 'carol')",
+            [],
+        ).unwrap();
+
+        // The command checks for existing pending invites before inserting.
+        // Since group_invite has no status column (all rows are implicitly pending),
+        // the check is: any row with (group_id, invitee_id) exists.
+        let existing: bool = conn.query_row(
+            "SELECT COUNT(*) FROM group_invite WHERE group_id = ?1 AND invitee_id = ?2",
+            rusqlite::params!["g1", "carol"],
+            |row| row.get::<_, i64>(0).map(|c| c > 0),
+        ).unwrap();
+        assert!(existing, "pending invite should already exist — app logic blocks duplicate");
+    }
+
+    #[test]
+    fn invite_cascade_deletes_with_group() {
+        let conn = db();
+        setup(&conn);
+
+        conn.execute(
+            "INSERT INTO group_invite (id, group_id, inviter_id, invitee_id) VALUES ('inv1', 'g1', 'alice', 'carol')",
+            [],
+        ).unwrap();
+
+        conn.execute("DELETE FROM groups WHERE id = 'g1'", []).unwrap();
+
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM group_invite WHERE id = 'inv1'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(count, 0, "invite should be cascade-deleted with group");
+    }
+
+    #[test]
+    fn invite_delete_on_accept() {
+        let conn = db();
+        setup(&conn);
+
+        conn.execute(
+            "INSERT INTO group_invite (id, group_id, inviter_id, invitee_id) VALUES ('inv1', 'g1', 'alice', 'carol')",
+            [],
+        ).unwrap();
+
+        // Accept: add member + delete invite
+        conn.execute(
+            "INSERT OR IGNORE INTO group_member (group_id, user_id, role) VALUES ('g1', 'carol', 'member')",
+            [],
+        ).unwrap();
+        conn.execute("DELETE FROM group_invite WHERE id = 'inv1'", []).unwrap();
+
+        let member_exists: bool = conn.query_row(
+            "SELECT COUNT(*) FROM group_member WHERE group_id = 'g1' AND user_id = 'carol'",
+            [],
+            |row| row.get::<_, i64>(0).map(|c| c > 0),
+        ).unwrap();
+        assert!(member_exists, "carol should now be a member");
+
+        let invite_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM group_invite",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(invite_count, 0, "invite should be deleted after acceptance");
+    }
+
+    // ── join requests ──────────────────────────────────────────────────────
+
+    #[test]
+    fn join_request_insert() {
+        let conn = db();
+        setup(&conn);
+
+        conn.execute(
+            "INSERT INTO group_join_request (id, group_id, requester_id, status) VALUES ('jr1', 'g1', 'carol', 'pending')",
+            [],
+        ).unwrap();
+
+        let status: String = conn.query_row(
+            "SELECT status FROM group_join_request WHERE id = 'jr1'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(status, "pending");
+    }
+
+    #[test]
+    fn join_request_blocked_when_already_member() {
+        let conn = db();
+        setup(&conn);
+
+        // bob is already a member — the command checks this before inserting
+        let is_member: bool = conn.query_row(
+            "SELECT COUNT(*) FROM group_member WHERE group_id = ?1 AND user_id = ?2",
+            rusqlite::params!["g1", "bob"],
+            |row| row.get::<_, i64>(0).map(|c| c > 0),
+        ).unwrap();
+        assert!(is_member, "bob is already a member — request_group_access should reject");
+    }
+
+    #[test]
+    fn join_request_unique_per_group_requester() {
+        let conn = db();
+        setup(&conn);
+
+        conn.execute(
+            "INSERT INTO group_join_request (id, group_id, requester_id, status) VALUES ('jr1', 'g1', 'carol', 'pending')",
+            [],
+        ).unwrap();
+
+        // Duplicate (group, requester) should conflict
+        let result = conn.execute(
+            "INSERT INTO group_join_request (id, group_id, requester_id, status) VALUES ('jr2', 'g1', 'carol', 'pending')",
+            [],
+        );
+        assert!(result.is_err(), "duplicate (group_id, requester_id) should violate unique index");
+    }
+
+    #[test]
+    fn join_request_upsert_resets_rejected_to_pending() {
+        let conn = db();
+        setup(&conn);
+
+        conn.execute(
+            "INSERT INTO group_join_request (id, group_id, requester_id, status) VALUES ('jr1', 'g1', 'carol', 'rejected')",
+            [],
+        ).unwrap();
+
+        // Re-apply via upsert — same pattern as request_group_access
+        conn.execute(
+            "INSERT INTO group_join_request (id, group_id, requester_id, status, created_at)
+             VALUES ('jr2', 'g1', 'carol', 'pending', datetime('now'))
+             ON CONFLICT(group_id, requester_id) DO UPDATE SET
+                 id = excluded.id,
+                 status = 'pending',
+                 created_at = excluded.created_at",
+            [],
+        ).unwrap();
+
+        let (id, status): (String, String) = conn.query_row(
+            "SELECT id, status FROM group_join_request WHERE group_id = 'g1' AND requester_id = 'carol'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        ).unwrap();
+        assert_eq!(id, "jr2", "id should be updated to the new one");
+        assert_eq!(status, "pending", "status should be reset to pending");
+    }
+
+    #[test]
+    fn join_request_status_check_constraint() {
+        let conn = db();
+        setup(&conn);
+
+        let result = conn.execute(
+            "INSERT INTO group_join_request (id, group_id, requester_id, status) VALUES ('jr1', 'g1', 'carol', 'invalid')",
+            [],
+        );
+        assert!(result.is_err(), "invalid status should violate CHECK constraint");
+    }
+
+    #[test]
+    fn join_request_approve_adds_member_and_updates_status() {
+        let conn = db();
+        setup(&conn);
+
+        conn.execute(
+            "INSERT INTO group_join_request (id, group_id, requester_id, status) VALUES ('jr1', 'g1', 'carol', 'pending')",
+            [],
+        ).unwrap();
+
+        // Approve: add member + update status
+        conn.execute(
+            "INSERT OR IGNORE INTO group_member (group_id, user_id, role) VALUES ('g1', 'carol', 'member')",
+            [],
+        ).unwrap();
+        conn.execute(
+            "UPDATE group_join_request SET status = 'approved', reviewed_by = 'alice', reviewed_at = datetime('now') WHERE id = 'jr1'",
+            [],
+        ).unwrap();
+
+        let status: String = conn.query_row(
+            "SELECT status FROM group_join_request WHERE id = 'jr1'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(status, "approved");
+
+        let is_member: bool = conn.query_row(
+            "SELECT COUNT(*) FROM group_member WHERE group_id = 'g1' AND user_id = 'carol'",
+            [],
+            |row| row.get::<_, i64>(0).map(|c| c > 0),
+        ).unwrap();
+        assert!(is_member);
+    }
+
+    #[test]
+    fn join_request_only_pending_returned_for_admins() {
+        let conn = db();
+        setup(&conn);
+
+        conn.execute(
+            "INSERT INTO group_join_request (id, group_id, requester_id, status) VALUES ('jr1', 'g1', 'carol', 'pending')",
+            [],
+        ).unwrap();
+
+        // Simulate a second user with a rejected request — need a new user
+        conn.execute("INSERT INTO users (id, email, username) VALUES ('dave', 'dave@x.com', 'dave')", []).unwrap();
+        conn.execute(
+            "INSERT INTO group_join_request (id, group_id, requester_id, status) VALUES ('jr2', 'g1', 'dave', 'rejected')",
+            [],
+        ).unwrap();
+
+        let pending: Vec<String> = conn.prepare(
+            "SELECT jr.id FROM group_join_request jr WHERE jr.group_id = ?1 AND jr.status = 'pending' ORDER BY jr.created_at ASC",
+        ).unwrap().query_map(
+            rusqlite::params!["g1"],
+            |row| row.get(0),
+        ).unwrap().map(|r| r.unwrap()).collect();
+
+        assert_eq!(pending, ["jr1"], "only pending requests should be returned");
+    }
+
+    #[test]
+    fn join_request_cascade_deletes_with_group() {
+        let conn = db();
+        setup(&conn);
+
+        conn.execute(
+            "INSERT INTO group_join_request (id, group_id, requester_id, status) VALUES ('jr1', 'g1', 'carol', 'pending')",
+            [],
+        ).unwrap();
+
+        conn.execute("DELETE FROM groups WHERE id = 'g1'", []).unwrap();
+
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM group_join_request",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(count, 0, "join requests should be cascade-deleted with group");
+    }
+
+    // ── search_group_by_slug ───────────────────────────────────────────────
+
+    #[test]
+    fn search_group_by_slug_finds_match() {
+        let conn = db();
+        setup(&conn);
+
+        // Simulate the scan + derive_slug pattern
+        let mut found = None;
+        let mut stmt = conn.prepare("SELECT id, name FROM groups").unwrap();
+        let rows = stmt.query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))).unwrap();
+        for r in rows {
+            let (id, name) = r.unwrap();
+            if super::derive_slug(&name) == "test-group" {
+                found = Some(id);
+                break;
+            }
+        }
+
+        assert_eq!(found.as_deref(), Some("g1"));
+    }
+
+    #[test]
+    fn search_group_by_slug_no_match() {
+        let conn = db();
+        setup(&conn);
+
+        let mut found = false;
+        let mut stmt = conn.prepare("SELECT name FROM groups").unwrap();
+        let rows = stmt.query_map([], |row| row.get::<_, String>(0)).unwrap();
+        for r in rows {
+            if super::derive_slug(&r.unwrap()) == "nonexistent-group" {
+                found = true;
+            }
+        }
+
+        assert!(!found);
+    }
+
+    // ── list_user_groups_with_channels query shape ─────────────────────────
+
+    #[test]
+    fn list_groups_with_channels_groups_and_nests_channels() {
+        let conn = db();
+        setup(&conn);
+
+        // Simulate the query used by list_user_groups_with_channels
+        let mut stmt = conn.prepare(
+            "SELECT g.id, g.name, g.description, g.owner_id, g.created_at,
+                    c.id, c.group_id, c.name, c.description, c.channel_type,
+                    gm.role
+             FROM groups g
+             JOIN group_member gm ON gm.group_id = g.id
+             LEFT JOIN channels c ON c.group_id = g.id
+             WHERE gm.user_id = ?1
+             ORDER BY g.created_at, c.name",
+        ).unwrap();
+
+        let rows: Vec<(String, Option<String>, String)> = stmt.query_map(
+            rusqlite::params!["alice"],
+            |row| Ok((row.get(0)?, row.get(5)?, row.get(10)?)),
+        ).unwrap().map(|r| r.unwrap()).collect();
+
+        // g1 has 2 channels — should get 2 rows, same group_id
+        assert_eq!(rows.len(), 2);
+        assert!(rows.iter().all(|(gid, _, _)| gid == "g1"));
+        // Both channel IDs present
+        let ch_ids: Vec<&str> = rows.iter().map(|(_, cid, _)| cid.as_deref().unwrap()).collect();
+        assert!(ch_ids.contains(&"ch1"));
+        assert!(ch_ids.contains(&"ch2"));
+        // Role is admin for alice
+        assert!(rows.iter().all(|(_, _, role)| role == "admin"));
+    }
+
+    #[test]
+    fn list_groups_with_channels_group_without_channels() {
+        let conn = db();
+        setup(&conn);
+
+        // Group with no channels
+        conn.execute("INSERT INTO groups (id, name, owner_id) VALUES ('g-empty', 'Empty', 'alice')", []).unwrap();
+        conn.execute("INSERT INTO group_member (group_id, user_id, role) VALUES ('g-empty', 'alice', 'admin')", []).unwrap();
+
+        let mut stmt = conn.prepare(
+            "SELECT g.id, c.id
+             FROM groups g
+             JOIN group_member gm ON gm.group_id = g.id
+             LEFT JOIN channels c ON c.group_id = g.id
+             WHERE gm.user_id = ?1
+             ORDER BY g.created_at, c.name",
+        ).unwrap();
+
+        let rows: Vec<(String, Option<String>)> = stmt.query_map(
+            rusqlite::params!["alice"],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        ).unwrap().map(|r| r.unwrap()).collect();
+
+        // g-empty should appear with NULL channel
+        let empty_rows: Vec<_> = rows.iter().filter(|(gid, _)| gid == "g-empty").collect();
+        assert_eq!(empty_rows.len(), 1);
+        assert!(empty_rows[0].1.is_none(), "channel_id should be NULL for empty group");
+    }
+
+    // ── db_err mapping ─────────────────────────────────────────────────────
+
+    #[test]
+    fn duplicate_group_member_violates_unique() {
+        let conn = db();
+        setup(&conn);
+
+        let result = conn.execute(
+            "INSERT INTO group_member (group_id, user_id, role) VALUES ('g1', 'alice', 'admin')",
+            [],
+        );
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("UNIQUE"), "error should mention UNIQUE constraint: {err_msg}");
+    }
+
+    #[test]
+    fn foreign_key_violation_on_invalid_group() {
+        let conn = db();
+        setup(&conn);
+
+        let result = conn.execute(
+            "INSERT INTO group_member (group_id, user_id, role) VALUES ('nonexistent', 'alice', 'member')",
+            [],
+        );
+        assert!(result.is_err(), "should fail due to foreign key constraint");
+    }
+}

--- a/src-tauri/src/commands/livekit.rs
+++ b/src-tauri/src/commands/livekit.rs
@@ -817,3 +817,380 @@ fn dispatch_data(payload: &[u8], channel: &tauri::ipc::Channel<RealtimeEvent>) {
         _ => {}
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::Connection;
+
+    const REMOTE_V001: &str = include_str!("../db/migrations/remote_schema.sql");
+
+    const VOICE_PRESENCE: &str = "
+        CREATE TABLE IF NOT EXISTS voice_presence (
+            user_id      TEXT NOT NULL,
+            group_id     TEXT NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+            channel_id   TEXT NOT NULL REFERENCES channels(id) ON DELETE CASCADE,
+            display_name TEXT NOT NULL,
+            joined_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            PRIMARY KEY (user_id, channel_id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_voice_presence_channel ON voice_presence(channel_id);
+        CREATE INDEX IF NOT EXISTS idx_voice_presence_group   ON voice_presence(group_id);
+    ";
+
+    fn db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys=ON;").unwrap();
+        conn.execute_batch(REMOTE_V001).unwrap();
+        conn.execute_batch(VOICE_PRESENCE).unwrap();
+        conn
+    }
+
+    fn setup(conn: &Connection) {
+        conn.execute("INSERT INTO users (id, email, username) VALUES ('alice', 'alice@x.com', 'alice')", []).unwrap();
+        conn.execute("INSERT INTO users (id, email, username) VALUES ('bob',   'bob@x.com',   'bob')", []).unwrap();
+        conn.execute("INSERT INTO users (id, email, username) VALUES ('carol', 'carol@x.com', 'carol')", []).unwrap();
+
+        conn.execute("INSERT INTO groups (id, name, owner_id) VALUES ('g1', 'Test Group', 'alice')", []).unwrap();
+        conn.execute("INSERT INTO channels (id, group_id, name, channel_type) VALUES ('vc1', 'g1', 'voice-1', 'voice')", []).unwrap();
+        conn.execute("INSERT INTO channels (id, group_id, name, channel_type) VALUES ('vc2', 'g1', 'voice-2', 'voice')", []).unwrap();
+    }
+
+    /// Simulate `publish_voice_presence(joined=true)`.
+    fn join(conn: &Connection, user_id: &str, group_id: &str, channel_id: &str, display_name: &str) {
+        conn.execute(
+            "INSERT OR REPLACE INTO voice_presence (user_id, group_id, channel_id, display_name, joined_at) \
+             VALUES (?1, ?2, ?3, ?4, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))",
+            rusqlite::params![user_id, group_id, channel_id, display_name],
+        ).unwrap();
+    }
+
+    /// Simulate `publish_voice_presence(joined=false)`.
+    fn leave(conn: &Connection, user_id: &str, channel_id: &str) {
+        conn.execute(
+            "DELETE FROM voice_presence WHERE user_id = ?1 AND channel_id = ?2",
+            rusqlite::params![user_id, channel_id],
+        ).unwrap();
+    }
+
+    /// Simulate `query_voice_participants` — returns (user_id, display_name) pairs.
+    fn participants(conn: &Connection, channel_id: &str) -> Vec<(String, String)> {
+        conn.prepare("SELECT user_id, display_name FROM voice_presence WHERE channel_id = ?1")
+            .unwrap()
+            .query_map(rusqlite::params![channel_id], |row| Ok((row.get(0)?, row.get(1)?)))
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect()
+    }
+
+    /// Simulate `query_voice_counts` for a single channel.
+    fn count(conn: &Connection, channel_id: &str) -> i64 {
+        conn.query_row(
+            "SELECT COUNT(*) FROM voice_presence WHERE channel_id = ?1",
+            rusqlite::params![channel_id],
+            |row| row.get(0),
+        ).unwrap()
+    }
+
+    // ── basic join/leave ───────────────────────────────────────────────────
+
+    #[test]
+    fn single_user_joins_and_appears_in_channel() {
+        let conn = db();
+        setup(&conn);
+
+        join(&conn, "alice", "g1", "vc1", "alice");
+
+        let p = participants(&conn, "vc1");
+        assert_eq!(p.len(), 1);
+        assert_eq!(p[0], ("alice".into(), "alice".into()));
+    }
+
+    #[test]
+    fn single_user_leaves_and_disappears() {
+        let conn = db();
+        setup(&conn);
+
+        join(&conn, "alice", "g1", "vc1", "alice");
+        leave(&conn, "alice", "vc1");
+
+        assert_eq!(count(&conn, "vc1"), 0);
+    }
+
+    // ── multiple users join/leave at different times ───────────────────────
+
+    #[test]
+    fn multiple_users_join_same_channel() {
+        let conn = db();
+        setup(&conn);
+
+        join(&conn, "alice", "g1", "vc1", "alice");
+        join(&conn, "bob", "g1", "vc1", "bob");
+
+        assert_eq!(count(&conn, "vc1"), 2);
+        let p = participants(&conn, "vc1");
+        let ids: Vec<&str> = p.iter().map(|(id, _)| id.as_str()).collect();
+        assert!(ids.contains(&"alice"));
+        assert!(ids.contains(&"bob"));
+    }
+
+    #[test]
+    fn first_user_leaves_second_stays() {
+        let conn = db();
+        setup(&conn);
+
+        join(&conn, "alice", "g1", "vc1", "alice");
+        join(&conn, "bob", "g1", "vc1", "bob");
+        leave(&conn, "alice", "vc1");
+
+        assert_eq!(count(&conn, "vc1"), 1);
+        let p = participants(&conn, "vc1");
+        assert_eq!(p[0].0, "bob");
+    }
+
+    #[test]
+    fn staggered_join_leave_join() {
+        let conn = db();
+        setup(&conn);
+
+        // Alice joins, then Bob joins, then Alice leaves, then Carol joins.
+        join(&conn, "alice", "g1", "vc1", "alice");
+        join(&conn, "bob", "g1", "vc1", "bob");
+        leave(&conn, "alice", "vc1");
+        join(&conn, "carol", "g1", "vc1", "carol");
+
+        assert_eq!(count(&conn, "vc1"), 2);
+        let p = participants(&conn, "vc1");
+        let ids: Vec<&str> = p.iter().map(|(id, _)| id.as_str()).collect();
+        assert!(ids.contains(&"bob"));
+        assert!(ids.contains(&"carol"));
+        assert!(!ids.contains(&"alice"));
+    }
+
+    #[test]
+    fn all_users_leave_channel_is_empty() {
+        let conn = db();
+        setup(&conn);
+
+        join(&conn, "alice", "g1", "vc1", "alice");
+        join(&conn, "bob", "g1", "vc1", "bob");
+        join(&conn, "carol", "g1", "vc1", "carol");
+
+        leave(&conn, "alice", "vc1");
+        leave(&conn, "bob", "vc1");
+        leave(&conn, "carol", "vc1");
+
+        assert_eq!(count(&conn, "vc1"), 0);
+        assert!(participants(&conn, "vc1").is_empty());
+    }
+
+    // ── multiple channels ─────────────────────────────────────────────────
+
+    #[test]
+    fn users_in_different_channels_isolated() {
+        let conn = db();
+        setup(&conn);
+
+        join(&conn, "alice", "g1", "vc1", "alice");
+        join(&conn, "bob", "g1", "vc2", "bob");
+
+        assert_eq!(count(&conn, "vc1"), 1);
+        assert_eq!(count(&conn, "vc2"), 1);
+        assert_eq!(participants(&conn, "vc1")[0].0, "alice");
+        assert_eq!(participants(&conn, "vc2")[0].0, "bob");
+    }
+
+    #[test]
+    fn user_cannot_be_in_two_channels_simultaneously() {
+        let conn = db();
+        setup(&conn);
+
+        // PK is (user_id, channel_id), but INSERT OR REPLACE means joining
+        // a second channel replaces the first row only if same channel_id.
+        // Different channel_ids would coexist. Verify this:
+        join(&conn, "alice", "g1", "vc1", "alice");
+        join(&conn, "alice", "g1", "vc2", "alice");
+
+        // Both rows exist — the app should leave the old channel first,
+        // but the schema allows it (no UNIQUE on user_id alone).
+        let total: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM voice_presence WHERE user_id = 'alice'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(total, 2, "schema allows user in multiple channels — app must enforce single-channel");
+    }
+
+    // ── rejoin same channel (INSERT OR REPLACE) ───────────────────────────
+
+    #[test]
+    fn rejoin_same_channel_does_not_duplicate() {
+        let conn = db();
+        setup(&conn);
+
+        join(&conn, "alice", "g1", "vc1", "alice");
+        join(&conn, "alice", "g1", "vc1", "alice");
+
+        assert_eq!(count(&conn, "vc1"), 1, "INSERT OR REPLACE should not create a duplicate");
+    }
+
+    #[test]
+    fn rejoin_updates_display_name() {
+        let conn = db();
+        setup(&conn);
+
+        join(&conn, "alice", "g1", "vc1", "alice");
+        join(&conn, "alice", "g1", "vc1", "Alice (renamed)");
+
+        let p = participants(&conn, "vc1");
+        assert_eq!(p.len(), 1);
+        assert_eq!(p[0].1, "Alice (renamed)");
+    }
+
+    // ── crash recovery: reconcile_voice_presence ──────────────────────────
+
+    #[test]
+    fn reconcile_removes_stale_users() {
+        let conn = db();
+        setup(&conn);
+
+        // Simulate: alice and bob both have presence rows, but only alice
+        // is actually online (bob crashed).
+        join(&conn, "alice", "g1", "vc1", "alice");
+        join(&conn, "bob", "g1", "vc1", "bob");
+
+        // Reconciliation: fetch all users with presence, compare against online set.
+        let online: std::collections::HashSet<String> = ["alice"].iter().map(|s| s.to_string()).collect();
+
+        let all_present: Vec<String> = conn
+            .prepare("SELECT DISTINCT user_id FROM voice_presence WHERE group_id = ?1")
+            .unwrap()
+            .query_map(rusqlite::params!["g1"], |row| row.get(0))
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+
+        let stale: Vec<&String> = all_present.iter().filter(|uid| !online.contains(*uid)).collect();
+        assert_eq!(stale, vec!["bob"]);
+
+        // Delete stale
+        for uid in &stale {
+            conn.execute(
+                "DELETE FROM voice_presence WHERE user_id = ?1 AND group_id = ?2",
+                rusqlite::params![uid.as_str(), "g1"],
+            ).unwrap();
+        }
+
+        assert_eq!(count(&conn, "vc1"), 1);
+        assert_eq!(participants(&conn, "vc1")[0].0, "alice");
+    }
+
+    // ── participant disconnect cleanup ─────────────────────────────────────
+
+    #[test]
+    fn disconnect_removes_user_from_all_channels_in_group() {
+        let conn = db();
+        setup(&conn);
+
+        // Bob is in two channels in the same group (unusual but schema allows it)
+        join(&conn, "bob", "g1", "vc1", "bob");
+        join(&conn, "bob", "g1", "vc2", "bob");
+        join(&conn, "alice", "g1", "vc1", "alice");
+
+        // Simulate handle_participant_disconnect: find affected channels, then delete.
+        let affected: Vec<String> = conn
+            .prepare("SELECT channel_id FROM voice_presence WHERE user_id = ?1 AND group_id = ?2")
+            .unwrap()
+            .query_map(rusqlite::params!["bob", "g1"], |row| row.get(0))
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+        assert_eq!(affected.len(), 2);
+
+        conn.execute(
+            "DELETE FROM voice_presence WHERE user_id = ?1 AND group_id = ?2",
+            rusqlite::params!["bob", "g1"],
+        ).unwrap();
+
+        assert_eq!(count(&conn, "vc1"), 1, "alice should remain");
+        assert_eq!(count(&conn, "vc2"), 0, "bob's other channel should be cleared");
+        assert_eq!(participants(&conn, "vc1")[0].0, "alice");
+    }
+
+    #[test]
+    fn disconnect_no_presence_is_noop() {
+        let conn = db();
+        setup(&conn);
+
+        // carol has no presence rows
+        let affected: Vec<String> = conn
+            .prepare("SELECT channel_id FROM voice_presence WHERE user_id = ?1 AND group_id = ?2")
+            .unwrap()
+            .query_map(rusqlite::params!["carol", "g1"], |row| row.get(0))
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+        assert!(affected.is_empty());
+    }
+
+    // ── cascade deletes ───────────────────────────────────────────────────
+
+    #[test]
+    fn deleting_channel_cascades_presence() {
+        let conn = db();
+        setup(&conn);
+
+        join(&conn, "alice", "g1", "vc1", "alice");
+        join(&conn, "bob", "g1", "vc1", "bob");
+
+        conn.execute("DELETE FROM channels WHERE id = 'vc1'", []).unwrap();
+
+        let total: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM voice_presence WHERE channel_id = 'vc1'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(total, 0, "presence should be cascade-deleted with channel");
+    }
+
+    #[test]
+    fn deleting_group_cascades_presence() {
+        let conn = db();
+        setup(&conn);
+
+        join(&conn, "alice", "g1", "vc1", "alice");
+        join(&conn, "bob", "g1", "vc2", "bob");
+
+        conn.execute("DELETE FROM groups WHERE id = 'g1'", []).unwrap();
+
+        let total: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM voice_presence",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(total, 0, "all presence should be cascade-deleted with group");
+    }
+
+    // ── leave idempotent ──────────────────────────────────────────────────
+
+    #[test]
+    fn leave_when_not_present_is_noop() {
+        let conn = db();
+        setup(&conn);
+
+        // carol never joined — leave should not error
+        leave(&conn, "carol", "vc1");
+        assert_eq!(count(&conn, "vc1"), 0);
+    }
+
+    #[test]
+    fn double_leave_is_noop() {
+        let conn = db();
+        setup(&conn);
+
+        join(&conn, "alice", "g1", "vc1", "alice");
+        leave(&conn, "alice", "vc1");
+        leave(&conn, "alice", "vc1");
+
+        assert_eq!(count(&conn, "vc1"), 0);
+    }
+}

--- a/src-tauri/src/commands/mls.rs
+++ b/src-tauri/src/commands/mls.rs
@@ -1403,16 +1403,12 @@ mod tests {
     /// part of account deletion), the remaining members' keys should rotate
     /// so the deleted user cannot decrypt future messages.
     ///
-    /// This test currently only covers the MLS remove + epoch advance path.
-    /// In production, account deletion also needs to:
-    ///   1. Enumerate all groups the user belongs to
-    ///   2. Issue a remove commit for each group
-    ///   3. Broadcast the commit so remaining members apply it
+    /// The `delete_account` command (auth.rs) enumerates all groups and DM
+    /// channels the user belongs to and calls `remove_member_mls_inner` for
+    /// each before deleting DB rows.  This test verifies the underlying MLS
+    /// removal + epoch advance works across multiple groups.
     ///
-    /// TODO: The full account-deletion flow should trigger automatic key
-    /// rotation for every group the deleted user was in. This test documents
-    /// the expected behavior — see the related issue for the end-to-end
-    /// implementation.
+    /// See: https://github.com/actuallydan/pollis/issues/103
     #[test]
     fn account_deletion_rotates_keys_for_remaining_members() {
         let group1 = "01JTEST000000000000ACCTDEL1";

--- a/src-tauri/src/commands/mls.rs
+++ b/src-tauri/src/commands/mls.rs
@@ -1293,6 +1293,71 @@ mod tests {
         );
     }
 
+    /// When a member leaves (is removed), the remaining members can still
+    /// communicate, the removed member cannot decrypt, and a newly added
+    /// member can participate in the group.
+    #[test]
+    fn leave_group_remaining_members_communicate_then_new_member_joins() {
+        let conv_id = "01JTEST0000000000000LEAVE1";
+
+        let alice_db = make_db();
+        let bob_db = make_db();
+        let carol_db = make_db();
+        let dave_db = make_db();
+
+        // Alice creates group, adds Bob and Carol.
+        create_group(&alice_db, conv_id, "alice");
+
+        let bob_kp = gen_key_package(&bob_db, "bob");
+        let (add_bob_commit, bob_welcome) = add_member_to_group(&alice_db, conv_id, &bob_kp);
+        join_via_welcome(&bob_db, &bob_welcome);
+        let _ = add_bob_commit;
+
+        let carol_kp = gen_key_package(&carol_db, "carol");
+        let (add_carol_commit, carol_welcome) = add_member_to_group(&alice_db, conv_id, &carol_kp);
+        join_via_welcome(&carol_db, &carol_welcome);
+        apply_commit(&bob_db, conv_id, &add_carol_commit);
+
+        // Verify all three can communicate before removal.
+        let pre_ct = try_mls_encrypt(&alice_db, conv_id, b"all three here").unwrap();
+        assert_eq!(try_mls_decrypt(&bob_db, conv_id, &pre_ct).unwrap(), b"all three here");
+        assert_eq!(try_mls_decrypt(&carol_db, conv_id, &pre_ct).unwrap(), b"all three here");
+
+        // Alice removes Bob. Carol applies the commit.
+        let remove_bob_commit = remove_member(&alice_db, conv_id, "bob");
+        apply_commit(&carol_db, conv_id, &remove_bob_commit);
+
+        // Alice and Carol can still communicate.
+        let alice_ct = try_mls_encrypt(&alice_db, conv_id, b"bob is gone").unwrap();
+        assert_eq!(try_mls_decrypt(&carol_db, conv_id, &alice_ct).unwrap(), b"bob is gone");
+
+        let carol_ct = try_mls_encrypt(&carol_db, conv_id, b"confirmed").unwrap();
+        assert_eq!(try_mls_decrypt(&alice_db, conv_id, &carol_ct).unwrap(), b"confirmed");
+
+        // Bob cannot decrypt post-removal messages.
+        assert!(
+            try_mls_decrypt(&bob_db, conv_id, &alice_ct).is_none(),
+            "removed bob must not decrypt"
+        );
+
+        // Alice adds Dave. Carol applies the commit.
+        let dave_kp = gen_key_package(&dave_db, "dave");
+        let (add_dave_commit, dave_welcome) = add_member_to_group(&alice_db, conv_id, &dave_kp);
+        join_via_welcome(&dave_db, &dave_welcome);
+        apply_commit(&carol_db, conv_id, &add_dave_commit);
+
+        // All three current members (Alice, Carol, Dave) can communicate.
+        let dave_ct = try_mls_encrypt(&dave_db, conv_id, b"dave here").unwrap();
+        assert_eq!(try_mls_decrypt(&alice_db, conv_id, &dave_ct).unwrap(), b"dave here");
+        assert_eq!(try_mls_decrypt(&carol_db, conv_id, &dave_ct).unwrap(), b"dave here");
+
+        // Bob still cannot decrypt.
+        assert!(
+            try_mls_decrypt(&bob_db, conv_id, &dave_ct).is_none(),
+            "bob must still be locked out after new member joins"
+        );
+    }
+
     /// After multiple add/remove cycles the group epoch is consistent and
     /// only current members can decrypt.
     #[test]
@@ -1331,6 +1396,93 @@ mod tests {
         assert!(
             try_mls_decrypt(&bob_db, conv_id, &ct).is_none(),
             "removed Bob must not decrypt after key rotation"
+        );
+    }
+
+    /// Simulates account deletion: when a user is removed from a group (as
+    /// part of account deletion), the remaining members' keys should rotate
+    /// so the deleted user cannot decrypt future messages.
+    ///
+    /// This test currently only covers the MLS remove + epoch advance path.
+    /// In production, account deletion also needs to:
+    ///   1. Enumerate all groups the user belongs to
+    ///   2. Issue a remove commit for each group
+    ///   3. Broadcast the commit so remaining members apply it
+    ///
+    /// TODO: The full account-deletion flow should trigger automatic key
+    /// rotation for every group the deleted user was in. This test documents
+    /// the expected behavior — see the related issue for the end-to-end
+    /// implementation.
+    #[test]
+    fn account_deletion_rotates_keys_for_remaining_members() {
+        let group1 = "01JTEST000000000000ACCTDEL1";
+        let group2 = "01JTEST000000000000ACCTDEL2";
+
+        let alice_db = make_db();
+        let bob_db = make_db();
+        let carol_db = make_db();
+
+        // --- Group 1: Alice + Bob + Carol ---
+        create_group(&alice_db, group1, "alice");
+
+        let bob_kp1 = gen_key_package(&bob_db, "bob");
+        let (_, bob_welcome1) = add_member_to_group(&alice_db, group1, &bob_kp1);
+        join_via_welcome(&bob_db, &bob_welcome1);
+
+        let carol_kp1 = gen_key_package(&carol_db, "carol");
+        let (add_carol_commit1, carol_welcome1) = add_member_to_group(&alice_db, group1, &carol_kp1);
+        join_via_welcome(&carol_db, &carol_welcome1);
+        apply_commit(&bob_db, group1, &add_carol_commit1);
+
+        // --- Group 2: Alice + Bob (Carol not in this one) ---
+        create_group(&alice_db, group2, "alice");
+
+        let bob_kp2 = gen_key_package(&bob_db, "bob");
+        let (_, bob_welcome2) = add_member_to_group(&alice_db, group2, &bob_kp2);
+        join_via_welcome(&bob_db, &bob_welcome2);
+
+        // Verify Bob can read in both groups before deletion.
+        let pre_g1 = try_mls_encrypt(&alice_db, group1, b"pre-delete g1").unwrap();
+        assert_eq!(try_mls_decrypt(&bob_db, group1, &pre_g1).unwrap(), b"pre-delete g1");
+
+        let pre_g2 = try_mls_encrypt(&alice_db, group2, b"pre-delete g2").unwrap();
+        assert_eq!(try_mls_decrypt(&bob_db, group2, &pre_g2).unwrap(), b"pre-delete g2");
+
+        // --- Simulate account deletion for Bob ---
+        // In production this would be done by delete_account iterating all
+        // groups and calling remove_member_mls_inner for each. Here we do
+        // the MLS removal manually per group.
+
+        // Remove Bob from group 1 — Carol applies commit.
+        let remove_g1 = remove_member(&alice_db, group1, "bob");
+        apply_commit(&carol_db, group1, &remove_g1);
+
+        // Remove Bob from group 2 — no other non-alice members to notify.
+        let _remove_g2 = remove_member(&alice_db, group2, "bob");
+
+        // --- Verify key rotation: Bob locked out of both groups ---
+        let post_g1 = try_mls_encrypt(&alice_db, group1, b"post-delete g1").unwrap();
+        assert!(
+            try_mls_decrypt(&bob_db, group1, &post_g1).is_none(),
+            "deleted Bob must not decrypt group1 messages after account deletion"
+        );
+
+        let post_g2 = try_mls_encrypt(&alice_db, group2, b"post-delete g2").unwrap();
+        assert!(
+            try_mls_decrypt(&bob_db, group2, &post_g2).is_none(),
+            "deleted Bob must not decrypt group2 messages after account deletion"
+        );
+
+        // --- Verify remaining members still work ---
+        // Group 1: Alice and Carol can still communicate.
+        assert_eq!(
+            try_mls_decrypt(&carol_db, group1, &post_g1).unwrap(),
+            b"post-delete g1"
+        );
+        let carol_msg = try_mls_encrypt(&carol_db, group1, b"carol still here").unwrap();
+        assert_eq!(
+            try_mls_decrypt(&alice_db, group1, &carol_msg).unwrap(),
+            b"carol still here"
         );
     }
 }

--- a/src-tauri/src/commands/user.rs
+++ b/src-tauri/src/commands/user.rs
@@ -143,3 +143,279 @@ pub async fn search_user_by_username(
         Ok(None)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::Connection;
+
+    const REMOTE_V001: &str = include_str!("../db/migrations/remote_schema.sql");
+
+    fn db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys=ON;").unwrap();
+        conn.execute_batch(REMOTE_V001).unwrap();
+        conn
+    }
+
+    fn setup(conn: &Connection) {
+        conn.execute(
+            "INSERT INTO users (id, email, username, phone, avatar_url) VALUES ('alice', 'alice@x.com', 'alice', '555-0001', 'https://img.example.com/alice.png')",
+            [],
+        ).unwrap();
+        conn.execute(
+            "INSERT INTO users (id, email, username) VALUES ('bob', 'bob@x.com', 'bob')",
+            [],
+        ).unwrap();
+    }
+
+    // ── get_user_profile ───────────────────────────────────────────────────
+
+    #[test]
+    fn get_user_profile_returns_existing_user() {
+        let conn = db();
+        setup(&conn);
+
+        let (id, username, phone, avatar): (String, Option<String>, Option<String>, Option<String>) =
+            conn.query_row(
+                "SELECT id, username, phone, avatar_url FROM users WHERE id = ?1",
+                rusqlite::params!["alice"],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            ).unwrap();
+
+        assert_eq!(id, "alice");
+        assert_eq!(username.as_deref(), Some("alice"));
+        assert_eq!(phone.as_deref(), Some("555-0001"));
+        assert_eq!(avatar.as_deref(), Some("https://img.example.com/alice.png"));
+    }
+
+    #[test]
+    fn get_user_profile_returns_none_for_missing_user() {
+        let conn = db();
+        setup(&conn);
+
+        let result = conn.query_row(
+            "SELECT id FROM users WHERE id = ?1",
+            rusqlite::params!["nonexistent"],
+            |row| row.get::<_, String>(0),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn get_user_profile_nullable_fields() {
+        let conn = db();
+        setup(&conn);
+
+        let (phone, avatar): (Option<String>, Option<String>) = conn.query_row(
+            "SELECT phone, avatar_url FROM users WHERE id = 'bob'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        ).unwrap();
+
+        assert!(phone.is_none());
+        assert!(avatar.is_none());
+    }
+
+    // ── update_user_profile (COALESCE) ─────────────────────────────────────
+
+    #[test]
+    fn update_profile_only_username() {
+        let conn = db();
+        setup(&conn);
+
+        conn.execute(
+            "UPDATE users SET username = COALESCE(?2, username), phone = COALESCE(?3, phone), avatar_url = COALESCE(?4, avatar_url) WHERE id = ?1",
+            rusqlite::params!["alice", Some("alice_new"), None::<String>, None::<String>],
+        ).unwrap();
+
+        let (username, phone, avatar): (Option<String>, Option<String>, Option<String>) =
+            conn.query_row(
+                "SELECT username, phone, avatar_url FROM users WHERE id = 'alice'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            ).unwrap();
+
+        assert_eq!(username.as_deref(), Some("alice_new"), "username should be updated");
+        assert_eq!(phone.as_deref(), Some("555-0001"), "phone should be preserved");
+        assert_eq!(avatar.as_deref(), Some("https://img.example.com/alice.png"), "avatar should be preserved");
+    }
+
+    #[test]
+    fn update_profile_only_phone() {
+        let conn = db();
+        setup(&conn);
+
+        conn.execute(
+            "UPDATE users SET username = COALESCE(?2, username), phone = COALESCE(?3, phone), avatar_url = COALESCE(?4, avatar_url) WHERE id = ?1",
+            rusqlite::params!["alice", None::<String>, Some("555-9999"), None::<String>],
+        ).unwrap();
+
+        let (username, phone): (Option<String>, Option<String>) = conn.query_row(
+            "SELECT username, phone FROM users WHERE id = 'alice'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        ).unwrap();
+
+        assert_eq!(username.as_deref(), Some("alice"), "username preserved");
+        assert_eq!(phone.as_deref(), Some("555-9999"), "phone updated");
+    }
+
+    #[test]
+    fn update_profile_all_fields() {
+        let conn = db();
+        setup(&conn);
+
+        conn.execute(
+            "UPDATE users SET username = COALESCE(?2, username), phone = COALESCE(?3, phone), avatar_url = COALESCE(?4, avatar_url) WHERE id = ?1",
+            rusqlite::params!["alice", Some("new_alice"), Some("555-0000"), Some("https://new-avatar.png")],
+        ).unwrap();
+
+        let (username, phone, avatar): (Option<String>, Option<String>, Option<String>) =
+            conn.query_row(
+                "SELECT username, phone, avatar_url FROM users WHERE id = 'alice'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            ).unwrap();
+
+        assert_eq!(username.as_deref(), Some("new_alice"));
+        assert_eq!(phone.as_deref(), Some("555-0000"));
+        assert_eq!(avatar.as_deref(), Some("https://new-avatar.png"));
+    }
+
+    #[test]
+    fn update_profile_no_fields_is_noop() {
+        let conn = db();
+        setup(&conn);
+
+        conn.execute(
+            "UPDATE users SET username = COALESCE(?2, username), phone = COALESCE(?3, phone), avatar_url = COALESCE(?4, avatar_url) WHERE id = ?1",
+            rusqlite::params!["alice", None::<String>, None::<String>, None::<String>],
+        ).unwrap();
+
+        let username: Option<String> = conn.query_row(
+            "SELECT username FROM users WHERE id = 'alice'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(username.as_deref(), Some("alice"), "should be unchanged");
+    }
+
+    // ── search_user_by_username ────────────────────────────────────────────
+
+    #[test]
+    fn search_by_username() {
+        let conn = db();
+        setup(&conn);
+
+        let id: String = conn.query_row(
+            "SELECT id FROM users WHERE username = ?1 OR email = ?1",
+            rusqlite::params!["bob"],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(id, "bob");
+    }
+
+    #[test]
+    fn search_by_email() {
+        let conn = db();
+        setup(&conn);
+
+        let id: String = conn.query_row(
+            "SELECT id FROM users WHERE username = ?1 OR email = ?1",
+            rusqlite::params!["alice@x.com"],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(id, "alice");
+    }
+
+    #[test]
+    fn search_no_match() {
+        let conn = db();
+        setup(&conn);
+
+        let result = conn.query_row(
+            "SELECT id FROM users WHERE username = ?1 OR email = ?1",
+            rusqlite::params!["nobody"],
+            |row| row.get::<_, String>(0),
+        );
+        assert!(result.is_err());
+    }
+
+    // ── preferences upsert ─────────────────────────────────────────────────
+
+    #[test]
+    fn preferences_upsert_insert_then_update() {
+        let conn = db();
+        setup(&conn);
+
+        // First save — INSERT
+        conn.execute(
+            "INSERT INTO user_preferences (user_id, preferences, updated_at) VALUES (?1, ?2, datetime('now'))
+             ON CONFLICT(user_id) DO UPDATE SET preferences = ?2, updated_at = datetime('now')",
+            rusqlite::params!["alice", r#"{"theme":"dark"}"#],
+        ).unwrap();
+
+        let prefs: String = conn.query_row(
+            "SELECT preferences FROM user_preferences WHERE user_id = 'alice'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(prefs, r#"{"theme":"dark"}"#);
+
+        // Second save — UPDATE via ON CONFLICT
+        conn.execute(
+            "INSERT INTO user_preferences (user_id, preferences, updated_at) VALUES (?1, ?2, datetime('now'))
+             ON CONFLICT(user_id) DO UPDATE SET preferences = ?2, updated_at = datetime('now')",
+            rusqlite::params!["alice", r#"{"theme":"light","font_size":14}"#],
+        ).unwrap();
+
+        let prefs: String = conn.query_row(
+            "SELECT preferences FROM user_preferences WHERE user_id = 'alice'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(prefs, r#"{"theme":"light","font_size":14}"#);
+
+        // Still only one row
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM user_preferences WHERE user_id = 'alice'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn preferences_cascade_deletes_with_user() {
+        let conn = db();
+        setup(&conn);
+
+        conn.execute(
+            "INSERT INTO user_preferences (user_id, preferences) VALUES ('alice', '{}')",
+            [],
+        ).unwrap();
+
+        conn.execute("DELETE FROM users WHERE id = 'alice'", []).unwrap();
+
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM user_preferences WHERE user_id = 'alice'",
+            [],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(count, 0, "preferences should be cascade-deleted with user");
+    }
+
+    // ── email uniqueness ───────────────────────────────────────────────────
+
+    #[test]
+    fn duplicate_email_rejected() {
+        let conn = db();
+        setup(&conn);
+
+        let result = conn.execute(
+            "INSERT INTO users (id, email, username) VALUES ('carol', 'alice@x.com', 'carol')",
+            [],
+        );
+        assert!(result.is_err(), "duplicate email should violate UNIQUE constraint");
+    }
+}


### PR DESCRIPTION
## Summary
- `delete_account` now issues MLS remove commits for every group and DM channel the user belongs to before deleting any DB rows, ensuring remaining members advance their epoch and the deleted user's key material cannot decrypt future messages
- Handles group ownership: sole-member groups are deleted, sole-admin groups get the first available member promoted to admin before the departing user is removed
- Adds Rust tests for ownership handoff logic and multi-group MLS removal scenarios

Closes #103

## Test plan
- [ ] User deletes account → remaining group members can still send/receive messages
- [ ] Sole-member group is fully deleted on account deletion
- [ ] Sole-admin group promotes another member before removal
- [ ] `cargo test` passes (144 tests)