### PR TITLE
ci/voice: gate webrtc-audio-processing out on windows

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -98,25 +98,6 @@ jobs:
         with:
           workspaces: src-tauri
 
-      # Activate the VS2022 x64 developer environment so cl.exe / link.exe /
-      # the SDK headers + libs are on PATH/INCLUDE/LIB for subsequent steps.
-      # Without this, meson auto-detects Strawberry Perl's MinGW g++ first
-      # and the MinGW <windows.foundation.h> blows up against MSVC-built deps.
-      - name: Set up MSVC developer environment
-        uses: ilammy/msvc-dev-cmd@v1
-        with:
-          arch: x64
-
-      # The windows-latest image ships Git for Windows with C:\Program Files\
-      # Git\usr\bin on the system PATH, and that dir contains GNU coreutils'
-      # `link` (a unix hard-link tool) named link.exe. rustc's PATH lookup
-      # for link.exe finds it before MSVC's, so the build dies on the first
-      # crate. Standard windows-latest fix: delete the GNU link.exe — Git
-      # itself doesn't use it.
-      - name: Remove conflicting GNU link.exe
-        shell: pwsh
-        run: Remove-Item "C:\Program Files\Git\usr\bin\link.exe" -Force -ErrorAction SilentlyContinue
-
       - name: Stamp version from git tag
         shell: bash
         run: |
@@ -142,17 +123,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
-
-      # webrtc-audio-processing-sys (vendored) drives its C++ build with
-      # meson + ninja. cmake/clang/MSVC are already on the windows-latest
-      # runner via Visual Studio 2022. Installing meson through chocolatey's
-      # MSI writes PATH only to the system registry, so subsequent shells
-      # don't see it; install via pip instead so it lands on the live PATH.
-      - name: Install audio-processing build deps
-        shell: pwsh
-        run: |
-          python -m pip install --upgrade 'meson>=1.3'
-          choco install -y ninja
 
       - name: Install OpenSSL via vcpkg
         shell: bash
@@ -217,22 +187,14 @@ jobs:
           echo "signCommand injected:"
           jq '.bundle.windows.signCommand' src-tauri/tauri.conf.json
 
-      # Use pwsh (not bash) so rustc's link.exe lookup hits MSVC's link.exe,
-      # not the GNU coreutils `link` shipped under C:\Program Files\Git\usr\bin
-      # which Git Bash prepends to PATH at startup and which fails as a linker.
       - name: Build Windows
-        shell: pwsh
+        shell: bash
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-          # Force meson + cc to use MSVC; without this, meson's auto-detection
-          # picks Strawberry Perl's MinGW g++ from C:\Strawberry\c\bin and
-          # webrtc-audio-processing-sys fails on MinGW header redefinitions.
-          CC: cl
-          CXX: cl
         run: pnpm build:windows
 
       - name: Upload Windows artifact

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -77,11 +77,6 @@ zeroize = { version = "1", features = ["derive"] }
 livekit = { version = "0.7", features = ["rustls-tls-webpki-roots"] }
 libwebrtc = "0.3"
 cpal = "0.15"
-# Vendor the WebRTC AudioProcessing module so AGC/NS/AEC are owned by us
-# end-to-end and tunable from Rust. The system pkg-config build branch wants
-# webrtc-audio-processing-2 >= 2.1 which most distros don't ship yet, and we'd
-# rather every platform build the same source than chase a moving target.
-webrtc-audio-processing = { version = "2", features = ["bundled"] }
 # RNNoise (Rust port) — runs as a pre-APM NS stage when the user enables
 # Click Suppression. Handles transients (keyboard clicks, mouse clicks)
 # that APM's spectral NS misses. Default features pull in clap/dasp/hound
@@ -105,6 +100,18 @@ tokio = { version = "1", features = ["full", "test-util"] }
 dotenvy = "0.15"
 serial_test = "3"
 tempfile = "3"
