### PR TITLE
ci(release): fix artifact paths after workspace move to repo root

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -69,10 +69,11 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: pollis-macos
+          if-no-files-found: error
           path: |
-            src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/*.dmg
-            src-tauri/target/aarch64-apple-darwin/release/bundle/macos/*.tar.gz
-            src-tauri/target/aarch64-apple-darwin/release/bundle/macos/*.sig
+            target/aarch64-apple-darwin/release/bundle/dmg/*.dmg
+            target/aarch64-apple-darwin/release/bundle/macos/*.tar.gz
+            target/aarch64-apple-darwin/release/bundle/macos/*.sig
 
   build-windows:
     runs-on: windows-latest
@@ -195,10 +196,11 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: pollis-windows
+          if-no-files-found: error
           path: |
-            src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis/*.exe
-            src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis/*.zip
-            src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis/*.sig
+            target/x86_64-pc-windows-msvc/release/bundle/nsis/*.exe
+            target/x86_64-pc-windows-msvc/release/bundle/nsis/*.zip
+            target/x86_64-pc-windows-msvc/release/bundle/nsis/*.sig
 
   build-linux:
     runs-on: ubuntu-22.04
@@ -267,12 +269,13 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: pollis-linux
+          if-no-files-found: error
           path: |
-            src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage/*.AppImage
-            src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage/*.tar.gz
-            src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage/*.sig
-            src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/deb/*.deb
-            src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/rpm/*.rpm
+            target/x86_64-unknown-linux-gnu/release/bundle/appimage/*.AppImage
+            target/x86_64-unknown-linux-gnu/release/bundle/appimage/*.tar.gz
+            target/x86_64-unknown-linux-gnu/release/bundle/appimage/*.sig
+            target/x86_64-unknown-linux-gnu/release/bundle/deb/*.deb
+            target/x86_64-unknown-linux-gnu/release/bundle/rpm/*.rpm
 
   apply-migrations:
     needs: [build-macos, build-windows, build-linux]


### PR DESCRIPTION
## Summary
- Drop `src-tauri/` prefix from the three `upload-artifact` paths — cargo workspace at repo root puts builds at `target/<triple>/...`, not `src-tauri/target/<triple>/...`. Without this, all three jobs uploaded zero files and the release job failed downloading nothing (run 24902632366).
- Add `if-no-files-found: error` so the next path drift fails the build job loudly instead of silently warning and propagating to release 25 minutes later.

## Test plan
- [ ] Re-tag (or re-run the v1.0.116 workflow) and confirm each build job's upload step lists files and the release job's `Debug artifact structure` finds them under `artifacts/pollis-{macos,windows,linux}/`.