### PR TITLE
Multi-device support (closes #20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ pnpm dev:frontend     # Frontend only in browser (no Tauri commands)
 
 Add `DEV_OTP=000000` to `.env.development`. With this set, hitting "Continue" on the login screen skips the Resend email call and stores a hash of `000000` as the valid code — type it in the OTP field to sign in. The session persists to the OS keystore so you only need to do this once per fresh install.
 
+For fully hands-free startup, set `DEV_EMAIL=you@example.com` instead. This bypasses OTP entirely and auto-logs in as that email on every launch (creating the user in Turso if needed).
+
 ### Testing with two users
 
 ```bash
@@ -63,17 +65,39 @@ Add `DEV_OTP=000000` to `.env.development`. With this set, hitting "Continue" on
 pnpm dev
 
 # Terminal 2 — user B
-POLLIS_DATA_DIR=/tmp/pollis2 pnpm dev
+POLLIS_DATA_DIR=/tmp/pollis-dev2 pnpm dev
 ```
 
-Both instances hit the same Turso database, so messages appear in real time across windows via LiveKit.
+`POLLIS_DATA_DIR` gives the second instance its own local SQLite database and keystore, so the two instances don't interfere. Both hit the same Turso database, so messages appear in real time across windows via LiveKit.
+
+### Testing multi-device (same user, two devices)
+
+```bash
+# Terminal 1 — device 1
+DEV_EMAIL=you@example.com pnpm dev
+
+# Terminal 2 — device 2
+DEV_EMAIL=you@example.com POLLIS_DATA_DIR=/tmp/pollis-dev2 pnpm dev
+```
+
+Both instances log in as the same user, but `POLLIS_DATA_DIR` isolates the keystore and local DB so each gets its own `device_id` and MLS state — they register as separate devices in the `user_device` table. Messages sent from a third user (or from either device) should appear on both.
+
+### Development environment variables
+
+All dev-only env vars. Set them in `.env.development` or pass inline.
+
+| Variable | Purpose |
+|----------|---------|
+| `DEV_OTP` | Fixed OTP code (e.g. `000000`) — skips Resend email, accepts this code on the OTP screen |
+| `DEV_EMAIL` | Auto-login as this email on startup — bypasses OTP entirely |
+| `POLLIS_DATA_DIR` | Override the local data directory — isolates local DB and keystore for running multiple instances |
 
 ### Building
 
 ```bash
 pnpm build            # Current platform
-pnpm build:macos      # Universal binary (Intel + Apple Silicon)
-pnpm build:linux      # amd64 AppImage
+pnpm build:macos      # Universal binary (Apple Silicon)
+pnpm build:linux      # amd64 AppImage, deb, rpm
 pnpm build:windows    # amd64 NSIS installer
 ```
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,6 +21,20 @@ import { Button } from "./components/ui/Button";
 
 type AppState = "initializing" | "loading" | "email-auth" | "logout-confirm" | "identity-setup" | "update-required" | "ready";
 
+// Dev-only: expose device list on window.__POLLIS_DEBUG__ for console inspection.
+function setupDebugDevices(userId: string) {
+  api.listUserDevices(userId).then((devices) => {
+    (window as unknown as Record<string, unknown>).__POLLIS_DEBUG__ = { userId, devices };
+    console.table(devices.map((d) => ({
+      device_id: d.device_id,
+      is_current: d.is_current ? "<<< THIS" : "",
+      last_seen: d.last_seen,
+    })));
+  }).catch((err) => {
+    console.warn("[debug] failed to fetch devices:", err);
+  });
+}
+
 function MainApp() {
   const {
     currentUser,
@@ -53,6 +67,9 @@ function MainApp() {
           await api.initializeIdentity(user.id);
         } catch (err) {
           console.error("[App] Failed to initialize identity:", err);
+        }
+        if (import.meta.env.DEV) {
+          setupDebugDevices(user.id);
         }
         // Load and apply saved preferences before showing the UI
         try {
@@ -128,6 +145,9 @@ function MainApp() {
       await api.initializeIdentity(user.id);
     } catch (err) {
       console.error("[App] Failed to initialize identity:", err);
+    }
+    if (import.meta.env.DEV) {
+      setupDebugDevices(user.id);
     }
     // Apply saved preferences for newly logged-in user
     try {

--- a/frontend/src/hooks/queries/useGroups.ts
+++ b/frontend/src/hooks/queries/useGroups.ts
@@ -437,7 +437,7 @@ export function useGroupJoinRequests(groupId: string | null) {
       return await invoke<JoinRequest[]>('get_group_join_requests', { groupId, requesterId: currentUser.id });
     },
     enabled: !!currentUser && !!groupId,
-    staleTime: 1000 * 30,
+    staleTime: 0,
     refetchOnWindowFocus: true,
   });
 }
@@ -456,6 +456,7 @@ export function useApproveJoinRequest() {
     },
     onSuccess: (groupId) => {
       queryClient.invalidateQueries({ queryKey: groupQueryKeys.joinRequests(groupId) });
+      queryClient.invalidateQueries({ queryKey: ["join-requests", "all-admin"] });
     },
   });
 }
@@ -474,6 +475,7 @@ export function useRejectJoinRequest() {
     },
     onSuccess: (groupId) => {
       queryClient.invalidateQueries({ queryKey: groupQueryKeys.joinRequests(groupId) });
+      queryClient.invalidateQueries({ queryKey: ["join-requests", "all-admin"] });
     },
   });
 }

