### PR TITLE
Fix Windows build: cast DWMWCP_ROUND to u32

### DIFF
--- a/src-tauri/src/commands/voice.rs
+++ b/src-tauri/src/commands/voice.rs
@@ -442,13 +442,13 @@ async fn attach_remote_track(
 /// hardware interfaces (hw:CARD=X,DEV=0). Everything else — sysdefault,
 /// speex, upmix, vdownmix, front:, iec958:, etc. — is filtered out.
 /// On macOS/Windows all devices pass through.
-fn is_useful_device(name: &str) -> bool {
+fn is_useful_device(_name: &str) -> bool {
     #[cfg(not(target_os = "linux"))]
     return true;
     #[cfg(target_os = "linux")]
     {
-        matches!(name, "default" | "pulse" | "pipewire" | "jack")
-            || (name.starts_with("hw:") && name.contains("DEV=0"))
+        matches!(_name, "default" | "pulse" | "pipewire" | "jack")
+            || (_name.starts_with("hw:") && _name.contains("DEV=0"))
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -83,7 +83,7 @@ fn apply_windows_rounded_corners(window: &tauri::WebviewWindow) {
     };
     if let Ok(hwnd) = window.hwnd() {
         let hwnd = hwnd.0 as HWND;
-        let pref: u32 = DWMWCP_ROUND;
+        let pref: u32 = DWMWCP_ROUND as u32;
         unsafe {
             let _ = DwmSetWindowAttribute(
                 hwnd,
@@ -382,11 +382,11 @@ commands::livekit::get_livekit_token,
         })
         .build(tauri::generate_context!())
         .expect("error while building Pollis")
-        .run(|app, event| {
+        .run(|_app, _event| {
             // On macOS, re-show the window when the dock icon is clicked.
             #[cfg(target_os = "macos")]
-            if let tauri::RunEvent::Reopen { .. } = event {
-                show_on_reopen(app);
+            if let tauri::RunEvent::Reopen { .. } = _event {
+                show_on_reopen(_app);
             }
         });
 }


### PR DESCRIPTION
## Summary
- Cast `DWMWCP_ROUND` to `u32` to fix Windows build failure (windows crate now exposes it as `i32`)
- Prefix unused `_app`/`_event`/`_name` params to silence warnings on non-macOS/non-Linux builds

## Test plan
- [ ] CI passes on Windows