### PR TITLE
fix(db): record v0 adoption when prod has v1..vN but no baseline row

### DIFF
--- a/scripts/db-apply.sh
+++ b/scripts/db-apply.sh
@@ -34,21 +34,24 @@ APPLIED=$(post '{"requests":[
   {"type":"close"}
 ]}' | jq -r '.results[0].response.result.rows[]?[0].value')
 
-# Adoption: if schema_migrations is empty but the DB already has user data
-# (the `users` table exists), silently record v0 instead of running the baseline.
-# This handles first-run against a DB that predates this tooling.
-if [ -z "${APPLIED:-}" ]; then
-  HAS_USERS=$(post '{"requests":[
-    {"type":"execute","stmt":{"sql":"SELECT 1 FROM sqlite_master WHERE type='"'"'table'"'"' AND name='"'"'users'"'"' LIMIT 1"}},
+# Adoption: if v0 isn't recorded but the DB already has user tables (anything
+# beyond the tracking tables), silently record v0 instead of running the
+# baseline. Covers both first-run against a pre-existing prod DB (v1..vN
+# already applied, no v0) and any future adoption of an established DB.
+# Greenfield DBs (no tables at all) fall through and run the baseline.
+if ! printf '%s\n' ${APPLIED:-} | grep -qx "0"; then
+  OTHER_TABLES=$(post '{"requests":[
+    {"type":"execute","stmt":{"sql":"SELECT COUNT(*) FROM sqlite_master WHERE type='"'"'table'"'"' AND name NOT IN ('"'"'schema_migrations'"'"', '"'"'sqlite_sequence'"'"')"}},
     {"type":"close"}
-  ]}' | jq -r '.results[0].response.result.rows | length')
-  if [ "$HAS_USERS" -gt 0 ]; then
+  ]}' | jq -r '.results[0].response.result.rows[0][0].value')
+  if [ "${OTHER_TABLES:-0}" -gt 0 ]; then
     echo "Adopting existing DB: recording v0 baseline without running baseline SQL"
     post '{"requests":[
       {"type":"execute","stmt":{"sql":"INSERT INTO schema_migrations (version, description) VALUES (0, '"'"'baseline'"'"')"}},
       {"type":"close"}
     ]}' > /dev/null
-    APPLIED="0"
+    APPLIED="${APPLIED:+$APPLIED
+}0"
   fi
 fi
 


### PR DESCRIPTION
## Summary
- Previous adoption check only triggered when \`schema_migrations\` was empty, so prod (18 existing migration rows, no v0) skipped adoption and tried to run the baseline — first \`CREATE TABLE\` failed and the batch rolled back.
- Now we check for v0 specifically in APPLIED, and adopt whenever the DB has any tables beyond the tracking ones. Greenfield DBs still fall through and run the baseline.

## Test plan
- [ ] Workflow run against prod succeeds: adoption records v0 and reports "No pending migrations."