### PR TITLE
voice_presence + OTP auto + UI polish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,8 +119,16 @@ frontend/               # React app (Vite, TypeScript, TailwindCSS)
     types/              # TypeScript types
     components/         # React components
     pages/              # Route pages
-website/                # Next.js marketing site (Vercel)
+website/                # Static HTML marketing site (Cloudflare Pages)
 ```
+
+## Media (voice / video)
+
+**All real-time media is handled in Rust, end to end.** Voice is implemented in `src-tauri/src/commands/voice.rs` using the `livekit` + `libwebrtc` crates (capture via `cpal`, publish via `NativeAudioSource` / `LocalAudioTrack`, playback via `NativeAudioStream` → cpal output).
+
+**Why Rust and not the webview**: Tauri's webview on Linux (WebKitGTK) does not support WebRTC. `getUserMedia`, `RTCPeerConnection`, etc. are unavailable. This means the "use livekit-client JS SDK in the webview" approach is NOT an option on our target platforms — do not suggest it. Any media feature (voice, video, screen share) must be implemented in Rust using the `livekit` crate directly and wired to Tauri commands. Frames are pushed to the frontend via `tauri::ipc::Channel` for UI purposes only (speaking indicators, participant events), never for rendering media itself.
+
+**Implication for future video**: video capture, publish, subscribe, and render must all run in Rust. Remote video frames cannot be handed to a `<video>` element via `srcObject` because there is no `MediaStream` in the webview. Rendering requires either a native OS surface layered behind the webview or pushing decoded frames to the frontend via IPC (latter is fine for small previews, not for real video).
 
 ## Security Model
 

--- a/frontend/src/components/Auth/EmailOTPAuth.tsx
+++ b/frontend/src/components/Auth/EmailOTPAuth.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import * as api from '../../services/api';
 import type { User } from '../../types';
 import { Button } from '../ui/Button';
@@ -21,6 +21,20 @@ export const EmailOTPAuth: React.FC<EmailOTPAuthProps> = ({ onSuccess, prefillEm
   const [otp, setOtp] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const hasAutoSubmittedRef = useRef(false);
+
+  useEffect(() => {
+    if (otp.length < 6) {
+      hasAutoSubmittedRef.current = false;
+      return;
+    }
+    if (hasAutoSubmittedRef.current || isLoading || error) {
+      return;
+    }
+    hasAutoSubmittedRef.current = true;
+    handleVerifyOTP();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [otp]);
 
   // Fire whenever the parent bumps the nonce (chip click). Skip nonce === 0
   // (initial mount) so we don't send a spurious request on page load.

--- a/frontend/src/components/Message/MessageItem.tsx
+++ b/frontend/src/components/Message/MessageItem.tsx
@@ -195,7 +195,7 @@ export const MessageItem: React.FC<MessageItemProps> = ({
 
       {/* Attachments — each on its own row */}
       {sortedAttachments && (
-        <div className="mt-1 flex flex-col gap-2">
+        <div className="mt-2 flex flex-col gap-2">
           {sortedAttachments.map((a) => (
             <AttachmentDisplay key={a.id} attachment={a} />
           ))}
@@ -271,7 +271,7 @@ const formatDuration = (seconds: number): string => {
 const lightboxBtnStyle: React.CSSProperties = {
   color: "var(--c-accent)",
   background: "none",
-  border: "1px solid transparent",
+  border: "2px solid transparent",
   borderRadius: 4,
   cursor: "pointer",
   padding: "2px 8px",
@@ -394,7 +394,10 @@ const AttachmentDisplay: React.FC<{ attachment: MessageAttachment }> = ({ attach
 
   // Auto-load images and audio from R2 once confirmed (object_key populated, no local URL).
   useEffect(() => {
-    if ((!isImage && !isAudio) || isPending || downloadUrl) { return; }
+    if ((!isImage && !isAudio) || isPending || downloadUrl) {
+      return;
+    }
+
     let mounted = true;
     setIsLoading(true);
     downloadAndDecryptMedia(
@@ -526,7 +529,6 @@ const AttachmentDisplay: React.FC<{ attachment: MessageAttachment }> = ({ attach
   const renderCaptionBar = (extra?: React.ReactNode) => (
     <div
       className="flex items-center gap-2 px-2 py-1"
-      style={{ borderTop: "1px solid var(--c-border)" }}
     >
       <span
         className="flex-1 min-w-0 text-xs font-mono truncate"
@@ -697,7 +699,6 @@ const AttachmentDisplay: React.FC<{ attachment: MessageAttachment }> = ({ attach
             <div
               className="flex items-center gap-2 px-3 py-2"
               style={{
-                border: "1px solid var(--c-border)",
                 background: "var(--c-surface-high)",
                 borderRadius: 8,
               }}

--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -27,7 +27,7 @@ export const Card: React.FC<CardProps> = ({
     className={className}
     style={{
       background: "var(--c-surface)",
-      border: "1px solid var(--c-border)",
+      border: "2px solid var(--c-border)",
       borderRadius: "6px",
       padding: paddingMap[padding],
       ...style,

--- a/frontend/src/components/ui/InlineAudioPlayer.tsx
+++ b/frontend/src/components/ui/InlineAudioPlayer.tsx
@@ -82,9 +82,9 @@ export const InlineAudioPlayer: React.FC<InlineAudioPlayerProps> = ({
 
   return (
     <div
-      className={`flex items-center gap-3 p-2 rounded-md ${className}`}
+      className={`flex items-center gap-3 p-2 rounded-lg ${className}`}
       style={{
-        border: "1px solid var(--c-border)",
+        border: "2px solid var(--c-border)",
         background: "var(--c-surface-high)",
         cursor: onClick ? "pointer" : "default",
       }}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -7,47 +7,57 @@
 @layer base {
   :root {
     /* ── Theme knobs — change these at runtime to retheme the app ── */
-    --accent-h:      38;     /* hue 0–360  */
-    --accent-s:      90%;    /* saturation */
-    --accent-l:      62%;    /* lightness  */
-    --bg-h:          38;     /* background hue */
-    --bg-s:          20%;    /* background saturation */
-    --bg-l:          4%;     /* background lightness */
-    --font-size-base: 15px;  /* base font size — scales all rem units */
+    --accent-h: 38;
+    /* hue 0–360  */
+    --accent-s: 90%;
+    /* saturation */
+    --accent-l: 62%;
+    /* lightness  */
+    --bg-h: 38;
+    /* background hue */
+    --bg-s: 20%;
+    /* background saturation */
+    --bg-l: 4%;
+    /* background lightness */
+    --font-size-base: 15px;
+    /* base font size — scales all rem units */
 
     /* ── Surfaces (dark, hue-tinted) ──────────────────────────────── */
-    --c-bg:             hsl(var(--bg-h) var(--bg-s) var(--bg-l));
-    --c-surface:        hsl(var(--bg-h) var(--bg-s) calc(var(--bg-l) + 3%));
+    --c-bg: hsl(var(--bg-h) var(--bg-s) var(--bg-l));
+    --c-surface: hsl(var(--bg-h) var(--bg-s) calc(var(--bg-l) + 3%));
     --c-surface-raised: hsl(var(--bg-h) var(--bg-s) calc(var(--bg-l) + 6%));
-    --c-surface-high:   hsl(var(--bg-h) var(--bg-s) calc(var(--bg-l) + 9%));
+    --c-surface-high: hsl(var(--bg-h) var(--bg-s) calc(var(--bg-l) + 9%));
 
     /* ── Accent scale ──────────────────────────────────────────────── */
-    --c-accent:         hsl(var(--accent-h) var(--accent-s) var(--accent-l));
-    --c-accent-bright:  hsl(var(--accent-h) var(--accent-s) calc(var(--accent-l) + 13%));
-    --c-accent-dim:     hsl(var(--accent-h) 45% 45%);
-    --c-accent-muted:   hsl(var(--accent-h) 35% 25%);
+    --c-accent: hsl(var(--accent-h) var(--accent-s) var(--accent-l));
+    --c-accent-bright: hsl(var(--accent-h) var(--accent-s) calc(var(--accent-l) + 13%));
+    --c-accent-dim: hsl(var(--accent-h) 45% 45%);
+    --c-accent-muted: hsl(var(--accent-h) 35% 25%);
 
     /* ── Borders ───────────────────────────────────────────────────── */
-    --c-border:         hsl(var(--accent-h) var(--accent-s) var(--accent-l) / 22%);
-    --c-border-active:  hsl(var(--accent-h) var(--accent-s) var(--accent-l) / 50%);
+    --c-border: hsl(var(--accent-h) var(--accent-s) var(--accent-l) / 22%);
+    --c-border-active: hsl(var(--accent-h) var(--accent-s) var(--accent-l) / 50%);
 
     /* ── Text — explicit lightness (not opacity) for readable contrast */
-    --c-text:           hsl(var(--accent-h) var(--accent-s) var(--accent-l));
-    --c-text-dim:       hsl(var(--accent-h) 28% 70%);  /* secondary text */
-    --c-text-muted:     hsl(var(--accent-h) 18% 55%);  /* tertiary text  */
+    --c-text: hsl(var(--accent-h) var(--accent-s) var(--accent-l));
+    --c-text-dim: hsl(var(--accent-h) 28% 70%);
+    /* secondary text */
+    --c-text-muted: hsl(var(--accent-h) 18% 55%);
+    /* tertiary text  */
 
     /* ── Hover overlays ────────────────────────────────────────────── */
-    --c-hover:          hsl(var(--accent-h) var(--accent-s) var(--accent-l) / 8%);
-    --c-active:         hsl(var(--accent-h) var(--accent-s) var(--accent-l) / 14%);
+    --c-hover: hsl(var(--accent-h) var(--accent-s) var(--accent-l) / 8%);
+    --c-active: hsl(var(--accent-h) var(--accent-s) var(--accent-l) / 14%);
 
     /* ── Focus ring (used by all input components) ──────────────── */
-    --c-focus-ring:     hsl(var(--accent-h) var(--accent-s) var(--accent-l) / 22%);
+    --c-focus-ring: hsl(var(--accent-h) var(--accent-s) var(--accent-l) / 22%);
 
     --font-mono: 'Atkinson Hyperlegible Mono', ui-monospace, monospace;
     --font-sans: 'Atkinson Hyperlegible Next', system-ui, sans-serif;
   }
 
-  html, body {
+  html,
+  body {
     height: 100%;
     width: 100%;
     margin: 0;
@@ -86,6 +96,7 @@ input[type="range"]::-moz-range-thumb {
 .accent-slider {
   background: hsl(var(--accent-h) var(--accent-s) var(--accent-l) / 20%);
 }
+
 .accent-slider::-webkit-slider-thumb {
   -webkit-appearance: none;
   width: 12px;
@@ -93,6 +104,7 @@ input[type="range"]::-moz-range-thumb {
   border-radius: 50%;
   cursor: pointer;
 }
+
 .accent-slider::-moz-range-thumb {
   width: 12px;
   height: 12px;
@@ -101,15 +113,17 @@ input[type="range"]::-moz-range-thumb {
 }
 
 @layer components {
+
   /* Panel ─────────────────────────────────────────────────────── */
   .panel {
     background: var(--c-surface);
-    border: 1px solid var(--c-border);
+    border: 2px solid var(--c-border);
     @apply rounded-panel;
   }
+
   .panel-raised {
     background: var(--c-surface-raised);
-    border: 1px solid var(--c-border);
+    border: 2px solid var(--c-border);
     @apply rounded-panel;
   }
 
@@ -121,14 +135,15 @@ input[type="range"]::-moz-range-thumb {
 
   /* Sidebar nav item ───────────────────────────────────────────── */
   .sidebar-item {
-    @apply flex items-center gap-2.5 w-full px-3 py-1.5 text-left text-xs
-           transition-colors duration-100 cursor-pointer select-none rounded-sm;
+    @apply flex items-center gap-2.5 w-full px-3 py-1.5 text-left text-xs transition-colors duration-100 cursor-pointer select-none rounded-sm;
     color: var(--c-text-dim);
   }
+
   .sidebar-item:hover {
     color: var(--c-text);
     background: var(--c-hover);
   }
+
   .sidebar-item-active {
     color: var(--c-accent);
     background: var(--c-active);
@@ -138,20 +153,20 @@ input[type="range"]::-moz-range-thumb {
 
   /* Icon buttons ───────────────────────────────────────────────── */
   .icon-btn {
-    @apply flex items-center justify-center w-8 h-8 rounded cursor-pointer
-           transition-colors duration-100;
+    @apply flex items-center justify-center w-8 h-8 rounded cursor-pointer transition-colors duration-100;
     color: var(--c-text-muted);
   }
+
   .icon-btn:hover {
     color: var(--c-accent);
     background: var(--c-hover);
   }
 
   .icon-btn-sm {
-    @apply flex items-center justify-center w-6 h-6 rounded cursor-pointer
-           transition-colors duration-100;
+    @apply flex items-center justify-center w-6 h-6 rounded cursor-pointer transition-colors duration-100;
     color: var(--c-text-muted);
   }
+
   .icon-btn-sm:hover {
     color: var(--c-accent);
     background: var(--c-hover);
@@ -159,19 +174,33 @@ input[type="range"]::-moz-range-thumb {
 
   /* Input / textarea ───────────────────────────────────────────── */
   .pollis-input {
-    @apply w-full rounded-panel px-3 py-2 text-sm outline-none
-           transition-colors duration-150;
+    @apply w-full rounded-panel px-3 py-2 text-sm outline-none transition-colors duration-150;
     background: var(--c-surface-high);
-    border: 1px solid var(--c-border);
+    border: 2px solid var(--c-border);
     color: var(--c-text);
   }
-  .pollis-input::placeholder { color: var(--c-text-muted); }
-  input::placeholder, textarea::placeholder { color: var(--c-text-muted); }
-  .pollis-input:focus { border-color: var(--c-border-active); }
+
+  .pollis-input::placeholder {
+    color: var(--c-text-muted);
+  }
+
+  input::placeholder,
+  textarea::placeholder {
+    color: var(--c-text-muted);
+  }
+
+  .pollis-input:focus {
+    border-color: var(--c-border-active);
+  }
 
   /* Chat input placeholder: muted when unfocused, dark when focused (on accent bg) */
-  .chat-input-textarea::placeholder { color: var(--c-text-muted); }
-  .chat-input-textarea:focus::placeholder { color: color-mix(in srgb, var(--c-bg) 65%, transparent); }
+  .chat-input-textarea::placeholder {
+    color: var(--c-text-muted);
+  }
+
+  .chat-input-textarea:focus::placeholder {
+    color: color-mix(in srgb, var(--c-bg) 65%, transparent);
+  }
 
   .pollis-textarea {
     @apply pollis-input resize-none;
@@ -179,22 +208,35 @@ input[type="range"]::-moz-range-thumb {
 
   /* Buttons ────────────────────────────────────────────────────── */
   .btn-primary {
-    @apply px-4 py-2 text-sm font-mono rounded-panel cursor-pointer
-           transition-colors duration-100 font-medium;
+    @apply px-4 py-2 text-sm font-mono rounded-panel cursor-pointer transition-colors duration-100 font-medium;
     background: var(--c-accent);
     color: var(--c-bg);
   }
-  .btn-primary:hover { background: var(--c-accent-bright); }
-  .btn-primary:disabled { opacity: 0.45; cursor: not-allowed; }
+
+  .btn-primary:hover {
+    background: var(--c-accent-bright);
+  }
+
+  .btn-primary:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
 
   .btn-ghost {
-    @apply px-3 py-2 text-sm rounded-panel cursor-pointer
-           transition-colors duration-100;
+    @apply px-3 py-2 text-sm rounded-panel cursor-pointer transition-colors duration-100;
     color: var(--c-text-dim);
-    border: 1px solid var(--c-border);
+    border: 2px solid var(--c-border);
   }
-  .btn-ghost:hover { color: var(--c-accent); border-color: var(--c-border-active); }
-  .btn-ghost:disabled { opacity: 0.45; cursor: not-allowed; }
+
+  .btn-ghost:hover {
+    color: var(--c-accent);
+    border-color: var(--c-border-active);
+  }
+
+  .btn-ghost:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
 
   /* Message link ──────────────────────────────────────────────── */
   .message-link {
@@ -205,13 +247,16 @@ input[type="range"]::-moz-range-thumb {
     border-radius: 2px;
     transition: background 100ms, color 100ms;
   }
+
   .message-link:hover {
     color: var(--c-accent-bright);
     background: var(--c-hover);
   }
 
   /* Divider ────────────────────────────────────────────────────── */
-  .divider { border-top: 1px solid var(--c-border); }
+  .divider {
+    border-top: 1px solid var(--c-border);
+  }
 }
 
 /* ── Mono font weight default ────────────────────────────────────── */
@@ -225,20 +270,48 @@ input[type="range"]::-moz-range-thumb {
   scrollbar-width: thin;
   scrollbar-color: var(--c-accent-muted) transparent;
 }
-::-webkit-scrollbar { width: 5px; height: 5px; }
-::-webkit-scrollbar-track { background: transparent; }
-::-webkit-scrollbar-thumb { background: var(--c-accent-muted); border-radius: 3px; }
-::-webkit-scrollbar-thumb:hover { background: var(--c-accent-dim); }
+
+::-webkit-scrollbar {
+  width: 5px;
+  height: 5px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--c-accent-muted);
+  border-radius: 3px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--c-accent-dim);
+}
 
 /* ── Status bar unread blink ─────────────────────────────────────── */
 @keyframes status-blink {
-  0%, 49% { opacity: 1; }
-  50%, 100%      { opacity: 0.5; }
+
+  0%,
+  49% {
+    opacity: 1;
+  }
+
+  50%,
+  100% {
+    opacity: 0.5;
+  }
 }
+
 .status-bar-blink {
   animation: status-blink 2s ease-in-out infinite;
 }
 
 /* ── Titlebar drag ───────────────────────────────────────────────── */
-.titlebar-drag    { --wails-draggable: drag; }
-.titlebar-no-drag { --wails-draggable: no-drag; }
+.titlebar-drag {
+  --wails-draggable: drag;
+}
+
+.titlebar-no-drag {
+  --wails-draggable: no-drag;
+}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -298,8 +298,8 @@ export const Settings: React.FC<SettingsProps> = ({ onDeleteAccount }) => {
             <div className="flex items-center gap-4">
               <div
                 data-testid="avatar-preview-container"
-                className="w-14 h-14 overflow-hidden flex items-center justify-center flex-shrink-0 cursor-pointer"
-                style={{ border: '1px solid var(--c-border)', background: 'var(--c-surface-high)' }}
+                className="w-14 h-14 overflow-hidden flex items-center justify-center flex-shrink-0 cursor-pointer rounded-panel"
+                style={{ border: '2px solid var(--c-border)', background: 'var(--c-surface-high)' }}
                 onClick={() => fileInputRef.current?.click()}
                 title="Click to choose image"
               >

--- a/frontend/src/pages/VoiceSettingsPage.tsx
+++ b/frontend/src/pages/VoiceSettingsPage.tsx
@@ -121,9 +121,9 @@ export const VoiceSettingsPage: React.FC = () => {
 
   return (
     <PageShell title="Voice Settings" onBack={() => router.history.back()} scrollable>
-      <div className="flex flex-col px-6 py-6 gap-6" style={{ maxWidth: 400 }}>
+      <div className="flex flex-col px-6 py-8 gap-8" style={{ maxWidth: 400 }}>
 
-        <section className="flex flex-col gap-4">
+        <section className="flex flex-col gap-4 mb-12">
           <h2
             className="text-xs font-mono font-medium uppercase tracking-widest pb-1 border-b"
             style={{ color: "var(--c-text)", borderColor: "var(--c-border)" }}
@@ -146,7 +146,7 @@ export const VoiceSettingsPage: React.FC = () => {
           />
         </section>
 
-        <section className="flex flex-col gap-4">
+        <section className="flex flex-col gap-4 mb-12">
           <h2
             className="text-xs font-mono font-medium uppercase tracking-widest pb-1 border-b"
             style={{ color: "var(--c-text)", borderColor: "var(--c-border)" }}
@@ -171,7 +171,7 @@ export const VoiceSettingsPage: React.FC = () => {
           />
         </section>
 
-        <section className="flex flex-col gap-4">
+        <section className="flex flex-col gap-4 mb-12">
           <h2
             className="text-xs font-mono font-medium uppercase tracking-widest pb-1 border-b"
             style={{ color: "var(--c-text)", borderColor: "var(--c-border)" }}

--- a/frontend/src/utils/imageProcessing.ts
+++ b/frontend/src/utils/imageProcessing.ts
@@ -27,6 +27,13 @@ export async function resizeImage(
     outputFormat = 'image/jpeg',
   } = options;
 
+  // GIFs must pass through untouched — canvas.toBlob() flattens them to a
+  // single frame, killing animation. Only the first frame would survive a
+  // resize, and we'd rather upload the original so avatars can animate.
+  if (file.type === 'image/gif') {
+    return file;
+  }
+
   return new Promise((resolve, reject) => {
     const img = new Image();
     const canvas = document.createElement('canvas');

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5312,6 +5312,7 @@ dependencies = [
  "dotenvy",
  "ed25519-dalek",
  "futures-util",
+ "gethostname",
  "hex",
  "hkdf",
  "hmac",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -73,6 +73,7 @@ openmls = "0.8"
 openmls_traits = "0.5"
 openmls_rust_crypto = "0.5"
 openmls_basic_credential = "0.5"
+gethostname = "1.1.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 webkit2gtk = { version = "2", features = ["v2_38"] }

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -356,11 +356,18 @@ async fn register_device(state: &Arc<AppState>, user_id: &str) -> Result<String>
         }
     };
 
+    let hostname = gethostname::gethostname().to_string_lossy().to_string();
+    let device_name = format!("{hostname} ({})", std::env::consts::OS);
+
+    // COALESCE preserves any existing device_name — fills it in only if NULL,
+    // so a user-set rename (future feature) is never overwritten on reconnect.
     let conn = state.remote_db.conn().await?;
     conn.execute(
-        "INSERT INTO user_device (device_id, user_id) VALUES (?1, ?2) \
-         ON CONFLICT(device_id) DO UPDATE SET last_seen = datetime('now')",
-        libsql::params![device_id.clone(), user_id],
+        "INSERT INTO user_device (device_id, user_id, device_name) VALUES (?1, ?2, ?3) \
+         ON CONFLICT(device_id) DO UPDATE SET \
+            last_seen = datetime('now'), \
+            device_name = COALESCE(user_device.device_name, excluded.device_name)",
+        libsql::params![device_id.clone(), user_id, device_name],
     ).await?;
 
     *state.device_id.lock().await = Some(device_id.clone());

--- a/src-tauri/src/commands/livekit.rs
+++ b/src-tauri/src/commands/livekit.rs
@@ -974,7 +974,8 @@ mod tests {
             channel_id   TEXT NOT NULL REFERENCES channels(id) ON DELETE CASCADE,
             display_name TEXT NOT NULL,
             joined_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
-            PRIMARY KEY (user_id, channel_id)
+            PRIMARY KEY (user_id, channel_id),
+            UNIQUE (user_id, group_id)
         );
         CREATE INDEX IF NOT EXISTS idx_voice_presence_channel ON voice_presence(channel_id);
         CREATE INDEX IF NOT EXISTS idx_voice_presence_group   ON voice_presence(group_id);
@@ -1143,24 +1144,29 @@ mod tests {
     }
 
     #[test]
-    fn user_cannot_be_in_two_channels_simultaneously() {
+    fn user_in_one_channel_only_via_unique_constraint() {
         let conn = db();
         setup(&conn);
 
-        // PK is (user_id, channel_id), but INSERT OR REPLACE means joining
-        // a second channel replaces the first row only if same channel_id.
-        // Different channel_ids would coexist. Verify this:
+        // UNIQUE (user_id, group_id) means joining a second channel in the
+        // same group atomically evicts the row for the first channel via
+        // INSERT OR REPLACE. The schema enforces single-channel-per-group
+        // even if the app's leave step crashed or raced.
         join(&conn, "alice", "g1", "vc1", "alice");
         join(&conn, "alice", "g1", "vc2", "alice");
 
-        // Both rows exist — the app should leave the old channel first,
-        // but the schema allows it (no UNIQUE on user_id alone).
         let total: i64 = conn.query_row(
             "SELECT COUNT(*) FROM voice_presence WHERE user_id = 'alice'",
             [],
             |row| row.get(0),
         ).unwrap();
-        assert_eq!(total, 2, "schema allows user in multiple channels — app must enforce single-channel");
+        assert_eq!(total, 1, "UNIQUE(user_id, group_id) must collapse to a single row");
+
+        // The surviving row is the most recent channel.
+        assert_eq!(count(&conn, "vc1"), 0, "old channel row should be evicted");
+        assert_eq!(count(&conn, "vc2"), 1, "new channel row should be present");
+        let p = participants(&conn, "vc2");
+        assert_eq!(p[0].0, "alice");
     }
 
     // ── rejoin same channel (INSERT OR REPLACE) ───────────────────────────
@@ -1234,8 +1240,8 @@ mod tests {
         let conn = db();
         setup(&conn);
 
-        // Bob is in two channels in the same group (unusual but schema allows it)
-        join(&conn, "bob", "g1", "vc1", "bob");
+        // Bob is in vc2; alice is in vc1. UNIQUE(user_id, group_id) means
+        // bob can only ever be in one channel per group at a time.
         join(&conn, "bob", "g1", "vc2", "bob");
         join(&conn, "alice", "g1", "vc1", "alice");
 
@@ -1247,7 +1253,8 @@ mod tests {
             .unwrap()
             .map(|r| r.unwrap())
             .collect();
-        assert_eq!(affected.len(), 2);
+        assert_eq!(affected.len(), 1);
+        assert_eq!(affected[0], "vc2");
 
         conn.execute(
             "DELETE FROM voice_presence WHERE user_id = ?1 AND group_id = ?2",
@@ -1255,7 +1262,7 @@ mod tests {
         ).unwrap();
 
         assert_eq!(count(&conn, "vc1"), 1, "alice should remain");
-        assert_eq!(count(&conn, "vc2"), 0, "bob's other channel should be cleared");
+        assert_eq!(count(&conn, "vc2"), 0, "bob's channel should be cleared");
         assert_eq!(participants(&conn, "vc1")[0].0, "alice");
     }
 

--- a/src-tauri/src/db/migrations/000012_voice_presence_unique.sql
+++ b/src-tauri/src/db/migrations/000012_voice_presence_unique.sql
@@ -1,0 +1,22 @@
+-- Tighten voice_presence to enforce single-channel-per-user per group.
+-- The previous PK (user_id, channel_id) allowed a user to have rows in
+-- multiple channels if their leave step failed. Adding UNIQUE(user_id, group_id)
+-- makes INSERT OR REPLACE atomically evict the old channel row.
+
+DROP TABLE IF EXISTS voice_presence;
+
+CREATE TABLE voice_presence (
+    user_id      TEXT NOT NULL,
+    group_id     TEXT NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+    channel_id   TEXT NOT NULL REFERENCES channels(id) ON DELETE CASCADE,
+    display_name TEXT NOT NULL,
+    joined_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    PRIMARY KEY (user_id, channel_id),
+    UNIQUE (user_id, group_id)
+);
+
+CREATE INDEX idx_voice_presence_channel ON voice_presence(channel_id);
+CREATE INDEX idx_voice_presence_group   ON voice_presence(group_id);
+
+INSERT INTO schema_migrations (version, description) VALUES
+    (12, 'voice_presence unique constraint on (user_id, group_id)');


### PR DESCRIPTION
## Closes
- #129 — enforce single voice channel per user per group via `UNIQUE (user_id, group_id)` in `voice_presence` (migration `000012`, tests updated)
- #122 — OTP auto-submits on 6th digit

## Other changes
- Backfill `device_name` with `hostname (os)` on every device registration path so sessions restored without re-OTP still get a name
- Document in `CLAUDE.md` that all real-time media is Rust-only (Linux WebKitGTK has no WebRTC) and fix stale "Next.js/Vercel" note — marketing site is static HTML on Cloudflare Pages
- Bump UI borders from 1px to 2px across panels, cards, inputs, buttons, message attachments, and the Settings avatar container (now `rounded-panel`)
- Match Voice Settings section spacing to Settings page (`gap-8` + `mb-12` per section)
- Preserve GIF animation in `resizeImage` by skipping the canvas roundtrip for `image/gif` — user avatars can now animate