### PR TITLE
Restore Linux rounded corners

### DIFF
--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -1,0 +1,20 @@
+{
+  "app": {
+    "windows": [
+      {
+        "label": "main",
+        "title": "Pollis",
+        "width": 650,
+        "height": 480,
+        "minWidth": 420,
+        "minHeight": 360,
+        "resizable": true,
+        "fullscreen": false,
+        "decorations": false,
+        "transparent": true,
+        "visible": true,
+        "shadow": false
+      }
+    ]
+  }
+}


### PR DESCRIPTION
PR #158 flipped `transparent` to false and removed `macOSPrivateApi`, which broke Linux window corner rounding (Linux relies on `transparent: true` + CSS `border-radius` on body/#root). Fixed with a `tauri.linux.conf.json` platform override that sets `transparent: true` and `shadow: false` for Linux only — macOS/Windows keep the runtime rounding paths added in #158/#159.