### PR TITLE
feat(#186): notification + sound dispatcher with categories

### DIFF
--- a/.codesight/wiki/index.md
+++ b/.codesight/wiki/index.md
@@ -13,6 +13,7 @@ Start here. Navigate to the article you need.
 - [Testing](./testing.md) — Integration harness for multi-client end-to-end tests
 - [Windows Signing](./windows-signing.md) — Azure Artifact Signing setup for Windows installer signing
 - [PIN Design](./pin-design.md) — Local PIN unlock: KDF/AEAD choices, blob format, lifecycle, threat model
+- [Notifications](./notifications.md) — Sound, OS notification, badge, and alert dispatcher (`notify()` + category table)
 
 ## Quick Reference
 

--- a/.codesight/wiki/notifications.md
+++ b/.codesight/wiki/notifications.md
@@ -1,0 +1,176 @@
+# Notifications & Sound
+
+How sound effects, OS notifications, unread badges, status-bar alerts, and overlay prompts are routed in Pollis.
+
+## TL;DR
+
+Every user-facing alert goes through one function: `notify(category, payload)` in `frontend/src/utils/notify.ts`. The function looks up a flat config table to decide which outputs to fire (sound, OS notification, badge, status-bar alert, overlay), applies cooldown + user prefs + OS permission, and dispatches.
+
+To change behavior, edit one row in `CATEGORIES`. To add a new alert type, add one row.
+
+## Architecture
+
+```
+RealtimeEvent (Rust → JS Channel)         Local action (e.g. self voice join)
+            │                                          │
+            ▼                                          ▼
+   useLiveKitRealtime.ts                     useVoiceChannel.ts
+   classify event → call notify()       call notify('voice_self_join')
+                              │                │
+                              ▼                ▼
+                      ┌──────────────────────────────┐
+                      │      notify(category, payload)│  ← frontend/src/utils/notify.ts
+                      │  • lookup CATEGORIES[cat]    │
+                      │  • check pref + OS permission│
+                      │  • check cooldown            │
+                      │  • fire each output          │
+                      └──────────────────────────────┘
+                              │       │       │       │       │
+                              ▼       ▼       ▼       ▼       ▼
+                          play_sfx  notify  badge   alert   overlay
+                          (Rust)   (Rust)   (Zustand) (Zustand) (Zustand)
+```
+
+There is **no parallel dispatcher in Rust**. All decisions happen in JS. Rust is just the transport for LiveKit events (via `tauri::ipc::Channel`) and the executor for sound (`play_sfx` rodio command) and OS notifications (`tauri-plugin-notification`).
+
+## The category table
+
+The single source of truth (`frontend/src/utils/notify.ts`):
+
+```ts
+const CATEGORIES: Record<Category, CategoryConfig> = {
+  direct_message:    { sound: 'ping',  osNotif: true,  badge: true, alert: true, cooldownMs: 2500 },
+  channel_message:   {                                  badge: true,              cooldownMs: 2500 },
+  voice_other_join:  { sound: 'join'                                                              },
+  voice_other_leave: { sound: 'leave'                                                             },
+  voice_self_join:   { sound: 'join'                                                              },
+  voice_self_leave:  { sound: 'leave'                                                             },
+  dm_request:        { sound: 'ping',  osNotif: true,               alert: true                   },
+  group_invite:      { sound: 'ping',  osNotif: true                                              },
+  enrollment:        { sound: 'ping',  osNotif: true,                            overlay: true    },
+};
+```
+
+### Output fields
+
+| Field | What it does | Pref gate | Notes |
+|---|---|---|---|
+| `sound` | Plays a sfx (`'ping'`/`'join'`/`'leave'`) via the `play_sfx` Rust command | `allow_sound_effects` | Cooldownable |
+| `osNotif` | Fires an OS notification banner via `plugin:notification\|notify` | `allow_desktop_notifications` + OS permission | Cooldownable |
+| `badge` | Increments the per-room unread count (`useAppStore.incrementUnread`) | none | Drives dock/taskbar badge via `useBadge` |
+| `alert` | Sets the blinking status-bar alert (`useAppStore.setStatusBarAlert`) | none | Cleared on navigation |
+| `overlay` | Sets `pendingEnrollmentApproval` so the UI takes over | none | Used only by enrollment |
+| `cooldownMs` | Suppresses repeat sound + OS-notif within the window | — | Keyed by `(category, roomId)` |
+
+### Conventions
+
+1. **Anything with `osNotif: true` should also have `sound: 'ping'`.** Users always hear every system notification. Don't ship a silent OS banner.
+2. **Pings are reserved for personal events.** Channel chatter only updates the badge — noisy rooms must not become a constant ping.
+3. **`badge` and `alert` are never cooldown-gated.** The unread count must stay accurate; only sound and OS notifications dedupe.
+
+## Categorization (the call site)
+
+The "which category does this event belong to" decision lives at the call site, not in the table. This keeps the table flat and event-shaped predicates (`isOwnMessage`, `isSelected`, `isOwnVoiceChannel`) out of the config.
+
+In `useLiveKitRealtime.ts`, the `new_message` handler categorizes:
+
+```ts
+if (isOwnMessage || isSelected || !incomingId) return;
+notify(conversationId ? 'direct_message' : 'channel_message', { roomId, title, body, senderUsername });
+```
+
+The voice handler categorizes:
+
+```ts
+if (event.user_id === currentUserIdRef.current) return;          // own join → handled in useVoiceChannel
+if (event.channel_id !== activeVoiceChannelIdRef.current) return; // different room → noise
+notify(event.type === 'voice_joined' ? 'voice_other_join' : 'voice_other_leave');
+```
+
+The membership handler reads the `kind` discriminator (see below):
+
+```ts
+if (event.kind === 'invite') {
+  notify('group_invite', { roomId: event.conversation_id, title: 'New group invite', body: '...' });
+}
+```
+
+## Pref + permission flow
+
+`useLiveKitRealtime.ts` owns the React-side state and pushes it into `notify.ts` via `setNotifyPrefs(...)`. The effect re-runs whenever `allow_sound_effects` or `allow_desktop_notifications` changes:
+
+1. Read current prefs from `usePreferences()`.
+2. Call `plugin:notification|is_permission_granted` — if not granted *and* the user has notifications enabled, request permission.
+3. Push `{ allowSound, allowOsNotif, osPermissionGranted }` into the dispatcher.
+
+Result: toggling notifications "on" in Preferences → granting the OS prompt → next event uses the new state, no restart needed.
+
+## Membership-changed `kind` discriminator
+
+`MembershipChanged` is overloaded — it covers four wire-equivalent cases:
+
+| Publisher | Audience | `kind` value | Notification |
+|---|---|---|---|
+| `send_group_invite` (`groups.rs:876`) | Invitee's personal inbox | `"invite"` | ping + OS notif |
+| `approve_join_request` (`groups.rs:1177`) | Requester's personal inbox | `"approval"` | silent |
+| `approve_join_request` (`groups.rs:1183`) | Group room | none | silent (refetch) |
+| `accept_group_invite` (`groups.rs:951`) | Group room | none | silent (refetch) |
+| `remove_member_from_group` (`groups.rs:444`) | Group room | none | silent (refetch) |
+| `leave_group` (`groups.rs:515`) | Group room | none | silent (refetch) |
+
+The Rust enum (`src-tauri/src/realtime.rs`):
+
+```rust
+MembershipChanged {
+    conversation_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    kind: Option<String>,
+},
+```
+
+Wire dispatch (`src-tauri/src/commands/livekit.rs`) reads the `kind` field from the JSON payload. Publishers set it via `serde_json::json!({"type": "membership_changed", ..., "kind": "invite"})`.
+
+The frontend type narrows it:
+
+```ts
+| { type: 'membership_changed'; conversation_id?: string | null; kind?: 'invite' | 'approval' | null }
+```
+
+When adding a new use of `MembershipChanged`, decide whether the receiver wants a notification. If yes, define a new `kind` value, set it on the publisher, and add the corresponding `notify(...)` call in the membership handler. If no, omit `kind` and the receiver will silently invalidate queries.
+
+## Adding a new alert
+
+1. **Add a row to `CATEGORIES`** in `frontend/src/utils/notify.ts`:
+   ```ts
+   friend_online: { sound: 'ping', osNotif: true, cooldownMs: 60000 },
+   ```
+2. **Add the literal to the `Category` union** in the same file.
+3. **Call `notify('friend_online', { ... })`** at the appropriate event handler.
+
+That's it. No new branches, no new refs, no new pref handling. If you need a new output type (e.g., a system-tray flash), add a column to `CategoryConfig`, handle it in the dispatcher, then opt categories in.
+
+## Cooldown semantics
+
+Cooldown is keyed by `${category}:${roomId ?? '_global'}`. It applies only to sound and OS notification — never to badge, alert, or overlay. The cooldown timestamp is recorded only when *something actually fired* (i.e., pref + permission allowed it). This means:
+
+- A 10-message burst from one DM pings once, OS-notifies once, but badges 10 times.
+- A burst across two DM rooms pings twice (different cooldown buckets).
+- If sound is disabled but OS notif is enabled, the OS notification still fires and starts the cooldown.
+
+## Files
+
+| File | Role |
+|---|---|
+| `frontend/src/utils/notify.ts` | Dispatcher + category table |
+| `frontend/src/utils/sfx.ts` | `playSfx()` wrapper around `play_sfx` Rust command |
+| `frontend/src/hooks/useLiveKitRealtime.ts` | Categorizes incoming Rust events, calls `notify(...)`, owns pref + permission sync |
+| `frontend/src/hooks/useVoiceChannel.ts` | Calls `notify('voice_self_join'/'voice_self_leave')` for local actions |
+| `frontend/src/hooks/useBadge.ts` | Reads `unreadCounts` from Zustand, applies dock/taskbar badge |
+| `src-tauri/src/realtime.rs` | `RealtimeEvent` enum (Rust → JS wire format) |
+| `src-tauri/src/commands/livekit.rs` | `dispatch_data()` parses payloads, sends typed events to JS |
+| `src-tauri/src/commands/sfx.rs` | `play_sfx` rodio implementation |
+| `src-tauri/src/commands/groups.rs` | Membership-change publishers (set `kind` here) |
+
+## Related issues
+
+- #186 — original audit + dispatcher refactor (PR #202).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,10 +193,16 @@ Concrete implications:
 - **Prefer editing existing files** over creating new ones
 - **Always use `pnpm`** not `npm`
 - **Never add Claude as a co-author on commits** — do not include `Co-Authored-By:` trailers or any Claude attribution in commit messages
+- **Keep commit messages to a single line** unless the commit spans many file changes or a large body of work
+- **Keep PR descriptions terse** — don't over-explain or over-detail unless the PR spans many commits or a large body of work
 - **Never remove `data-testid` attributes** from JSX/HTML — they are used by Playwright E2E tests (`pnpm test:e2e`)
 - **Never reinvent UI components** — always use existing components from `frontend/src/components/ui/`. Toggles/switches use `Switch`, buttons use `Button`, text inputs use `TextInput`, etc. Do not build custom styled `<button>` or `<input>` elements when a ui/ component already exists.
 - **NO MODALS** — this is absolute. No fixed-position overlays, no backdrops, no dialog elements, no modal patterns of any kind. The only exception is the Cmd+K search menu. If a flow needs confirmation or input, replace the chat input bar (edit/delete bar pattern in `MainContent`) or navigate to a new page/view. A full page with two buttons is preferable to a modal.
 - **Confirmation and editing flows replace the chat input bar** — render a bar in place of the chat input at the bottom of `MainContent`, following the edit/delete bar pattern already established there.
+
+## Design Choices
+
+When weighing a design decision — or answering the user's question about one — look at how production apps like Slack, Discord, Linear, or other well-architected products handle the same problem. Use them as reference. Don't reinvent solved problems.
 
 ## Coding Style
 

--- a/frontend/src/hooks/useLiveKitRealtime.ts
+++ b/frontend/src/hooks/useLiveKitRealtime.ts
@@ -1,16 +1,12 @@
 import { useEffect, useRef, useMemo } from 'react';
 import { Channel, invoke } from '@tauri-apps/api/core';
-import { getCurrentWindow } from '@tauri-apps/api/window';
-// Note: we invoke the Rust-side notification plugin directly instead of using
-// the JS wrapper, because the wrapper's sendNotification/requestPermission use
-// `window.Notification` which WKWebView on macOS doesn't properly support.
 import { useQueryClient } from '@tanstack/react-query';
 import { useAppStore } from '../stores/appStore';
 import { useTauriReady } from './useTauriReady';
 import { messageQueryKeys, useDMConversations } from './queries/useMessages';
 import { usePreferences } from './queries/usePreferences';
 import { groupQueryKeys, useUserGroupsWithChannels } from './queries/useGroups';
-import { playSfx, SFX } from '../utils/sfx';
+import { notify, setNotifyPrefs } from '../utils/notify';
 
 // Mirrors the RealtimeEvent enum in src-tauri/src/realtime.rs.
 // Add new variants here as new event types are added on the Rust side.
@@ -71,9 +67,6 @@ export function useLiveKitRealtime() {
     selectedConversationId,
     currentUser,
     networkStatus,
-    incrementUnread,
-    setStatusBarAlert,
-    setPendingEnrollmentApproval,
   } = useAppStore();
 
   const { query: prefsQuery } = usePreferences();
@@ -133,36 +126,13 @@ export function useLiveKitRealtime() {
   useEffect(() => { selectedChannelIdRef.current = selectedChannelId; }, [selectedChannelId]);
   useEffect(() => { selectedConversationIdRef.current = selectedConversationId; }, [selectedConversationId]);
 
-  const isWindowFocusedRef = useRef<boolean>(true);
-
-  const allowNotificationsRef = useRef<boolean>(prefsQuery.data?.allow_desktop_notifications ?? false);
-
-  const notificationPermissionRef = useRef<boolean>(false);
-
-  // Keep the notification preference ref in sync with the saved preference.
-  useEffect(() => {
-    allowNotificationsRef.current = prefsQuery.data?.allow_desktop_notifications ?? false;
-  }, [prefsQuery.data?.allow_desktop_notifications]);
-
-  // queryClient and incrementUnread change reference on every render but are
-  // stable in practice; keep refs so the handler doesn't need to be recreated.
+  // queryClient changes reference on every render but is stable in practice;
+  // keep a ref so the channel handler doesn't need to be recreated.
   const queryClientRef = useRef(queryClient);
   useEffect(() => { queryClientRef.current = queryClient; }, [queryClient]);
-  const incrementUnreadRef = useRef(incrementUnread);
-  useEffect(() => { incrementUnreadRef.current = incrementUnread; }, [incrementUnread]);
-  const setStatusBarAlertRef = useRef(setStatusBarAlert);
-  useEffect(() => { setStatusBarAlertRef.current = setStatusBarAlert; }, [setStatusBarAlert]);
 
   const currentUserIdRef = useRef<string | null>(currentUser?.id ?? null);
   useEffect(() => { currentUserIdRef.current = currentUser?.id ?? null; }, [currentUser?.id]);
-
-  // Sound effects have their own preference, separate from OS notifications —
-  // users often want silent badges without giving up the ping/join/leave cues,
-  // or vice versa. Defaults on so first-time users hear the app come alive.
-  const allowSoundRef = useRef<boolean>(prefsQuery.data?.allow_sound_effects ?? true);
-  useEffect(() => {
-    allowSoundRef.current = prefsQuery.data?.allow_sound_effects ?? true;
-  }, [prefsQuery.data?.allow_sound_effects]);
 
   // Track the voice room the user is currently connected to so we only play
   // join/leave cues for rooms they can actually hear.
@@ -170,56 +140,32 @@ export function useLiveKitRealtime() {
   const activeVoiceChannelIdRef = useRef<string | null>(activeVoiceChannelId);
   useEffect(() => { activeVoiceChannelIdRef.current = activeVoiceChannelId; }, [activeVoiceChannelId]);
 
-  // Per-room ping cooldown. A flood of messages from one conversation should
-  // ping once, not once-per-message.
-  const lastPingAtRef = useRef<Map<string, number>>(new Map());
-  const PING_COOLDOWN_MS = 2500;
-
-  // ── OS-level window focus via Tauri events ────────────────────────────────
-  // DOM focus/blur don't fire on minimize in Tauri — use the OS window events.
+  // ── Notification permission + prefs → notify() ────────────────────────────
+  // Re-checks the OS permission whenever the user's notification preference
+  // changes so toggling "on" in Preferences → granting the OS prompt →
+  // immediately makes notify() start firing OS banners.
 
   useEffect(() => {
     if (!isTauriReady) {
       return;
     }
-    let unlisten: (() => void) | undefined;
-    const setup = async () => {
-      const win = getCurrentWindow();
-      unlisten = await win.onFocusChanged(({ payload: focused }) => {
-        isWindowFocusedRef.current = focused;
-      });
-    };
-    setup().catch((err) => { console.error('[realtime] window listener setup failed:', err); });
-    return () => {
-      unlisten?.();
-    };
-  }, [isTauriReady]);
+    const allowSound = prefsQuery.data?.allow_sound_effects ?? true;
+    const allowOsNotif = prefsQuery.data?.allow_desktop_notifications ?? false;
 
-  // ── Notification permission ────────────────────────────────────────────────
-  // Re-checks whenever the user's notification preference changes so that
-  // toggling "on" in Preferences → granting the OS prompt → immediately
-  // updates the ref used by the channel handler.
-
-  useEffect(() => {
-    if (!isTauriReady) {
-      return;
-    }
-    const check = async () => {
-      // Returns true/false/null (null = prompt needed)
+    const sync = async () => {
       const result: boolean | null = await invoke('plugin:notification|is_permission_granted');
-      if (result === true) {
-        notificationPermissionRef.current = true;
-        return;
-      }
-      if (allowNotificationsRef.current) {
+      let granted = result === true;
+      if (!granted && allowOsNotif) {
         const state: string = await invoke('plugin:notification|request_permission');
-        notificationPermissionRef.current = state === 'granted';
-      } else {
-        notificationPermissionRef.current = false;
+        granted = state === 'granted';
       }
+      setNotifyPrefs({ allowSound, allowOsNotif, osPermissionGranted: granted });
     };
-    check().catch((err) => { console.error('[realtime] notification permission check failed:', err); });
-  }, [isTauriReady, prefsQuery.data?.allow_desktop_notifications]);
+    sync().catch((err) => {
+      console.error('[realtime] notification permission sync failed:', err);
+      setNotifyPrefs({ allowSound, allowOsNotif, osPermissionGranted: false });
+    });
+  }, [isTauriReady, prefsQuery.data?.allow_sound_effects, prefsQuery.data?.allow_desktop_notifications]);
 
   // ── Subscribe: open a typed Tauri Channel, wire handler, register with Rust ─
   // Recreated if the user identity changes (e.g. logout → login as someone else).
@@ -248,6 +194,12 @@ export function useLiveKitRealtime() {
           userId: currentUser.id,
         }).catch((err) => {
           console.warn('[realtime] dm_created: process_pending_commits failed:', err);
+        });
+        notify('dm_request', {
+          roomId: event.conversation_id,
+          title: 'New conversation',
+          body: 'Someone started a conversation with you',
+          senderUsername: 'New DM',
         });
         return;
       }
@@ -292,11 +244,10 @@ export function useLiveKitRealtime() {
         // Here we only fire for OTHER participants, and only when the user
         // is in the same room — otherwise it's noise from unrelated rooms.
         if (
-          allowSoundRef.current
-          && event.user_id !== currentUserIdRef.current
+          event.user_id !== currentUserIdRef.current
           && event.channel_id === activeVoiceChannelIdRef.current
         ) {
-          playSfx(event.type === 'voice_joined' ? SFX.join : SFX.leave);
+          notify(event.type === 'voice_joined' ? 'voice_other_join' : 'voice_other_leave');
         }
         return;
       }
@@ -323,11 +274,16 @@ export function useLiveKitRealtime() {
       if (event.type === 'enrollment_requested') {
         // Immediate UI takeover — the user must explicitly approve or
         // reject the request. Silently ignoring an enrollment is a quiet
-        // account-takeover vector.
-        setPendingEnrollmentApproval({
-          requestId: event.request_id,
-          newDeviceId: event.new_device_id,
-          verificationCode: event.verification_code,
+        // account-takeover vector. Sound + OS notification + overlay are
+        // all configured on the 'enrollment' category.
+        notify('enrollment', {
+          title: 'New device sign-in',
+          body: 'A new device is requesting access to your account',
+          enrollment: {
+            requestId: event.request_id,
+            newDeviceId: event.new_device_id,
+            verificationCode: event.verification_code,
+          },
         });
         return;
       }
@@ -356,16 +312,6 @@ export function useLiveKitRealtime() {
         queryClientRef.current.invalidateQueries({ queryKey: messageQueryKeys.conversation(conversationId) });
       }
 
-      const isSelected =
-        (channelId && channelId === selectedChannelIdRef.current) ||
-        (conversationId && conversationId === selectedConversationIdRef.current);
-      if (!isSelected && incomingId && !isOwnMessage) {
-        incrementUnreadRef.current(incomingId);
-        if (conversationId) {
-          setStatusBarAlertRef.current({ senderUsername, roomId: incomingId });
-        }
-      }
-
       // Always update the last-message preview regardless of which channel is selected
       if (channelId) {
         queryClientRef.current.invalidateQueries({ queryKey: ["last-message", "channel", channelId] });
@@ -373,33 +319,21 @@ export function useLiveKitRealtime() {
         queryClientRef.current.invalidateQueries({ queryKey: ["last-message", "conversation", conversationId] });
       }
 
-      // Ping on incoming messages when the window is unfocused. A per-room
-      // cooldown prevents a 10-message burst from pinging 10 times.
-      if (
-        !isOwnMessage
-        && !isWindowFocusedRef.current
-        && allowSoundRef.current
-        && incomingId
-      ) {
-        const now = Date.now();
-        const last = lastPingAtRef.current.get(incomingId) ?? 0;
-        if (now - last >= PING_COOLDOWN_MS) {
-          lastPingAtRef.current.set(incomingId, now);
-          playSfx(SFX.ping);
-        }
+      const isSelected =
+        (channelId && channelId === selectedChannelIdRef.current) ||
+        (conversationId && conversationId === selectedConversationIdRef.current);
+      if (isOwnMessage || isSelected || !incomingId) {
+        return;
       }
 
-      if (!isOwnMessage && !isWindowFocusedRef.current && allowNotificationsRef.current && notificationPermissionRef.current) {
-        const title = incomingId
-          ? (roomNameMapRef.current.get(incomingId) ?? 'New message')
-          : 'New message';
-        const body = `${senderUsername}: New message`;
-        try {
-          invoke('plugin:notification|notify', { options: { title, body } }).catch(() => {});
-        } catch {
-          // ignore
-        }
-      }
+      const title = roomNameMapRef.current.get(incomingId) ?? 'New message';
+      const body = `${senderUsername}: New message`;
+      notify(conversationId ? 'direct_message' : 'channel_message', {
+        roomId: incomingId,
+        title,
+        body,
+        senderUsername,
+      });
     };
 
     invoke('subscribe_realtime', { onEvent: channel }).catch((err) => {

--- a/frontend/src/hooks/useLiveKitRealtime.ts
+++ b/frontend/src/hooks/useLiveKitRealtime.ts
@@ -25,6 +25,10 @@ type RealtimeEvent =
   | {
     type: 'membership_changed';
     conversation_id?: string | null;
+    // 'invite' = you've been invited to a group (ping/notify)
+    // 'approval' = your join request was approved (silent)
+    // omitted = generic reconcile (silent — refetch only)
+    kind?: 'invite' | 'approval' | null;
   }
   | {
     type: 'voice_joined';
@@ -205,9 +209,9 @@ export function useLiveKitRealtime() {
       }
 
       if (event.type === 'membership_changed') {
-        // Invalidate all group and invite queries — covers both invite received
-        // and join-request approved scenarios. The ['groups'] prefix also covers
-        // member queries (["groups", groupId, "members"]).
+        // Invalidate all group and invite queries — covers invite received,
+        // join-request approved, member removed, member left. The ['groups']
+        // prefix also covers member queries (["groups", groupId, "members"]).
         queryClientRef.current.invalidateQueries({ queryKey: ['groups'] });
         queryClientRef.current.invalidateQueries({ queryKey: ['group-invites'] });
         // Same as dm_created: a membership change may have added us to an
@@ -221,6 +225,15 @@ export function useLiveKitRealtime() {
             userId: currentUser.id,
           }).catch((err) => {
             console.warn('[realtime] membership_changed: process_pending_commits failed:', err);
+          });
+        }
+        // Only invites raise a user-facing notification. Approvals and
+        // generic reconciles are silent — query invalidation handles them.
+        if (event.kind === 'invite') {
+          notify('group_invite', {
+            roomId: event.conversation_id ?? undefined,
+            title: 'New group invite',
+            body: 'You have been invited to a group',
           });
         }
         return;

--- a/frontend/src/hooks/useVoiceChannel.ts
+++ b/frontend/src/hooks/useVoiceChannel.ts
@@ -5,7 +5,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useAppStore } from '../stores/appStore';
 import { useTauriReady } from './useTauriReady';
 import { usePreferences } from './queries/usePreferences';
-import { playSfx, SFX } from '../utils/sfx';
+import { notify } from '../utils/notify';
 
 const VOICE_DEVICES_KEY = 'pollis:voice-devices';
 
@@ -217,9 +217,7 @@ export function useVoiceChannel(channelId: string | null, groupId: string | null
         }
       } else {
         joinedRef.current = true;
-        if (preferences.query.data?.allow_sound_effects ?? true) {
-          playSfx(SFX.join);
-        }
+        notify('voice_self_join');
         if (groupId) {
           invoke('publish_voice_presence', {
             groupId,
@@ -269,8 +267,8 @@ export function useVoiceChannel(channelId: string | null, groupId: string | null
       // fires a phantom leave before we've even joined.
       const didJoin = joinedRef.current;
       joinedRef.current = false;
-      if (didJoin && (preferences.query.data?.allow_sound_effects ?? true)) {
-        playSfx(SFX.leave);
+      if (didJoin) {
+        notify('voice_self_leave');
       }
       // Optimistically remove self from the voice-participants cache so the
       // observer list in the UI drops us immediately instead of waiting for
@@ -331,7 +329,6 @@ export function useVoiceChannel(channelId: string | null, groupId: string | null
     setVoiceIsMuted,
     setIsLocalSpeaking,
     setActiveVoiceChannelId,
-    preferences.query.data?.allow_sound_effects,
     queryClient,
   ]);
 

--- a/frontend/src/utils/notify.ts
+++ b/frontend/src/utils/notify.ts
@@ -10,6 +10,7 @@ export type Category =
   | 'voice_self_join'
   | 'voice_self_leave'
   | 'dm_request'
+  | 'group_invite'
   | 'enrollment';
 
 type CategoryConfig = {
@@ -26,14 +27,20 @@ type CategoryConfig = {
 // below applies these by reading user prefs + OS permission and firing the
 // matching outputs. Cooldown is applied per (category, roomId) and only to
 // sound and OS notification — never to the badge or status-bar alert.
+//
+// Convention: anything that fires `osNotif` should also fire `sound: 'ping'`
+// so the user always hears every system notification. Pings are reserved for
+// personal events (DMs, invites, enrollment) — channel chatter only updates
+// the unread badge so noisy rooms don't become a constant ping.
 const CATEGORIES: Record<Category, CategoryConfig> = {
   direct_message:    { sound: 'ping',  osNotif: true,  badge: true, alert: true, cooldownMs: 2500 },
-  channel_message:   { sound: 'ping',                  badge: true,              cooldownMs: 2500 },
+  channel_message:   {                                  badge: true,              cooldownMs: 2500 },
   voice_other_join:  { sound: 'join'                                                              },
   voice_other_leave: { sound: 'leave'                                                             },
   voice_self_join:   { sound: 'join'                                                              },
   voice_self_leave:  { sound: 'leave'                                                             },
   dm_request:        { sound: 'ping',  osNotif: true,               alert: true                   },
+  group_invite:      { sound: 'ping',  osNotif: true                                              },
   enrollment:        { sound: 'ping',  osNotif: true,                            overlay: true    },
 };
 

--- a/frontend/src/utils/notify.ts
+++ b/frontend/src/utils/notify.ts
@@ -1,0 +1,105 @@
+import { invoke } from '@tauri-apps/api/core';
+import { playSfx } from './sfx';
+import { useAppStore } from '../stores/appStore';
+
+export type Category =
+  | 'direct_message'
+  | 'channel_message'
+  | 'voice_other_join'
+  | 'voice_other_leave'
+  | 'voice_self_join'
+  | 'voice_self_leave'
+  | 'dm_request'
+  | 'enrollment';
+
+type CategoryConfig = {
+  sound?: 'ping' | 'join' | 'leave';
+  osNotif?: boolean;
+  badge?: boolean;
+  alert?: boolean;
+  overlay?: boolean;
+  cooldownMs?: number;
+};
+
+// Single source of truth for notification behaviour. Edit a row to change
+// what an event does. Add a row to introduce a new category. The dispatcher
+// below applies these by reading user prefs + OS permission and firing the
+// matching outputs. Cooldown is applied per (category, roomId) and only to
+// sound and OS notification — never to the badge or status-bar alert.
+const CATEGORIES: Record<Category, CategoryConfig> = {
+  direct_message:    { sound: 'ping',  osNotif: true,  badge: true, alert: true, cooldownMs: 2500 },
+  channel_message:   { sound: 'ping',                  badge: true,              cooldownMs: 2500 },
+  voice_other_join:  { sound: 'join'                                                              },
+  voice_other_leave: { sound: 'leave'                                                             },
+  voice_self_join:   { sound: 'join'                                                              },
+  voice_self_leave:  { sound: 'leave'                                                             },
+  dm_request:        { sound: 'ping',  osNotif: true,               alert: true                   },
+  enrollment:        { sound: 'ping',  osNotif: true,                            overlay: true    },
+};
+
+export type NotifyPayload = {
+  roomId?: string;
+  title?: string;
+  body?: string;
+  senderUsername?: string;
+  enrollment?: { requestId: string; newDeviceId: string; verificationCode: string };
+};
+
+type NotifyPrefs = {
+  allowSound: boolean;
+  allowOsNotif: boolean;
+  osPermissionGranted: boolean;
+};
+
+let prefs: NotifyPrefs = { allowSound: true, allowOsNotif: false, osPermissionGranted: false };
+
+const cooldowns = new Map<string, number>();
+
+export function setNotifyPrefs(next: NotifyPrefs): void {
+  prefs = next;
+}
+
+export function notify(category: Category, payload: NotifyPayload = {}): void {
+  const config = CATEGORIES[category];
+  if (!config) {
+    return;
+  }
+
+  const cooldownKey = `${category}:${payload.roomId ?? '_global'}`;
+  const now = Date.now();
+  const cooled = config.cooldownMs !== undefined
+    && now - (cooldowns.get(cooldownKey) ?? 0) < config.cooldownMs;
+
+  let fired = false;
+
+  if (config.sound && prefs.allowSound && !cooled) {
+    playSfx(config.sound);
+    fired = true;
+  }
+
+  if (config.osNotif && prefs.allowOsNotif && prefs.osPermissionGranted && !cooled) {
+    const title = payload.title ?? 'New message';
+    const body = payload.body ?? (payload.senderUsername ? `${payload.senderUsername}: New message` : '');
+    invoke('plugin:notification|notify', { options: { title, body } }).catch(() => {});
+    fired = true;
+  }
+
+  if (config.badge && payload.roomId) {
+    useAppStore.getState().incrementUnread(payload.roomId);
+  }
+
+  if (config.alert && payload.roomId && payload.senderUsername) {
+    useAppStore.getState().setStatusBarAlert({
+      senderUsername: payload.senderUsername,
+      roomId: payload.roomId,
+    });
+  }
+
+  if (config.overlay && payload.enrollment) {
+    useAppStore.getState().setPendingEnrollmentApproval(payload.enrollment);
+  }
+
+  if (config.cooldownMs !== undefined && fired) {
+    cooldowns.set(cooldownKey, now);
+  }
+}

--- a/src-tauri/src/commands/groups.rs
+++ b/src-tauri/src/commands/groups.rs
@@ -870,10 +870,12 @@ pub async fn send_group_invite(
     }
 
     // Notify invitee via their inbox so the pending invite appears immediately.
+    // `kind: "invite"` lets the frontend raise a ping/OS notification — a
+    // generic membership_changed (kind: null) would only invalidate queries.
     if let Err(e) = crate::commands::livekit::publish_to_user_inbox(
         &state.config,
         &invitee_id,
-        serde_json::json!({"type": "membership_changed", "group_id": group_id}),
+        serde_json::json!({"type": "membership_changed", "group_id": group_id, "kind": "invite"}),
     ).await {
         eprintln!("[inbox] send_group_invite: notify {invitee_id} failed: {e}");
     }
@@ -1171,10 +1173,12 @@ pub async fn approve_join_request(
     }
 
     // Notify requester their join request was approved so they see the group immediately.
+    // `kind: "approval"` keeps this silent on the requester's device — they
+    // initiated the request, so an unsolicited ping isn't warranted.
     if let Err(e) = crate::commands::livekit::publish_to_user_inbox(
         &state.config,
         &requester_id,
-        serde_json::json!({"type": "membership_changed", "group_id": group_id}),
+        serde_json::json!({"type": "membership_changed", "group_id": group_id, "kind": "approval"}),
     ).await {
         eprintln!("[inbox] approve_join_request: notify {requester_id} failed: {e}");
     }

--- a/src-tauri/src/commands/livekit.rs
+++ b/src-tauri/src/commands/livekit.rs
@@ -880,8 +880,10 @@ fn dispatch_data(payload: &[u8], channel: &tauri::ipc::Channel<RealtimeEvent>) -
                 .or_else(|| data.get("conversation_id"))
                 .and_then(|v| v.as_str())
                 .map(str::to_owned);
+            let kind = data.get("kind").and_then(|v| v.as_str()).map(str::to_owned);
             let _ = channel.send(RealtimeEvent::MembershipChanged {
                 conversation_id: conv_id.clone(),
+                kind,
             });
             return conv_id;
         }

--- a/src-tauri/src/realtime.rs
+++ b/src-tauri/src/realtime.rs
@@ -21,9 +21,18 @@ pub enum RealtimeEvent {
         conversation_id: String,
     },
     /// Sent to a user's personal inbox room when they are added to a group
-    /// (via invite acceptance or join-request approval).
+    /// (via invite acceptance or join-request approval), or to a group room
+    /// when its membership changes for any other reason.
+    ///
+    /// `kind` discriminates the cause so the frontend can decide whether to
+    /// raise a user-facing notification:
+    /// - `Some("invite")`     — you've been invited to a group (ping/notify)
+    /// - `Some("approval")`   — your join request was approved (silent — you asked for this)
+    /// - `None` / other       — generic reconcile (silent — refetch only)
     MembershipChanged {
         conversation_id: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        kind: Option<String>,
     },
     /// Sent to a group room when a user joins a voice channel in that group.
     VoiceJoined {


### PR DESCRIPTION
Closes #186.

Replaces the scattered `playSfx`/`invoke('plugin:notification|notify')` calls + window-focus guards with a single `notify(category, payload)` dispatcher driven by a flat category table in `frontend/src/utils/notify.ts`. Editing one row changes what an event does.

## Behavior changes

- DM messages: ping + OS notification (was: gated on window focus, now gated on room-not-selected).
- Channel messages: badge only — no ping, no OS notification.
- Group invites received: ping + OS notification (was: silent).
- DM created: ping + OS notification + status-bar alert (was: silent).
- Enrollment requested: ping + OS notification + overlay (was: overlay only).
- Join request approved: silent (unchanged — you initiated it).
- OS notifications now share the same per-room 2.5s cooldown as the ping.

## Rust

`MembershipChanged` gains an optional `kind` discriminator (`"invite"` | `"approval"` | `null`). `send_group_invite` tags `"invite"`; `approve_join_request` tags `"approval"`. Other publishers (member removed/left, accept_invite group-room broadcast) leave it unset.