### PR TITLE
Move apply_migrations from bin to example so tauri bundler skips it

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,19 +13,6 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 name = "pollis"
 path = "src/main.rs"
 
-[[bin]]
-name = "migrate"
-path = "src/bin/migrate.rs"
-required-features = ["migrate-bin"]
-
-[[bin]]
-name = "apply_migrations"
-path = "src/bin/apply_migrations.rs"
-required-features = ["migrate-bin"]
-
-[features]
-migrate-bin = []
-
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 

--- a/src-tauri/examples/apply_migrations.rs
+++ b/src-tauri/examples/apply_migrations.rs
@@ -16,8 +16,8 @@
 ///
 /// Usage:
 ///   cargo run --manifest-path src-tauri/Cargo.toml \
-///     --bin apply_migrations --features pollis/migrate-bin
-///   cargo run … --bin apply_migrations --features pollis/migrate-bin -- --full
+///     --example apply_migrations
+///   cargo run … --example apply_migrations -- --full
 
 use std::fs;
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
Tauri bundler tries to build every [[bin]] target, which broke release builds because apply_migrations is a dev-only migration tool. Moving it to examples/ keeps it runnable via `cargo run --example` without being bundled into the app.