### PR TITLE
ci: install meson via pip on linux+windows for webrtc-audio-processin…

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -126,10 +126,14 @@ jobs:
 
       # webrtc-audio-processing-sys (vendored) drives its C++ build with
       # meson + ninja. cmake/clang/MSVC are already on the windows-latest
-      # runner via Visual Studio 2022.
+      # runner via Visual Studio 2022. Installing meson through chocolatey's
+      # MSI writes PATH only to the system registry, so subsequent shells
+      # don't see it; install via pip instead so it lands on the live PATH.
       - name: Install audio-processing build deps
         shell: pwsh
-        run: choco install -y meson ninja
+        run: |
+          python -m pip install --upgrade 'meson>=1.3'
+          choco install -y ninja
 
       - name: Install OpenSSL via vcpkg
         shell: bash
@@ -254,8 +258,15 @@ jobs:
             rpm \
             cmake \
             clang \
-            meson \
             ninja-build
+
+      # Ubuntu 22.04 ships meson 0.61, but webrtc-audio-processing-sys passes
+      # `--reconfigure` to meson on its first run, which requires meson >= 1.1.
+      # Install a current meson via pip instead of apt.
+      - name: Install meson (newer than apt)
+        run: |
+          python3 -m pip install --user 'meson>=1.3'
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Load production secrets
         run: |


### PR DESCRIPTION
…g-sys

Ubuntu 22.04 ships meson 0.61, but webrtc-audio-processing-sys passes --reconfigure to meson on first run, which needs >= 1.1. On Windows, choco install meson writes PATH only to the system registry, so the next bash step never sees it. Install via pip on both runners — current version, lands on the live PATH.