### PR TITLE
ci: pin windows build to MSVC so meson stops picking strawberry mingw

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -98,6 +98,15 @@ jobs:
         with:
           workspaces: src-tauri
 
+      # Activate the VS2022 x64 developer environment so cl.exe / link.exe /
+      # the SDK headers + libs are on PATH/INCLUDE/LIB for subsequent steps.
+      # Without this, meson auto-detects Strawberry Perl's MinGW g++ first
+      # and the MinGW <windows.foundation.h> blows up against MSVC-built deps.
+      - name: Set up MSVC developer environment
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
       - name: Stamp version from git tag
         shell: bash
         run: |
@@ -206,6 +215,11 @@ jobs:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          # Force meson + cc to use MSVC; without this, meson's auto-detection
+          # picks Strawberry Perl's MinGW g++ from C:\Strawberry\c\bin and
+          # webrtc-audio-processing-sys fails on MinGW header redefinitions.
+          CC: cl
+          CXX: cl
         run: pnpm build:windows
 
       - name: Upload Windows artifact


### PR DESCRIPTION
The Windows runner has Strawberry Perl on PATH (C:\Strawberry\c\bin), which ships an x86_64-w64-mingw32 g++. Meson auto-detects that first because the VS dev env isn't activated by default, then webrtc-audio- processing-sys's vendored abseil chokes on MinGW <windows.foundation.h> redefinitions when built against an MSVC-targeted Rust binary.

Activate VS2022 x64 dev env via ilammy/msvc-dev-cmd@v1 so cl.exe is on PATH, and pin CC=cl / CXX=cl in the build step as a belt-and-braces guard against any leftover MinGW tools.