### PR TITLE
ci: run windows build in pwsh so rustc finds MSVC link.exe, not git's

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -207,8 +207,11 @@ jobs:
           echo "signCommand injected:"
           jq '.bundle.windows.signCommand' src-tauri/tauri.conf.json
 
+      # Use pwsh (not bash) so rustc's link.exe lookup hits MSVC's link.exe,
+      # not the GNU coreutils `link` shipped under C:\Program Files\Git\usr\bin
+      # which Git Bash prepends to PATH at startup and which fails as a linker.
       - name: Build Windows
-        shell: bash
+        shell: pwsh
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}


### PR DESCRIPTION
shell: bash on windows-latest is Git Bash, which prepends C:\Program Files\Git\usr\bin to PATH at startup. That dir contains GNU coreutils' link.exe (the unix hard-link command), which shadows MSVC's link.exe even though msvc-dev-cmd put MSVC's bin on $GITHUB_PATH. rustc invokes the wrong linker and the build dies on the first crate (quote / proc-macro2). pwsh doesn't reorder PATH that way, so MSVC wins.