+
+# Vendor the WebRTC AudioProcessing module so AGC/NS/AEC are owned by us
+# end-to-end and tunable from Rust. The system pkg-config build branch wants
+# webrtc-audio-processing-2 >= 2.1 which most distros don't ship yet.
+#
+# Windows is excluded: webrtc-audio-processing-sys 2.0.4 vendors a meson +
+# abseil-cpp build that has zero MSVC support upstream (see
+# https://github.com/tonarino/webrtc-audio-processing/issues/34, open since
+# 2023). Voice still works on Windows — it just runs without AEC/AGC/NS.
+# voice_apm.rs provides no-op stubs gated on this same cfg.
+[target.'cfg(not(target_os = "windows"))'.dependencies]
+webrtc-audio-processing = { version = "2", features = ["bundled"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 webkit2gtk = { version = "2", features = ["v2_38"] }

--- a/src-tauri/src/commands/voice.rs
+++ b/src-tauri/src/commands/voice.rs
@@ -22,10 +22,9 @@ use livekit::{
 use serde::{Deserialize, Serialize};
 use tauri::State;
 use tokio::time::MissedTickBehavior;
-use webrtc_audio_processing::Processor as ApmProcessor;
 
 use crate::{
-    commands::{livekit::make_token, voice_apm, voice_denoiser},
+    commands::{livekit::make_token, voice_apm, voice_apm::Processor as ApmProcessor, voice_denoiser},
     error::Result,
     state::AppState,
 };

--- a/src-tauri/src/commands/voice_apm.rs
+++ b/src-tauri/src/commands/voice_apm.rs
@@ -21,16 +21,36 @@
 //! APM rate is locked to the cpal mic input rate. WebRTC supports
 //! 8/16/32/48 kHz, and the rest of the pipeline (mic stream, speaker stream,
 //! mixer) is configured to match.
+//!
+//! Windows: `webrtc-audio-processing-sys` doesn't build with MSVC (upstream
+//! has no Windows CI; see Cargo.toml comment). On Windows the public API
+//! here resolves to no-op stubs — voice still works, just without AEC/AGC/NS.
 
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+
+#[cfg(not(target_os = "windows"))]
 use webrtc_audio_processing::{
     config::{
         AdaptiveDigital, CaptureAmplifier, EchoCanceller, GainController, GainController2,
         HighPassFilter, NoiseSuppression, NoiseSuppressionLevel, PreAmplifier,
     },
-    Config, Processor,
+    Config,
 };
+
+/// The underlying APM processor. Re-exported from `webrtc-audio-processing`
+/// where the crate builds; a unit-like stub on Windows so the rest of the
+/// voice pipeline keeps a single set of types.
+#[cfg(not(target_os = "windows"))]
+pub use webrtc_audio_processing::Processor;
+
+#[cfg(target_os = "windows")]
+pub struct Processor;
+
+#[cfg(target_os = "windows")]
+impl Processor {
+    pub fn set_output_will_be_muted(&self, _muted: bool) {}
+}
 
 /// Number of mono samples in a 10ms APM frame at `sample_rate_hz`.
 pub const fn frame_samples(sample_rate_hz: u32) -> usize {
@@ -102,6 +122,7 @@ pub enum NsLevel {
     High,
 }
 
+#[cfg(not(target_os = "windows"))]
 impl ApmConfig {
     fn to_processor_config(&self) -> Config {
         let noise_suppression = match self.ns_level {
@@ -196,6 +217,7 @@ impl ApmStage {
     /// match the mic stream rate (and the render reference rate); otherwise
     /// `process_capture_frame` / `analyze_render_frame` will panic on frame
     /// size mismatches.
+    #[cfg(not(target_os = "windows"))]
     pub fn new(sample_rate_hz: u32, config: ApmConfig) -> Result<Self, String> {
         if !matches!(sample_rate_hz, 8_000 | 16_000 | 32_000 | 48_000) {
             return Err(format!(
@@ -222,6 +244,31 @@ impl ApmStage {
         })
     }
 
+    #[cfg(target_os = "windows")]
+    pub fn new(sample_rate_hz: u32, config: ApmConfig) -> Result<Self, String> {
+        if !matches!(sample_rate_hz, 8_000 | 16_000 | 32_000 | 48_000) {
+            return Err(format!(
+                "APM only supports 8/16/32/48 kHz, got {sample_rate_hz} Hz"
+            ));
+        }
+        eprintln!(
+            "[voice/apm] disabled on Windows (webrtc-audio-processing-sys has no MSVC \
+             support upstream); requested config is stored but not applied: \
+             boost={} dB, AGC2={} (headroom={} dB), NS={:?}, AEC={}, RNNoise={}",
+            config.mic_boost_db,
+            config.agc_enabled,
+            config.agc_target_dbfs,
+            config.ns_level,
+            config.aec_enabled,
+            config.click_suppression,
+        );
+        Ok(Self {
+            processor: Arc::new(Processor),
+            sample_rate_hz,
+            config,
+        })
+    }
+
     pub fn handle(&self) -> Arc<Processor> {
         Arc::clone(&self.processor)
     }
@@ -241,6 +288,7 @@ impl ApmStage {
     /// Apply a new config without recreating the processor. Internal state
     /// (echo estimate, noise estimate, AGC envelope) is preserved; only
     /// changed submodules are re-initialised.
+    #[cfg(not(target_os = "windows"))]
     pub fn set_config(&mut self, config: ApmConfig) {
         self.processor.set_config(config.to_processor_config());
         eprintln!(
@@ -254,12 +302,20 @@ impl ApmStage {
         );
         self.config = config;
     }
+
+    #[cfg(target_os = "windows")]
+    pub fn set_config(&mut self, config: ApmConfig) {
+        // No-op on Windows: APM isn't running, but we still store the config
+        // so reads (and the eventual real-APM swap-in) reflect user prefs.
+        self.config = config;
+    }
 }
 
 /// Run APM on a 10ms i16 mono capture frame, in place. `samples.len()` must
 /// equal [`ApmStage::frame_samples`]. Converts to non-interleaved f32 for the
 /// FFI call and converts back; the round-trip is the same precision loss
 /// libwebrtc's internal pipeline already incurs.
+#[cfg(not(target_os = "windows"))]
 pub fn run_capture(
     processor: &Processor,
     samples: &mut [i16],
@@ -274,9 +330,22 @@ pub fn run_capture(
     Ok(())
 }
 
+/// Windows no-op: passes the capture frame through untouched. Returns
+/// [`std::convert::Infallible`] in the error position so the call site's
+/// `if let Err(e)` pattern still type-checks.
+#[cfg(target_os = "windows")]
+pub fn run_capture(
+    _processor: &Processor,
+    _samples: &mut [i16],
+    _expected_len: usize,
+) -> Result<(), std::convert::Infallible> {
+    Ok(())
+}
+
 /// Feed a 10ms f32 mono render frame (what's about to hit the speaker) into
 /// APM as the AEC reference. Doesn't modify the frame; APM only inspects.
 /// `samples.len()` must equal [`ApmStage::frame_samples`].
+#[cfg(not(target_os = "windows"))]
 pub fn analyze_render(
     processor: &Processor,
     samples: &[f32],
@@ -284,4 +353,14 @@ pub fn analyze_render(
 ) -> Result<(), webrtc_audio_processing::Error> {
     debug_assert_eq!(samples.len(), expected_len, "render frame size mismatch");
     processor.analyze_render_frame([samples])
+}
+
+/// Windows no-op: APM has no AEC reference to feed.
+#[cfg(target_os = "windows")]
+pub fn analyze_render(
+    _processor: &Processor,
+    _samples: &[f32],
+    _expected_len: usize,
+) -> Result<(), std::convert::Infallible> {
+    Ok(())
 }


### PR DESCRIPTION
Fixes Windows CI by gating `webrtc-audio-processing` to non-Windows targets — its vendored meson + abseil-cpp build has no MSVC support upstream ([tonarino#34](https://github.com/tonarino/webrtc-audio-processing/issues/34), open since 2023). Voice still works on Windows; runs without AEC/AGC/NS until we evaluate `aec3-rs` as a pure-Rust replacement.

Reverts the Windows-only CI scaffolding added during the chase (msvc-dev-cmd, link.exe removal, pwsh, CC=cl, choco-meson) since none of it was needed pre-APM.