--- a/frontend/src/hooks/useLiveKitRealtime.ts
+++ b/frontend/src/hooks/useLiveKitRealtime.ts
@@ -28,6 +28,7 @@ type RealtimeEvent =
   }
   | {
     type: 'membership_changed';
+    group_id?: string;
   }
   | {
     type: 'voice_joined';
@@ -217,7 +218,8 @@ export function useLiveKitRealtime() {
 
       if (event.type === 'membership_changed') {
         // Invalidate all group and invite queries — covers both invite received
-        // and join-request approved scenarios.
+        // and join-request approved scenarios. The ['groups'] prefix also covers
+        // member queries (["groups", groupId, "members"]).
         queryClientRef.current.invalidateQueries({ queryKey: ['groups'] });
         queryClientRef.current.invalidateQueries({ queryKey: ['group-invites'] });
         return;
@@ -244,10 +246,6 @@ export function useLiveKitRealtime() {
       }
 
       if (event.type === 'edited_message') {
-        // Skip own edits — optimistic update already applied by useEditMessage.
-        if (event.sender_id === currentUser.id) {
-          return;
-        }
         const channelId = event.channel_id;
         const conversationId = event.conversation_id;
         if (channelId && channelId === selectedChannelIdRef.current) {
@@ -262,23 +260,21 @@ export function useLiveKitRealtime() {
         return;
       }
 
-      // Skip own messages — optimistic update already applied by useSendMessage.
-      if (event.sender_id === currentUser.id) {
-        return;
-      }
-
       const channelId = event.channel_id;
       const conversationId = event.conversation_id;
       const senderUsername = event.sender_username ?? 'Someone';
       const incomingId = channelId ?? conversationId;
 
+      // Messages from the same user on another device should update the
+      // conversation data but never trigger notifications or unread badges.
+      const isOwnMessage = event.sender_id === currentUserIdRef.current;
+
       if (channelId && channelId === selectedChannelIdRef.current) {
         queryClientRef.current.invalidateQueries({ queryKey: messageQueryKeys.channel(channelId) });
       } else if (conversationId && conversationId === selectedConversationIdRef.current) {
         queryClientRef.current.invalidateQueries({ queryKey: messageQueryKeys.conversation(conversationId) });
-      } else if (incomingId) {
+      } else if (incomingId && !isOwnMessage) {
         incrementUnreadRef.current(incomingId);
-        // Only show status bar alert for DMs, not group channels
         if (conversationId) {
           setStatusBarAlertRef.current({ senderUsername, roomId: incomingId });
         }
@@ -291,19 +287,11 @@ export function useLiveKitRealtime() {
         queryClientRef.current.invalidateQueries({ queryKey: ["last-message", "conversation", conversationId] });
       }
 
-      // TODO: play ping sound on incoming message when window is unfocused.
-      // if (!isWindowFocusedRef.current && allowSoundRef.current) {
-      //   playSfx(SFX.ping);
-      // }
-
-      if (!isWindowFocusedRef.current && allowNotificationsRef.current && notificationPermissionRef.current) {
+      if (!isOwnMessage && !isWindowFocusedRef.current && allowNotificationsRef.current && notificationPermissionRef.current) {
         const title = incomingId
           ? (roomNameMapRef.current.get(incomingId) ?? 'New message')
           : 'New message';
         const body = `${senderUsername}: New message`;
-        // Use the Rust-side notification plugin directly via invoke.
-        // The JS wrapper's sendNotification() uses `new window.Notification()`
-        // which WKWebView on macOS doesn't support.
         try {
           invoke('plugin:notification|notify', { options: { title, body } }).catch(() => {});
         } catch {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -50,6 +50,18 @@ export async function listKnownAccounts(): Promise<AccountsIndex> {
   return invoke('list_known_accounts');
 }
 
+export interface DeviceInfo {
+  device_id: string;
+  device_name: string | null;
+  created_at: string;
+  last_seen: string;
+  is_current: boolean;
+}
+
+export async function listUserDevices(userId: string): Promise<DeviceInfo[]> {
+  return invoke('list_user_devices', { userId });
+}
+
 // ── User ───────────────────────────────────────────────────────────────────
 
 export interface UserProfileData {

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -605,6 +605,39 @@ pub fn list_known_accounts() -> crate::accounts::AccountsIndex {
     crate::accounts::read_accounts_index()
 }
 
+/// List all registered devices for a user. Returns each device's ID,
+/// name, timestamps, and whether it is the current device.
+#[tauri::command]
+pub async fn list_user_devices(
+    state: State<'_, Arc<AppState>>,
+    user_id: String,
+) -> Result<Vec<serde_json::Value>> {
+    let current_device_id = state.device_id.lock().await.clone();
+    let conn = state.remote_db.conn().await?;
+    let mut rows = conn.query(
+        "SELECT device_id, device_name, created_at, last_seen FROM user_device WHERE user_id = ?1 ORDER BY created_at ASC",
+        libsql::params![user_id],
+    ).await?;
+
+    let mut devices = Vec::new();
+    while let Some(row) = rows.next().await? {
+        let did: String = row.get(0)?;
+        let name: Option<String> = row.get(1).ok();
+        let created: String = row.get(2)?;
+        let seen: String = row.get(3)?;
+        let is_current = current_device_id.as_deref() == Some(did.as_str());
+        devices.push(serde_json::json!({
+            "device_id": did,
+            "device_name": name,
+            "created_at": created,
+            "last_seen": seen,
+            "is_current": is_current,
+        }));
+    }
+
+    Ok(devices)
+}
+
 #[cfg(test)]
 mod tests {
     use rusqlite::Connection;

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -9,6 +9,7 @@ use crate::state::AppState;
 use ulid::Ulid;
 
 const SESSION_KEY: &str = "session";
+const DEVICE_ID_KEY: &str = "device_id";
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct UserProfile {
@@ -31,8 +32,11 @@ pub async fn initialize_identity(
     state: State<'_, Arc<AppState>>,
     user_id: String,
 ) -> Result<IdentityInfo> {
-    match crate::commands::mls::ensure_mls_key_package(&state, &user_id).await {
-        Ok(()) => eprintln!("[identity] MLS key package ensured for {user_id}"),
+    let device_id = state.device_id.lock().await.clone()
+        .ok_or_else(|| anyhow::anyhow!("device_id not set — login incomplete"))?;
+
+    match crate::commands::mls::ensure_mls_key_package(&state, &user_id, &device_id).await {
+        Ok(()) => eprintln!("[identity] MLS key package ensured for {user_id} device {device_id}"),
         Err(e) => eprintln!("[identity] MLS key package error (non-fatal): {e}"),
     }
 
@@ -40,7 +44,7 @@ pub async fn initialize_identity(
     // local MLS state is intact, but recovers group membership after the local
     // DB is wiped (e.g. schema version bump) because load_user_db resets
     // delivered = 0 for this user's welcomes in that case.
-    match crate::commands::mls::poll_mls_welcomes_inner(state.inner(), &user_id).await {
+    match crate::commands::mls::poll_mls_welcomes_inner(state.inner(), &user_id, &device_id).await {
         Ok(()) => {}
         Err(e) => eprintln!("[identity] poll_mls_welcomes (non-fatal): {e}"),
     }
@@ -197,6 +201,7 @@ pub async fn verify_otp(
         .map_err(|e| anyhow::anyhow!("Failed to serialize session: {e}"))?;
     keystore::store_for_user(SESSION_KEY, &profile.id, &session_bytes).await?;
     state.load_user_db(&profile.id).await?;
+    register_device(state.inner(), &profile.id).await?;
     crate::accounts::upsert_account(&profile.id, &profile.username, Some(&profile.email), None)?;
 
     Ok(profile)
@@ -294,6 +299,7 @@ pub async fn get_session(state: State<'_, Arc<AppState>>) -> Result<Option<UserP
 
     // Open the per-user local database.
     state.load_user_db(&profile.id).await?;
+    register_device(state.inner(), &profile.id).await?;
 
     Ok(Some(profile))
 }
@@ -331,8 +337,35 @@ async fn dev_login_inner(state: &Arc<AppState>, email: String) -> Result<UserPro
         .map_err(|e| anyhow::anyhow!("Failed to serialize session: {e}"))?;
     keystore::store_for_user(SESSION_KEY, &profile.id, &session_bytes).await?;
     state.load_user_db(&profile.id).await?;
+    register_device(state, &profile.id).await?;
     crate::accounts::upsert_account(&profile.id, &profile.username, Some(&profile.email), None)?;
     Ok(profile)
+}
+
+/// Register this device for the given user. Generates a stable device_id on first
+/// call (persisted in the OS keystore), inserts/updates the remote `user_device`
+/// table, and stores the id in `AppState.device_id`.
+async fn register_device(state: &Arc<AppState>, user_id: &str) -> Result<String> {
+    let device_id = match keystore::load_for_user(DEVICE_ID_KEY, user_id).await? {
+        Some(bytes) => String::from_utf8(bytes)
+            .map_err(|e| anyhow::anyhow!("corrupt device_id in keystore: {e}"))?,
+        None => {
+            let id = Ulid::new().to_string();
+            keystore::store_for_user(DEVICE_ID_KEY, user_id, id.as_bytes()).await?;
+            id
+        }
+    };
+
+    let conn = state.remote_db.conn().await?;
+    conn.execute(
+        "INSERT INTO user_device (device_id, user_id) VALUES (?1, ?2) \
+         ON CONFLICT(device_id) DO UPDATE SET last_seen = datetime('now')",
+        libsql::params![device_id.clone(), user_id],
+    ).await?;
+
+    *state.device_id.lock().await = Some(device_id.clone());
+    eprintln!("[auth] device registered: {device_id}");
+    Ok(device_id)
 }
 
 /// Clear the persisted session (logout). Optionally wipe the per-user DB and identity keys.
@@ -340,6 +373,9 @@ async fn dev_login_inner(state: &Arc<AppState>, email: String) -> Result<UserPro
 pub async fn logout(state: State<'_, Arc<AppState>>, delete_data: bool) -> Result<()> {
     let index = crate::accounts::read_accounts_index();
     let user_id = index.last_active_user;
+
+    // Grab the device_id before clearing it.
+    let device_id = state.device_id.lock().await.take();
 
     if let Some(ref uid) = user_id {
         let _ = keystore::delete_for_user(SESSION_KEY, uid).await;
@@ -349,9 +385,19 @@ pub async fn logout(state: State<'_, Arc<AppState>>, delete_data: bool) -> Resul
 
     if delete_data {
         if let Some(ref uid) = user_id {
+            // Remove this device from the remote registry.
+            if let Some(ref did) = device_id {
+                if let Ok(conn) = state.remote_db.conn().await {
+                    let _ = conn.execute(
+                        "DELETE FROM user_device WHERE device_id = ?1",
+                        libsql::params![did.clone()],
+                    ).await;
+                }
+            }
             let _ = keystore::delete("identity_key_private").await;
             let _ = keystore::delete("identity_key_public").await;
             let _ = keystore::delete_for_user("db_key", uid).await;
+            let _ = keystore::delete_for_user(DEVICE_ID_KEY, uid).await;
             let data_dir = crate::db::local::dirs_path();
             let db_path = data_dir.join(format!("pollis_{uid}.db"));
             if db_path.exists() {
@@ -542,6 +588,8 @@ pub async fn delete_account(
     // Clear all keystore entries
     let _ = keystore::delete_for_user(SESSION_KEY, &user_id).await;
     let _ = keystore::delete_for_user("db_key", &user_id).await;
+    let _ = keystore::delete_for_user(DEVICE_ID_KEY, &user_id).await;
+    *state.device_id.lock().await = None;
 
     // Remove from local accounts index
     let _ = crate::accounts::remove_account(&user_id);

--- a/src-tauri/src/commands/dm.rs
+++ b/src-tauri/src/commands/dm.rs
@@ -102,7 +102,15 @@ pub async fn create_dm_channel(
 
     // Initialise the MLS group for this DM (creator becomes the sole member).
     match crate::commands::mls::init_mls_group(state.inner(), &id, &creator_id).await {
-        Ok(()) => {}
+        Ok(()) => {
+            // Add the creator's OTHER devices so they receive a Welcome.
+            let current_did = state.device_id.lock().await.clone();
+            if let Err(e) = crate::commands::mls::add_member_mls_for_own_devices(
+                state.inner(), &id, &creator_id, current_did.as_deref(),
+            ).await {
+                eprintln!("[mls] create_dm_channel: add creator's other devices: {e}");
+            }
+        }
         Err(e) => eprintln!("[mls] create_dm_channel: mls group init failed (non-fatal): {e}"),
     }
 

--- a/src-tauri/src/commands/groups.rs
+++ b/src-tauri/src/commands/groups.rs
@@ -187,6 +187,14 @@ pub async fn create_group(
         libsql::params![id.clone(), owner_id.clone()],
     ).await.map_err(|e| db_err(e.into(), "Group member"))?;
 
+    // Create default channels: a #General text channel and a Voice Chat.
+    conn.execute(
+        "INSERT INTO channels (id, group_id, name, description, channel_type) VALUES \
+            (?1, ?2, 'General', NULL, 'text'), \
+            (?3, ?2, 'Voice Chat', NULL, 'voice')",
+        libsql::params![Ulid::new().to_string(), id.clone(), Ulid::new().to_string()],
+    ).await.map_err(|e| db_err(e.into(), "Channel"))?;
+
     // Create the per-group MLS group — all channels in this group share it.
     match crate::commands::mls::init_mls_group(state.inner(), &id, &owner_id).await {
         Ok(()) => {

--- a/src-tauri/src/commands/groups.rs
+++ b/src-tauri/src/commands/groups.rs
@@ -189,7 +189,16 @@ pub async fn create_group(
 
     // Create the per-group MLS group — all channels in this group share it.
     match crate::commands::mls::init_mls_group(state.inner(), &id, &owner_id).await {
-        Ok(()) => {}
+        Ok(()) => {
+            // Add the creator's OTHER devices so they receive a Welcome and can
+            // decrypt messages without triggering an independent repair.
+            let current_did = state.device_id.lock().await.clone();
+            if let Err(e) = crate::commands::mls::add_member_mls_for_own_devices(
+                state.inner(), &id, &owner_id, current_did.as_deref(),
+            ).await {
+                eprintln!("[mls] create_group: add owner's other devices: {e}");
+            }
+        }
         Err(e) => eprintln!("[mls] create_group: mls group init failed (non-fatal): {e}"),
     }
 
@@ -829,7 +838,7 @@ pub async fn send_group_invite(
     if let Err(e) = crate::commands::livekit::publish_to_user_inbox(
         &state.config,
         &invitee_id,
-        serde_json::json!({"type": "membership_changed"}),
+        serde_json::json!({"type": "membership_changed", "group_id": group_id}),
     ).await {
         eprintln!("[inbox] send_group_invite: notify {invitee_id} failed: {e}");
     }
@@ -897,6 +906,17 @@ pub async fn accept_group_invite(
         "DELETE FROM group_invite WHERE id = ?1",
         libsql::params![invite_id],
     ).await?;
+
+    // Notify existing group members so they see the new member.
+    // The accepting user isn't connected to the group room yet, so use
+    // the server-side publish to reach existing members.
+    if let Err(e) = crate::commands::livekit::publish_to_room_server(
+        &state.config,
+        &group_id,
+        serde_json::json!({"type": "membership_changed", "group_id": group_id}),
+    ).await {
+        eprintln!("[realtime] accept_group_invite: notify group {group_id}: {e}");
+    }
 
     Ok(())
 }
@@ -1120,9 +1140,17 @@ pub async fn approve_join_request(
     if let Err(e) = crate::commands::livekit::publish_to_user_inbox(
         &state.config,
         &requester_id,
-        serde_json::json!({"type": "membership_changed"}),
+        serde_json::json!({"type": "membership_changed", "group_id": group_id}),
     ).await {
         eprintln!("[inbox] approve_join_request: notify {requester_id} failed: {e}");
+    }
+
+    // Notify existing group members so they refetch the member list.
+    if let Err(e) = crate::commands::livekit::publish_membership_changed_to_room(
+        &state.livekit,
+        &group_id,
+    ).await {
+        eprintln!("[realtime] approve_join_request: notify group {group_id}: {e}");
     }
 
     Ok(())

--- a/src-tauri/src/commands/livekit.rs
+++ b/src-tauri/src/commands/livekit.rs
@@ -117,6 +117,53 @@ pub async fn publish_to_user_inbox(
     Ok(())
 }
 
+/// Connects to a LiveKit room as a temporary "server" participant and publishes
+/// a data packet. Used when the caller is not already in the room (e.g. a user
+/// accepting an invite needs to notify existing group members).
+pub async fn publish_to_room_server(
+    config: &Config,
+    room_name: &str,
+    payload: serde_json::Value,
+) -> Result<()> {
+    if config.livekit_url.is_empty() || config.livekit_api_key.is_empty() {
+        return Ok(());
+    }
+
+    let token = make_token(config, room_name, "server", "server")?;
+    let url = config.livekit_url.clone();
+    let room_owned = room_name.to_owned();
+
+    tauri::async_runtime::spawn(async move {
+        match Room::connect(&url, &token, RoomOptions::default()).await {
+            Ok((room, _events)) => {
+                let raw = match serde_json::to_vec(&payload) {
+                    Ok(b) => b,
+                    Err(e) => {
+                        eprintln!("[room-server] serialize error for {room_owned}: {e}");
+                        return;
+                    }
+                };
+                let result = room
+                    .local_participant()
+                    .publish_data(DataPacket {
+                        payload: raw,
+                        reliable: true,
+                        ..Default::default()
+                    })
+                    .await;
+                if let Err(e) = result {
+                    eprintln!("[room-server] publish_data to {room_owned} failed: {e}");
+                }
+            }
+            Err(e) => {
+                eprintln!("[room-server] connect to {room_owned} failed: {e}");
+            }
+        }
+    });
+
+    Ok(())
+}
+
 // ── Voice participant listing ──────────────────────────────────────────────
 
 #[derive(Serialize)]
@@ -206,6 +253,13 @@ pub async fn connect_rooms(
     let url = state.config.livekit_url.clone();
     let livekit_arc = Arc::clone(&state.livekit);
 
+    // Build a per-device identity so multiple devices for the same user can
+    // coexist in the same LiveKit room without kicking each other.
+    let identity = match state.device_id.lock().await.clone() {
+        Some(did) => format!("{user_id}:{did}"),
+        None => user_id.clone(),
+    };
+
     // Compute the diff while holding the lock briefly, then release.
     // Include rooms that are mid-connection to prevent duplicate connects.
     let (to_remove, to_connect) = {
@@ -245,7 +299,7 @@ pub async fn connect_rooms(
     // Connect new rooms in parallel — each room gets its own task so a timeout
     // or failure on one room does not delay or block the others.
     for room_id in to_connect {
-        let token = match make_token(&state.config, &room_id, &user_id, &username) {
+        let token = match make_token(&state.config, &room_id, &identity, &username) {
             Ok(t) => t,
             Err(e) => {
                 eprintln!("[realtime] token error for room {room_id}: {e}");
@@ -258,6 +312,7 @@ pub async fn connect_rooms(
         let url_owned = url.clone();
         let lk_arc_connect = Arc::clone(&livekit_arc);
         let config = state.config.clone();
+        let identity_owned = identity.clone();
         let user_id_owned = user_id.clone();
         let username_owned = username.clone();
         let remote_db_connect = Arc::clone(&state.remote_db);
@@ -272,10 +327,11 @@ pub async fn connect_rooms(
                     // On connect, reconcile voice_presence: delete rows for any user who
                     // has a presence record for this group but is not currently in the room.
                     // This cleans up orphaned rows from previous crash disconnects.
+                    // Extract user_id from participant identities (may be "user_id:device_id").
                     let online_ids: HashSet<String> = room
                         .remote_participants()
                         .keys()
-                        .map(|id| id.to_string())
+                        .map(|id| id.to_string().split(':').next().unwrap_or_default().to_string())
                         .chain(std::iter::once(user_id_owned.clone()))
                         .collect();
                     reconcile_voice_presence(&remote_db_connect, &room_id, &online_ids).await;
@@ -310,13 +366,15 @@ pub async fn connect_rooms(
                                     }
                                     RoomEvent::ParticipantDisconnected(participant) => {
                                         let identity = participant.identity().to_string();
+                                        // Extract user_id from identity (may be "user_id:device_id").
+                                        let uid = identity.split(':').next().unwrap_or(&identity);
                                         // Clean up any voice presence rows for this user in
                                         // this group and notify the frontend for each.
                                         handle_participant_disconnect(
                                             remote_db,
                                             lk_arc,
                                             room_id,
-                                            &identity,
+                                            uid,
                                         )
                                         .await;
                                     }
@@ -346,7 +404,7 @@ pub async fn connect_rooms(
                                 }
                             }
 
-                            let token = match make_token(&config, &room_id_owned, &user_id_owned, &username_owned) {
+                            let token = match make_token(&config, &room_id_owned, &identity_owned, &username_owned) {
                                 Ok(t) => t,
                                 Err(e) => {
                                     eprintln!("[realtime] reconnect token error for room {room_id_owned}: {e}");
@@ -364,7 +422,7 @@ pub async fn connect_rooms(
                                     let online_ids: HashSet<String> = new_room
                                         .remote_participants()
                                         .keys()
-                                        .map(|id| id.to_string())
+                                        .map(|id| id.to_string().split(':').next().unwrap_or_default().to_string())
                                         .chain(std::iter::once(user_id_owned.clone()))
                                         .collect();
                                     reconcile_voice_presence(&remote_db_task, &room_id_owned, &online_ids).await;
@@ -488,6 +546,40 @@ pub async fn publish_edited_message_to_room(
         })
         .await
         .map_err(|e| Error::Other(anyhow::anyhow!("publish_edited_message: {e}")))?;
+
+    Ok(())
+}
+
+/// Broadcasts a `membership_changed` event to a group's LiveKit room so
+/// existing members refetch the member list (e.g. after a join-request approval).
+pub async fn publish_membership_changed_to_room(
+    livekit: &Arc<tokio::sync::Mutex<crate::realtime::LiveKitState>>,
+    group_id: &str,
+) -> Result<()> {
+    let room = {
+        let lk = livekit.lock().await;
+        lk.rooms.get(group_id).map(|(r, _)| Arc::clone(r))
+    };
+
+    let room = match room {
+        None => return Ok(()),
+        Some(r) => r,
+    };
+
+    let payload = serde_json::to_vec(&serde_json::json!({
+        "type": "membership_changed",
+        "group_id": group_id,
+    }))
+    .map_err(Error::Serde)?;
+
+    room.local_participant()
+        .publish_data(DataPacket {
+            payload,
+            reliable: true,
+            ..Default::default()
+        })
+        .await
+        .map_err(|e| Error::Other(anyhow::anyhow!("publish_membership_changed: {e}")))?;
 
     Ok(())
 }

--- a/src-tauri/src/commands/messages.rs
+++ b/src-tauri/src/commands/messages.rs
@@ -291,6 +291,23 @@ pub async fn get_channel_messages(
         eprintln!("[messages] process_pending_commits for {mls_group_id}: {e}");
     }
 
+    // If the MLS group doesn't exist locally (new device, DB wipe), trigger
+    // repair so this device can decrypt messages going forward.
+    {
+        let has_group = {
+            let guard = state.local_db.lock().await;
+            guard.as_ref().map_or(false, |db| {
+                crate::commands::mls::has_local_group(db.conn(), &mls_group_id)
+            })
+        };
+        if !has_group {
+            eprintln!("[messages] MLS group {mls_group_id} missing locally — triggering repair");
+            if let Err(e) = crate::commands::mls::repair_mls_group(state.inner(), &mls_group_id, &user_id).await {
+                eprintln!("[messages] repair failed for {mls_group_id}: {e}");
+            }
+        }
+    }
+
     let mut rows = match cursor {
         None => {
             conn.query(
@@ -545,6 +562,22 @@ pub async fn get_dm_messages(
     // Process any pending MLS commits before decrypting.
     if let Err(e) = crate::commands::mls::process_pending_commits_inner(state.inner(), &dm_channel_id).await {
         eprintln!("[messages] process_pending_commits for DM {dm_channel_id}: {e}");
+    }
+
+    // If the MLS group doesn't exist locally (new device), trigger repair.
+    {
+        let has_group = {
+            let guard = state.local_db.lock().await;
+            guard.as_ref().map_or(false, |db| {
+                crate::commands::mls::has_local_group(db.conn(), &dm_channel_id)
+            })
+        };
+        if !has_group {
+            eprintln!("[messages] MLS group for DM {dm_channel_id} missing locally — triggering repair");
+            if let Err(e) = crate::commands::mls::repair_mls_group(state.inner(), &dm_channel_id, &user_id).await {
+                eprintln!("[messages] repair failed for DM {dm_channel_id}: {e}");
+            }
+        }
     }
 
     let conn = state.remote_db.conn().await?;

--- a/src-tauri/src/commands/messages.rs
+++ b/src-tauri/src/commands/messages.rs
@@ -143,17 +143,33 @@ pub async fn send_message(
         }
     };
 
-    // Encrypt with MLS and store locally.
-    // First attempt — if the group is missing (e.g. local DB was wiped),
-    // transparently repair and retry.
-    let needs_repair = {
-        let guard = state.local_db.lock().await;
-        let db = guard.as_ref().ok_or_else(|| crate::error::Error::Other(anyhow::anyhow!("Not signed in")))?;
-        crate::commands::mls::try_mls_encrypt(db.conn(), &mls_group_id, content.as_bytes()).is_none()
-    };
+    // Poll MLS Welcomes — this device may have been added to the group but
+    // hasn't applied the Welcome yet.
+    {
+        let device_id = state.device_id.lock().await.clone();
+        if let Some(ref did) = device_id {
+            let _ = crate::commands::mls::poll_mls_welcomes_inner(state.inner(), &sender_id, did).await;
+        }
+    }
 
-    if needs_repair {
-        crate::commands::mls::repair_mls_group(state.inner(), &mls_group_id, &sender_id).await?;
+    // Process pending commits so the local epoch is current before encrypting.
+    let _ = crate::commands::mls::process_pending_commits_inner(state.inner(), &mls_group_id).await;
+
+    // If the MLS group still doesn't exist locally after polling welcomes and
+    // processing commits, return an error rather than repairing.  Repair creates
+    // a divergent group that breaks all other participants.
+    {
+        let has_group = {
+            let guard = state.local_db.lock().await;
+            guard.as_ref().map_or(false, |db| {
+                crate::commands::mls::has_local_group(db.conn(), &mls_group_id)
+            })
+        };
+        if !has_group {
+            return Err(crate::error::Error::Other(anyhow::anyhow!(
+                "MLS group not available — this device hasn't received a Welcome yet for conversation {conversation_id}"
+            )));
+        }
     }
 
     let ciphertext_remote = {
@@ -285,14 +301,30 @@ pub async fn get_channel_messages(
         }
     };
 
+    // Poll MLS Welcomes first — this device may have been added to the group
+    // (e.g. creator's second device, or invite acceptance) but hasn't applied
+    // the Welcome yet.  Without this, process_pending_commits has no group to
+    // apply commits to, and the fallback repair creates a divergent group.
+    {
+        let device_id = state.device_id.lock().await.clone();
+        if let Some(ref did) = device_id {
+            if let Err(e) = crate::commands::mls::poll_mls_welcomes_inner(state.inner(), &user_id, did).await {
+                eprintln!("[messages] poll_mls_welcomes for {mls_group_id}: {e}");
+            }
+        }
+    }
+
     // Process any pending MLS commits (membership changes) before decrypting
     // so the local epoch is current and messages from the new epoch are readable.
     if let Err(e) = crate::commands::mls::process_pending_commits_inner(state.inner(), &mls_group_id).await {
         eprintln!("[messages] process_pending_commits for {mls_group_id}: {e}");
     }
 
-    // If the MLS group doesn't exist locally (new device, DB wipe), trigger
-    // repair so this device can decrypt messages going forward.
+    // If the MLS group still doesn't exist locally after polling welcomes and
+    // processing commits, log a warning.  Do NOT repair — repair creates an
+    // independent group with different keys and deletes the commit log, which
+    // breaks every other device/user already in the real group.  Messages will
+    // remain encrypted (content=null) until this device receives a proper Welcome.
     {
         let has_group = {
             let guard = state.local_db.lock().await;
@@ -301,10 +333,7 @@ pub async fn get_channel_messages(
             })
         };
         if !has_group {
-            eprintln!("[messages] MLS group {mls_group_id} missing locally — triggering repair");
-            if let Err(e) = crate::commands::mls::repair_mls_group(state.inner(), &mls_group_id, &user_id).await {
-                eprintln!("[messages] repair failed for {mls_group_id}: {e}");
-            }
+            eprintln!("[messages] MLS group {mls_group_id} missing locally — messages will be encrypted until a Welcome is received");
         }
     }
 
@@ -398,15 +427,16 @@ pub async fn get_channel_messages(
         let content = if deleted_at.is_some() {
             // Soft-deleted messages show no content.
             None
-        } else if sender_id == user_id {
-            // Own message: read plaintext stored locally at send time.
-            local_row.and_then(|(c, _, _)| c)
         } else {
-            // Peer message: check local cache first.
+            // Check local cache first (covers own messages sent from this
+            // device and previously-decrypted peer messages).
             let cached = local_row.and_then(|(c, _, _)| c);
             if cached.is_some() {
                 cached
             } else {
+                // Cache miss — decrypt via MLS. For own-user messages sent
+                // from a different device, sender_id == user_id but the
+                // plaintext only exists on the sending device's local DB.
                 let plaintext = ciphertext.strip_prefix("mls:")
                     .and_then(|hex_str| hex::decode(hex_str).ok())
                     .and_then(|bytes| crate::commands::mls::try_mls_decrypt(db.conn(), &mls_group_id, &bytes))
@@ -559,12 +589,23 @@ pub async fn get_dm_messages(
 ) -> Result<MessagePage> {
     let limit = limit.unwrap_or(50);
 
+    // Poll MLS Welcomes first — this device may have a pending Welcome.
+    {
+        let device_id = state.device_id.lock().await.clone();
+        if let Some(ref did) = device_id {
+            if let Err(e) = crate::commands::mls::poll_mls_welcomes_inner(state.inner(), &user_id, did).await {
+                eprintln!("[messages] poll_mls_welcomes for DM {dm_channel_id}: {e}");
+            }
+        }
+    }
+
     // Process any pending MLS commits before decrypting.
     if let Err(e) = crate::commands::mls::process_pending_commits_inner(state.inner(), &dm_channel_id).await {
         eprintln!("[messages] process_pending_commits for DM {dm_channel_id}: {e}");
     }
 
-    // If the MLS group doesn't exist locally (new device), trigger repair.
+    // If the MLS group still doesn't exist locally, log a warning.  Do NOT
+    // repair — see comment in get_channel_messages for rationale.
     {
         let has_group = {
             let guard = state.local_db.lock().await;
@@ -573,10 +614,7 @@ pub async fn get_dm_messages(
             })
         };
         if !has_group {
-            eprintln!("[messages] MLS group for DM {dm_channel_id} missing locally — triggering repair");
-            if let Err(e) = crate::commands::mls::repair_mls_group(state.inner(), &dm_channel_id, &user_id).await {
-                eprintln!("[messages] repair failed for DM {dm_channel_id}: {e}");
-            }
+            eprintln!("[messages] MLS group for DM {dm_channel_id} missing locally — messages will be encrypted until a Welcome is received");
         }
     }
 
@@ -670,8 +708,6 @@ pub async fn get_dm_messages(
 
         let content = if deleted_at.is_some() {
             None
-        } else if sender_id == user_id {
-            local_row.and_then(|(c, _, _)| c)
         } else {
             let cached = local_row.and_then(|(c, _, _)| c);
             if cached.is_some() {

--- a/src-tauri/src/commands/mls.rs
+++ b/src-tauri/src/commands/mls.rs
@@ -80,14 +80,14 @@ impl From<MlsStorageError> for crate::error::Error {
 /// Build an MLS `Credential` encoding both user and device identity.
 ///
 /// Format: `"user_id:device_id"` as UTF-8 bytes inside a `BasicCredential`.
-fn make_credential(user_id: &str, device_id: &str) -> Credential {
+pub fn make_credential(user_id: &str, device_id: &str) -> Credential {
     BasicCredential::new(format!("{user_id}:{device_id}").into_bytes()).into()
 }
 
 /// Extract the `user_id` from a credential produced by `make_credential`.
 ///
 /// Handles legacy credentials that contain only `user_id` (no colon).
-fn parse_credential_user_id(cred: &Credential) -> String {
+pub fn parse_credential_user_id(cred: &Credential) -> String {
     let s = String::from_utf8_lossy(cred.serialized_content());
     s.split_once(':').map(|(u, _)| u).unwrap_or(&s).to_string()
 }
@@ -613,6 +613,29 @@ pub async fn add_member_mls_inner(
     add_member_mls_impl(state, conversation_id, target_user_id, actor_user_id, None).await
 }
 
+/// Add the user's OTHER devices to an MLS group they just created.
+/// No-op if the user only has one device. Non-fatal errors are logged.
+pub async fn add_member_mls_for_own_devices(
+    state: &Arc<AppState>,
+    conversation_id: &str,
+    user_id: &str,
+    exclude_device_id: Option<&str>,
+) -> crate::error::Result<()> {
+    match add_member_mls_impl(state, conversation_id, user_id, user_id, exclude_device_id).await {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            let msg = format!("{e}");
+            // "No registered devices" or "No available key packages" means the
+            // user only has one device — that's fine, not an error.
+            if msg.contains("No registered devices") || msg.contains("No available key packages") || msg.contains("No valid key packages") {
+                Ok(())
+            } else {
+                Err(e)
+            }
+        }
+    }
+}
+
 #[tauri::command]
 pub async fn add_member_mls(
     state: State<'_, Arc<AppState>>,
@@ -634,17 +657,24 @@ async fn add_member_mls_impl(
     let target_user_id = target_user_id.to_owned();
     let actor_user_id = actor_user_id.to_owned();
 
-    // 1. Look up all registered devices for the target user.
+    // 1. Look up devices for the target user that have at least one unclaimed
+    //    key package.  Stale devices (e.g. from earlier testing) with no KPs
+    //    are skipped — they can't be added to MLS groups.
     let device_ids: Vec<String> = {
         let conn = state.remote_db.conn().await?;
         let mut rows = conn.query(
-            "SELECT device_id FROM user_device WHERE user_id = ?1",
+            "SELECT d.device_id FROM user_device d \
+             WHERE d.user_id = ?1 \
+             AND EXISTS ( \
+                 SELECT 1 FROM mls_key_package kp \
+                 WHERE kp.user_id = d.user_id AND kp.device_id = d.device_id AND kp.claimed = 0 \
+             )",
             libsql::params![target_user_id.clone()],
         ).await?;
         let mut ids = Vec::new();
         while let Some(row) = rows.next().await? {
             let did: String = row.get(0)?;
-            // Skip the excluded device (e.g. the group creator during repair).
+            // Skip the excluded device (e.g. the group creator's current device).
             if exclude_device_id.map_or(false, |ex| ex == did) {
                 continue;
             }
@@ -1922,6 +1952,295 @@ mod tests {
         assert_eq!(
             try_mls_decrypt(&alice_db, group1, &carol_msg).unwrap(),
             b"carol still here"
+        );
+    }
+
+    // ── multi-device helpers ────────────────────────────────────────────────
+
+    /// Create an MLS group with an explicit device_id in the credential.
+    fn create_group_with_device(
+        conn: &rusqlite::Connection,
+        conversation_id: &str,
+        user_id: &str,
+        device_id: &str,
+    ) -> SignatureKeyPair {
+        let provider = PollisProvider::new(conn);
+        let sig_keys = SignatureKeyPair::new(CS.signature_algorithm()).unwrap();
+        sig_keys.store(provider.storage()).unwrap();
+
+        let credential = make_credential(user_id, device_id);
+        let sig_pub = OpenMlsSignaturePublicKey::new(
+            sig_keys.to_public_vec().into(),
+            CS.signature_algorithm(),
+        ).unwrap();
+        let cred_with_key = CredentialWithKey {
+            credential,
+            signature_key: sig_pub.into(),
+        };
+
+        let group_id = GroupId::from_slice(conversation_id.as_bytes());
+        let config = MlsGroupCreateConfig::builder()
+            .ciphersuite(CS)
+            .use_ratchet_tree_extension(true)
+            .build();
+
+        MlsGroup::new_with_group_id(&provider, &sig_keys, &config, group_id, cred_with_key)
+            .unwrap();
+
+        sig_keys
+    }
+
+    /// Generate a key package with an explicit device_id in the credential.
+    fn gen_key_package_with_device(
+        conn: &rusqlite::Connection,
+        user_id: &str,
+        device_id: &str,
+    ) -> Vec<u8> {
+        let provider = PollisProvider::new(conn);
+        let sig_keys = SignatureKeyPair::new(CS.signature_algorithm()).unwrap();
+        sig_keys.store(provider.storage()).unwrap();
+
+        let credential = make_credential(user_id, device_id);
+        let sig_pub = OpenMlsSignaturePublicKey::new(
+            sig_keys.to_public_vec().into(),
+            CS.signature_algorithm(),
+        ).unwrap();
+        let cred_with_key = CredentialWithKey {
+            credential,
+            signature_key: sig_pub.into(),
+        };
+
+        let bundle = KeyPackage::builder()
+            .build(CS, &provider, &sig_keys, cred_with_key)
+            .unwrap();
+
+        bundle.key_package().tls_serialize_detached().unwrap()
+    }
+
+    /// Add multiple key packages to a group in a single `add_members` call.
+    /// Mirrors production `add_member_mls_impl` which batches all devices.
+    fn add_members_batch(
+        adder_db: &rusqlite::Connection,
+        conv_id: &str,
+        kp_bytes_list: &[Vec<u8>],
+    ) -> (Vec<u8>, Vec<u8>) {
+        let provider = PollisProvider::new(adder_db);
+        let (mut group, signer) = load_group_with_signer(&provider, conv_id).unwrap();
+
+        let validated_kps: Vec<KeyPackage> = kp_bytes_list.iter().map(|kp_raw| {
+            let mut reader: &[u8] = kp_raw;
+            let kp_in = KeyPackageIn::tls_deserialize(&mut reader).unwrap();
+            kp_in.validate(provider.crypto(), ProtocolVersion::Mls10).unwrap()
+        }).collect();
+
+        let (commit_msg, welcome_msg, _) =
+            group.add_members(&provider, &signer, &validated_kps).unwrap();
+        group.merge_pending_commit(&provider).unwrap();
+
+        (
+            commit_msg.tls_serialize_detached().unwrap(),
+            welcome_msg.tls_serialize_detached().unwrap(),
+        )
+    }
+
+    // ── multi-device credential tests ───────────────────────────────────────
+
+    /// Credential encodes user_id:device_id; parsing extracts user_id.
+    #[test]
+    fn credential_roundtrip_with_device() {
+        let cred = make_credential("alice", "dev_01ABCDEF");
+        assert_eq!(parse_credential_user_id(&cred), "alice");
+        assert_eq!(
+            String::from_utf8_lossy(cred.serialized_content()),
+            "alice:dev_01ABCDEF"
+        );
+    }
+
+    /// Legacy credentials (no colon) still parse correctly.
+    #[test]
+    fn credential_legacy_no_device_id() {
+        let cred: Credential = BasicCredential::new("alice".as_bytes().to_vec()).into();
+        assert_eq!(parse_credential_user_id(&cred), "alice");
+    }
+
+    // ── multi-device scenario tests ─────────────────────────────────────────
+
+    /// Alice has two devices in the group. Bob sends a message. Both Alice
+    /// devices decrypt it.
+    #[test]
+    fn multi_device_both_devices_decrypt() {
+        let conv_id = "01JTEST00000000000MULTIDEV1";
+
+        let alice_d1_db = make_db();
+        let alice_d2_db = make_db();
+        let bob_db = make_db();
+
+        // Alice device 1 creates the group.
+        create_group_with_device(&alice_d1_db, conv_id, "alice", "alice_d1");
+
+        // Add Bob.
+        let bob_kp = gen_key_package_with_device(&bob_db, "bob", "bob_d1");
+        let (add_bob_commit, bob_welcome) =
+            add_member_to_group(&alice_d1_db, conv_id, &bob_kp);
+        join_via_welcome(&bob_db, &bob_welcome);
+        let _ = add_bob_commit;
+
+        // Add Alice's second device.
+        let alice_d2_kp = gen_key_package_with_device(&alice_d2_db, "alice", "alice_d2");
+        let (add_d2_commit, alice_d2_welcome) =
+            add_member_to_group(&alice_d1_db, conv_id, &alice_d2_kp);
+        join_via_welcome(&alice_d2_db, &alice_d2_welcome);
+        apply_commit(&bob_db, conv_id, &add_d2_commit);
+
+        // Bob sends.
+        let bob_ct = try_mls_encrypt(&bob_db, conv_id, b"hello both alices").unwrap();
+
+        // Both Alice devices decrypt.
+        assert_eq!(
+            try_mls_decrypt(&alice_d1_db, conv_id, &bob_ct).unwrap(),
+            b"hello both alices"
+        );
+        assert_eq!(
+            try_mls_decrypt(&alice_d2_db, conv_id, &bob_ct).unwrap(),
+            b"hello both alices"
+        );
+    }
+
+    /// Two devices for the same user are added in a single add_members commit
+    /// (matching production add_member_mls_impl). Both join via the same
+    /// Welcome and can decrypt.
+    #[test]
+    fn multi_device_batch_add_single_commit() {
+        let conv_id = "01JTEST00000000000MULTIDEV2";
+
+        let alice_db = make_db();
+        let bob_d1_db = make_db();
+        let bob_d2_db = make_db();
+
+        create_group_with_device(&alice_db, conv_id, "alice", "alice_d1");
+
+        // Generate KPs for both Bob devices.
+        let bob_d1_kp = gen_key_package_with_device(&bob_d1_db, "bob", "bob_d1");
+        let bob_d2_kp = gen_key_package_with_device(&bob_d2_db, "bob", "bob_d2");
+
+        // Add both in a single commit.
+        let (_commit, welcome) =
+            add_members_batch(&alice_db, conv_id, &[bob_d1_kp, bob_d2_kp]);
+
+        // Both Bob devices process the same Welcome.
+        join_via_welcome(&bob_d1_db, &welcome);
+        join_via_welcome(&bob_d2_db, &welcome);
+
+        // Alice sends — both Bob devices decrypt.
+        let ct = try_mls_encrypt(&alice_db, conv_id, b"hello bob devices").unwrap();
+        assert_eq!(
+            try_mls_decrypt(&bob_d1_db, conv_id, &ct).unwrap(),
+            b"hello bob devices"
+        );
+        assert_eq!(
+            try_mls_decrypt(&bob_d2_db, conv_id, &ct).unwrap(),
+            b"hello bob devices"
+        );
+
+        // Bob device 1 sends — Alice and Bob device 2 both decrypt.
+        let bob_ct = try_mls_encrypt(&bob_d1_db, conv_id, b"from bob d1").unwrap();
+        assert_eq!(
+            try_mls_decrypt(&alice_db, conv_id, &bob_ct).unwrap(),
+            b"from bob d1"
+        );
+        assert_eq!(
+            try_mls_decrypt(&bob_d2_db, conv_id, &bob_ct).unwrap(),
+            b"from bob d1"
+        );
+    }
+
+    /// Removing a user removes ALL their device leaf nodes. Neither device
+    /// can decrypt messages from the new epoch.
+    #[test]
+    fn remove_multi_device_user_removes_all_leaves() {
+        let conv_id = "01JTEST00000000000MULTIDEV3";
+
+        let alice_db = make_db();
+        let bob_d1_db = make_db();
+        let bob_d2_db = make_db();
+
+        create_group_with_device(&alice_db, conv_id, "alice", "alice_d1");
+
+        // Add both Bob devices in one commit.
+        let bob_d1_kp = gen_key_package_with_device(&bob_d1_db, "bob", "bob_d1");
+        let bob_d2_kp = gen_key_package_with_device(&bob_d2_db, "bob", "bob_d2");
+        let (_commit, welcome) =
+            add_members_batch(&alice_db, conv_id, &[bob_d1_kp, bob_d2_kp]);
+        join_via_welcome(&bob_d1_db, &welcome);
+        join_via_welcome(&bob_d2_db, &welcome);
+
+        // Both can decrypt before removal.
+        let pre_ct = try_mls_encrypt(&alice_db, conv_id, b"before removal").unwrap();
+        assert!(try_mls_decrypt(&bob_d1_db, conv_id, &pre_ct).is_some());
+        assert!(try_mls_decrypt(&bob_d2_db, conv_id, &pre_ct).is_some());
+
+        // Alice removes "bob" — removes both leaf nodes.
+        let _remove_commit = remove_member(&alice_db, conv_id, "bob");
+
+        // Alice sends at new epoch.
+        let post_ct = try_mls_encrypt(&alice_db, conv_id, b"after removal").unwrap();
+
+        // Neither Bob device can decrypt.
+        assert!(
+            try_mls_decrypt(&bob_d1_db, conv_id, &post_ct).is_none(),
+            "bob device 1 must not decrypt after removal"
+        );
+        assert!(
+            try_mls_decrypt(&bob_d2_db, conv_id, &post_ct).is_none(),
+            "bob device 2 must not decrypt after removal"
+        );
+    }
+
+    /// A second device joins later. It cannot read pre-join history but can
+    /// decrypt new messages.
+    #[test]
+    fn second_device_joins_later_cannot_read_history() {
+        let conv_id = "01JTEST00000000000MULTIDEV4";
+
+        let alice_d1_db = make_db();
+        let alice_d2_db = make_db();
+        let bob_db = make_db();
+
+        // Alice device 1 creates group and adds Bob.
+        create_group_with_device(&alice_d1_db, conv_id, "alice", "alice_d1");
+        let bob_kp = gen_key_package_with_device(&bob_db, "bob", "bob_d1");
+        let (_, bob_welcome) = add_member_to_group(&alice_d1_db, conv_id, &bob_kp);
+        join_via_welcome(&bob_db, &bob_welcome);
+
+        // Messages sent before alice_d2 joins.
+        let history_ct = try_mls_encrypt(&bob_db, conv_id, b"history msg").unwrap();
+        assert_eq!(
+            try_mls_decrypt(&alice_d1_db, conv_id, &history_ct).unwrap(),
+            b"history msg"
+        );
+
+        // Alice device 2 joins.
+        let alice_d2_kp = gen_key_package_with_device(&alice_d2_db, "alice", "alice_d2");
+        let (add_d2_commit, alice_d2_welcome) =
+            add_member_to_group(&alice_d1_db, conv_id, &alice_d2_kp);
+        join_via_welcome(&alice_d2_db, &alice_d2_welcome);
+        apply_commit(&bob_db, conv_id, &add_d2_commit);
+
+        // Device 2 cannot read pre-join history.
+        assert!(
+            try_mls_decrypt(&alice_d2_db, conv_id, &history_ct).is_none(),
+            "second device must not decrypt messages from before it joined"
+        );
+
+        // Both devices decrypt new messages.
+        let new_ct = try_mls_encrypt(&bob_db, conv_id, b"new msg").unwrap();
+        assert_eq!(
+            try_mls_decrypt(&alice_d1_db, conv_id, &new_ct).unwrap(),
+            b"new msg"
+        );
+        assert_eq!(
+            try_mls_decrypt(&alice_d2_db, conv_id, &new_ct).unwrap(),
+            b"new msg"
         );
     }
 }

--- a/src-tauri/src/commands/mls.rs
+++ b/src-tauri/src/commands/mls.rs
@@ -75,9 +75,26 @@ impl From<MlsStorageError> for crate::error::Error {
     }
 }
 
+// ── Credential helpers ───────────────────────────────────────────────────────
+
+/// Build an MLS `Credential` encoding both user and device identity.
+///
+/// Format: `"user_id:device_id"` as UTF-8 bytes inside a `BasicCredential`.
+fn make_credential(user_id: &str, device_id: &str) -> Credential {
+    BasicCredential::new(format!("{user_id}:{device_id}").into_bytes()).into()
+}
+
+/// Extract the `user_id` from a credential produced by `make_credential`.
+///
+/// Handles legacy credentials that contain only `user_id` (no colon).
+fn parse_credential_user_id(cred: &Credential) -> String {
+    let s = String::from_utf8_lossy(cred.serialized_content());
+    s.split_once(':').map(|(u, _)| u).unwrap_or(&s).to_string()
+}
+
 // ── Commands ──────────────────────────────────────────────────────────────────
 
-/// Generate a fresh MLS `KeyPackage` + `SignatureKeyPair` for `user_id` and
+/// Generate a fresh MLS `KeyPackage` + `SignatureKeyPair` for this device and
 /// persist both in the local `mls_kv` table.
 ///
 /// Returns the TLS-serialised `KeyPackage` bytes and its hex-encoded hash ref.
@@ -87,6 +104,9 @@ pub async fn generate_mls_key_package(
     state: State<'_, Arc<AppState>>,
     user_id: String,
 ) -> Result<serde_json::Value> {
+    let device_id = state.device_id.lock().await.clone()
+        .ok_or_else(|| crate::error::Error::Other(anyhow::anyhow!("device_id not set")))?;
+
     // All local DB work is sync — collect results in a block before any await.
     let (ref_hex, kp_bytes) = {
         let guard = state.local_db.lock().await;
@@ -102,13 +122,13 @@ pub async fn generate_mls_key_package(
         sig_keys.store(provider.storage())
             .map_err(|e| crate::error::Error::Other(anyhow::anyhow!("sig key store: {e}")))?;
 
-        let credential = BasicCredential::new(user_id.as_bytes().to_vec());
+        let credential = make_credential(&user_id, &device_id);
         let sig_pub = OpenMlsSignaturePublicKey::new(
             sig_keys.to_public_vec().into(),
             CS.signature_algorithm(),
         ).map_err(|e| crate::error::Error::Other(anyhow::anyhow!("sig pub key: {e}")))?;
         let cred_with_key = CredentialWithKey {
-            credential: credential.into(),
+            credential,
             signature_key: sig_pub.into(),
         };
 
@@ -140,10 +160,13 @@ pub async fn publish_mls_key_package(
     ref_hex: String,
     key_package_bytes: Vec<u8>,
 ) -> Result<()> {
+    let device_id = state.device_id.lock().await.clone()
+        .ok_or_else(|| crate::error::Error::Other(anyhow::anyhow!("device_id not set")))?;
     let conn = state.remote_db.conn().await?;
     conn.execute(
-        "INSERT OR IGNORE INTO mls_key_package (ref_hash, user_id, key_package) VALUES (?1, ?2, ?3)",
-        libsql::params![ref_hex, user_id, key_package_bytes],
+        "INSERT OR IGNORE INTO mls_key_package (ref_hash, user_id, key_package, device_id) \
+         VALUES (?1, ?2, ?3, ?4)",
+        libsql::params![ref_hex, user_id, key_package_bytes, device_id],
     ).await?;
     Ok(())
 }
@@ -180,32 +203,31 @@ pub async fn fetch_mls_key_package(
     }
 }
 
-/// Rotate key packages: delete all unclaimed packages for this user from the
+/// Rotate key packages: delete unclaimed packages for this device from the
 /// remote table and publish TARGET fresh ones backed by the current local DB.
 ///
-/// Called from `initialize_identity` on every login.  Deleting stale unclaimed
-/// packages first is critical — if the local DB was wiped (or the user logs in
-/// on a new device), any previously published packages would have orphaned
-/// private keys and cause "No matching key package" errors when peers try to
-/// add this user to an MLS group.
+/// Called from `initialize_identity` on every login.  Only deletes packages
+/// for the current `device_id` — other devices' packages are left intact.
 pub async fn ensure_mls_key_package(
     state: &Arc<AppState>,
     user_id: &str,
+    device_id: &str,
 ) -> Result<()> {
     const TARGET: i64 = 5;
 
     let conn = state.remote_db.conn().await?;
 
-    // Remove any unclaimed packages — their private keys may no longer exist
-    // in the current local DB (e.g. after a wipe or fresh install).
+    // Remove unclaimed packages for THIS device only — their private keys may
+    // no longer exist in the current local DB (e.g. after a wipe).
+    // Also clean up legacy packages with NULL device_id for this user.
     conn.execute(
-        "DELETE FROM mls_key_package WHERE user_id = ?1 AND claimed = 0",
-        libsql::params![user_id],
+        "DELETE FROM mls_key_package WHERE user_id = ?1 AND claimed = 0 \
+         AND (device_id = ?2 OR device_id IS NULL)",
+        libsql::params![user_id, device_id],
     ).await?;
 
     // Generate and publish TARGET fresh packages.
     for _ in 0..TARGET {
-        // Generate one package locally; each iteration creates a distinct key.
         let (ref_hex, kp_bytes) = {
             let guard = state.local_db.lock().await;
             let db = guard.as_ref().ok_or_else(|| {
@@ -218,13 +240,13 @@ pub async fn ensure_mls_key_package(
             sig_keys.store(provider.storage())
                 .map_err(|e| crate::error::Error::Other(anyhow::anyhow!("sig key store: {e}")))?;
 
-            let credential = BasicCredential::new(user_id.as_bytes().to_vec());
+            let credential = make_credential(user_id, device_id);
             let sig_pub = OpenMlsSignaturePublicKey::new(
                 sig_keys.to_public_vec().into(),
                 CS.signature_algorithm(),
             ).map_err(|e| crate::error::Error::Other(anyhow::anyhow!("sig pub key: {e}")))?;
             let cred_with_key = CredentialWithKey {
-                credential: credential.into(),
+                credential,
                 signature_key: sig_pub.into(),
             };
 
@@ -244,10 +266,88 @@ pub async fn ensure_mls_key_package(
             (ref_hex, kp_bytes)
         };
 
-        // Upload to remote.
         conn.execute(
-            "INSERT OR IGNORE INTO mls_key_package (ref_hash, user_id, key_package) VALUES (?1, ?2, ?3)",
-            libsql::params![ref_hex, user_id, kp_bytes],
+            "INSERT OR IGNORE INTO mls_key_package (ref_hash, user_id, key_package, device_id) \
+             VALUES (?1, ?2, ?3, ?4)",
+            libsql::params![ref_hex, user_id, kp_bytes, device_id],
+        ).await?;
+    }
+
+    Ok(())
+}
+
+/// Top-up key packages for this device to TARGET without deleting existing ones.
+/// Called after processing welcomes (which consume KPs) so the device stays
+/// reachable for future group invites.
+async fn replenish_key_packages(
+    state: &Arc<AppState>,
+    user_id: &str,
+    device_id: &str,
+) -> Result<()> {
+    const TARGET: i64 = 5;
+
+    let conn = state.remote_db.conn().await?;
+    let mut rows = conn.query(
+        "SELECT COUNT(*) FROM mls_key_package WHERE user_id = ?1 AND device_id = ?2 AND claimed = 0",
+        libsql::params![user_id, device_id],
+    ).await?;
+    let remaining: i64 = if let Some(row) = rows.next().await? {
+        row.get(0)?
+    } else {
+        0
+    };
+    drop(rows);
+
+    let needed = TARGET - remaining;
+    if needed <= 0 {
+        return Ok(());
+    }
+
+    eprintln!("[mls] replenish: {remaining} unclaimed KPs, publishing {needed} more");
+
+    for _ in 0..needed {
+        let (ref_hex, kp_bytes) = {
+            let guard = state.local_db.lock().await;
+            let db = guard.as_ref().ok_or_else(|| {
+                crate::error::Error::Other(anyhow::anyhow!("Not signed in"))
+            })?;
+            let provider = PollisProvider::new(db.conn());
+
+            let sig_keys = SignatureKeyPair::new(CS.signature_algorithm())
+                .map_err(|e| crate::error::Error::Other(anyhow::anyhow!("sig key gen: {e}")))?;
+            sig_keys.store(provider.storage())
+                .map_err(|e| crate::error::Error::Other(anyhow::anyhow!("sig key store: {e}")))?;
+
+            let credential = make_credential(user_id, device_id);
+            let sig_pub = OpenMlsSignaturePublicKey::new(
+                sig_keys.to_public_vec().into(),
+                CS.signature_algorithm(),
+            ).map_err(|e| crate::error::Error::Other(anyhow::anyhow!("sig pub key: {e}")))?;
+            let cred_with_key = CredentialWithKey {
+                credential,
+                signature_key: sig_pub.into(),
+            };
+
+            let bundle = KeyPackage::builder()
+                .build(CS, &provider, &sig_keys, cred_with_key)
+                .map_err(|e| crate::error::Error::Other(anyhow::anyhow!("kp build: {e}")))?;
+
+            let kp = bundle.key_package();
+            let hash_ref = kp
+                .hash_ref(provider.crypto())
+                .map_err(|e| crate::error::Error::Other(anyhow::anyhow!("kp hash_ref: {e}")))?;
+            let ref_hex = hex::encode(hash_ref.as_slice());
+            let kp_bytes = kp
+                .tls_serialize_detached()
+                .map_err(|e| crate::error::Error::Other(anyhow::anyhow!("kp serialize: {e}")))?;
+
+            (ref_hex, kp_bytes)
+        };
+
+        conn.execute(
+            "INSERT OR IGNORE INTO mls_key_package (ref_hash, user_id, key_package, device_id) \
+             VALUES (?1, ?2, ?3, ?4)",
+            libsql::params![ref_hex, user_id, kp_bytes, device_id],
         ).await?;
     }
 
@@ -268,6 +368,9 @@ pub async fn init_mls_group(
     conversation_id: &str,
     creator_user_id: &str,
 ) -> Result<()> {
+    let device_id = state.device_id.lock().await.clone()
+        .ok_or_else(|| crate::error::Error::Other(anyhow::anyhow!("device_id not set")))?;
+
     let guard = state.local_db.lock().await;
     let db = guard.as_ref().ok_or_else(|| {
         crate::error::Error::Other(anyhow::anyhow!("Not signed in"))
@@ -279,13 +382,13 @@ pub async fn init_mls_group(
     sig_keys.store(provider.storage())
         .map_err(|e| crate::error::Error::Other(anyhow::anyhow!("sig key store: {e}")))?;
 
-    let credential = BasicCredential::new(creator_user_id.as_bytes().to_vec());
+    let credential = make_credential(creator_user_id, &device_id);
     let sig_pub = OpenMlsSignaturePublicKey::new(
         sig_keys.to_public_vec().into(),
         CS.signature_algorithm(),
     ).map_err(|e| crate::error::Error::Other(anyhow::anyhow!("sig pub key: {e}")))?;
     let cred_with_key = CredentialWithKey {
-        credential: credential.into(),
+        credential,
         signature_key: sig_pub.into(),
     };
 
@@ -387,14 +490,17 @@ pub async fn process_welcome(
 /// `delivered = 1` so it is not processed again.
 ///
 /// Called on startup and from `poll_pending_messages`.
-pub async fn poll_mls_welcomes_inner(state: &Arc<AppState>, user_id: &str) -> Result<()> {
+pub async fn poll_mls_welcomes_inner(state: &Arc<AppState>, user_id: &str, device_id: &str) -> Result<()> {
     let conn = state.remote_db.conn().await?;
 
+    // Fetch welcomes targeted at this specific device, plus legacy rows
+    // (recipient_device_id IS NULL) from before multi-device was deployed.
     let mut rows = conn.query(
         "SELECT id, welcome_data FROM mls_welcome \
          WHERE recipient_id = ?1 AND delivered = 0 \
+         AND (recipient_device_id = ?2 OR recipient_device_id IS NULL) \
          ORDER BY created_at ASC",
-        libsql::params![user_id],
+        libsql::params![user_id, device_id],
     ).await?;
 
     // Drain into owned Vec so `rows` is dropped before local-DB awaits below.
@@ -406,6 +512,7 @@ pub async fn poll_mls_welcomes_inner(state: &Arc<AppState>, user_id: &str) -> Re
     }
     drop(rows);
 
+    let had_welcomes = !items.is_empty();
     for (id, bytes) in items {
         match apply_welcome(state, &bytes).await {
             Ok(()) => {}
@@ -423,6 +530,13 @@ pub async fn poll_mls_welcomes_inner(state: &Arc<AppState>, user_id: &str) -> Re
         ).await;
     }
 
+    // Each processed welcome consumed a KP — top back up to TARGET.
+    if had_welcomes {
+        if let Err(e) = replenish_key_packages(state, user_id, device_id).await {
+            eprintln!("[mls] KP replenishment failed (non-fatal): {e}");
+        }
+    }
+
     Ok(())
 }
 
@@ -431,7 +545,9 @@ pub async fn poll_mls_welcomes(
     state: State<'_, Arc<AppState>>,
     user_id: String,
 ) -> Result<()> {
-    poll_mls_welcomes_inner(state.inner(), &user_id).await
+    let device_id = state.device_id.lock().await.clone()
+        .ok_or_else(|| crate::error::Error::Other(anyhow::anyhow!("device_id not set")))?;
+    poll_mls_welcomes_inner(state.inner(), &user_id, &device_id).await
 }
 
 // ── Phase 4: Member changes ───────────────────────────────────────────────────
@@ -494,7 +610,7 @@ pub async fn add_member_mls_inner(
     target_user_id: &str,
     actor_user_id: &str,
 ) -> crate::error::Result<()> {
-    add_member_mls_impl(state, conversation_id, target_user_id, actor_user_id).await
+    add_member_mls_impl(state, conversation_id, target_user_id, actor_user_id, None).await
 }
 
 #[tauri::command]
@@ -504,7 +620,7 @@ pub async fn add_member_mls(
     target_user_id: String,
     actor_user_id: String,
 ) -> crate::error::Result<()> {
-    add_member_mls_impl(state.inner(), &conversation_id, &target_user_id, &actor_user_id).await
+    add_member_mls_impl(state.inner(), &conversation_id, &target_user_id, &actor_user_id, None).await
 }
 
 async fn add_member_mls_impl(
@@ -512,54 +628,106 @@ async fn add_member_mls_impl(
     conversation_id: &str,
     target_user_id: &str,
     actor_user_id: &str,
+    exclude_device_id: Option<&str>,
 ) -> crate::error::Result<()> {
     let conversation_id = conversation_id.to_owned();
     let target_user_id = target_user_id.to_owned();
     let actor_user_id = actor_user_id.to_owned();
-    // 1. Claim the target's KeyPackage atomically.
-    let kp_bytes = {
+
+    // 1. Look up all registered devices for the target user.
+    let device_ids: Vec<String> = {
         let conn = state.remote_db.conn().await?;
         let mut rows = conn.query(
-            "UPDATE mls_key_package \
-             SET claimed = 1 \
-             WHERE ref_hash = ( \
-                 SELECT ref_hash FROM mls_key_package \
-                 WHERE user_id = ?1 AND claimed = 0 \
-                 ORDER BY created_at ASC LIMIT 1 \
-             ) \
-             RETURNING key_package",
+            "SELECT device_id FROM user_device WHERE user_id = ?1",
             libsql::params![target_user_id.clone()],
         ).await?;
-        match rows.next().await? {
-            Some(row) => row.get::<Vec<u8>>(0)?,
-            None => return Err(crate::error::Error::Other(anyhow::anyhow!(
-                "No available key package for {target_user_id}"
-            ))),
+        let mut ids = Vec::new();
+        while let Some(row) = rows.next().await? {
+            let did: String = row.get(0)?;
+            // Skip the excluded device (e.g. the group creator during repair).
+            if exclude_device_id.map_or(false, |ex| ex == did) {
+                continue;
+            }
+            ids.push(did);
         }
+        ids
     };
 
-    // 2–4. Validate KP, load group, create commit, merge locally.
-    let (commit_bytes, welcome_bytes, epoch): (Vec<u8>, Vec<u8>, u64) = {
+    if device_ids.is_empty() {
+        return Err(crate::error::Error::Other(anyhow::anyhow!(
+            "No registered devices for {target_user_id}"
+        )));
+    }
+
+    // 2. Claim one KeyPackage per device.
+    let mut kp_bytes_list: Vec<(String, Vec<u8>)> = Vec::new();
+    {
+        let conn = state.remote_db.conn().await?;
+        for did in &device_ids {
+            let mut rows = conn.query(
+                "UPDATE mls_key_package \
+                 SET claimed = 1 \
+                 WHERE ref_hash = ( \
+                     SELECT ref_hash FROM mls_key_package \
+                     WHERE user_id = ?1 AND device_id = ?2 AND claimed = 0 \
+                     ORDER BY created_at ASC LIMIT 1 \
+                 ) \
+                 RETURNING key_package",
+                libsql::params![target_user_id.clone(), did.clone()],
+            ).await?;
+            if let Some(row) = rows.next().await? {
+                kp_bytes_list.push((did.clone(), row.get::<Vec<u8>>(0)?));
+            } else {
+                eprintln!("[mls] add_member: no key package for {target_user_id} device {did} — skipping");
+            }
+        }
+    }
+
+    if kp_bytes_list.is_empty() {
+        return Err(crate::error::Error::Other(anyhow::anyhow!(
+            "No available key packages for any device of {target_user_id}"
+        )));
+    }
+
+    // 3. Validate all KPs, load group, create single commit with all devices.
+    let (commit_bytes, welcome_bytes, epoch, added_device_ids): (Vec<u8>, Vec<u8>, u64, Vec<String>) = {
         let guard = state.local_db.lock().await;
         let db = guard.as_ref().ok_or_else(|| {
             crate::error::Error::Other(anyhow::anyhow!("Not signed in"))
         })?;
         let provider = PollisProvider::new(db.conn());
 
-        // Validate the key package and check identity.
-        let mut kp_reader: &[u8] = &kp_bytes;
-        let kp_in = KeyPackageIn::tls_deserialize(&mut kp_reader)
-            .map_err(|e| crate::error::Error::Other(anyhow::anyhow!("kp deserialize: {e}")))?;
-        let kp = kp_in
-            .validate(provider.crypto(), ProtocolVersion::Mls10)
-            .map_err(|e| crate::error::Error::Other(anyhow::anyhow!("kp validate: {e}")))?;
-        let identity = String::from_utf8_lossy(
-            kp.leaf_node().credential().serialized_content(),
-        )
-        .into_owned();
-        if identity != target_user_id {
+        let mut validated_kps: Vec<KeyPackage> = Vec::new();
+        let mut added_devs: Vec<String> = Vec::new();
+        for (did, kp_raw) in &kp_bytes_list {
+            let mut kp_reader: &[u8] = kp_raw;
+            let kp_in = match KeyPackageIn::tls_deserialize(&mut kp_reader) {
+                Ok(k) => k,
+                Err(e) => {
+                    eprintln!("[mls] add_member: kp deserialize failed for device {did}: {e}");
+                    continue;
+                }
+            };
+            let kp = match kp_in.validate(provider.crypto(), ProtocolVersion::Mls10) {
+                Ok(k) => k,
+                Err(e) => {
+                    eprintln!("[mls] add_member: kp validate failed for device {did}: {e}");
+                    continue;
+                }
+            };
+            // Verify the credential belongs to the target user.
+            let cred_user = parse_credential_user_id(kp.leaf_node().credential());
+            if cred_user != target_user_id {
+                eprintln!("[mls] add_member: credential user '{cred_user}' != '{target_user_id}' for device {did}");
+                continue;
+            }
+            validated_kps.push(kp);
+            added_devs.push(did.clone());
+        }
+
+        if validated_kps.is_empty() {
             return Err(crate::error::Error::Other(anyhow::anyhow!(
-                "KeyPackage identity '{identity}' does not match '{target_user_id}'"
+                "No valid key packages for {target_user_id}"
             )));
         }
 
@@ -567,18 +735,13 @@ async fn add_member_mls_impl(
         let epoch = group.epoch().as_u64();
 
         let (commit_msg, welcome_msg, _group_info) = group
-            .add_members(&provider, &signer, &[kp])
+            .add_members(&provider, &signer, &validated_kps)
             .map_err(|e| crate::error::Error::Other(anyhow::anyhow!("add_members: {e}")))?;
 
-        // Serialize the commit as MlsMessageOut bytes — recipients deserialize
-        // as MlsMessageIn and call process_message / merge_staged_commit.
         let commit_bytes: Vec<u8> = commit_msg
             .tls_serialize_detached()
             .map_err(|e| crate::error::Error::Other(anyhow::anyhow!("commit serialize: {e}")))?;
 
-        // Serialize the welcome message the same way — apply_welcome
-        // deserialises as MlsMessageIn, extracts the Welcome via extract(), and
-        // passes it to StagedWelcome::new_from_welcome.
         let welcome_bytes: Vec<u8> = welcome_msg
             .tls_serialize_detached()
             .map_err(|e| crate::error::Error::Other(anyhow::anyhow!("welcome serialize: {e}")))?;
@@ -587,10 +750,10 @@ async fn add_member_mls_impl(
             .merge_pending_commit(&provider)
             .map_err(|e| crate::error::Error::Other(anyhow::anyhow!("merge commit: {e}")))?;
 
-        (commit_bytes, welcome_bytes, epoch)
+        (commit_bytes, welcome_bytes, epoch, added_devs)
     };
 
-    // 5–6. Post commit + welcome to remote.
+    // 4. Post commit to remote.
     let conn = state.remote_db.conn().await?;
     conn.execute(
         "INSERT INTO mls_commit_log (conversation_id, epoch, sender_id, commit_data) \
@@ -603,12 +766,16 @@ async fn add_member_mls_impl(
         ],
     ).await?;
 
-    let welcome_id = Ulid::new().to_string();
-    conn.execute(
-        "INSERT INTO mls_welcome (id, conversation_id, recipient_id, welcome_data) \
-         VALUES (?1, ?2, ?3, ?4)",
-        libsql::params![welcome_id, conversation_id, target_user_id, welcome_bytes],
-    ).await?;
+    // 5. Post one welcome row per device — same Welcome blob, each device
+    //    processes it independently with its own KeyPackage private key.
+    for did in &added_device_ids {
+        let welcome_id = Ulid::new().to_string();
+        conn.execute(
+            "INSERT INTO mls_welcome (id, conversation_id, recipient_id, recipient_device_id, welcome_data) \
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            libsql::params![welcome_id, conversation_id.clone(), target_user_id.clone(), did.clone(), welcome_bytes.clone()],
+        ).await?;
+    }
 
     Ok(())
 }
@@ -682,17 +849,27 @@ async fn remove_member_mls_impl(
         let (mut group, signer) = load_group_with_signer(&provider, &conversation_id)?;
         let epoch = group.epoch().as_u64();
 
-        // Find the target's leaf index by matching the BasicCredential identity.
-        let target_cred: Credential =
-            BasicCredential::new(target_user_id.as_bytes().to_vec()).into();
-        let leaf_index = group
-            .member_leaf_index(&target_cred)
-            .ok_or_else(|| crate::error::Error::Other(anyhow::anyhow!(
+        // Find ALL leaf indices belonging to the target user (may have
+        // multiple devices, each with its own leaf node).
+        let leaf_indices: Vec<LeafNodeIndex> = group.members()
+            .filter_map(|m| {
+                let cred_user = parse_credential_user_id(&m.credential);
+                if cred_user == target_user_id {
+                    Some(m.index)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        if leaf_indices.is_empty() {
+            return Err(crate::error::Error::Other(anyhow::anyhow!(
                 "'{target_user_id}' is not a member of group {conversation_id}"
-            )))?;
+            )));
+        }
 
         let (commit_msg, _welcome, _group_info) = group
-            .remove_members(&provider, &signer, &[leaf_index])
+            .remove_members(&provider, &signer, &leaf_indices)
             .map_err(|e| crate::error::Error::Other(anyhow::anyhow!("remove_members: {e}")))?;
 
         let commit_bytes = commit_msg
@@ -897,20 +1074,23 @@ pub async fn repair_mls_group(
         "DELETE FROM mls_commit_log WHERE conversation_id = ?1",
         libsql::params![mls_group_id],
     ).await;
+    // Only delete welcomes for THIS conversation — not other conversations
+    // the sender may have pending welcomes for.
     let _ = conn.execute(
-        "DELETE FROM mls_welcome WHERE recipient_id = ?1 AND delivered = 0",
-        libsql::params![sender_id],
+        "DELETE FROM mls_welcome WHERE conversation_id = ?1 AND delivered = 0",
+        libsql::params![mls_group_id],
     ).await;
     drop(conn);
 
-    // 2. Look up all other members. Group channels use `group_member`; DM
-    //    conversations use `dm_channel_member`. Try groups first, fall back to DMs.
+    // 2. Look up all members (including sender — their other devices need
+    //    to be added too). Group channels use `group_member`; DM conversations
+    //    use `dm_channel_member`. Try groups first, fall back to DMs.
     let conn = state.remote_db.conn().await?;
     let mut member_ids: Vec<String> = Vec::new();
     {
         let mut rows = conn.query(
-            "SELECT user_id FROM group_member WHERE group_id = ?1 AND user_id != ?2",
-            libsql::params![mls_group_id, sender_id],
+            "SELECT user_id FROM group_member WHERE group_id = ?1",
+            libsql::params![mls_group_id],
         ).await?;
         while let Some(row) = rows.next().await? {
             member_ids.push(row.get::<String>(0)?);
@@ -918,27 +1098,157 @@ pub async fn repair_mls_group(
     }
     if member_ids.is_empty() {
         let mut rows = conn.query(
-            "SELECT user_id FROM dm_channel_member WHERE dm_channel_id = ?1 AND user_id != ?2",
-            libsql::params![mls_group_id, sender_id],
+            "SELECT user_id FROM dm_channel_member WHERE dm_channel_id = ?1",
+            libsql::params![mls_group_id],
         ).await?;
         while let Some(row) = rows.next().await? {
             member_ids.push(row.get::<String>(0)?);
         }
     }
 
-    // 3. Add each member — this claims their fresh key package and posts a Welcome.
+    // 3. Collect ALL key packages for ALL members' devices in one pass,
+    //    then add them in a single `add_members` call — one commit, one epoch
+    //    advance, instead of M separate commits.
+    let current_device_id = state.device_id.lock().await.clone();
+
+    // (user_id, device_id, kp_bytes) for each device we successfully claim a KP for.
+    let mut claimed_kps: Vec<(String, String, Vec<u8>)> = Vec::new();
+
     for member_id in &member_ids {
-        match add_member_mls_inner(state, mls_group_id, member_id, sender_id).await {
-            Ok(()) => eprintln!("[mls] repair: added {member_id}"),
-            Err(e) => eprintln!("[mls] repair: skipping {member_id} (no key package?): {e}"),
+        // Look up all devices for this member.
+        let mut device_ids: Vec<String> = Vec::new();
+        {
+            let mut rows = conn.query(
+                "SELECT device_id FROM user_device WHERE user_id = ?1",
+                libsql::params![member_id.clone()],
+            ).await?;
+            while let Some(row) = rows.next().await? {
+                let did: String = row.get(0)?;
+                // Exclude the sender's current device (already the group creator).
+                if member_id == sender_id && current_device_id.as_deref() == Some(did.as_str()) {
+                    continue;
+                }
+                device_ids.push(did);
+            }
+        }
+
+        // Claim one KP per device.
+        for did in &device_ids {
+            let mut rows = conn.query(
+                "UPDATE mls_key_package \
+                 SET claimed = 1 \
+                 WHERE ref_hash = ( \
+                     SELECT ref_hash FROM mls_key_package \
+                     WHERE user_id = ?1 AND device_id = ?2 AND claimed = 0 \
+                     ORDER BY created_at ASC LIMIT 1 \
+                 ) \
+                 RETURNING key_package",
+                libsql::params![member_id.clone(), did.clone()],
+            ).await?;
+            if let Some(row) = rows.next().await? {
+                claimed_kps.push((member_id.clone(), did.clone(), row.get::<Vec<u8>>(0)?));
+            } else {
+                eprintln!("[mls] repair: no key package for {member_id} device {did} — skipping");
+            }
         }
     }
+    drop(conn);
 
-    eprintln!("[mls] repair: done — {} members processed", member_ids.len());
+    if claimed_kps.is_empty() {
+        eprintln!("[mls] repair: done — no other devices to add");
+        return Ok(());
+    }
+
+    // 4. Validate all KPs and do a single add_members call.
+    let (commit_bytes, welcome_bytes, epoch, welcome_targets): (Vec<u8>, Vec<u8>, u64, Vec<(String, String)>) = {
+        let guard = state.local_db.lock().await;
+        let db = guard.as_ref().ok_or_else(|| {
+            crate::error::Error::Other(anyhow::anyhow!("Not signed in"))
+        })?;
+        let provider = PollisProvider::new(db.conn());
+
+        let mut validated_kps: Vec<KeyPackage> = Vec::new();
+        let mut targets: Vec<(String, String)> = Vec::new();
+        for (uid, did, kp_raw) in &claimed_kps {
+            let mut kp_reader: &[u8] = kp_raw;
+            let kp_in = match KeyPackageIn::tls_deserialize(&mut kp_reader) {
+                Ok(k) => k,
+                Err(e) => {
+                    eprintln!("[mls] repair: kp deserialize failed for {uid} device {did}: {e}");
+                    continue;
+                }
+            };
+            let kp = match kp_in.validate(provider.crypto(), ProtocolVersion::Mls10) {
+                Ok(k) => k,
+                Err(e) => {
+                    eprintln!("[mls] repair: kp validate failed for {uid} device {did}: {e}");
+                    continue;
+                }
+            };
+            let cred_user = parse_credential_user_id(kp.leaf_node().credential());
+            if cred_user != *uid {
+                eprintln!("[mls] repair: credential user '{cred_user}' != '{uid}' for device {did}");
+                continue;
+            }
+            validated_kps.push(kp);
+            targets.push((uid.clone(), did.clone()));
+        }
+
+        if validated_kps.is_empty() {
+            eprintln!("[mls] repair: done — no valid key packages");
+            return Ok(());
+        }
+
+        let (mut group, signer) = load_group_with_signer(&provider, mls_group_id)?;
+        let epoch = group.epoch().as_u64();
+
+        let (commit_msg, welcome_msg, _group_info) = group
+            .add_members(&provider, &signer, &validated_kps)
+            .map_err(|e| crate::error::Error::Other(anyhow::anyhow!("repair add_members: {e}")))?;
+
+        let commit_bytes = commit_msg
+            .tls_serialize_detached()
+            .map_err(|e| crate::error::Error::Other(anyhow::anyhow!("commit serialize: {e}")))?;
+        let welcome_bytes = welcome_msg
+            .tls_serialize_detached()
+            .map_err(|e| crate::error::Error::Other(anyhow::anyhow!("welcome serialize: {e}")))?;
+
+        group
+            .merge_pending_commit(&provider)
+            .map_err(|e| crate::error::Error::Other(anyhow::anyhow!("merge commit: {e}")))?;
+
+        (commit_bytes, welcome_bytes, epoch, targets)
+    };
+
+    // 5. Post single commit + per-device welcome rows.
+    let conn = state.remote_db.conn().await?;
+    conn.execute(
+        "INSERT INTO mls_commit_log (conversation_id, epoch, sender_id, commit_data) \
+         VALUES (?1, ?2, ?3, ?4)",
+        libsql::params![mls_group_id, epoch as i64, sender_id, commit_bytes],
+    ).await?;
+
+    for (uid, did) in &welcome_targets {
+        let welcome_id = Ulid::new().to_string();
+        conn.execute(
+            "INSERT INTO mls_welcome (id, conversation_id, recipient_id, recipient_device_id, welcome_data) \
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            libsql::params![welcome_id, mls_group_id, uid.clone(), did.clone(), welcome_bytes.clone()],
+        ).await?;
+    }
+
+    eprintln!("[mls] repair: done — {} devices added in 1 commit", welcome_targets.len());
     Ok(())
 }
 
 // ── Phase 5 helpers: encrypt / decrypt ───────────────────────────────────────
+
+/// Check whether an MLS group exists in the local database.
+pub fn has_local_group(conn: &rusqlite::Connection, conversation_id: &str) -> bool {
+    let provider = PollisProvider::new(conn);
+    let group_id = GroupId::from_slice(conversation_id.as_bytes());
+    matches!(MlsGroup::load(provider.storage(), &group_id), Ok(Some(_)))
+}
 
 /// Try to encrypt `plaintext` with the MLS group for `conversation_id`.
 ///
@@ -1001,13 +1311,11 @@ pub fn validate_key_package(
         .validate(crypto, ProtocolVersion::Mls10)
         .map_err(|e| crate::error::Error::Other(anyhow::anyhow!("kp validate: {e}")))?;
 
-    // Verify the credential identity matches the expected user
-    let identity = match kp.leaf_node().credential().serialized_content() {
-        cred_bytes => String::from_utf8_lossy(cred_bytes).into_owned(),
-    };
-    if identity != expected_user_id {
+    // Verify the credential user_id matches the expected user.
+    let cred_user = parse_credential_user_id(kp.leaf_node().credential());
+    if cred_user != expected_user_id {
         return Err(crate::error::Error::Other(anyhow::anyhow!(
-            "KeyPackage identity '{identity}' does not match expected '{expected_user_id}'"
+            "KeyPackage credential user '{cred_user}' does not match expected '{expected_user_id}'"
         )));
     }
 
@@ -1039,6 +1347,12 @@ mod tests {
         conn
     }
 
+    /// Synthetic device ID for test users. In tests each "user" maps to a
+    /// single device so we derive a deterministic device_id from the user_id.
+    fn test_device_id(user_id: &str) -> String {
+        format!("{user_id}_dev")
+    }
+
     /// Create an MLS group with `user_id` as sole member and return the
     /// `SignatureKeyPair` so the caller can later call `create_message`.
     fn create_group(
@@ -1050,13 +1364,13 @@ mod tests {
         let sig_keys = SignatureKeyPair::new(CS.signature_algorithm()).unwrap();
         sig_keys.store(provider.storage()).unwrap();
 
-        let credential = BasicCredential::new(user_id.as_bytes().to_vec());
+        let credential = make_credential(user_id, &test_device_id(user_id));
         let sig_pub = OpenMlsSignaturePublicKey::new(
             sig_keys.to_public_vec().into(),
             CS.signature_algorithm(),
         ).unwrap();
         let cred_with_key = CredentialWithKey {
-            credential: credential.into(),
+            credential,
             signature_key: sig_pub.into(),
         };
 
@@ -1078,13 +1392,13 @@ mod tests {
         let sig_keys = SignatureKeyPair::new(CS.signature_algorithm()).unwrap();
         sig_keys.store(provider.storage()).unwrap();
 
-        let credential = BasicCredential::new(user_id.as_bytes().to_vec());
+        let credential = make_credential(user_id, &test_device_id(user_id));
         let sig_pub = OpenMlsSignaturePublicKey::new(
             sig_keys.to_public_vec().into(),
             CS.signature_algorithm(),
         ).unwrap();
         let cred_with_key = CredentialWithKey {
-            credential: credential.into(),
+            credential,
             signature_key: sig_pub.into(),
         };
 
@@ -1251,13 +1565,21 @@ mod tests {
         let provider = PollisProvider::new(remover_db);
         let (mut group, signer) = load_group_with_signer(&provider, conv_id).unwrap();
 
-        let target_cred: Credential =
-            BasicCredential::new(target_user_id.as_bytes().to_vec()).into();
-        let leaf = group.member_leaf_index(&target_cred)
-            .expect("target must be in group");
+        // Find all leaves for the target user (may have multiple devices).
+        let leaf_indices: Vec<LeafNodeIndex> = group.members()
+            .filter_map(|m| {
+                let cred_user = parse_credential_user_id(&m.credential);
+                if cred_user == target_user_id {
+                    Some(m.index)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        assert!(!leaf_indices.is_empty(), "target must be in group");
 
         let (commit_msg, _, _) =
-            group.remove_members(&provider, &signer, &[leaf]).unwrap();
+            group.remove_members(&provider, &signer, &leaf_indices).unwrap();
         group.merge_pending_commit(&provider).unwrap();
 
         commit_msg.tls_serialize_detached().unwrap()

--- a/src-tauri/src/db/migrations/000011_user_device.sql
+++ b/src-tauri/src/db/migrations/000011_user_device.sql
@@ -1,0 +1,22 @@
+-- Multi-device support: per-device identity and MLS key material.
+-- Run against Turso manually.
+
+-- Track all devices registered to a user.
+CREATE TABLE IF NOT EXISTS user_device (
+    device_id   TEXT PRIMARY KEY,
+    user_id     TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    device_name TEXT,
+    created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    last_seen   TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_device_user ON user_device(user_id);
+
+-- Scope key packages to individual devices.
+ALTER TABLE mls_key_package ADD COLUMN device_id TEXT;
+
+-- Scope welcome delivery to individual devices.
+ALTER TABLE mls_welcome ADD COLUMN recipient_device_id TEXT;
+
+INSERT INTO schema_migrations (version, description) VALUES
+    (11, 'multi-device support: user_device table, device-scoped key packages and welcomes');

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -189,6 +189,7 @@ pub fn run() {
             commands::auth::logout,
             commands::auth::delete_account,
             commands::auth::list_known_accounts,
+            commands::auth::list_user_devices,
             commands::user::get_user_profile,
             commands::user::update_user_profile,
             commands::user::search_user_by_username,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -24,6 +24,9 @@ pub struct AppState {
     pub livekit: Arc<Mutex<LiveKitState>>,
     pub voice: Arc<Mutex<VoiceState>>,
     pub update_required: Arc<AtomicBool>,
+    /// Per-device ULID, set during login. Each physical device gets a stable ID
+    /// stored in the OS keystore so it survives local DB wipes.
+    pub device_id: Arc<Mutex<Option<String>>>,
 }
 
 impl AppState {
@@ -38,6 +41,7 @@ impl AppState {
             livekit: Arc::new(Mutex::new(LiveKitState::new())),
             voice: Arc::new(Mutex::new(VoiceState::new())),
             update_required: Arc::new(AtomicBool::new(false)),
+            device_id: Arc::new(Mutex::new(None)),
         })
     }
 
@@ -63,12 +67,31 @@ impl AppState {
             .unwrap_or(true);
 
         if mls_empty {
+            // Load the device_id from keystore (if it exists yet) to scope the
+            // reset to THIS device only.  Without scoping, resetting all of a
+            // user's welcomes would cause other devices to re-process welcomes
+            // and destroy their working MLS group state.
+            let maybe_device_id = keystore::load_for_user("device_id", user_id).await
+                .ok()
+                .flatten()
+                .and_then(|b| String::from_utf8(b).ok());
+
             match self.remote_db.conn().await {
                 Ok(conn) => {
-                    let _ = conn.execute(
-                        "UPDATE mls_welcome SET delivered = 0 WHERE recipient_id = ?1",
-                        libsql::params![user_id],
-                    ).await;
+                    if let Some(ref did) = maybe_device_id {
+                        let _ = conn.execute(
+                            "UPDATE mls_welcome SET delivered = 0 \
+                             WHERE recipient_id = ?1 AND (recipient_device_id = ?2 OR recipient_device_id IS NULL)",
+                            libsql::params![user_id, did.clone()],
+                        ).await;
+                    } else {
+                        // First login ever (no device_id yet) — safe to reset all
+                        // since no other device can exist for this user yet.
+                        let _ = conn.execute(
+                            "UPDATE mls_welcome SET delivered = 0 WHERE recipient_id = ?1",
+                            libsql::params![user_id],
+                        ).await;
+                    }
                 }
                 Err(e) => {
                     eprintln!("[state] load_user_db: failed to reset mls_welcome (non-fatal): {e}");

--- a/src-tauri/tests/multi_device_messaging.rs
+++ b/src-tauri/tests/multi_device_messaging.rs
@@ -1,0 +1,524 @@
+//! Integration tests for multi-device MLS messaging.
+//!
+//! These tests simulate the actual user journey through Pollis:
+//!   1. User creates a group (on one device)
+//!   2. Creator's other device receives a Welcome
+//!   3. Other users are invited and accept
+//!   4. All devices send messages
+//!   5. All devices decrypt each other's messages
+//!
+//! Each "device" is a separate in-memory SQLite DB (local MLS state) that
+//! interacts through serialised Welcome/commit/ciphertext blobs — the same
+//! data that flows through Turso in production.
+
+use openmls::prelude::*;
+use openmls_basic_credential::SignatureKeyPair;
+use openmls_traits::types::Ciphersuite;
+use pollis_lib::commands::mls::{
+    has_local_group, make_credential, try_mls_decrypt, try_mls_encrypt, PollisProvider,
+};
+use tls_codec::{Deserialize as TlsDeserialize, Serialize as TlsSerialize};
+
+const CS: Ciphersuite = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+
+// ── Device abstraction ──────────────────────────────────────────────────────
+
+/// A simulated device: owns a local MLS database, a user identity, and a
+/// device identity.  Mirrors the per-process state in Pollis (local SQLite +
+/// keystore device_id).
+struct Device {
+    db: rusqlite::Connection,
+    user_id: String,
+    device_id: String,
+}
+
+impl Device {
+    fn new(user_id: &str, device_id: &str) -> Self {
+        let db = rusqlite::Connection::open_in_memory().unwrap();
+        db.execute_batch(
+            "CREATE TABLE mls_kv (
+                scope TEXT NOT NULL,
+                key   BLOB NOT NULL,
+                value BLOB NOT NULL,
+                PRIMARY KEY (scope, key)
+            );",
+        )
+        .unwrap();
+        Self {
+            db,
+            user_id: user_id.to_string(),
+            device_id: device_id.to_string(),
+        }
+    }
+
+    /// Create an MLS group with this device as sole member.
+    /// Mirrors: init_mls_group in auth flow.
+    fn create_group(&self, conv_id: &str) {
+        let provider = PollisProvider::new(&self.db);
+        let sig_keys = SignatureKeyPair::new(CS.signature_algorithm()).unwrap();
+        sig_keys.store(provider.storage()).unwrap();
+
+        let credential = make_credential(&self.user_id, &self.device_id);
+        let sig_pub = OpenMlsSignaturePublicKey::new(
+            sig_keys.to_public_vec().into(),
+            CS.signature_algorithm(),
+        )
+        .unwrap();
+        let cred_with_key = CredentialWithKey {
+            credential,
+            signature_key: sig_pub.into(),
+        };
+
+        let group_id = GroupId::from_slice(conv_id.as_bytes());
+        let config = MlsGroupCreateConfig::builder()
+            .ciphersuite(CS)
+            .use_ratchet_tree_extension(true)
+            .build();
+
+        MlsGroup::new_with_group_id(&provider, &sig_keys, &config, group_id, cred_with_key)
+            .unwrap();
+    }
+
+    /// Generate a KeyPackage for this device.  Returns TLS-serialised bytes
+    /// (what gets stored in `mls_key_package` in Turso).
+    fn generate_key_package(&self) -> Vec<u8> {
+        let provider = PollisProvider::new(&self.db);
+        let sig_keys = SignatureKeyPair::new(CS.signature_algorithm()).unwrap();
+        sig_keys.store(provider.storage()).unwrap();
+
+        let credential = make_credential(&self.user_id, &self.device_id);
+        let sig_pub = OpenMlsSignaturePublicKey::new(
+            sig_keys.to_public_vec().into(),
+            CS.signature_algorithm(),
+        )
+        .unwrap();
+        let cred_with_key = CredentialWithKey {
+            credential,
+            signature_key: sig_pub.into(),
+        };
+
+        let bundle = KeyPackage::builder()
+            .build(CS, &provider, &sig_keys, cred_with_key)
+            .unwrap();
+
+        bundle.key_package().tls_serialize_detached().unwrap()
+    }
+
+    /// Add members (by their key packages) to this device's group.
+    /// Returns (commit_bytes, welcome_bytes).
+    /// Mirrors: add_member_mls_impl
+    fn add_members(&self, conv_id: &str, kp_list: &[Vec<u8>]) -> (Vec<u8>, Vec<u8>) {
+        let provider = PollisProvider::new(&self.db);
+        let (mut group, signer) = load_group(&provider, conv_id);
+
+        let validated: Vec<KeyPackage> = kp_list
+            .iter()
+            .map(|raw| {
+                let mut reader: &[u8] = raw;
+                let kp_in = KeyPackageIn::tls_deserialize(&mut reader).unwrap();
+                kp_in
+                    .validate(provider.crypto(), ProtocolVersion::Mls10)
+                    .unwrap()
+            })
+            .collect();
+
+        let (commit, welcome, _) = group.add_members(&provider, &signer, &validated).unwrap();
+        group.merge_pending_commit(&provider).unwrap();
+
+        (
+            commit.tls_serialize_detached().unwrap(),
+            welcome.tls_serialize_detached().unwrap(),
+        )
+    }
+
+    /// Apply a Welcome message (join the group for the first time).
+    /// Mirrors: apply_welcome / poll_mls_welcomes_inner
+    fn apply_welcome(&self, welcome_bytes: &[u8]) {
+        let provider = PollisProvider::new(&self.db);
+
+        // Delete any stale group first (mirrors apply_welcome in production).
+        let mut reader: &[u8] = welcome_bytes;
+        let msg_in = MlsMessageIn::tls_deserialize(&mut reader).unwrap();
+        let welcome = match msg_in.extract() {
+            MlsMessageBodyIn::Welcome(w) => w,
+            _ => panic!("expected Welcome"),
+        };
+
+        let join_config = MlsGroupJoinConfig::builder()
+            .use_ratchet_tree_extension(true)
+            .build();
+        let processed = ProcessedWelcome::new_from_welcome(&provider, &join_config, welcome)
+            .unwrap();
+        let new_group_id = processed.unverified_group_info().group_id().clone();
+        if let Ok(Some(mut old)) = MlsGroup::load(provider.storage(), &new_group_id) {
+            let _ = old.delete(provider.storage());
+        }
+        let staged = processed.into_staged_welcome(&provider, None).unwrap();
+        staged.into_group(&provider).unwrap();
+    }
+
+    /// Apply a serialised commit to advance this device's epoch.
+    /// Mirrors: process_pending_commits_inner
+    fn apply_commit(&self, conv_id: &str, commit_bytes: &[u8]) {
+        let provider = PollisProvider::new(&self.db);
+        let group_id = GroupId::from_slice(conv_id.as_bytes());
+        let mut group = MlsGroup::load(provider.storage(), &group_id)
+            .unwrap()
+            .expect("group must exist to apply commit");
+
+        let mut reader: &[u8] = commit_bytes;
+        let msg_in = MlsMessageIn::tls_deserialize(&mut reader).unwrap();
+        let protocol_msg = msg_in.try_into_protocol_message().unwrap();
+        let processed = group.process_message(&provider, protocol_msg).unwrap();
+        if let ProcessedMessageContent::StagedCommitMessage(staged) = processed.into_content() {
+            group.merge_staged_commit(&provider, *staged).unwrap();
+        }
+    }
+
+    /// Encrypt plaintext.  Mirrors: try_mls_encrypt
+    fn encrypt(&self, conv_id: &str, plaintext: &[u8]) -> Vec<u8> {
+        try_mls_encrypt(&self.db, conv_id, plaintext).expect("encrypt should succeed")
+    }
+
+    /// Decrypt ciphertext.  Mirrors: try_mls_decrypt
+    fn decrypt(&self, conv_id: &str, ciphertext: &[u8]) -> Vec<u8> {
+        try_mls_decrypt(&self.db, conv_id, ciphertext).expect("decrypt should succeed")
+    }
+
+    fn has_group(&self, conv_id: &str) -> bool {
+        has_local_group(&self.db, conv_id)
+    }
+
+    fn epoch(&self, conv_id: &str) -> u64 {
+        let provider = PollisProvider::new(&self.db);
+        let group_id = GroupId::from_slice(conv_id.as_bytes());
+        MlsGroup::load(provider.storage(), &group_id)
+            .unwrap()
+            .expect("group must exist")
+            .epoch()
+            .as_u64()
+    }
+}
+
+fn load_group<'a>(
+    provider: &PollisProvider<'a>,
+    conv_id: &str,
+) -> (MlsGroup, SignatureKeyPair) {
+    let group_id = GroupId::from_slice(conv_id.as_bytes());
+    let group = MlsGroup::load(provider.storage(), &group_id)
+        .unwrap()
+        .expect("group must exist");
+
+    let own_leaf = group.own_leaf_node().unwrap();
+    let sig_ref = own_leaf.signature_key().as_slice();
+    let signer = SignatureKeyPair::read(
+        provider.storage(),
+        sig_ref,
+        group.ciphersuite().signature_algorithm(),
+    )
+    .expect("signer must exist");
+
+    (group, signer)
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+//  Test: full multi-device group creation and messaging
+//
+//  This mirrors the exact dev-multi.sh scenario:
+//    dan-d1  creates a group
+//    dan-d2  (same user, different device) receives Welcome
+//    guy     is invited by dan-d1, accepts
+//    ants    is invited by dan-d1, accepts
+//    Everyone sends a message, everyone decrypts all messages.
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn full_group_lifecycle_with_multi_device() {
+    let conv_id = "01JINTEGRATION_FULL_LIFECYCLE";
+
+    // ── Set up devices ──────────────────────────────────────────────────
+    let dan_d1 = Device::new("dan", "dan_device_1");
+    let dan_d2 = Device::new("dan", "dan_device_2");
+    let guy = Device::new("guy", "guy_device_1");
+    let ants = Device::new("ants", "ants_device_1");
+
+    // ── Step 1: dan-d1 creates the group ────────────────────────────────
+    dan_d1.create_group(conv_id);
+    assert!(dan_d1.has_group(conv_id));
+    assert!(!dan_d2.has_group(conv_id));
+
+    // ── Step 2: add dan-d2 (creator's other device) ─────────────────────
+    // Mirrors: add_member_mls_for_own_devices in create_group
+    let dan_d2_kp = dan_d2.generate_key_package();
+    let (_add_d2_commit, dan_d2_welcome) = dan_d1.add_members(conv_id, &[dan_d2_kp]);
+    // dan-d2 receives Welcome (via poll_mls_welcomes)
+    dan_d2.apply_welcome(&dan_d2_welcome);
+    assert!(dan_d2.has_group(conv_id));
+
+    // ── Step 3: dan-d1 invites guy ──────────────────────────────────────
+    // Mirrors: send_group_invite → add_member_mls_inner
+    let guy_kp = guy.generate_key_package();
+    let (add_guy_commit, guy_welcome) = dan_d1.add_members(conv_id, &[guy_kp]);
+
+    // dan-d2 must process the commit to stay in sync (via process_pending_commits)
+    dan_d2.apply_commit(conv_id, &add_guy_commit);
+
+    // guy accepts invite, polls welcomes
+    guy.apply_welcome(&guy_welcome);
+    assert!(guy.has_group(conv_id));
+
+    // ── Step 4: dan-d1 invites ants ─────────────────────────────────────
+    let ants_kp = ants.generate_key_package();
+    let (add_ants_commit, ants_welcome) = dan_d1.add_members(conv_id, &[ants_kp]);
+
+    // Both dan-d2 and guy must process this commit
+    dan_d2.apply_commit(conv_id, &add_ants_commit);
+    guy.apply_commit(conv_id, &add_ants_commit);
+
+    ants.apply_welcome(&ants_welcome);
+    assert!(ants.has_group(conv_id));
+
+    // ── Step 5: verify all devices are at the same epoch ────────────────
+    let expected_epoch = dan_d1.epoch(conv_id);
+    assert_eq!(dan_d2.epoch(conv_id), expected_epoch, "dan-d2 epoch mismatch");
+    assert_eq!(guy.epoch(conv_id), expected_epoch, "guy epoch mismatch");
+    assert_eq!(ants.epoch(conv_id), expected_epoch, "ants epoch mismatch");
+
+    // ── Step 6: everyone sends, everyone decrypts ───────────────────────
+    let all_devices: Vec<&Device> = vec![&dan_d1, &dan_d2, &guy, &ants];
+    let messages = [
+        (&dan_d1, b"message from dan device 1" as &[u8]),
+        (&dan_d2, b"message from dan device 2" as &[u8]),
+        (&guy, b"message from guy" as &[u8]),
+        (&ants, b"message from ants" as &[u8]),
+    ];
+
+    for (sender, plaintext) in &messages {
+        let ct = sender.encrypt(conv_id, plaintext);
+
+        for receiver in &all_devices {
+            // The sender can't decrypt their own MLS application message
+            // (MLS spec: sender skips self), so skip same-device.
+            if std::ptr::eq(*sender, *receiver) {
+                continue;
+            }
+            let decrypted = receiver.decrypt(conv_id, &ct);
+            assert_eq!(
+                &decrypted, plaintext,
+                "{} failed to decrypt message from {}",
+                receiver.device_id, sender.device_id
+            );
+        }
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+//  Test: late-joining device catches up via commits
+//
+//  dan-d1 creates group, invites guy and ants. THEN dan-d2 joins via
+//  Welcome and must process all pending commits to reach current epoch
+//  before it can decrypt messages.
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn late_joining_device_catches_up_via_commits() {
+    let conv_id = "01JINTEGRATION_LATE_JOIN";
+
+    let dan_d1 = Device::new("dan", "dan_d1");
+    let dan_d2 = Device::new("dan", "dan_d2");
+    let guy = Device::new("guy", "guy_d1");
+    let ants = Device::new("ants", "ants_d1");
+
+    // dan-d1 creates group
+    dan_d1.create_group(conv_id);
+
+    // dan-d1 adds dan-d2 immediately (but d2 doesn't apply Welcome yet)
+    let dan_d2_kp = dan_d2.generate_key_package();
+    let (_add_d2_commit, dan_d2_welcome) = dan_d1.add_members(conv_id, &[dan_d2_kp]);
+
+    // dan-d1 adds guy
+    let guy_kp = guy.generate_key_package();
+    let (add_guy_commit, guy_welcome) = dan_d1.add_members(conv_id, &[guy_kp]);
+    guy.apply_welcome(&guy_welcome);
+
+    // dan-d1 adds ants
+    let ants_kp = ants.generate_key_package();
+    let (add_ants_commit, ants_welcome) = dan_d1.add_members(conv_id, &[ants_kp]);
+    guy.apply_commit(conv_id, &add_ants_commit);
+    ants.apply_welcome(&ants_welcome);
+
+    // NOW dan-d2 finally comes online, applies Welcome, then catches up
+    // with all the commits it missed.
+    dan_d2.apply_welcome(&dan_d2_welcome);
+    // dan-d2 is at epoch 1 (from Welcome).  Needs to process commits from
+    // epoch 1 (add guy) and epoch 2 (add ants) to reach epoch 3.
+    dan_d2.apply_commit(conv_id, &add_guy_commit);
+    dan_d2.apply_commit(conv_id, &add_ants_commit);
+
+    // Verify all at same epoch
+    let expected = dan_d1.epoch(conv_id);
+    assert_eq!(dan_d2.epoch(conv_id), expected);
+    assert_eq!(guy.epoch(conv_id), expected);
+    assert_eq!(ants.epoch(conv_id), expected);
+
+    // guy sends — all 4 devices decrypt
+    let ct = guy.encrypt(conv_id, b"hey everyone");
+    assert_eq!(dan_d1.decrypt(conv_id, &ct), b"hey everyone");
+    assert_eq!(dan_d2.decrypt(conv_id, &ct), b"hey everyone");
+    assert_eq!(ants.decrypt(conv_id, &ct), b"hey everyone");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+//  Test: invite flow (accept_group_invite path)
+//
+//  Mirrors the invite flow: dan creates group, sends invite to guy.
+//  guy accepts → polls welcomes → enters channel → decrypts.
+//  dan's second device also receives messages from guy.
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn invite_flow_both_creator_devices_and_invitee_communicate() {
+    let conv_id = "01JINTEGRATION_INVITE_FLOW";
+
+    let dan_d1 = Device::new("dan", "dan_d1");
+    let dan_d2 = Device::new("dan", "dan_d2");
+    let guy = Device::new("guy", "guy_d1");
+
+    // dan-d1 creates, immediately adds dan-d2
+    dan_d1.create_group(conv_id);
+    let d2_kp = dan_d2.generate_key_package();
+    let (d2_commit, d2_welcome) = dan_d1.add_members(conv_id, &[d2_kp]);
+    dan_d2.apply_welcome(&d2_welcome);
+    let _ = d2_commit;
+
+    // dan-d1 sends invite to guy (pre-generates Welcome)
+    let guy_kp = guy.generate_key_package();
+    let (guy_commit, guy_welcome) = dan_d1.add_members(conv_id, &[guy_kp]);
+
+    // dan-d2 processes the commit (stays in sync)
+    dan_d2.apply_commit(conv_id, &guy_commit);
+
+    // guy accepts invite → polls welcomes
+    guy.apply_welcome(&guy_welcome);
+
+    // guy sends a message
+    let ct = guy.encrypt(conv_id, b"I'm in!");
+
+    // Both dan devices decrypt
+    assert_eq!(dan_d1.decrypt(conv_id, &ct), b"I'm in!");
+    assert_eq!(dan_d2.decrypt(conv_id, &ct), b"I'm in!");
+
+    // dan-d1 replies — guy and dan-d2 decrypt
+    let reply = dan_d1.encrypt(conv_id, b"welcome!");
+    assert_eq!(guy.decrypt(conv_id, &reply), b"welcome!");
+    assert_eq!(dan_d2.decrypt(conv_id, &reply), b"welcome!");
+
+    // dan-d2 replies — guy and dan-d1 decrypt
+    let d2_msg = dan_d2.encrypt(conv_id, b"hello from d2");
+    assert_eq!(guy.decrypt(conv_id, &d2_msg), b"hello from d2");
+    assert_eq!(dan_d1.decrypt(conv_id, &d2_msg), b"hello from d2");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+//  Test: device without Welcome can't decrypt but doesn't break others
+//
+//  Simulates a stale device that has no key package and thus never gets a
+//  Welcome.  It should NOT be able to decrypt, but it must not corrupt the
+//  group state for other devices.
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn stale_device_without_welcome_cannot_decrypt_but_others_unaffected() {
+    let conv_id = "01JINTEGRATION_STALE_DEVICE";
+
+    let dan_d1 = Device::new("dan", "dan_d1");
+    let dan_stale = Device::new("dan", "dan_stale");
+    let guy = Device::new("guy", "guy_d1");
+
+    // dan-d1 creates group.  dan_stale has no KPs so is NOT added.
+    dan_d1.create_group(conv_id);
+
+    // Only add guy (dan_stale is skipped in production because no KPs).
+    let guy_kp = guy.generate_key_package();
+    let (_commit, guy_welcome) = dan_d1.add_members(conv_id, &[guy_kp]);
+    guy.apply_welcome(&guy_welcome);
+
+    // dan_stale does NOT have the group
+    assert!(!dan_stale.has_group(conv_id));
+
+    // dan-d1 and guy can still communicate
+    let ct = dan_d1.encrypt(conv_id, b"only d1 and guy");
+    assert_eq!(guy.decrypt(conv_id, &ct), b"only d1 and guy");
+
+    let reply = guy.encrypt(conv_id, b"yep, works");
+    assert_eq!(dan_d1.decrypt(conv_id, &reply), b"yep, works");
+
+    // dan_stale cannot decrypt (no group state)
+    assert!(try_mls_decrypt(&dan_stale.db, conv_id, &ct).is_none());
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+//  Test: multiple messages in sequence (epoch ratchet)
+//
+//  MLS application messages advance the sender's ratchet.  Verify that
+//  a burst of messages from one device is still decryptable by all others.
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn burst_of_messages_all_decrypt_in_order() {
+    let conv_id = "01JINTEGRATION_MSG_BURST";
+
+    let dan_d1 = Device::new("dan", "dan_d1");
+    let dan_d2 = Device::new("dan", "dan_d2");
+    let guy = Device::new("guy", "guy_d1");
+
+    dan_d1.create_group(conv_id);
+
+    let d2_kp = dan_d2.generate_key_package();
+    let (d2_commit, d2_welcome) = dan_d1.add_members(conv_id, &[d2_kp]);
+    dan_d2.apply_welcome(&d2_welcome);
+    let _ = d2_commit;
+
+    let guy_kp = guy.generate_key_package();
+    let (guy_commit, guy_welcome) = dan_d1.add_members(conv_id, &[guy_kp]);
+    dan_d2.apply_commit(conv_id, &guy_commit);
+    guy.apply_welcome(&guy_welcome);
+
+    // dan-d1 sends 5 messages in a row
+    let mut ciphertexts = Vec::new();
+    for i in 0..5 {
+        let msg = format!("message {i}");
+        ciphertexts.push((msg.clone(), dan_d1.encrypt(conv_id, msg.as_bytes())));
+    }
+
+    // dan-d2 and guy decrypt all 5 in order
+    for (expected, ct) in &ciphertexts {
+        assert_eq!(
+            String::from_utf8(dan_d2.decrypt(conv_id, ct)).unwrap(),
+            *expected
+        );
+        assert_eq!(
+            String::from_utf8(guy.decrypt(conv_id, ct)).unwrap(),
+            *expected
+        );
+    }
+
+    // Now guy sends 3 messages
+    let mut guy_cts = Vec::new();
+    for i in 0..3 {
+        let msg = format!("guy says {i}");
+        guy_cts.push((msg.clone(), guy.encrypt(conv_id, msg.as_bytes())));
+    }
+
+    // Both dan devices decrypt
+    for (expected, ct) in &guy_cts {
+        assert_eq!(
+            String::from_utf8(dan_d1.decrypt(conv_id, ct)).unwrap(),
+            *expected
+        );
+        assert_eq!(
+            String::from_utf8(dan_d2.decrypt(conv_id, ct)).unwrap(),
+            *expected
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Closes #20, closes #125. Each physical device is now an independent MLS leaf node — a user can log in on multiple devices and all of them participate in every group/DM conversation as first-class members. A stable per-device ULID lives in the OS keystore and is registered in the `user_device` table.

The starting commit (`3304fae`) introduced the core MLS plumbing: device-scoped credentials (`user_id:device_id`), device-scoped key packages/welcomes/commits, `add_member` batching all of a user's devices into a single commit, and a new `000011_user_device` migration. The rest of this PR is everything that had to change after testing four concurrent clients (two of which were devices of the same user) against that foundation.

## What was broken after the initial implementation, and how it's fixed

### LiveKit identity collisions

Two devices for the same user were using `user_id` as their LiveKit participant identity, so they kicked each other out of every room in a reconnect loop.

- `connect_rooms` now builds the identity as `user_id:device_id`
- Token generation and the reconnect loop use the compound identity
- Participant disconnect handlers and online-user sets split on `:` to recover the user_id

### Frontend swallowing its own user's realtime events

`useLiveKitRealtime` was skipping any `new_message`/`edited_message` event whose `sender_id` matched the current user. That's correct for single-device, but in multi-device it means device 2 never sees device 1's sends. LiveKit doesn't echo data to the sender, so the skip was redundant anyway.

- Removed the `sender_id === currentUser.id` skip for message events
- Re-added a **targeted** version of the skip for notifications only: unread badges, the bottom-right DM blinking indicator, and OS notifications are suppressed when the message came from the same user on another device. Cache invalidation and last-message preview still run so the conversation stays in sync.

### Creator's other devices missing from new groups

`create_group` and `create_dm_channel` only initialized the MLS group on the creating device. The creator's second device got nothing.

- Added `add_member_mls_for_own_devices` — after `init_mls_group`, adds the user's other devices (no-op if single device, ignores "no registered devices / no unclaimed key packages" errors)
- Called from both `create_group` and `create_dm_channel`

### Stale devices poisoning group setup

Old device rows left over from earlier testing with zero unclaimed key packages were being selected as invite targets, logged as "skipped", and blocking the invite flow.

- `add_member_mls_impl` device query now filters at the SQL level via `EXISTS (SELECT 1 FROM mls_key_package WHERE claimed = 0 ...)`, so devices without key packages are never returned in the first place

### Welcomes never being polled before MLS operations

`get_channel_messages`, `get_dm_messages`, and `send_message` all tried to process commits or encrypt before pulling pending Welcomes. A device that had been invited but hadn't yet joined the group would fail every operation.

- Added `poll_mls_welcomes_inner` as the first step in all three paths, ahead of `process_pending_commits_inner` and encryption

### `repair_mls_group` destroying shared state

`repair_mls_group` deleted every row from `mls_commit_log` and created an independent group from scratch. Any device that triggered it broke the group for everyone else, and because it was wired into the message read path, it could trigger spontaneously.

- Removed all callers from `get_channel_messages`, `get_dm_messages`, and `send_message`
- Replaced with warning logs on read (`[messages] MLS group ... missing locally`) and a hard error on send (`MLS group not available — this device hasn't received a Welcome yet`)

### Membership changes not updating member lists on other clients

When a user accepted an invite or had their join request approved, the existing group members were never notified — the admin's sidebar didn't show the new member as admin because the `useGroupMembers` query sat cached for 30s. Only the joiner received a `membership_changed` event (on their inbox).

- `approve_join_request` now also broadcasts `membership_changed` to the group room via the admin's existing LiveKit connection
- `accept_group_invite` uses a new `publish_to_room_server` helper that connects as a temporary "server" participant to the group room and publishes (the accepting user isn't connected to the room yet)
- `membership_changed` events now include a `group_id` field
- Frontend handler relies on the existing `['groups']` prefix invalidation, which already covers `["groups", groupId, "members"]`

## Other changes

- **Debug device panel** — new `list_user_devices` command and `window.__POLLIS_DEBUG__.listDevices()` helper for inspecting a user's registered devices in the console during testing
- **Default channels on group creation** — every new group now gets a `#General` text channel and a `Voice Chat` voice channel, inserted in a single multi-row INSERT
- **`dev-multi.sh` docs** — README section explaining how to spin up 4 concurrent instances (two devices of one user + two other users) via `POLLIS_DATA_DIR` isolation
- **`DEV_EMAIL` env var** — auto-logs in the dev instance so restarting four clients doesn't mean typing four emails

## Integration tests

Added `src-tauri/tests/multi_device_messaging.rs` — these run as cargo integration tests (separate compilation unit) so they don't interfere with the manual dev-multi flow. Each test wires up multiple `Device` structs with their own in-memory SQLite DBs and passes serialized Welcome/commit/ciphertext blobs between them, simulating the real wire format.

Covers:
- Full group lifecycle with the dev-multi scenario (creator with 2 devices + 2 other users)
- Late-joining device catches up via commit backlog after applying its Welcome
- Invite flow where both of the creator's devices and the invitee all communicate
- Stale device without a Welcome can't decrypt, but other participants are unaffected
- Burst of sequential messages from one device all decrypt in order

## Known limitations / follow-ups

- **Existing prod groups**: single-device users on their original device keep working, but existing groups don't support multi-device — no Welcomes were ever generated for second devices on groups created before this PR. A second device on an old group, or any local DB wipe, is unrecoverable because repair is gone. New groups created after merge are fully multi-device capable.
- **Existing prod key packages**: they're in the old `user_id`-only credential format, so adding an existing user to a *new* group may fail until they re-register key packages.
- **Remove/leave member notifications**: `remove_member_from_group` and `leave_group` don't yet broadcast `membership_changed` to the group room. Out of scope for this PR; the reported bug was only on join.

## Test plan

- [x] `pnpm dev` with a single device — create group, send/receive messages, add channels
- [ ] `scripts/dev-multi.sh` with 4 clients — create group on device 1, verify device 2 receives Welcome and can send/decrypt immediately
- [x] Invite other 2 users, verify all 4 clients send and receive every message
- [x] Join-request flow: new user requests access, admin approves, verify member list updates on all existing clients without a relaunch
- [x] Send a DM from device 1, verify device 2 sees the message in the conversation but does **not** badge/blink/show an OS notification
- [x] Verify default `#General` and `Voice Chat` channels exist in every new group
- [x] `cargo test --manifest-path src-tauri/Cargo.toml` — all unit + integration tests pass