### PR TITLE
Small UX fixes: nav, voice defaults, username colors, voice self-test

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -395,6 +395,7 @@ function MainApp() {
     return (
       <SaveSecretKeyScreen
         secretKey={pendingSecretKey}
+        username={pendingEnrollmentUser?.username ?? currentUser?.username ?? null}
         onConfirmed={handleSecretKeySaved}
       />
     );

--- a/frontend/src/components/Auth/LoginScreen.tsx
+++ b/frontend/src/components/Auth/LoginScreen.tsx
@@ -42,7 +42,7 @@ export const LoginScreen: React.FC<LoginScreenProps> = ({
             <div data-testid="wipe-confirm-section" className="flex flex-col gap-5">
               <div>
                 <h2 className="text-sm font-mono font-semibold" style={{ color: "var(--c-text)" }}>
-                  Wipe this computer
+                  Delete local profiles
                 </h2>
                 <p
                   className="text-xs mt-2 font-mono"
@@ -162,6 +162,7 @@ export const LoginScreen: React.FC<LoginScreenProps> = ({
                     border: "none",
                     cursor: "pointer",
                     padding: "0.25rem 0",
+                    marginTop: "1rem",
                   }}
                   onMouseEnter={(e) => {
                     (e.currentTarget as HTMLButtonElement).style.color = "#ff6b6b";
@@ -170,7 +171,7 @@ export const LoginScreen: React.FC<LoginScreenProps> = ({
                     (e.currentTarget as HTMLButtonElement).style.color = "var(--c-text-muted)";
                   }}
                 >
-                  Wipe this computer
+                  Delete local profiles
                 </button>
               )}
             </div>

--- a/frontend/src/components/Auth/SaveSecretKeyScreen.tsx
+++ b/frontend/src/components/Auth/SaveSecretKeyScreen.tsx
@@ -10,6 +10,11 @@ interface SaveSecretKeyScreenProps {
   /// to the user once. We never store it on disk; once they confirm we
   /// pass control back to the parent.
   secretKey: string;
+  /// Username of the account this key belongs to — used as a suffix on
+  /// the downloaded emergency-kit filename so users with multiple
+  /// accounts can tell their kits apart. Optional; omitted → unsuffixed
+  /// filename.
+  username?: string | null;
   /// Called once the user has typed the key back to confirm they saved it.
   onConfirmed: () => void;
 }
@@ -25,7 +30,14 @@ function normalize(input: string): string {
     .toUpperCase();
 }
 
-function downloadEmergencyKit(secretKey: string) {
+// Restrict filename chars to a conservative alphanumeric/hyphen/
+// underscore set so any exotic username (emoji, slashes, whitespace)
+// can't produce an invalid filename on any OS.
+function sanitizeForFilename(input: string): string {
+  return input.replace(/[^a-zA-Z0-9_-]+/g, "_").replace(/^_+|_+$/g, "");
+}
+
+function downloadEmergencyKit(secretKey: string, username?: string | null) {
   const text = [
     "POLLIS — EMERGENCY KIT",
     "======================",
@@ -49,11 +61,16 @@ function downloadEmergencyKit(secretKey: string) {
     "",
   ].join("\n");
 
+  const safeName = username ? sanitizeForFilename(username) : "";
+  const filename = safeName
+    ? `pollis-emergency-kit-${safeName}.txt`
+    : "pollis-emergency-kit.txt";
+
   const blob = new Blob([text], { type: "text/plain" });
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;
-  a.download = "pollis-emergency-kit.txt";
+  a.download = filename;
   document.body.appendChild(a);
   a.click();
   document.body.removeChild(a);
@@ -64,6 +81,7 @@ type Phase = "warn" | "show" | "confirm";
 
 export const SaveSecretKeyScreen: React.FC<SaveSecretKeyScreenProps> = ({
   secretKey,
+  username,
   onConfirmed,
 }) => {
   const [phase, setPhase] = useState<Phase>("warn");
@@ -216,7 +234,7 @@ export const SaveSecretKeyScreen: React.FC<SaveSecretKeyScreenProps> = ({
                 <Button
                   data-testid="download-secret-key-button"
                   onClick={() => {
-                    downloadEmergencyKit(secretKey);
+                    downloadEmergencyKit(secretKey, username);
                     setDownloaded(true);
                     window.setTimeout(() => setDownloaded(false), 2000);
                   }}

--- a/frontend/src/components/Layout/AppShell.tsx
+++ b/frontend/src/components/Layout/AppShell.tsx
@@ -4,19 +4,20 @@ import { useQueryClient } from "@tanstack/react-query";
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { TitleBar } from "./TitleBar";
+import { BreadcrumbNav } from "./BreadcrumbNav";
+import { StatusBarSummary } from "./StatusBarSummary";
 import { VoiceBar } from "../Voice/VoiceBar";
 import { LoadingSpinner } from "../ui/LoaderSpinner";
 import { SearchPanel } from "../SearchPanel";
 import { useAppStore } from "../../stores/appStore";
 import { useUserGroupsWithChannels } from "../../hooks/queries/useGroups";
-import { useDMConversations } from "../../hooks/queries/useMessages";
 import { useLiveKitRealtime } from "../../hooks/useLiveKitRealtime";
 import { useBadge } from "../../hooks/useBadge";
 import { Mail } from "lucide-react";
 
 /**
  * AppShell is the root route component rendered by RouterProvider.
- * It owns the terminal chrome (TitleBar, VoiceBar, bottom breadcrumb bar)
+ * It owns the terminal chrome (TitleBar, BreadcrumbNav, VoiceBar, bottom status bar)
  * and renders the matched child route via <Outlet />.
  */
 export const AppShell: React.FC = () => {
@@ -27,7 +28,6 @@ export const AppShell: React.FC = () => {
   const router = useRouter();
 
   const {
-    channels,
     setGroups,
     setChannels,
     activeVoiceChannelId,
@@ -37,7 +37,6 @@ export const AppShell: React.FC = () => {
   } = useAppStore();
 
   const { data: groupsWithChannels } = useUserGroupsWithChannels();
-  const { data: dmConversations = [] } = useDMConversations();
 
   const currentUser = useAppStore((s) => s.currentUser);
 
@@ -210,8 +209,6 @@ export const AppShell: React.FC = () => {
     return () => window.removeEventListener("focus", handleWindowFocus);
   }, []);
 
-  // ─── Breadcrumb derived from current route location ──────────────────────────
-
   // Clear the status bar alert when the user navigates to the room that
   // triggered it.
   useEffect(() => {
@@ -232,86 +229,6 @@ export const AppShell: React.FC = () => {
     }
     return false;
   }, [pathname]);
-
-  const breadcrumb = useMemo(() => {
-    if (pathname === "/") {
-      return "";
-    }
-
-    const segments: string[] = [];
-
-    if (pathname.startsWith("/groups")) {
-      segments.push("Groups");
-
-      const groupIdMatch = pathname.match(/^\/groups\/([^/]+)/);
-      const groupId = groupIdMatch?.[1];
-
-      if (groupId && groupId !== "new" && groupId !== "search") {
-        const group = groupsWithChannels?.find((g) => g.id === groupId);
-        if (group) {
-          segments.push(group.name);
-        }
-
-        if (pathname.includes("/channels/")) {
-          const channelIdMatch = pathname.match(/\/channels\/([^/]+)/);
-          const channelId = channelIdMatch?.[1];
-
-          if (channelId && channelId !== "new") {
-            const groupChannels = channels[groupId] ?? [];
-            const ch = groupChannels.find((c) => c.id === channelId);
-            if (ch) {
-              segments.push(ch.name);
-            }
-          } else if (pathname.endsWith("/channels/new")) {
-            segments.push("New Channel");
-          }
-        } else if (pathname.includes("/voice/")) {
-          const channelIdMatch = pathname.match(/\/voice\/([^/]+)/);
-          const channelId = channelIdMatch?.[1];
-          const group = groupsWithChannels?.find((g) => g.id === groupId);
-          const ch = group?.channels.find((c) => c.id === channelId);
-          segments.push(ch?.name ?? "voice");
-        } else if (pathname.endsWith("/join-requests")) {
-          segments.push("Join Requests");
-        } else if (pathname.endsWith("/invite")) {
-          segments.push("Invite Member");
-        } else if (pathname.endsWith("/leave")) {
-          segments.push("Leave Group");
-        }
-      } else if (groupId === "new") {
-        segments.push("Create Group");
-      } else if (groupId === "search") {
-        segments.push("Find Group");
-      }
-    } else if (pathname.startsWith("/dms")) {
-      segments.push("Direct Messages");
-
-      const convIdMatch = pathname.match(/^\/dms\/([^/]+)/);
-      const conversationId = convIdMatch?.[1];
-
-      if (conversationId && conversationId !== "new") {
-        const conv = dmConversations.find((c) => c.id === conversationId);
-        if (conv) {
-          segments.push(`@${conv.user2_identifier}`);
-        }
-        if (pathname.endsWith("/settings")) {
-          segments.push("Conversation Settings");
-        }
-      } else if (conversationId === "new") {
-        segments.push("New Message");
-      }
-    } else if (pathname === "/preferences") {
-      segments.push("Preferences");
-    } else if (pathname === "/settings") {
-      segments.push("Settings");
-    } else if (pathname === "/invites") {
-      segments.push("Invites");
-    } else if (pathname === "/search") {
-      segments.push("Search");
-    }
-
-    return segments.join(" / ");
-  }, [pathname, groupsWithChannels, dmConversations, channels]);
 
   // Find the voice channel name for the VoiceBar
   const voiceChannelName = useMemo(() => {
@@ -345,6 +262,9 @@ export const AppShell: React.FC = () => {
 
       {/* Title bar */}
       <TitleBar />
+
+      {/* Breadcrumb nav — appears on every authenticated page */}
+      <BreadcrumbNav />
 
       {/* Sync indicator — floats top-right below title bar */}
       {isSyncing && (
@@ -397,7 +317,7 @@ export const AppShell: React.FC = () => {
         </div>
       )}
 
-      {/* Bottom bar — breadcrumb left, unread alert right */}
+      {/* Bottom bar — unread summary on the left, status alert on the right */}
       {/* On chat screens, invert: dark bg with accent text. Otherwise: accent bg with dark text. */}
       <div
         style={{
@@ -412,12 +332,7 @@ export const AppShell: React.FC = () => {
           paddingRight: 12,
         }}
       >
-        <span
-          className="text-xs font-mono"
-          style={{ color: isChatScreen ? "var(--c-accent)" : "black" }}
-        >
-          {breadcrumb}
-        </span>
+        <StatusBarSummary color={isChatScreen ? "var(--c-accent)" : "black"} />
         {statusBarAlert ? (
           <button
             className="text-xs font-mono status-bar-blink flex items-center gap-1 cursor-pointer"

--- a/frontend/src/components/Layout/BreadcrumbNav.tsx
+++ b/frontend/src/components/Layout/BreadcrumbNav.tsx
@@ -1,0 +1,218 @@
+import React, { useMemo } from "react";
+import { useRouter, useRouterState } from "@tanstack/react-router";
+import { ChevronLeft } from "lucide-react";
+import { useAppStore } from "../../stores/appStore";
+import { useUserGroupsWithChannels } from "../../hooks/queries/useGroups";
+import { useDMConversations } from "../../hooks/queries/useMessages";
+
+interface Segment {
+  label: string;
+  to: string;
+}
+
+/**
+ * BreadcrumbNav renders below the TitleBar on authenticated pages.
+ * Shows a persistent back button that navigates up one level in the
+ * breadcrumb hierarchy (not browser-history back) plus the breadcrumb
+ * trail itself ("Home / Direct Messages / @someone").
+ */
+export const BreadcrumbNav: React.FC = () => {
+  const router = useRouter();
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+  const { data: groupsWithChannels } = useUserGroupsWithChannels();
+  const { data: dmConversations = [] } = useDMConversations();
+  const channels = useAppStore((s) => s.channels);
+
+  const segments = useMemo<Segment[]>(() => {
+    const out: Segment[] = [{ label: "Home", to: "/" }];
+
+    if (pathname === "/") {
+      return out;
+    }
+
+    if (pathname.startsWith("/groups")) {
+      out.push({ label: "Groups", to: "/groups" });
+
+      const groupIdMatch = pathname.match(/^\/groups\/([^/]+)/);
+      const groupId = groupIdMatch?.[1];
+
+      if (groupId === "new") {
+        out.push({ label: "Create Group", to: "/groups/new" });
+      } else if (groupId === "search") {
+        out.push({ label: "Find Group", to: "/groups/search" });
+      } else if (groupId) {
+        const group = groupsWithChannels?.find((g) => g.id === groupId);
+        if (group) {
+          out.push({ label: group.name, to: `/groups/${groupId}` });
+        }
+
+        if (pathname.includes("/channels/")) {
+          const channelIdMatch = pathname.match(/\/channels\/([^/]+)/);
+          const channelId = channelIdMatch?.[1];
+          if (channelId === "new") {
+            out.push({ label: "New Channel", to: `/groups/${groupId}/channels/new` });
+          } else if (channelId) {
+            const groupChannels = channels[groupId] ?? [];
+            const ch = groupChannels.find((c) => c.id === channelId);
+            if (ch) {
+              out.push({ label: ch.name, to: `/groups/${groupId}/channels/${channelId}` });
+            }
+          }
+        } else if (pathname.includes("/voice/")) {
+          const channelIdMatch = pathname.match(/\/voice\/([^/]+)/);
+          const channelId = channelIdMatch?.[1];
+          const ch = group?.channels.find((c) => c.id === channelId);
+          out.push({
+            label: ch?.name ?? "voice",
+            to: `/groups/${groupId}/voice/${channelId}`,
+          });
+        } else if (pathname.endsWith("/join-requests")) {
+          out.push({ label: "Join Requests", to: `/groups/${groupId}/join-requests` });
+        } else if (pathname.endsWith("/invite")) {
+          out.push({ label: "Invite Member", to: `/groups/${groupId}/invite` });
+        } else if (pathname.endsWith("/leave")) {
+          out.push({ label: "Leave Group", to: `/groups/${groupId}/leave` });
+        } else if (pathname.endsWith("/members")) {
+          out.push({ label: "Members", to: `/groups/${groupId}/members` });
+        } else if (pathname.includes("/members/") && pathname.endsWith("/kick")) {
+          out.push({ label: "Members", to: `/groups/${groupId}/members` });
+          out.push({ label: "Remove Member", to: pathname });
+        }
+      }
+    } else if (pathname.startsWith("/dms")) {
+      out.push({ label: "Direct Messages", to: "/dms" });
+
+      const convIdMatch = pathname.match(/^\/dms\/([^/]+)/);
+      const conversationId = convIdMatch?.[1];
+
+      if (conversationId === "new") {
+        out.push({ label: "New Message", to: "/dms/new" });
+      } else if (conversationId === "requests") {
+        out.push({ label: "Requests", to: "/dms/requests" });
+      } else if (conversationId === "blocked") {
+        out.push({ label: "Blocked Users", to: "/dms/blocked" });
+      } else if (conversationId) {
+        const conv = dmConversations.find((c) => c.id === conversationId);
+        if (conv) {
+          out.push({
+            label: `@${conv.user2_identifier}`,
+            to: `/dms/${conversationId}`,
+          });
+        }
+        if (pathname.endsWith("/settings")) {
+          out.push({
+            label: "Conversation Settings",
+            to: `/dms/${conversationId}/settings`,
+          });
+        }
+      }
+    } else if (pathname === "/preferences") {
+      out.push({ label: "Preferences", to: "/preferences" });
+    } else if (pathname === "/voice-settings") {
+      out.push({ label: "Voice Settings", to: "/voice-settings" });
+    } else if (pathname === "/settings") {
+      out.push({ label: "Settings", to: "/settings" });
+    } else if (pathname === "/security") {
+      out.push({ label: "Security", to: "/security" });
+    } else if (pathname === "/invites") {
+      out.push({ label: "Invites", to: "/invites" });
+    } else if (pathname === "/join-requests") {
+      out.push({ label: "Join Requests", to: "/join-requests" });
+    } else if (pathname === "/search") {
+      out.push({ label: "Search", to: "/search" });
+    }
+
+    return out;
+  }, [pathname, groupsWithChannels, dmConversations, channels]);
+
+  // Back = up one segment in the breadcrumb stack (not browser history)
+  const parentTo = segments.length > 1 ? segments[segments.length - 2].to : null;
+
+  const handleBack = () => {
+    if (!parentTo) {
+      return;
+    }
+    router.navigate({ to: parentTo });
+  };
+
+  // At the root there's nowhere to go back to and no trail to show — omit the bar entirely
+  if (!parentTo) {
+    return null;
+  }
+
+  return (
+    <div
+      data-testid="breadcrumb-nav"
+      style={{
+        height: 28,
+        flexShrink: 0,
+        borderBottom: "1px solid var(--c-border)",
+        background: "var(--c-surface)",
+        display: "flex",
+        alignItems: "center",
+        gap: 8,
+        paddingLeft: 8,
+        paddingRight: 12,
+      }}
+    >
+      <button
+        data-testid="breadcrumb-back-button"
+        onClick={handleBack}
+        aria-label="Back"
+        className="flex items-center justify-center transition-colors"
+        style={{
+          width: 20,
+          height: 20,
+          background: "none",
+          border: "none",
+          padding: 0,
+          color: "var(--c-text-muted)",
+          cursor: "pointer",
+        }}
+        onMouseEnter={(e) => {
+          (e.currentTarget as HTMLButtonElement).style.color = "var(--c-accent)";
+        }}
+        onMouseLeave={(e) => {
+          (e.currentTarget as HTMLButtonElement).style.color = "var(--c-text-muted)";
+        }}
+      >
+        <ChevronLeft size={14} />
+      </button>
+      <span
+        data-testid="breadcrumb-trail"
+        className="text-xs font-mono truncate"
+        style={{ color: "var(--c-text-muted)" }}
+      >
+        {segments.map((seg, i) => (
+          <React.Fragment key={`${seg.to}-${i}`}>
+            {i > 0 && <span style={{ opacity: 0.5 }}> / </span>}
+            {i === segments.length - 1 ? (
+              <span style={{ color: "var(--c-text)" }}>{seg.label}</span>
+            ) : (
+              <button
+                onClick={() => router.navigate({ to: seg.to })}
+                className="font-mono"
+                style={{
+                  background: "none",
+                  border: "none",
+                  padding: 0,
+                  color: "inherit",
+                  cursor: "pointer",
+                  fontSize: "inherit",
+                }}
+                onMouseEnter={(e) => {
+                  (e.currentTarget as HTMLButtonElement).style.color = "var(--c-accent)";
+                }}
+                onMouseLeave={(e) => {
+                  (e.currentTarget as HTMLButtonElement).style.color = "";
+                }}
+              >
+                {seg.label}
+              </button>
+            )}
+          </React.Fragment>
+        ))}
+      </span>
+    </div>
+  );
+};

--- a/frontend/src/components/Layout/PageShell.tsx
+++ b/frontend/src/components/Layout/PageShell.tsx
@@ -1,9 +1,7 @@
 import React, { useEffect, useRef } from "react";
-import { ArrowLeft } from "lucide-react";
 
 interface PageShellProps {
   title: string;
-  onBack: () => void;
   children: React.ReactNode;
   scrollable?: boolean;
 }
@@ -13,11 +11,11 @@ const FOCUSABLE_SELECTOR =
 
 /**
  * Thin chrome wrapper used by router-driven page components.
- * Renders an arrow-back header and a scrollable (or hidden-overflow) body.
- * On mount, focuses the first interactive element inside the content area
- * so keyboard users land on real content, not the back button.
+ * Renders a title header and a scrollable (or hidden-overflow) body.
+ * Navigation "back" lives in the global BreadcrumbNav, so no back button here.
+ * On mount, focuses the first interactive element inside the content area.
  */
-export const PageShell: React.FC<PageShellProps> = ({ title, onBack, children, scrollable = false }) => {
+export const PageShell: React.FC<PageShellProps> = ({ title, children, scrollable = false }) => {
   const contentRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -40,16 +38,6 @@ export const PageShell: React.FC<PageShellProps> = ({ title, onBack, children, s
           color: "var(--c-text-muted)",
         }}
       >
-        <button
-          tabIndex={-1}
-          onClick={onBack}
-          className="mr-3 inline-flex items-center gap-1 leading-none transition-colors"
-          style={{ color: "var(--c-text-muted)" }}
-          onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.color = "var(--c-accent)"; }}
-          onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = "var(--c-text-muted)"; }}
-        >
-          <ArrowLeft size={12} />
-        </button>
         <span style={{ flex: 1, color: "var(--c-text)" }}>{title}</span>
       </div>
       <div ref={contentRef} className={`flex-1 ${scrollable ? "overflow-auto" : "overflow-hidden"}`}>

--- a/frontend/src/components/Layout/StatusBarSummary.tsx
+++ b/frontend/src/components/Layout/StatusBarSummary.tsx
@@ -1,0 +1,124 @@
+import React, { useMemo } from "react";
+import { useRouter } from "@tanstack/react-router";
+import { Hash, MessageCircle, UserPlus } from "lucide-react";
+import { useAppStore } from "../../stores/appStore";
+import { useUserGroupsWithChannels } from "../../hooks/queries/useGroups";
+import { useDMConversations } from "../../hooks/queries/useMessages";
+import { useAllPendingJoinRequests } from "../../hooks/queries/useGroups";
+
+interface SummaryItemProps {
+  icon: React.ReactNode;
+  count: number;
+  to: string;
+  label: string;
+  color: string;
+  testId: string;
+}
+
+// Reserve space for two digits whether or not the count is rendered, so the
+// row doesn't reflow as unread counts tick in and out.
+const SummaryItem: React.FC<SummaryItemProps> = ({ icon, count, to, label, color, testId }) => {
+  const router = useRouter();
+  // Cap visible count at 99 — we only have space for two digits.
+  const display = count <= 0 ? "" : count > 99 ? "99" : String(count);
+
+  return (
+    <button
+      data-testid={testId}
+      aria-label={`${label}: ${count}`}
+      onClick={() => router.navigate({ to })}
+      className="flex items-center gap-1 font-mono text-xs transition-colors"
+      style={{
+        background: "none",
+        border: "none",
+        padding: 0,
+        color,
+        cursor: "pointer",
+      }}
+      onMouseEnter={(e) => {
+        (e.currentTarget as HTMLButtonElement).style.opacity = "0.7";
+      }}
+      onMouseLeave={(e) => {
+        (e.currentTarget as HTMLButtonElement).style.opacity = "1";
+      }}
+    >
+      {icon}
+      <span
+        style={{
+          display: "inline-block",
+          minWidth: "2ch",
+          textAlign: "left",
+          fontVariantNumeric: "tabular-nums",
+        }}
+      >
+        {display}
+      </span>
+    </button>
+  );
+};
+
+interface StatusBarSummaryProps {
+  color: string;
+}
+
+/**
+ * At-a-glance unread counts rendered on the left side of the bottom bar:
+ * unread channel messages across groups, unread DMs, and pending group
+ * join requests you need to act on. Zeros render as blank space so the
+ * row doesn't jitter as counts change.
+ */
+export const StatusBarSummary: React.FC<StatusBarSummaryProps> = ({ color }) => {
+  const unreadCounts = useAppStore((s) => s.unreadCounts);
+  const { data: groupsWithChannels = [] } = useUserGroupsWithChannels();
+  const { data: dmConversations = [] } = useDMConversations();
+  const { data: pendingJoinRequests = [] } = useAllPendingJoinRequests();
+
+  const groupUnread = useMemo(() => {
+    let sum = 0;
+    for (const g of groupsWithChannels) {
+      for (const ch of g.channels) {
+        sum += unreadCounts[ch.id] ?? 0;
+      }
+    }
+    return sum;
+  }, [groupsWithChannels, unreadCounts]);
+
+  const dmUnread = useMemo(() => {
+    let sum = 0;
+    for (const c of dmConversations) {
+      sum += unreadCounts[c.id] ?? 0;
+    }
+    return sum;
+  }, [dmConversations, unreadCounts]);
+
+  const joinRequestCount = pendingJoinRequests.length;
+
+  return (
+    <div data-testid="status-bar-summary" className="flex items-center gap-3">
+      <SummaryItem
+        testId="status-bar-groups-unread"
+        icon={<Hash size={12} />}
+        count={groupUnread}
+        to="/groups"
+        label="Unread group messages"
+        color={color}
+      />
+      <SummaryItem
+        testId="status-bar-dms-unread"
+        icon={<MessageCircle size={12} />}
+        count={dmUnread}
+        to="/dms"
+        label="Unread direct messages"
+        color={color}
+      />
+      <SummaryItem
+        testId="status-bar-join-requests"
+        icon={<UserPlus size={12} />}
+        count={joinRequestCount}
+        to="/join-requests"
+        label="Pending join requests"
+        color={color}
+      />
+    </div>
+  );
+};

--- a/frontend/src/components/Message/MessageItem.tsx
+++ b/frontend/src/components/Message/MessageItem.tsx
@@ -8,6 +8,7 @@ import { LinkifiedText } from "../ui/LinkifiedText";
 import { LoadingSpinner } from "../ui/LoaderSpinner";
 import { InlineAudioPlayer } from "../ui/InlineAudioPlayer";
 import { AudioPlayer } from "../ui/AudioPlayer";
+import { getUsernameColor, useBackgroundIsLight } from "../../utils/usernameColor";
 // import { MessageReactions } from "./MessageReactions";
 import type { Message, MessageAttachment } from "../../types";
 
@@ -43,6 +44,13 @@ export const MessageItem: React.FC<MessageItemProps> = ({
 }) => {
   const { currentUser } = useAppStore();
   const isOwn = message.sender_id === currentUser?.id;
+  const isLightBg = useBackgroundIsLight();
+
+  // Stable per-user color for non-own, non-admin authors. Key on username
+  // when available so the same person keeps the same color across groups
+  // even if their user id rotates; fall back to sender_id otherwise.
+  const authorColorKey = message.sender_username ?? message.sender_id;
+  const authorColor = getUsernameColor(authorColorKey, isLightBg);
 
   const replyTo = message.reply_to_message_id
     ? allMessages.find((m) => m.id === message.reply_to_message_id)
@@ -50,6 +58,9 @@ export const MessageItem: React.FC<MessageItemProps> = ({
 
   const replyToAuthor = replyTo
     ? (replyTo.sender_username ?? replyTo.sender_id)
+    : null;
+  const replyToAuthorColor = replyTo
+    ? getUsernameColor(replyTo.sender_username ?? replyTo.sender_id, isLightBg)
     : null;
 
   const isDeleted = !!message.deleted_at;
@@ -83,7 +94,10 @@ export const MessageItem: React.FC<MessageItemProps> = ({
           >
             <Reply size={10} style={{ transform: "scaleX(-1)" }} />
             {replyToAuthor && (
-              <span className="font-semibold flex-shrink-0" style={{ color: "var(--c-text-dim)" }}>
+              <span
+                className="font-semibold flex-shrink-0"
+                style={{ color: replyToAuthorColor ?? "var(--c-text-dim)" }}
+              >
                 {replyToAuthor}:
               </span>
             )}
@@ -122,7 +136,7 @@ export const MessageItem: React.FC<MessageItemProps> = ({
             paddingLeft: "0.5rem",
             paddingRight: "0.5rem",
           } : {
-            color: isOwn ? "var(--c-accent)" : "var(--c-text-dim)",
+            color: isOwn ? "var(--c-accent)" : authorColor,
           }}
         >
           {authorUsername}

--- a/frontend/src/components/Message/ReplyPreview.tsx
+++ b/frontend/src/components/Message/ReplyPreview.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { X } from 'lucide-react';
 import type { Message } from '../../types';
+import { getUsernameColor, useBackgroundIsLight } from '../../utils/usernameColor';
 
 interface ReplyPreviewProps {
   messageId: string;
@@ -15,11 +16,13 @@ export const ReplyPreview: React.FC<ReplyPreviewProps> = ({
   onDismiss,
   onScrollToMessage,
 }) => {
+  const isLightBg = useBackgroundIsLight();
   const message = allMessages.find((m) => m.id === messageId);
   if (!message) {
     return null;
   }
   const author = message.sender_username ?? message.sender_id;
+  const authorColor = getUsernameColor(author, isLightBg);
   const content = message.content_decrypted || '[Encrypted message]';
   const snippet = content.length > 80 ? content.substring(0, 80) + '...' : content;
 
@@ -32,7 +35,7 @@ export const ReplyPreview: React.FC<ReplyPreviewProps> = ({
       <div className="flex-1 min-w-0">
         <span className="text-2xs font-mono uppercase tracking-widest" style={{ color: 'var(--c-text-muted)' }}>
           replying to{' '}
-          <span className="font-semibold" style={{ color: 'var(--c-text-dim)' }}>
+          <span className="font-semibold" style={{ color: authorColor }}>
             {author}
           </span>
         </span>

--- a/frontend/src/components/ui/NavigableList.tsx
+++ b/frontend/src/components/ui/NavigableList.tsx
@@ -174,8 +174,8 @@ export function NavigableList<T>({
 
   if (items.length === 0) {
     return (
-      <div className="flex-1 flex items-center justify-center">
-        <p className="text-xs font-mono" style={{ color: "var(--c-text-dim)" }}>
+      <div className="flex-1" style={{ paddingTop: "1rem", paddingLeft: "1rem", paddingRight: "1rem" }}>
+        <p className="text-xs font-mono text-left" style={{ color: "var(--c-text-dim)" }}>
           {emptyLabel}
         </p>
       </div>

--- a/frontend/src/hooks/queries/usePreferences.ts
+++ b/frontend/src/hooks/queries/usePreferences.ts
@@ -50,7 +50,7 @@ export function usePreferences() {
         font_size: getPreference<string | undefined>(json, "font_size", undefined),
         allow_desktop_notifications: getPreference<boolean>(json, "allow_desktop_notifications", false),
         auto_gain_control: getPreference<boolean>(json, "auto_gain_control", true),
-        auto_join_voice: getPreference<boolean>(json, "auto_join_voice", true),
+        auto_join_voice: getPreference<boolean>(json, "auto_join_voice", false),
       };
     },
     enabled: !!currentUser,

--- a/frontend/src/hooks/useVoiceTest.ts
+++ b/frontend/src/hooks/useVoiceTest.ts
@@ -1,0 +1,213 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Channel, invoke } from "@tauri-apps/api/core";
+
+// Mirrors VoiceTestEvent in src-tauri/src/commands/voice_test.rs
+type VoiceTestEvent =
+  | { type: "frame"; peak: number; rms: number; gated: boolean }
+  | { type: "recording_started" }
+  | { type: "recording_finished" }
+  | { type: "playback_started" }
+  | { type: "playback_finished" };
+
+export type VoiceTestPhase =
+  | "idle"
+  | "mic_listening"
+  | "recording"
+  | "playing";
+
+export type TonePreset = "sweep" | "chime";
+
+interface UseVoiceTestResult {
+  peak: number;
+  rms: number;
+  gated: boolean;
+  monitor: boolean;
+  phase: VoiceTestPhase;
+  error: string | null;
+  startMicTest: (inputDeviceId: string, outputDeviceId: string, monitor: boolean) => Promise<void>;
+  stopMicTest: () => Promise<void>;
+  setMonitor: (enabled: boolean, outputDeviceId: string) => Promise<void>;
+  recordAndPlayBack: (inputDeviceId: string, outputDeviceId: string, durationMs: number) => Promise<void>;
+  playTone: (outputDeviceId: string, kind: TonePreset) => Promise<void>;
+  stopPlayback: () => Promise<void>;
+}
+
+/**
+ * Drives the Voice Settings pre-flight test harness. Opens a single Tauri
+ * Channel to receive level frames and lifecycle events from the Rust side,
+ * then exposes a thin wrapper around the voice_test invoke commands.
+ *
+ * Only one VoiceSettingsPage can mount at a time, so it's fine to own a
+ * single channel here rather than a global subscription.
+ */
+export function useVoiceTest(): UseVoiceTestResult {
+  const [peak, setPeak] = useState(0);
+  const [rms, setRms] = useState(0);
+  const [gated, setGated] = useState(false);
+  const [phase, setPhase] = useState<VoiceTestPhase>("idle");
+  const [monitor, setMonitorState] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Track the current phase in a ref so event handlers see the latest value
+  // without rebinding the channel onmessage closure.
+  const phaseRef = useRef<VoiceTestPhase>("idle");
+  const setPhaseBoth = useCallback((next: VoiceTestPhase) => {
+    phaseRef.current = next;
+    setPhase(next);
+  }, []);
+
+  const resetMeter = useCallback(() => {
+    setPeak(0);
+    setRms(0);
+    setGated(false);
+  }, []);
+
+  useEffect(() => {
+    const ch = new Channel<VoiceTestEvent>();
+    ch.onmessage = (ev) => {
+      switch (ev.type) {
+        case "frame":
+          setPeak(ev.peak);
+          setRms(ev.rms);
+          setGated(ev.gated);
+          break;
+        case "recording_started":
+          phaseRef.current = "recording";
+          setPhase("recording");
+          break;
+        case "recording_finished":
+          // Transitional — wait for playback_started before flipping phase.
+          break;
+        case "playback_started":
+          phaseRef.current = "playing";
+          setPhase("playing");
+          break;
+        case "playback_finished":
+          phaseRef.current = "idle";
+          setPhase("idle");
+          setPeak(0);
+          setRms(0);
+          setGated(false);
+          break;
+      }
+    };
+    invoke("subscribe_voice_test_events", { onEvent: ch }).catch((e) => {
+      console.warn("[voice-test] subscribe failed:", e);
+    });
+
+    return () => {
+      // Leaving the page: kill anything still running on the Rust side so
+      // the mic doesn't stay hot and tones don't keep playing.
+      invoke("stop_mic_test").catch(() => {});
+      invoke("stop_test_playback").catch(() => {});
+    };
+  }, []);
+
+  const startMicTest = useCallback(
+    async (inputDeviceId: string, outputDeviceId: string, mon: boolean) => {
+      setError(null);
+      resetMeter();
+      setMonitorState(mon);
+      try {
+        await invoke("start_mic_test", {
+          inputDeviceId,
+          outputDeviceId,
+          monitor: mon,
+        });
+        setPhaseBoth("mic_listening");
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+        setPhaseBoth("idle");
+      }
+    },
+    [resetMeter, setPhaseBoth],
+  );
+
+  const stopMicTest = useCallback(async () => {
+    setError(null);
+    try {
+      await invoke("stop_mic_test");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+    setPhaseBoth("idle");
+    resetMeter();
+  }, [resetMeter, setPhaseBoth]);
+
+  const setMonitor = useCallback(
+    async (enabled: boolean, outputDeviceId: string) => {
+      setMonitorState(enabled);
+      try {
+        await invoke("set_mic_test_monitor", {
+          enabled,
+          outputDeviceId,
+        });
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    },
+    [],
+  );
+
+  const recordAndPlayBack = useCallback(
+    async (inputDeviceId: string, outputDeviceId: string, durationMs: number) => {
+      setError(null);
+      resetMeter();
+      // Optimistic phase — the Rust side will emit RecordingStarted shortly.
+      setPhaseBoth("recording");
+      try {
+        await invoke("record_and_play_back", {
+          inputDeviceId,
+          outputDeviceId,
+          durationMs,
+        });
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+        setPhaseBoth("idle");
+      }
+    },
+    [resetMeter, setPhaseBoth],
+  );
+
+  const playTone = useCallback(
+    async (outputDeviceId: string, kind: TonePreset) => {
+      setError(null);
+      setPhaseBoth("playing");
+      try {
+        await invoke("play_test_tone", {
+          outputDeviceId,
+          kind,
+        });
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+        setPhaseBoth("idle");
+      }
+    },
+    [setPhaseBoth],
+  );
+
+  const stopPlayback = useCallback(async () => {
+    setError(null);
+    try {
+      await invoke("stop_test_playback");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+    setPhaseBoth("idle");
+  }, [setPhaseBoth]);
+
+  return {
+    peak,
+    rms,
+    gated,
+    monitor,
+    phase,
+    error,
+    startMicTest,
+    stopMicTest,
+    setMonitor,
+    recordAndPlayBack,
+    playTone,
+    stopPlayback,
+  };
+}

--- a/frontend/src/pages/AllJoinRequests.tsx
+++ b/frontend/src/pages/AllJoinRequests.tsx
@@ -72,8 +72,8 @@ export const AllJoinRequests: React.FC = () => {
         className="flex-1 flex flex-col overflow-auto"
         style={{ background: "var(--c-bg)" }}
       >
-        <div className="flex-1 flex items-center justify-center">
-          <p className="text-xs font-mono" style={{ color: "var(--c-text-dim)" }}>
+        <div className="flex-1" style={{ paddingTop: "1rem", paddingLeft: "1rem", paddingRight: "1rem" }}>
+          <p className="text-xs font-mono text-left" style={{ color: "var(--c-text-dim)" }}>
             No pending join requests.
           </p>
         </div>

--- a/frontend/src/pages/AllJoinRequestsPage.tsx
+++ b/frontend/src/pages/AllJoinRequestsPage.tsx
@@ -1,13 +1,10 @@
 import React from "react";
-import { useNavigate } from "@tanstack/react-router";
 import { PageShell } from "../components/Layout/PageShell";
 import { AllJoinRequests } from "./AllJoinRequests";
 
 export const AllJoinRequestsPage: React.FC = () => {
-  const navigate = useNavigate();
-
   return (
-    <PageShell title="Join Requests" onBack={() => navigate({ to: "/" })}>
+    <PageShell title="Join Requests">
       <AllJoinRequests />
     </PageShell>
   );

--- a/frontend/src/pages/BlockedPage.tsx
+++ b/frontend/src/pages/BlockedPage.tsx
@@ -1,13 +1,10 @@
 import React from "react";
-import { useNavigate } from "@tanstack/react-router";
 import { PageShell } from "../components/Layout/PageShell";
 import { Blocked } from "./Blocked";
 
 export const BlockedPage: React.FC = () => {
-  const navigate = useNavigate();
-
   return (
-    <PageShell title="Blocked Users" onBack={() => navigate({ to: "/dms" })}>
+    <PageShell title="Blocked Users">
       <Blocked />
     </PageShell>
   );

--- a/frontend/src/pages/Channel.tsx
+++ b/frontend/src/pages/Channel.tsx
@@ -1,12 +1,10 @@
 import React, { useEffect } from "react";
-import { useNavigate, useParams } from "@tanstack/react-router";
-import { ArrowLeft } from "lucide-react";
+import { useParams } from "@tanstack/react-router";
 import { MainContent } from "../components/Layout/MainContent";
 import { useUserGroupsWithChannels } from "../hooks/queries/useGroups";
 import { useAppStore } from "../stores/appStore";
 
 export const ChannelPage: React.FC = () => {
-  const navigate = useNavigate();
   const { groupId, channelId } = useParams({ from: "/groups/$groupId/channels/$channelId" });
   const setSelectedChannelId = useAppStore((s) => s.setSelectedChannelId);
 
@@ -30,15 +28,6 @@ export const ChannelPage: React.FC = () => {
           color: "var(--c-text-muted)",
         }}
       >
-        <button
-          onClick={() => navigate({ to: "/groups/$groupId", params: { groupId } })}
-          className="mr-3 inline-flex items-center gap-1 leading-none transition-colors"
-          style={{ color: "var(--c-text-muted)" }}
-          onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.color = "var(--c-accent)"; }}
-          onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = "var(--c-text-muted)"; }}
-        >
-          <ArrowLeft size={12} />
-        </button>
         <span>{title}</span>
       </div>
       <div className="flex-1 overflow-hidden flex flex-col min-h-0">

--- a/frontend/src/pages/CreateChannelPage.tsx
+++ b/frontend/src/pages/CreateChannelPage.tsx
@@ -10,10 +10,7 @@ export const CreateChannelPage: React.FC = () => {
   const { setSelectedChannelId } = useAppStore();
 
   return (
-    <PageShell
-      title="New Channel"
-      onBack={() => navigate({ to: "/groups/$groupId", params: { groupId } })}
-    >
+    <PageShell title="New Channel">
       <CreateChannel
         onSuccess={(channelId, channelType) => {
           if (!channelId || channelType === "voice") {

--- a/frontend/src/pages/CreateGroupPage.tsx
+++ b/frontend/src/pages/CreateGroupPage.tsx
@@ -7,7 +7,7 @@ export const CreateGroupPage: React.FC = () => {
   const navigate = useNavigate();
 
   return (
-    <PageShell title="Create Group" onBack={() => navigate({ to: "/groups" })}>
+    <PageShell title="Create Group">
       <CreateGroup onSuccess={(groupId) => navigate({ to: "/groups/$groupId", params: { groupId } })} />
     </PageShell>
   );

--- a/frontend/src/pages/DM.tsx
+++ b/frontend/src/pages/DM.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
 import { useNavigate, useParams } from "@tanstack/react-router";
-import { ArrowLeft, Ban } from "lucide-react";
+import { Ban } from "lucide-react";
 import { MainContent } from "../components/Layout/MainContent";
 import { useDMConversations } from "../hooks/queries/useMessages";
 import { useBlockUser } from "../hooks/queries";
@@ -82,15 +82,6 @@ export const DMPage: React.FC = () => {
           color: "var(--c-text-muted)",
         }}
       >
-        <button
-          onClick={() => navigate({ to: "/dms" })}
-          className="mr-3 inline-flex items-center gap-1 leading-none transition-colors"
-          style={{ color: "var(--c-text-muted)" }}
-          onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.color = "var(--c-accent)"; }}
-          onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = "var(--c-text-muted)"; }}
-        >
-          <ArrowLeft size={12} />
-        </button>
         <span style={{ flex: 1 }}>{title}</span>
         {canBlock && (
           <Button

--- a/frontend/src/pages/DMSettings.tsx
+++ b/frontend/src/pages/DMSettings.tsx
@@ -12,10 +12,7 @@ export const DMSettingsPage: React.FC = () => {
   const leaveDMMutation = useLeaveDM();
 
   return (
-    <PageShell
-      title="Conversation Settings"
-      onBack={() => navigate({ to: "/dms/$conversationId", params: { conversationId } })}
-    >
+    <PageShell title="Conversation Settings">
       <div className="h-full flex flex-col items-center justify-center gap-4 px-6">
         {leaveDMMutation.isError && (
           <p className="text-xs font-mono" style={{ color: "#ff6b6b" }}>

--- a/frontend/src/pages/DMs.tsx
+++ b/frontend/src/pages/DMs.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useNavigate } from "@tanstack/react-router";
-import { ArrowLeft, Inbox, Ban } from "lucide-react";
+import { ArrowLeft, Inbox, Ban, Plus } from "lucide-react";
 import { TerminalMenu, type TerminalMenuItem } from "../components/ui/TerminalMenu";
 import { useAppStore } from "../stores/appStore";
 import { useDMConversations } from "../hooks/queries/useMessages";
@@ -19,6 +19,7 @@ export const DMsPage: React.FC = () => {
   items.push({
     id: "new-dm",
     label: "New Message",
+    icon: <Plus size={14} />,
     action: () => navigate({ to: "/dms/new" }),
     type: "system" as const,
     testId: "menu-item-new-dm",
@@ -38,7 +39,7 @@ export const DMsPage: React.FC = () => {
 
   items.push({
     id: "dm-blocked",
-    label: "Blocked",
+    label: "Blocked Users",
     icon: <Ban size={14} />,
     action: () => navigate({ to: "/dms/blocked" }),
     type: "system" as const,

--- a/frontend/src/pages/Group.tsx
+++ b/frontend/src/pages/Group.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from "react";
 import { useNavigate, useParams } from "@tanstack/react-router";
-import { ArrowLeft, Hash, Volume2 } from "lucide-react";
+import { ArrowLeft, Hash, Plus, Volume2 } from "lucide-react";
 import { TerminalMenu, type TerminalMenuItem } from "../components/ui/TerminalMenu";
 import { useAppStore } from "../stores/appStore";
 import { useUserGroupsWithChannels, useGroupJoinRequests } from "../hooks/queries/useGroups";
@@ -103,7 +103,8 @@ export const GroupPage: React.FC = () => {
     ...(isAdmin ? [
       {
         id: "create-channel",
-        label: "+ New Channel",
+        label: "New Channel",
+        icon: <Plus size={14} />,
         action: () => {
           setSelectedGroupId(group.id);
           navigate({ to: "/groups/$groupId/channels/new", params: { groupId } });

--- a/frontend/src/pages/InviteMemberPage.tsx
+++ b/frontend/src/pages/InviteMemberPage.tsx
@@ -1,11 +1,10 @@
 import React from "react";
-import { useNavigate, useParams } from "@tanstack/react-router";
+import { useParams } from "@tanstack/react-router";
 import { PageShell } from "../components/Layout/PageShell";
 import { InviteMember } from "./InviteMember";
 import { useUserGroupsWithChannels } from "../hooks/queries/useGroups";
 
 export const InviteMemberPage: React.FC = () => {
-  const navigate = useNavigate();
   const { groupId } = useParams({ from: "/groups/$groupId/invite" });
 
   const { data: groupsWithChannels, isLoading } = useUserGroupsWithChannels();
@@ -16,10 +15,7 @@ export const InviteMemberPage: React.FC = () => {
   }
 
   return (
-    <PageShell
-      title={`Invite Member :: ${group.name}`}
-      onBack={() => navigate({ to: "/groups/$groupId", params: { groupId } })}
-    >
+    <PageShell title={`Invite Member :: ${group.name}`}>
       <InviteMember groupId={group.id} groupName={group.name} />
     </PageShell>
   );

--- a/frontend/src/pages/InvitesPage.tsx
+++ b/frontend/src/pages/InvitesPage.tsx
@@ -1,13 +1,10 @@
 import React from "react";
-import { useNavigate } from "@tanstack/react-router";
 import { PageShell } from "../components/Layout/PageShell";
 import { Invites } from "./Invites";
 
 export const InvitesPage: React.FC = () => {
-  const navigate = useNavigate();
-
   return (
-    <PageShell title="Invites" onBack={() => navigate({ to: "/" })}>
+    <PageShell title="Invites">
       <Invites />
     </PageShell>
   );

--- a/frontend/src/pages/JoinRequestsPage.tsx
+++ b/frontend/src/pages/JoinRequestsPage.tsx
@@ -1,11 +1,10 @@
 import React from "react";
-import { useNavigate, useParams } from "@tanstack/react-router";
+import { useParams } from "@tanstack/react-router";
 import { PageShell } from "../components/Layout/PageShell";
 import { JoinRequests } from "./JoinRequests";
 import { useUserGroupsWithChannels } from "../hooks/queries/useGroups";
 
 export const JoinRequestsPage: React.FC = () => {
-  const navigate = useNavigate();
   const { groupId } = useParams({ from: "/groups/$groupId/join-requests" });
 
   const { data: groupsWithChannels, isLoading } = useUserGroupsWithChannels();
@@ -16,10 +15,7 @@ export const JoinRequestsPage: React.FC = () => {
   }
 
   return (
-    <PageShell
-      title={`Join Requests :: ${group.name}`}
-      onBack={() => navigate({ to: "/groups/$groupId", params: { groupId } })}
-    >
+    <PageShell title={`Join Requests :: ${group.name}`}>
       <JoinRequests groupId={group.id} groupName={group.name} />
     </PageShell>
   );

--- a/frontend/src/pages/KickMemberPage.tsx
+++ b/frontend/src/pages/KickMemberPage.tsx
@@ -12,10 +12,7 @@ export const KickMemberPage: React.FC = () => {
   const member = members.find((m) => m.user_id === userId);
 
   return (
-    <PageShell
-      title="Remove Member"
-      onBack={() => navigate({ to: "/groups/$groupId/members", params: { groupId } })}
-    >
+    <PageShell title="Remove Member">
       <div className="h-full flex flex-col items-center justify-center gap-4 px-6">
         <p className="text-xs font-mono text-center" style={{ color: "var(--c-text-dim)" }}>
           Remove <strong>{member?.username ?? userId}</strong> from this group?

--- a/frontend/src/pages/LeaveGroup.tsx
+++ b/frontend/src/pages/LeaveGroup.tsx
@@ -19,10 +19,7 @@ export const LeaveGroupPage: React.FC = () => {
   }
 
   return (
-    <PageShell
-      title="Leave Group"
-      onBack={() => navigate({ to: "/groups/$groupId", params: { groupId } })}
-    >
+    <PageShell title="Leave Group">
       <div className="h-full flex flex-col items-center justify-center gap-4 px-6">
         <p className="text-xs font-mono text-center" style={{ color: "var(--c-text-dim)" }}>
           Are you sure you want to leave <strong>{group.name}</strong>?

--- a/frontend/src/pages/MembersPage.tsx
+++ b/frontend/src/pages/MembersPage.tsx
@@ -1,11 +1,10 @@
 import React from "react";
-import { useNavigate, useParams } from "@tanstack/react-router";
+import { useParams } from "@tanstack/react-router";
 import { useUserGroupsWithChannels } from "../hooks/queries/useGroups";
 import { Members } from "./Members";
 import { PageShell } from "../components/Layout/PageShell";
 
 export const MembersPage: React.FC = () => {
-  const navigate = useNavigate();
   const { groupId } = useParams({ from: "/groups/$groupId/members" });
   const { data: groupsWithChannels } = useUserGroupsWithChannels();
   const group = groupsWithChannels?.find((g) => g.id === groupId);
@@ -15,11 +14,7 @@ export const MembersPage: React.FC = () => {
   }
 
   return (
-    <PageShell
-      title="Members"
-      onBack={() => navigate({ to: "/groups/$groupId", params: { groupId } })}
-      scrollable
-    >
+    <PageShell title="Members" scrollable>
       <div className="pt-8 flex-1 flex flex-col overflow-hidden">
         <Members groupId={groupId} isAdmin={group.current_user_role === "admin"} />
       </div>

--- a/frontend/src/pages/PreferencesPage.tsx
+++ b/frontend/src/pages/PreferencesPage.tsx
@@ -1,13 +1,10 @@
 import React from "react";
-import { useNavigate } from "@tanstack/react-router";
 import { PageShell } from "../components/Layout/PageShell";
 import { Preferences } from "./Preferences";
 
 export const PreferencesPage: React.FC = () => {
-  const navigate = useNavigate();
-
   return (
-    <PageShell title="Preferences" onBack={() => navigate({ to: "/" })} scrollable>
+    <PageShell title="Preferences" scrollable>
       <Preferences />
     </PageShell>
   );

--- a/frontend/src/pages/RequestsPage.tsx
+++ b/frontend/src/pages/RequestsPage.tsx
@@ -1,13 +1,10 @@
 import React from "react";
-import { useNavigate } from "@tanstack/react-router";
 import { PageShell } from "../components/Layout/PageShell";
 import { Requests } from "./Requests";
 
 export const RequestsPage: React.FC = () => {
-  const navigate = useNavigate();
-
   return (
-    <PageShell title="Message Requests" onBack={() => navigate({ to: "/dms" })}>
+    <PageShell title="Message Requests">
       <Requests />
     </PageShell>
   );

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -9,7 +9,7 @@ export const SearchPage: React.FC = () => {
   const { setSelectedConversationId } = useAppStore();
 
   return (
-    <PageShell title="Search" onBack={() => navigate({ to: "/" })}>
+    <PageShell title="Search">
       <SearchView
         onNavigateToConversation={(conversationId) => {
           setSelectedConversationId(conversationId);

--- a/frontend/src/pages/SearchGroupPage.tsx
+++ b/frontend/src/pages/SearchGroupPage.tsx
@@ -1,13 +1,10 @@
 import React from "react";
-import { useNavigate } from "@tanstack/react-router";
 import { PageShell } from "../components/Layout/PageShell";
 import { SearchGroup } from "./SearchGroup";
 
 export const SearchGroupPage: React.FC = () => {
-  const navigate = useNavigate();
-
   return (
-    <PageShell title="Find Group" onBack={() => navigate({ to: "/groups" })}>
+    <PageShell title="Find Group">
       <SearchGroup />
     </PageShell>
   );

--- a/frontend/src/pages/SecurityPage.tsx
+++ b/frontend/src/pages/SecurityPage.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from "react";
-import { useNavigate } from "@tanstack/react-router";
 import { PageShell } from "../components/Layout/PageShell";
 import { useAppStore } from "../stores/appStore";
 import * as api from "../services/api";
@@ -59,7 +58,6 @@ function formatTimestamp(iso: string): string {
 }
 
 export const SecurityPage: React.FC = () => {
-  const navigate = useNavigate();
   const { currentUser } = useAppStore();
   const [events, setEvents] = useState<api.SecurityEvent[] | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -88,7 +86,7 @@ export const SecurityPage: React.FC = () => {
   }, [currentUser?.id]);
 
   return (
-    <PageShell title="Security" onBack={() => navigate({ to: "/settings" })} scrollable>
+    <PageShell title="Security" scrollable>
       <div
         className="flex flex-col gap-4 p-4 font-mono"
         data-testid="security-page"

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,16 +1,15 @@
 import React from "react";
-import { useNavigate, useRouter } from "@tanstack/react-router";
+import { useRouter } from "@tanstack/react-router";
 import { PageShell } from "../components/Layout/PageShell";
 import { Settings } from "./Settings";
 import type { RouterContext } from "../types/router";
 
 export const SettingsPage: React.FC = () => {
-  const navigate = useNavigate();
   const router = useRouter();
   const { onDeleteAccount } = router.options.context as RouterContext;
 
   return (
-    <PageShell title="Settings" onBack={() => navigate({ to: "/" })} scrollable>
+    <PageShell title="Settings" scrollable>
       <Settings onDeleteAccount={onDeleteAccount} />
     </PageShell>
   );

--- a/frontend/src/pages/StartDMPage.tsx
+++ b/frontend/src/pages/StartDMPage.tsx
@@ -9,7 +9,7 @@ export const StartDMPage: React.FC = () => {
   const { setSelectedConversationId } = useAppStore();
 
   return (
-    <PageShell title="New Message" onBack={() => navigate({ to: "/dms" })}>
+    <PageShell title="New Message">
       <StartDM
         onSuccess={(conversationId) => {
           setSelectedConversationId(conversationId);

--- a/frontend/src/pages/VoiceChannel.tsx
+++ b/frontend/src/pages/VoiceChannel.tsx
@@ -35,7 +35,7 @@ export const VoiceChannelPage: React.FC = () => {
     if (hasAutoJoined.current || isInCall || !preferences.query.data) {
       return;
     }
-    if (preferences.query.data.auto_join_voice !== false) {
+    if (preferences.query.data.auto_join_voice === true) {
       hasAutoJoined.current = true;
       setActiveVoiceChannelId(channelId);
     }

--- a/frontend/src/pages/VoiceSettingsPage.tsx
+++ b/frontend/src/pages/VoiceSettingsPage.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from "react";
 import { ChevronDown } from "lucide-react";
-import { useRouter } from "@tanstack/react-router";
 import { invoke } from "@tauri-apps/api/core";
 import { PageShell } from "../components/Layout/PageShell";
 import { RangeSlider } from "../components/ui/RangeSlider";
@@ -64,7 +63,6 @@ const DeviceSelect: React.FC<DeviceSelectProps> = ({ label, devices, value, onCh
 );
 
 export const VoiceSettingsPage: React.FC = () => {
-  const router = useRouter();
   const preferences = usePreferences();
 
   const [inputs, setInputs] = useState<AudioDevice[]>([]);
@@ -114,13 +112,13 @@ export const VoiceSettingsPage: React.FC = () => {
     preferences.mutation.mutate({ ...preferences.query.data, auto_gain_control: enabled });
   };
 
-  const autoJoinVoice = preferences.query.data?.auto_join_voice ?? true;
+  const autoJoinVoice = preferences.query.data?.auto_join_voice ?? false;
   const handleAutoJoinVoice = (enabled: boolean) => {
     preferences.mutation.mutate({ ...preferences.query.data, auto_join_voice: enabled });
   };
 
   return (
-    <PageShell title="Voice Settings" onBack={() => router.history.back()} scrollable>
+    <PageShell title="Voice Settings" scrollable>
       <div className="flex flex-col px-6 py-8 gap-8" style={{ maxWidth: 400 }}>
 
         <section className="flex flex-col gap-4 mb-12">
@@ -176,7 +174,7 @@ export const VoiceSettingsPage: React.FC = () => {
             className="text-xs font-mono font-medium uppercase tracking-widest pb-1 border-b"
             style={{ color: "var(--c-text)", borderColor: "var(--c-border)" }}
           >
-            Behaviour
+            Behavior
           </h2>
           <Switch
             label="Auto Join Voice"

--- a/frontend/src/pages/VoiceSettingsPage.tsx
+++ b/frontend/src/pages/VoiceSettingsPage.tsx
@@ -4,8 +4,10 @@ import { invoke } from "@tauri-apps/api/core";
 import { PageShell } from "../components/Layout/PageShell";
 import { RangeSlider } from "../components/ui/RangeSlider";
 import { Switch } from "../components/ui/Switch";
+import { Button } from "../components/ui/Button";
 import { usePreferences } from "../hooks/queries/usePreferences";
 import { switchVoiceDevice } from "../hooks/useVoiceChannel";
+import { useVoiceTest } from "../hooks/useVoiceTest";
 import type { AudioDevice } from "../types";
 
 const VOICE_DEVICES_KEY = "pollis:voice-devices";
@@ -64,6 +66,7 @@ const DeviceSelect: React.FC<DeviceSelectProps> = ({ label, devices, value, onCh
 
 export const VoiceSettingsPage: React.FC = () => {
   const preferences = usePreferences();
+  const test = useVoiceTest();
 
   const [inputs, setInputs] = useState<AudioDevice[]>([]);
   const [outputs, setOutputs] = useState<AudioDevice[]>([]);
@@ -94,11 +97,20 @@ export const VoiceSettingsPage: React.FC = () => {
   const setInput = (id: string) => {
     setSelectedInputState(id);
     switchVoiceDevice("audioinput", id);
+    // Stop any running test so it doesn't keep hitting the stale device.
+    if (test.phase !== "idle") {
+      test.stopMicTest();
+      test.stopPlayback();
+    }
   };
 
   const setOutput = (id: string) => {
     setSelectedOutputState(id);
     switchVoiceDevice("audiooutput", id);
+    if (test.phase !== "idle") {
+      test.stopMicTest();
+      test.stopPlayback();
+    }
   };
 
   const handleNoiseFloor = (val: number) => {
@@ -142,6 +154,141 @@ export const VoiceSettingsPage: React.FC = () => {
             onChange={setOutput}
             fallbackLabel="Default speaker"
           />
+        </section>
+
+        <section className="flex flex-col gap-5 mb-12" data-testid="voice-test-section">
+          <h2
+            className="text-xs font-mono font-medium uppercase tracking-widest pb-1 border-b"
+            style={{ color: "var(--c-text)", borderColor: "var(--c-border)" }}
+          >
+            Test
+          </h2>
+
+          {/* ── Microphone test ────────────────────────────────────────── */}
+          <div className="flex flex-col gap-2" style={{ maxWidth: 320 }}>
+            <span style={{ color: "var(--c-text-muted)" }}>Microphone</span>
+
+            {/* Level meter. Reserves its height even when idle so the
+                layout doesn't jump on start/stop. */}
+            <div
+              data-testid="voice-test-meter"
+              aria-label="Microphone level"
+              style={{
+                height: 12,
+                background: "var(--c-surface)",
+                borderRadius: 4,
+                overflow: "hidden",
+                border: "1px solid var(--c-border)",
+              }}
+            >
+              <div
+                style={{
+                  width: `${Math.max(test.peak, test.rms) * 100}%`,
+                  height: "100%",
+                  background: test.gated ? "var(--c-text-muted)" : "var(--c-accent)",
+                  transition: "width 60ms linear",
+                }}
+              />
+            </div>
+            {test.phase === "mic_listening" && test.gated && (
+              <span
+                className="text-xs font-mono"
+                style={{ color: "var(--c-text-muted)" }}
+              >
+                below noise gate — raise your voice or lower the gate
+              </span>
+            )}
+
+            <div className="flex flex-wrap gap-2 mt-1">
+              <Button
+                data-testid={
+                  test.phase === "mic_listening"
+                    ? "voice-test-stop-mic"
+                    : "voice-test-start-mic"
+                }
+                variant="secondary"
+                disabled={
+                  test.phase === "recording" || test.phase === "playing"
+                }
+                onClick={() =>
+                  test.phase === "mic_listening"
+                    ? test.stopMicTest()
+                    : test.startMicTest(selectedInput, selectedOutput, false)
+                }
+              >
+                {test.phase === "mic_listening"
+                  ? "Stop mic test"
+                  : "Start mic test"}
+              </Button>
+              <Button
+                data-testid="voice-test-record-playback"
+                variant="secondary"
+                disabled={test.phase === "recording" || test.phase === "playing"}
+                onClick={() =>
+                  test.recordAndPlayBack(selectedInput, selectedOutput, 3000)
+                }
+              >
+                {test.phase === "recording"
+                  ? "Recording…"
+                  : test.phase === "playing"
+                    ? "Playing…"
+                    : "Record 3s & play back"}
+              </Button>
+            </div>
+
+            {/* Always rendered so the section height doesn't jump when the
+                mic test starts/stops. Disabled unless the mic test is live. */}
+            <Switch
+              label="Hear myself (may echo)"
+              checked={test.monitor}
+              disabled={test.phase !== "mic_listening"}
+              onChange={(enabled) => test.setMonitor(enabled, selectedOutput)}
+              description="Loops the mic back through the selected output. Use headphones to avoid feedback."
+            />
+          </div>
+
+          {/* ── Speaker test ───────────────────────────────────────────── */}
+          <div className="flex flex-col gap-2" style={{ maxWidth: 320 }}>
+            <span style={{ color: "var(--c-text-muted)" }}>Speaker</span>
+            <div className="flex flex-wrap gap-2">
+              <Button
+                data-testid="voice-test-play-sweep"
+                variant="secondary"
+                disabled={test.phase === "playing" || test.phase === "recording"}
+                onClick={() => test.playTone(selectedOutput, "sweep")}
+              >
+                Play sweep
+              </Button>
+              <Button
+                data-testid="voice-test-play-chime"
+                variant="secondary"
+                disabled={test.phase === "playing" || test.phase === "recording"}
+                onClick={() => test.playTone(selectedOutput, "chime")}
+              >
+                Play chime
+              </Button>
+              {/* Always rendered so the row doesn't grow/shrink when a tone
+                  starts/stops. Disabled when there's nothing to stop. */}
+              <Button
+                data-testid="voice-test-stop-playback"
+                variant="secondary"
+                disabled={test.phase !== "playing"}
+                onClick={() => test.stopPlayback()}
+              >
+                Stop
+              </Button>
+            </div>
+          </div>
+
+          {test.error && (
+            <p
+              data-testid="voice-test-error"
+              className="text-xs font-mono"
+              style={{ color: "#ff6b6b" }}
+            >
+              {test.error}
+            </p>
+          )}
         </section>
 
         <section className="flex flex-col gap-4 mb-12">

--- a/frontend/src/utils/colorUtils.ts
+++ b/frontend/src/utils/colorUtils.ts
@@ -1,3 +1,5 @@
+import { setBackgroundLightness } from "./usernameColor";
+
 /** Convert a hex color string to [h (0-360), s (0-100), l (0-100)] */
 export function hexToHsl(hex: string): [number, number, number] {
   const r = parseInt(hex.slice(1, 3), 16) / 255;
@@ -45,6 +47,8 @@ export function applyBackgroundColor(hex: string): void {
   document.documentElement.style.setProperty("--bg-h", String(h));
   document.documentElement.style.setProperty("--bg-s", `${s}%`);
   document.documentElement.style.setProperty("--bg-l", `${l}%`);
+  // Notify subscribers (e.g. username coloring) that contrast target shifted.
+  setBackgroundLightness(l);
 }
 
 /** Apply a font size (in px) to the document CSS variable */

--- a/frontend/src/utils/usernameColor.ts
+++ b/frontend/src/utils/usernameColor.ts
@@ -1,0 +1,115 @@
+import { useSyncExternalStore } from "react";
+
+/**
+ * Stable per-user color for message authors.
+ *
+ * - Deterministic: same `key` → same hue on every device and every render.
+ * - Accessible: lightness flips based on the current background — bright
+ *   saturated colors on dark bg, darker muted colors on light bg.
+ * - Fast: O(n) FNV-1a hash over the key string (short usernames / ids),
+ *   then the result is memoised forever in a module-level cache keyed on
+ *   (key, bg-variant). Rendering hundreds of messages is a series of
+ *   Map.get() hits after the first pass.
+ */
+
+// ── bg-lightness store ────────────────────────────────────────────────────
+// We need to know whether the current background is light or dark so we
+// can pick contrasting colors. Exposed as a tiny external store so
+// components using `useBackgroundIsLight` re-render when the user
+// changes their background preference.
+
+// Default from index.css (`--bg-l: 4%`). Overwritten once the DOM is
+// readable, and again on every `applyBackgroundColor` call.
+let currentBgL = 4;
+let initialized = false;
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  listeners.forEach((cb) => cb());
+}
+
+function initFromDom(): void {
+  if (initialized || typeof document === "undefined") {
+    return;
+  }
+  const raw = getComputedStyle(document.documentElement)
+    .getPropertyValue("--bg-l")
+    .trim();
+  const parsed = parseFloat(raw);
+  if (!isNaN(parsed)) {
+    currentBgL = parsed;
+  }
+  initialized = true;
+}
+
+/**
+ * Called from `applyBackgroundColor` whenever the user's background-color
+ * preference resolves or changes. Notifies `useBackgroundIsLight`
+ * subscribers so message rows re-render against the new contrast target.
+ * The cache holds both light and dark variants keyed separately, so no
+ * invalidation is required.
+ */
+export function setBackgroundLightness(l: number): void {
+  if (currentBgL === l && initialized) {
+    return;
+  }
+  currentBgL = l;
+  initialized = true;
+  emit();
+}
+
+export function isBackgroundLight(): boolean {
+  initFromDom();
+  return currentBgL > 50;
+}
+
+export function useBackgroundIsLight(): boolean {
+  return useSyncExternalStore(
+    (cb) => {
+      listeners.add(cb);
+      return () => {
+        listeners.delete(cb);
+      };
+    },
+    isBackgroundLight,
+    // SSR fallback — assume dark so initial paint matches the default theme.
+    () => false,
+  );
+}
+
+// ── hash + color derivation ───────────────────────────────────────────────
+
+// FNV-1a 32-bit. Tiny, allocation-free, good enough distribution for
+// bucketing into 360 hues.
+function hashString(str: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}
+
+const cache = new Map<string, string>();
+
+/**
+ * Return a stable HSL color for `key` that contrasts with the current
+ * background. Pass `isLightBg` from `useBackgroundIsLight()` so the
+ * caller re-renders when the user swaps themes.
+ */
+export function getUsernameColor(key: string, isLightBg: boolean): string {
+  const cacheKey = `${isLightBg ? "L" : "D"}:${key}`;
+  const hit = cache.get(cacheKey);
+  if (hit !== undefined) {
+    return hit;
+  }
+  const hue = hashString(key) % 360;
+  // Saturation is kept moderate: too high reads as neon on either theme.
+  // Lightness flips: bright on dark bg, darker on light bg, both chosen
+  // to stay roughly at 4.5:1 contrast against typical theme bgs.
+  const s = 65;
+  const l = isLightBg ? 35 : 68;
+  const color = `hsl(${hue} ${s}% ${l}%)`;
+  cache.set(cacheKey, color);
+  return color;
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -12,3 +12,4 @@ pub mod r2;
 pub mod sfx;
 pub mod update;
 pub mod voice;
+pub mod voice_test;

--- a/src-tauri/src/commands/voice.rs
+++ b/src-tauri/src/commands/voice.rs
@@ -25,7 +25,7 @@ use crate::{commands::livekit::make_token, error::Result, state::AppState};
 
 // ── cpal::Stream is Send on Linux and macOS. On Windows WASAPI it is not,
 // so we wrap it with an explicit unsafe impl to allow storage in AppState.
-struct SendableStream(cpal::Stream);
+pub(crate) struct SendableStream(pub(crate) cpal::Stream);
 unsafe impl Send for SendableStream {}
 unsafe impl Sync for SendableStream {}
 
@@ -123,7 +123,7 @@ impl VoiceState {
 
 // ── Internal helpers ──────────────────────────────────────────────────────
 
-fn get_device(host: &cpal::Host, name: Option<&str>, is_input: bool) -> Result<cpal::Device> {
+pub(crate) fn get_device(host: &cpal::Host, name: Option<&str>, is_input: bool) -> Result<cpal::Device> {
     let device = match name {
         None => {
             // On Linux, ALSA's system default may be a virtual device like
@@ -199,7 +199,7 @@ fn get_device(host: &cpal::Host, name: Option<&str>, is_input: bool) -> Result<c
 
 /// Build a cpal input stream that converts mic audio to i16 mono and sends
 /// 10ms chunks to `frame_tx`. Downmixes multi-channel input to mono.
-fn start_mic_stream(
+pub(crate) fn start_mic_stream(
     device: &cpal::Device,
     frame_tx: tokio::sync::mpsc::UnboundedSender<(Vec<i16>, u32)>,
     is_muted: Arc<AtomicBool>,
@@ -276,7 +276,7 @@ fn start_mic_stream(
 
 /// Build a cpal output stream driven by a shared ring buffer.
 /// Returns the stream (kept alive by the caller) and the buffer to push into.
-fn start_speaker_stream(
+pub(crate) fn start_speaker_stream(
     device: &cpal::Device,
 ) -> Result<(SendableStream, u32, u32, Arc<Mutex<VecDeque<f32>>>)> {
     let config = device

--- a/src-tauri/src/commands/voice_test.rs
+++ b/src-tauri/src/commands/voice_test.rs
@@ -1,0 +1,597 @@
+use std::collections::VecDeque;
+use std::f32::consts::PI;
+use std::sync::{
+    atomic::{AtomicBool, AtomicU32, Ordering},
+    Arc, Mutex,
+};
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use tauri::State;
+
+use crate::commands::voice::{
+    get_device, start_mic_stream, start_speaker_stream, SendableStream,
+};
+use crate::error::Result;
+use crate::state::AppState;
+
+// ── Events pushed to the frontend ─────────────────────────────────────────
+
+/// Lifecycle + meter events for the Voice Settings test harness.
+/// `Frame` is emitted at ~30 Hz while a mic test is running. The record /
+/// tone commands emit the Recording*/Playback* markers so the UI can
+/// reflect state transitions without the frontend having to poll.
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum VoiceTestEvent {
+    /// Mic level sample. `peak` and `rms` are normalized 0.0..1.0 and are
+    /// computed on the raw (ungated) signal so the meter still moves when
+    /// the user speaks below the current noise floor. `gated` reports
+    /// whether the same sample would be dropped by the real gate.
+    Frame { peak: f32, rms: f32, gated: bool },
+    RecordingStarted,
+    RecordingFinished,
+    PlaybackStarted,
+    PlaybackFinished,
+}
+
+// ── Test session state ────────────────────────────────────────────────────
+
+/// All state owned by the test harness. Held in a tokio Mutex inside
+/// `AppState`. There is at most one active test at a time — starting a
+/// new one (mic test, tone, or record+play) tears the previous one down.
+pub struct VoiceTestState {
+    pub channel: Option<tauri::ipc::Channel<VoiceTestEvent>>,
+    // ── Mic test ──
+    pub mic_stream: Option<SendableStream>,
+    pub mic_task: Option<tokio::task::JoinHandle<()>>,
+    pub monitor_enabled: Arc<AtomicBool>,
+    /// Always zero — `start_mic_stream` gates before forwarding, and we
+    /// want the meter to see every frame. Real gate status is computed in
+    /// the emit task against the live voice `noise_floor`.
+    pub test_noise_floor: Arc<AtomicU32>,
+    // ── Output (shared between monitor / tone / record-playback) ──
+    pub output_stream: Option<SendableStream>,
+    pub output_buf: Option<Arc<Mutex<VecDeque<f32>>>>,
+    pub output_channels: u32,
+    pub output_sample_rate: u32,
+    pub output_device_name: Option<String>,
+    pub playback_task: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl VoiceTestState {
+    pub fn new() -> Self {
+        Self {
+            channel: None,
+            mic_stream: None,
+            mic_task: None,
+            monitor_enabled: Arc::new(AtomicBool::new(false)),
+            test_noise_floor: Arc::new(AtomicU32::new(0u32)),
+            output_stream: None,
+            output_buf: None,
+            output_channels: 2,
+            output_sample_rate: 48_000,
+            output_device_name: None,
+            playback_task: None,
+        }
+    }
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────
+
+/// Abort any running playback / monitor / mic tasks and drop their streams.
+/// Called at the start of every `start_*` command so tests are mutually
+/// exclusive and idempotent.
+fn stop_everything(state: &mut VoiceTestState) {
+    if let Some(t) = state.playback_task.take() {
+        t.abort();
+    }
+    if let Some(t) = state.mic_task.take() {
+        t.abort();
+    }
+    // Dropping the cpal streams stops them.
+    state.mic_stream = None;
+    state.output_stream = None;
+    state.output_buf = None;
+    state.output_device_name = None;
+    state.monitor_enabled.store(false, Ordering::Relaxed);
+}
+
+/// Ensure `state.output_*` is populated for `device_name`. If an output
+/// stream is already open on a different device, tear it down first.
+/// Runs the blocking cpal init on a dedicated thread so the async mutex
+/// stays responsive.
+async fn ensure_output(
+    state_arc: &Arc<tokio::sync::Mutex<VoiceTestState>>,
+    device_name: &str,
+) -> Result<(Arc<Mutex<VecDeque<f32>>>, u32, u32)> {
+    {
+        let s = state_arc.lock().await;
+        if s.output_device_name.as_deref() == Some(device_name) {
+            if let (Some(buf), sr, ch) = (
+                s.output_buf.clone(),
+                s.output_sample_rate,
+                s.output_channels,
+            ) {
+                return Ok((buf, sr, ch));
+            }
+        }
+    }
+
+    let dev_name = device_name.to_string();
+    let (stream, sample_rate, channels, buf) = tokio::task::spawn_blocking(move || {
+        let host = cpal::default_host();
+        let dev = get_device(&host, Some(&dev_name), false)?;
+        start_speaker_stream(&dev)
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("speaker init panicked: {e}"))??;
+
+    let mut s = state_arc.lock().await;
+    // If a previous stream was opened on another device, drop it so the
+    // new one takes over cleanly.
+    s.output_stream = None;
+    s.output_stream = Some(stream);
+    s.output_buf = Some(buf.clone());
+    s.output_sample_rate = sample_rate;
+    s.output_channels = channels;
+    s.output_device_name = Some(device_name.to_string());
+    Ok((buf, sample_rate, channels))
+}
+
+/// Fire an event on the registered channel, if any. No-op when the frontend
+/// hasn't called `subscribe_voice_test_events` yet.
+async fn emit(state_arc: &Arc<tokio::sync::Mutex<VoiceTestState>>, ev: VoiceTestEvent) {
+    let s = state_arc.lock().await;
+    if let Some(ch) = &s.channel {
+        let _ = ch.send(ev);
+    }
+}
+
+// ── Tauri commands ────────────────────────────────────────────────────────
+
+/// Register the Tauri Channel used to push VoiceTestEvents.
+/// Call once when the Voice Settings page mounts.
+#[tauri::command]
+pub async fn subscribe_voice_test_events(
+    on_event: tauri::ipc::Channel<VoiceTestEvent>,
+    state: State<'_, Arc<AppState>>,
+) -> Result<()> {
+    let mut s = state.voice_test.lock().await;
+    s.channel = Some(on_event);
+    Ok(())
+}
+
+/// Start a mic self-test against `input_device_id`. Opens the same cpal
+/// input stream the voice chat uses, computes peak/RMS on every frame, and
+/// pushes a `Frame` event to the frontend at ~30 Hz. When `monitor` is
+/// true, also opens the output device and loops the mic back through it
+/// (feedback warning).
+///
+/// Cancels any previous test.
+#[tauri::command]
+pub async fn start_mic_test(
+    input_device_id: String,
+    output_device_id: String,
+    monitor: bool,
+    state: State<'_, Arc<AppState>>,
+) -> Result<()> {
+    let state_arc = Arc::clone(&state.voice_test);
+
+    // Cancel any previous test atomically.
+    {
+        let mut s = state_arc.lock().await;
+        stop_everything(&mut s);
+    }
+
+    // Open the output first if we're monitoring — makes feedback obvious
+    // from the first mic frame rather than after a one-way warmup gap.
+    let output = if monitor {
+        Some(ensure_output(&state_arc, &output_device_id).await?)
+    } else {
+        None
+    };
+
+    // Pull the shared atomics we need before spawning the blocking init.
+    let (is_muted, test_gate, monitor_flag, real_noise_floor) = {
+        let s = state_arc.lock().await;
+        let voice = state.voice.lock().await;
+        (
+            Arc::clone(&voice.is_muted),
+            Arc::clone(&s.test_noise_floor),
+            Arc::clone(&s.monitor_enabled),
+            Arc::clone(&voice.noise_floor),
+        )
+    };
+    monitor_flag.store(monitor, Ordering::Relaxed);
+
+    let (frame_tx, mut frame_rx) =
+        tokio::sync::mpsc::unbounded_channel::<(Vec<i16>, u32)>();
+
+    let input_id = input_device_id.clone();
+    let (mic_stream, _mic_rate) = tokio::task::spawn_blocking(move || {
+        let host = cpal::default_host();
+        let dev = get_device(&host, Some(&input_id), true)?;
+        start_mic_stream(&dev, frame_tx, is_muted, test_gate)
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("mic init panicked: {e}"))??;
+
+    let state_task = Arc::clone(&state_arc);
+    let monitor_flag_task = Arc::clone(&monitor_flag);
+    let task = tokio::spawn(async move {
+        // Emit one frame every 3 mic chunks (≈30ms ≈ 33Hz). Keeps the
+        // IPC volume reasonable while still feeling responsive.
+        const EMIT_EVERY: u32 = 3;
+        let mut chunks_seen: u32 = 0;
+        let mut acc_peak: i16 = 0;
+        let mut acc_sq: f64 = 0.0;
+        let mut acc_count: usize = 0;
+
+        while let Some((samples, _rate)) = frame_rx.recv().await {
+            // Level math on the raw chunk.
+            let mut chunk_peak: i16 = 0;
+            let mut chunk_sq: f64 = 0.0;
+            for &s in &samples {
+                let a = s.saturating_abs();
+                if a > chunk_peak {
+                    chunk_peak = a;
+                }
+                let f = s as f64;
+                chunk_sq += f * f;
+            }
+            if chunk_peak > acc_peak {
+                acc_peak = chunk_peak;
+            }
+            acc_sq += chunk_sq;
+            acc_count += samples.len();
+
+            // Feed monitor output if enabled. Mono → output_channels by
+            // duplication. Use the same ring buffer cap strategy as the
+            // call-path: trim to 200ms so it doesn't drift.
+            if monitor_flag_task.load(Ordering::Relaxed) {
+                let (buf_opt, ch) = {
+                    let s = state_task.lock().await;
+                    (s.output_buf.clone(), s.output_channels)
+                };
+                if let Some(buf) = buf_opt {
+                    let mut b = buf.lock().unwrap();
+                    for &sample in &samples {
+                        let f = sample as f32 / 32_768.0;
+                        for _ in 0..ch {
+                            b.push_back(f);
+                        }
+                    }
+                    let cap = (48_000 * ch / 5) as usize;
+                    while b.len() > cap {
+                        b.pop_front();
+                    }
+                }
+            }
+
+            chunks_seen += 1;
+            if chunks_seen >= EMIT_EVERY {
+                let peak_norm = (acc_peak as f32 / 32_768.0).clamp(0.0, 1.0);
+                let rms_norm = if acc_count > 0 {
+                    ((acc_sq / acc_count as f64).sqrt() as f32 / 32_768.0).clamp(0.0, 1.0)
+                } else {
+                    0.0
+                };
+                let gate = f32::from_bits(real_noise_floor.load(Ordering::Relaxed));
+                let gated = gate > 0.0 && peak_norm < gate;
+
+                let ev = VoiceTestEvent::Frame {
+                    peak: peak_norm,
+                    rms: rms_norm,
+                    gated,
+                };
+                {
+                    let s = state_task.lock().await;
+                    if let Some(ch_) = &s.channel {
+                        let _ = ch_.send(ev);
+                    }
+                }
+
+                chunks_seen = 0;
+                acc_peak = 0;
+                acc_sq = 0.0;
+                acc_count = 0;
+            }
+        }
+    });
+
+    let _ = output; // suppress unused in monitor=false path
+    let mut s = state_arc.lock().await;
+    s.mic_stream = Some(mic_stream);
+    s.mic_task = Some(task);
+    Ok(())
+}
+
+/// Toggle the monitor (loopback) path on or off while a mic test is
+/// running. No-op if no test is active.
+#[tauri::command]
+pub async fn set_mic_test_monitor(
+    enabled: bool,
+    output_device_id: String,
+    state: State<'_, Arc<AppState>>,
+) -> Result<()> {
+    let state_arc = Arc::clone(&state.voice_test);
+
+    // When enabling, make sure the output is open on the requested device
+    // before flipping the flag so we don't drop the first 100ms of monitor
+    // audio into a silent ring.
+    if enabled {
+        ensure_output(&state_arc, &output_device_id).await?;
+    }
+
+    let s = state_arc.lock().await;
+    s.monitor_enabled.store(enabled, Ordering::Relaxed);
+    Ok(())
+}
+
+/// Stop any running mic test (monitor + meter). Idempotent.
+#[tauri::command]
+pub async fn stop_mic_test(state: State<'_, Arc<AppState>>) -> Result<()> {
+    let mut s = state.voice_test.lock().await;
+    stop_everything(&mut s);
+    Ok(())
+}
+
+/// Record `duration_ms` of microphone audio into memory, then play it back
+/// through the output device. Cancels any other running test. Emits
+/// RecordingStarted → RecordingFinished → PlaybackStarted → PlaybackFinished.
+#[tauri::command]
+pub async fn record_and_play_back(
+    input_device_id: String,
+    output_device_id: String,
+    duration_ms: u32,
+    state: State<'_, Arc<AppState>>,
+) -> Result<()> {
+    let state_arc = Arc::clone(&state.voice_test);
+    let voice_arc = Arc::clone(&state.voice);
+
+    {
+        let mut s = state_arc.lock().await;
+        stop_everything(&mut s);
+    }
+
+    // Set up mic (gated with zero floor so we record the whole signal,
+    // not post-gate silence).
+    let (is_muted, test_gate) = {
+        let s = state_arc.lock().await;
+        let v = voice_arc.lock().await;
+        (Arc::clone(&v.is_muted), Arc::clone(&s.test_noise_floor))
+    };
+    let (frame_tx, mut frame_rx) =
+        tokio::sync::mpsc::unbounded_channel::<(Vec<i16>, u32)>();
+
+    let input_id = input_device_id.clone();
+    let (mic_stream, mic_rate) = tokio::task::spawn_blocking(move || {
+        let host = cpal::default_host();
+        let dev = get_device(&host, Some(&input_id), true)?;
+        start_mic_stream(&dev, frame_tx, is_muted, test_gate)
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("mic init panicked: {e}"))??;
+
+    // Store mic stream so cancellation can drop it.
+    {
+        let mut s = state_arc.lock().await;
+        s.mic_stream = Some(mic_stream);
+    }
+
+    let state_task = Arc::clone(&state_arc);
+    let task = tokio::spawn(async move {
+        emit(&state_task, VoiceTestEvent::RecordingStarted).await;
+
+        // Accumulate samples for `duration_ms`.
+        let target_samples = (mic_rate as u64 * duration_ms as u64 / 1_000) as usize;
+        let mut recorded: Vec<i16> = Vec::with_capacity(target_samples + 4_800);
+        let deadline = tokio::time::Instant::now()
+            + Duration::from_millis(duration_ms as u64);
+
+        loop {
+            let timeout = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if timeout.is_zero() {
+                break;
+            }
+            match tokio::time::timeout(timeout, frame_rx.recv()).await {
+                Ok(Some((samples, _rate))) => {
+                    recorded.extend_from_slice(&samples);
+                    if recorded.len() >= target_samples {
+                        break;
+                    }
+                }
+                _ => break, // channel closed or deadline hit
+            }
+        }
+
+        // Stop the mic — we have what we need.
+        {
+            let mut s = state_task.lock().await;
+            s.mic_stream = None;
+        }
+        emit(&state_task, VoiceTestEvent::RecordingFinished).await;
+
+        // Playback phase.
+        let output = match ensure_output(&state_task, &output_device_id).await {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("[voice-test] record-playback output init failed: {e}");
+                return;
+            }
+        };
+        let (buf, out_rate, out_channels) = output;
+
+        emit(&state_task, VoiceTestEvent::PlaybackStarted).await;
+
+        // Push recorded mono i16 into the f32 ring, duplicated per channel.
+        // Assumes mic_rate == out_rate (both forced to 48 kHz elsewhere).
+        {
+            let mut b = buf.lock().unwrap();
+            for &sample in &recorded {
+                let f = sample as f32 / 32_768.0;
+                for _ in 0..out_channels {
+                    b.push_back(f);
+                }
+            }
+        }
+
+        // Wait for drain. Poll at 50ms; covers ~20 ticks/sec.
+        let drained_at_wait = {
+            let total_samples = recorded.len() as u64 * out_channels as u64;
+            Duration::from_millis(total_samples * 1_000 / out_rate as u64 + 250)
+        };
+        let start = tokio::time::Instant::now();
+        loop {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            let empty = {
+                let b = buf.lock().unwrap();
+                b.is_empty()
+            };
+            if empty || start.elapsed() > drained_at_wait {
+                break;
+            }
+        }
+
+        // Tear down the output now that playback is done.
+        {
+            let mut s = state_task.lock().await;
+            s.output_stream = None;
+            s.output_buf = None;
+            s.output_device_name = None;
+        }
+        emit(&state_task, VoiceTestEvent::PlaybackFinished).await;
+    });
+
+    let mut s = state_arc.lock().await;
+    s.playback_task = Some(task);
+    Ok(())
+}
+
+/// Play a test tone through `output_device_id`.
+/// `kind` is `"sweep"` (200→2000 Hz linear sine over 1.5s) or `"chime"`
+/// (C5-E5-G5 arpeggio, 200ms each). Cancels any other running test.
+#[tauri::command]
+pub async fn play_test_tone(
+    output_device_id: String,
+    kind: String,
+    state: State<'_, Arc<AppState>>,
+) -> Result<()> {
+    let state_arc = Arc::clone(&state.voice_test);
+
+    {
+        let mut s = state_arc.lock().await;
+        stop_everything(&mut s);
+    }
+
+    let (buf, sample_rate, channels) =
+        ensure_output(&state_arc, &output_device_id).await?;
+
+    let samples: Vec<f32> = match kind.as_str() {
+        "sweep" => generate_sweep(sample_rate, 1_500, 200.0, 2_000.0),
+        "chime" => generate_chime(sample_rate),
+        other => {
+            return Err(anyhow::anyhow!("unknown tone kind: {other}").into());
+        }
+    };
+
+    let total_duration_ms =
+        (samples.len() as u64 * 1_000 / sample_rate as u64) as u64;
+
+    let state_task = Arc::clone(&state_arc);
+    let task = tokio::spawn(async move {
+        emit(&state_task, VoiceTestEvent::PlaybackStarted).await;
+
+        // Push mono samples duplicated to output channels.
+        {
+            let mut b = buf.lock().unwrap();
+            for &s in &samples {
+                for _ in 0..channels {
+                    b.push_back(s);
+                }
+            }
+        }
+
+        // Wait for the ring to drain, with a small grace period.
+        tokio::time::sleep(Duration::from_millis(total_duration_ms + 250)).await;
+
+        // Tear down so the next test starts clean.
+        {
+            let mut s = state_task.lock().await;
+            s.output_stream = None;
+            s.output_buf = None;
+            s.output_device_name = None;
+        }
+        emit(&state_task, VoiceTestEvent::PlaybackFinished).await;
+    });
+
+    let mut s = state_arc.lock().await;
+    s.playback_task = Some(task);
+    Ok(())
+}
+
+/// Stop any running tone / record-playback. Mic test (if separately running)
+/// is untouched. Idempotent.
+#[tauri::command]
+pub async fn stop_test_playback(state: State<'_, Arc<AppState>>) -> Result<()> {
+    let mut s = state.voice_test.lock().await;
+    if let Some(t) = s.playback_task.take() {
+        t.abort();
+    }
+    s.output_stream = None;
+    s.output_buf = None;
+    s.output_device_name = None;
+    Ok(())
+}
+
+// ── Tone generators ───────────────────────────────────────────────────────
+
+/// Linear-frequency sine sweep with a short attack/release envelope to
+/// avoid clicks at the edges.
+fn generate_sweep(sample_rate: u32, duration_ms: u32, f0: f32, f1: f32) -> Vec<f32> {
+    let total = (sample_rate as u64 * duration_ms as u64 / 1_000) as usize;
+    let mut out = Vec::with_capacity(total);
+    let env_samples = sample_rate as usize / 50; // 20ms fade
+    let mut phase = 0.0f32;
+    for i in 0..total {
+        let t = i as f32 / total as f32;
+        let f = f0 + (f1 - f0) * t;
+        phase += 2.0 * PI * f / sample_rate as f32;
+        if phase > 2.0 * PI {
+            phase -= 2.0 * PI;
+        }
+        let env = if i < env_samples {
+            i as f32 / env_samples as f32
+        } else if i > total - env_samples {
+            (total - i) as f32 / env_samples as f32
+        } else {
+            1.0
+        };
+        out.push(phase.sin() * 0.15 * env);
+    }
+    out
+}
+
+/// C5–E5–G5 arpeggio, 200ms per note, with envelopes. Just enough of a
+/// "voice ready" jingle to confirm the output path is wired up end-to-end.
+fn generate_chime(sample_rate: u32) -> Vec<f32> {
+    let notes: [f32; 3] = [523.25, 659.25, 783.99];
+    let per_note_ms = 200u32;
+    let note_samples = (sample_rate as u64 * per_note_ms as u64 / 1_000) as usize;
+    let mut out = Vec::with_capacity(note_samples * notes.len());
+    for freq in notes {
+        let mut phase = 0.0f32;
+        for i in 0..note_samples {
+            phase += 2.0 * PI * freq / sample_rate as f32;
+            if phase > 2.0 * PI {
+                phase -= 2.0 * PI;
+            }
+            // Exponential decay inside each note so it sounds plucked
+            // rather than held.
+            let env = (-4.0 * i as f32 / note_samples as f32).exp();
+            out.push(phase.sin() * 0.15 * env);
+        }
+    }
+    out
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -280,6 +280,13 @@ commands::livekit::get_livekit_token,
             commands::voice::set_voice_input_device,
             commands::voice::set_voice_output_device,
             commands::voice::set_noise_floor,
+            commands::voice_test::subscribe_voice_test_events,
+            commands::voice_test::start_mic_test,
+            commands::voice_test::set_mic_test_monitor,
+            commands::voice_test::stop_mic_test,
+            commands::voice_test::record_and_play_back,
+            commands::voice_test::play_test_tone,
+            commands::voice_test::stop_test_playback,
             commands::sfx::play_sfx,
         ])
         // On macOS, hide the window on close instead of quitting.

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -7,6 +7,7 @@ use crate::config::Config;
 use crate::db::{local::LocalDb, remote::RemoteDb};
 use crate::keystore;
 use crate::commands::voice::VoiceState;
+use crate::commands::voice_test::VoiceTestState;
 use crate::realtime::LiveKitState;
 
 #[derive(Clone)]
@@ -23,6 +24,7 @@ pub struct AppState {
     pub otp_store: Arc<Mutex<HashMap<String, OtpEntry>>>,
     pub livekit: Arc<Mutex<LiveKitState>>,
     pub voice: Arc<Mutex<VoiceState>>,
+    pub voice_test: Arc<Mutex<VoiceTestState>>,
     pub update_required: Arc<AtomicBool>,
     /// Per-device ULID, set during login. Each physical device gets a stable ID
     /// stored in the OS keystore so it survives local DB wipes.
@@ -48,6 +50,7 @@ impl AppState {
             otp_store: Arc::new(Mutex::new(HashMap::new())),
             livekit: Arc::new(Mutex::new(LiveKitState::new())),
             voice: Arc::new(Mutex::new(VoiceState::new())),
+            voice_test: Arc::new(Mutex::new(VoiceTestState::new())),
             update_required: Arc::new(AtomicBool::new(false)),
             device_id: Arc::new(Mutex::new(None)),
             enrollment_ephemeral_keys: Arc::new(Mutex::new(HashMap::new())),


### PR DESCRIPTION
Bundle of small UX fixes bound for the 2026-04-13 cut. Each commit is a
self-contained unit; reviewing commit-by-commit is easier than the diff.

## What's in here

- **#151** voice chat defaults to explicit-join instead of auto-joining.
- **#148** per-user hashed colors for message authors, contrast-aware
  against the active background.
- **#145 / #146** new top-of-page breadcrumb bar with a persistent back
  button; breadcrumb removed from the bottom status bar. `PageShell` back
  arrow and chat-header back arrows dropped too, since navigation is now
  global.
- **#127 / #126** mic + speaker self-test in Voice Settings. All audio
  runs in Rust through cpal/libwebrtc; the webview never touches WebRTC.
- Unrelated polish: emergency-kit filename suffixed with username;
  "Delete local profiles" copy; empty-list left-aligned with padding;
  Plus icons on New Message / New Channel; "Blocked Users" rename.

## Test plan

- [ ] Fresh account + existing account — back button and breadcrumb
  behave on every authenticated page; none on root; PageShell pages no
  longer double up with their own back arrow.
- [ ] DM and channel headers no longer show an ArrowLeft.
- [ ] Open a voice channel on a fresh account — does NOT auto-join.
  Toggle the preference on, reopen, does auto-join.
- [ ] Message authors are colored consistently across restarts; swap
  background preference and colors re-derive for legibility.
- [ ] Voice Settings → Test: level meter moves with speech; gate label
  shows when noise gate is cutting signal; Record 3s & play back loops
  back correctly; sweep + chime play at reasonable volume; Stop button
  stays in place (no layout shift).
- [ ] Bottom status bar shows unread group / DM / join-request counts
  with icons, leaves blank space when zero.

Closes #126.
Closes #127.
Closes #145.
Closes #146.
Closes #148.
Closes #151.