### PR TITLE
Voice bar speaker filter, Linux clipboard image paste, lightbox refocus

### DIFF
--- a/frontend/src/components/Layout/MainContent.tsx
+++ b/frontend/src/components/Layout/MainContent.tsx
@@ -128,6 +128,14 @@ export const MainContent: React.FC = () => {
     }
   }, [nextCursor]);
 
+  // MessageItem dispatches this when an attachment lightbox closes so focus
+  // returns to the chat input — keeps the keyboard-driven flow intact.
+  useEffect(() => {
+    const handler = () => chatInputRef.current?.focus();
+    window.addEventListener("pollis:focus-chat-input", handler);
+    return () => window.removeEventListener("pollis:focus-chat-input", handler);
+  }, []);
+
   // Merge older fetched pages with the live initial page, deduplicated and
   // sorted oldest-first. Dedup keeps the first occurrence by message ID.
   const allMessages = useMemo(() => {

--- a/frontend/src/components/Message/MessageItem.tsx
+++ b/frontend/src/components/Message/MessageItem.tsx
@@ -347,6 +347,18 @@ const AttachmentDisplay: React.FC<{ attachment: MessageAttachment }> = ({ attach
     return () => window.removeEventListener("keydown", handler, { capture: true });
   }, [viewerOpen]);
 
+  // After the lightbox closes, return focus to the chat input. MessageItem
+  // doesn't own the input ref, so signal via a window event that MainContent
+  // listens for. Only fire on a true→false transition so unrelated unmounts
+  // (virtualized scroll, channel switch) don't steal focus.
+  const prevViewerOpenRef = useRef(viewerOpen);
+  useEffect(() => {
+    if (prevViewerOpenRef.current && !viewerOpen) {
+      window.dispatchEvent(new Event("pollis:focus-chat-input"));
+    }
+    prevViewerOpenRef.current = viewerOpen;
+  }, [viewerOpen]);
+
   // Video: read duration + capture a poster frame via canvas.
   // Safe to seek now that gst-plugins-good is installed.
   useEffect(() => {

--- a/frontend/src/components/Voice/VoiceBar.tsx
+++ b/frontend/src/components/Voice/VoiceBar.tsx
@@ -11,7 +11,7 @@ interface VoiceBarProps {
 }
 
 export const VoiceBar: React.FC<VoiceBarProps> = ({ channelId, channelName }) => {
-  const { voiceParticipants, voiceIsMuted, voiceActiveSpeakerIds } = useAppStore();
+  const { voiceParticipants, voiceIsMuted, voiceActiveSpeakerIds, currentUser } = useAppStore();
   const { data: groupsWithChannels } = useUserGroupsWithChannels();
   const navigate = useNavigate();
 
@@ -20,6 +20,12 @@ export const VoiceBar: React.FC<VoiceBarProps> = ({ channelId, channelName }) =>
   )?.id ?? null;
 
   const { toggleMute, leave } = useVoiceChannel(channelId, groupId);
+
+  // Local participant identity is `voice-${userId}` (see useVoiceChannel.ts).
+  // The voice bar is feedback about *other* speakers, so always exclude self.
+  const localIdentity = currentUser ? `voice-${currentUser.id}` : null;
+  const remoteActiveSpeakerIds = voiceActiveSpeakerIds.filter((id) => id !== localIdentity);
+  const lastRemoteSpeakerId = remoteActiveSpeakerIds.at(-1);
 
   return (
     <div
@@ -99,10 +105,10 @@ export const VoiceBar: React.FC<VoiceBarProps> = ({ channelId, channelName }) =>
         style={{ marginLeft: "auto", color: "var(--c-text-dim)" }}
         className="flex items-center gap-1"
       >
-        {voiceActiveSpeakerIds.length > 0
+        {lastRemoteSpeakerId
           ? <>
             <Volume2 size={12} style={{ verticalAlign: "middle" }} />
-            {voiceParticipants.find(p => voiceActiveSpeakerIds.at(-1) === p.identity)?.name}
+            {voiceParticipants.find(p => p.identity === lastRemoteSpeakerId)?.name}
           </>
           : null}
       </span>

--- a/frontend/src/components/ui/ChatInput.tsx
+++ b/frontend/src/components/ui/ChatInput.tsx
@@ -438,7 +438,17 @@ export const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(({
     invoke<string[]>("read_clipboard_files").then((paths) => {
       if (paths.length > 0) {
         handlePaths(paths);
+        return;
       }
+      // WebKitGTK doesn't expose clipboard images as DataTransferItem files
+      // the way macOS WebKit does, so screenshots / "copy image" from a
+      // browser fall through to here. Fetch the raster image from the OS
+      // clipboard via Rust, write it to temp, and import as an attachment.
+      invoke<string>("read_clipboard_image_to_temp").then((path) => {
+        if (path) {
+          handlePaths([path]);
+        }
+      }).catch(() => { /* no image on clipboard */ });
     }).catch(() => { /* clipboard unreadable */ });
   }, [handleBrowserFile, handlePaths]);
 

--- a/frontend/src/components/ui/ChatInput.tsx
+++ b/frontend/src/components/ui/ChatInput.tsx
@@ -222,6 +222,16 @@ export const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(({
     return () => window.removeEventListener("keydown", handler, { capture: true });
   }, [expandedPreview]);
 
+  // Refocus the textarea after the pre-send preview lightbox closes so
+  // typing resumes immediately without an extra click.
+  const prevExpandedPreviewRef = useRef(expandedPreview);
+  useEffect(() => {
+    if (prevExpandedPreviewRef.current && !expandedPreview) {
+      textareaRef.current?.focus();
+    }
+    prevExpandedPreviewRef.current = expandedPreview;
+  }, [expandedPreview]);
+
   // ── Shared path-based attachment builder (picker + OS drag-drop) ─────────
   const handlePaths = useCallback(async (paths: string[]) => {
     // De-dupe against already-queued paths.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -176,6 +176,47 @@ fn read_clipboard_files(app: tauri::AppHandle) -> Vec<String> {
     }
 }
 
+/// Read a raster image from the OS clipboard, encode it as PNG, and write
+/// it to a temporary file. Returns the absolute path, or an empty string
+/// if the clipboard does not contain image data.
+///
+/// Used as a fallback for clipboard content that the WebKit paste event
+/// doesn't expose as `DataTransferItem` files — notably screenshots and
+/// images copied from a browser on Linux. macOS WebKit surfaces these as
+/// JS File objects directly, so this is mainly a Linux/Windows path.
+#[tauri::command]
+async fn read_clipboard_image_to_temp(app: tauri::AppHandle) -> String {
+    use tauri_plugin_clipboard_manager::ClipboardExt;
+
+    let image = match app.clipboard().read_image() {
+        Ok(img) => img,
+        Err(_) => return String::new(),
+    };
+
+    let width = image.width();
+    let height = image.height();
+    let rgba = image.rgba().to_vec();
+
+    let buffer = match image::RgbaImage::from_raw(width, height, rgba) {
+        Some(buf) => buf,
+        None => return String::new(),
+    };
+
+    let path = std::env::temp_dir().join(format!(
+        "pollis-paste-{}.png",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ));
+
+    if buffer.save(&path).is_err() {
+        return String::new();
+    }
+
+    path.to_string_lossy().into_owned()
+}
+
 /// Cmd+W handler: hide the window on macOS (matching hide_on_close behaviour)
 /// or close it on Windows/Linux.
 #[tauri::command]
@@ -269,6 +310,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             hide_window,
             read_clipboard_files,
+            read_clipboard_image_to_temp,
             commands::auth::initialize_identity,
             commands::auth::get_identity,
             commands::auth::request_otp,


### PR DESCRIPTION
## Summary

Three small, independently-scoped fixes batched on one branch.

- **#187** — In `VoiceBar.tsx`, exclude the local user from the speaker indicator. The bar is feedback about *who else is talking*, but with the local user spoken alongside others the active-speaker `.at(-1)` could land on themselves. Derive `localIdentity = voice-${currentUser.id}` and filter it out of `voiceActiveSpeakerIds` before picking the most recent. The voice page itself (`VoiceChannelView.tsx`) is untouched per the issue's scope.
- **#182** — Pasting clipboard images on Linux. WebKitGTK doesn't surface pasted raster data as `DataTransferItem` files the way macOS WebKit does, so screenshots and "copy image" from a browser fell through both the JS files-list check and the existing `read_clipboard_files` Rust command (which only reads URI-list text). Added a new `read_clipboard_image_to_temp` Tauri command that pulls the raster image via the clipboard plugin, encodes PNG with the existing `image` crate, writes to the OS temp dir, and returns the path. The paste handler in `ChatInput.tsx` falls back to it after the existing checks. File-from-file-manager paste continues to work via the URI-list path.
- **#172** — Refocus the chat input after closing an attachment preview lightbox. Two surfaces:
  - `MessageItem.tsx`'s message-attachment lightbox (image/video/audio) — dispatches a `pollis:focus-chat-input` window event on a true→false transition of `viewerOpen`. `MainContent.tsx` listens and calls `chatInputRef.current?.focus()`.
  - `ChatInput.tsx`'s pre-send preview (`expandedPreview`) — refocuses the textarea directly via the in-scope ref.

  Both use a `useRef` previous-state guard so virtualized scroll unmounts and channel switches don't spuriously steal focus.

## Test plan

- [ ] Voice bar: speak alone → indicator empty; speak with another user → only their name; another user speaks alone → their name shows
- [ ] Voice page: speaking indicator on the voice page itself still includes the local user
- [ ] Linux paste: screenshot → paste into chat → attachment appears as a PNG; "copy image" from a browser → paste → attachment appears
- [ ] Linux paste: copy a file from Nautilus → paste → still works (regression check on the existing path)
- [ ] macOS paste: unchanged behaviour (pasted images already came through as files)
- [ ] Lightbox refocus: open image lightbox in a chat → press Esc → typing goes to chat input; same for clicking backdrop and the [esc] button
- [ ] Lightbox refocus: same checks for video and audio lightboxes
- [ ] Pre-send preview: attach an image, click thumbnail to expand, close → typing returns to the input

Closes #187
Closes #182
Closes #172