### PR TITLE
fix: DM admin highlighting, Voice Settings button, device revocation

### DIFF
--- a/frontend/src/components/Layout/MainContent.tsx
+++ b/frontend/src/components/Layout/MainContent.tsx
@@ -406,7 +406,7 @@ export const MainContent: React.FC = () => {
         ) : (
           <MessageList
             messages={allMessages}
-            adminUserIds={selectedGroupId ? adminUserIds : undefined}
+            adminUserIds={selectedChannelId ? adminUserIds : undefined}
             onReply={(id) => {
               setEditingMessage(null);
               setPendingDeleteId(null);

--- a/frontend/src/components/ui/TerminalMenu.tsx
+++ b/frontend/src/components/ui/TerminalMenu.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect, useCallback } from "react";
-import { ChevronRight, ArrowUp, ArrowDown, MoreVertical } from "lucide-react";
+import { ChevronRight, ArrowUp, ArrowDown, Settings } from "lucide-react";
 import { Button } from "./Button";
 
 export interface TerminalMenuItem {
@@ -253,7 +253,7 @@ export const TerminalMenu: React.FC<TerminalMenuProps> = ({
                 <Button
                   data-testid={item.testId ? `${item.testId}-secondary` : undefined}
                   aria-label={item.secondaryActionLabel ?? "More options"}
-                  variant="secondary"
+                  variant="ghost"
                   className="flex-shrink-0 !px-1 !py-0.5"
                   onClick={(e) => {
                     e.stopPropagation();
@@ -267,7 +267,7 @@ export const TerminalMenu: React.FC<TerminalMenuProps> = ({
                     }
                   }}
                 >
-                  <MoreVertical size={14} aria-hidden="true" />
+                  <Settings size={14} aria-hidden="true" />
                 </Button>
               )}
             </div>

--- a/frontend/src/pages/Preferences.tsx
+++ b/frontend/src/pages/Preferences.tsx
@@ -5,6 +5,7 @@ import { usePreferences, applyPreferences } from "../hooks/queries/usePreference
 import { hslToHex, hexToHsl, applyAccentColor, applyBackgroundColor } from "../utils/colorUtils";
 import { RangeSlider } from "../components/ui/RangeSlider";
 import { Switch } from "../components/ui/Switch";
+import { Button } from "../components/ui/Button";
 
 function getRootVar(name: string): string {
   return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
@@ -373,21 +374,11 @@ export const Preferences: React.FC = () => {
             >
               Voice
             </h2>
-            <button
-              onClick={() => navigate({ to: "/voice-settings" })}
-              className="self-start text-xs font-mono px-3 py-1.5 transition-colors focus:outline-none focus:ring-4 focus:ring-[var(--c-accent)] focus:ring-offset-2 focus:ring-offset-black"
-              style={{
-                border: "1px solid var(--c-border)",
-                borderRadius: 4,
-                color: "var(--c-text)",
-                background: "transparent",
-                cursor: "pointer",
-              }}
-              onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.borderColor = "var(--c-accent)"; (e.currentTarget as HTMLElement).style.color = "var(--c-accent)"; }}
-              onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.borderColor = "var(--c-border)"; (e.currentTarget as HTMLElement).style.color = "var(--c-text)"; }}
-            >
-              Voice Settings →
-            </button>
+            <div className="self-start">
+              <Button variant="secondary" size="sm" onClick={() => navigate({ to: "/voice-settings" })}>
+                Voice Settings
+              </Button>
+            </div>
           </section>
 
         </div>

--- a/frontend/src/pages/SecurityPage.tsx
+++ b/frontend/src/pages/SecurityPage.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { PageShell } from "../components/Layout/PageShell";
 import { Button } from "../components/ui/Button";
+import { TextInput } from "../components/ui/TextInput";
 import { useAppStore } from "../stores/appStore";
 import * as api from "../services/api";
 
@@ -65,6 +66,25 @@ export const SecurityPage: React.FC = () => {
   const [events, setEvents] = useState<api.SecurityEvent[] | null>(null);
   const [error, setError] = useState<string | null>(null);
 
+  const [devices, setDevices] = useState<api.DeviceInfo[] | null>(null);
+  const [devicesError, setDevicesError] = useState<string | null>(null);
+  const [confirmingDeviceId, setConfirmingDeviceId] = useState<string | null>(null);
+  const [confirmInput, setConfirmInput] = useState("");
+  const [revokingDeviceId, setRevokingDeviceId] = useState<string | null>(null);
+
+  const loadDevices = React.useCallback(() => {
+    if (!currentUser) {
+      return;
+    }
+    api
+      .listUserDevices(currentUser.id)
+      .then(setDevices)
+      .catch((err) => {
+        setDevicesError(err instanceof Error ? err.message : "Failed to load devices");
+        setDevices([]);
+      });
+  }, [currentUser?.id]);
+
   useEffect(() => {
     if (!currentUser) {
       return;
@@ -83,10 +103,39 @@ export const SecurityPage: React.FC = () => {
           setEvents([]);
         }
       });
+    loadDevices();
     return () => {
       cancelled = true;
     };
-  }, [currentUser?.id]);
+  }, [currentUser?.id, loadDevices]);
+
+  const startConfirm = (deviceId: string) => {
+    setConfirmingDeviceId(deviceId);
+    setConfirmInput("");
+    setDevicesError(null);
+  };
+
+  const cancelConfirm = () => {
+    setConfirmingDeviceId(null);
+    setConfirmInput("");
+  };
+
+  const revoke = async (device: api.DeviceInfo) => {
+    if (!currentUser) {
+      return;
+    }
+    setRevokingDeviceId(device.device_id);
+    setDevicesError(null);
+    try {
+      await api.revokeDevice(currentUser.id, device.device_id);
+      cancelConfirm();
+      loadDevices();
+    } catch (err) {
+      setDevicesError(err instanceof Error ? err.message : "Failed to revoke device");
+    } finally {
+      setRevokingDeviceId(null);
+    }
+  };
 
   return (
     <PageShell title="Security" scrollable>
@@ -114,6 +163,124 @@ export const SecurityPage: React.FC = () => {
           >
             Change PIN
           </Button>
+        </div>
+
+        <div>
+          <h2 className="text-sm font-bold" style={{ color: "var(--c-accent)" }}>
+            Devices
+          </h2>
+          <p
+            className="text-xs mt-1"
+            style={{ color: "var(--c-text-muted)", lineHeight: 1.5 }}
+          >
+            Every device signed in to your account. Revoke any you don't
+            recognise — the device loses access to all groups and DMs on
+            its next sync.
+          </p>
+
+          {devicesError && (
+            <p
+              data-testid="devices-error"
+              className="text-xs mt-2"
+              style={{ color: "#ff6b6b" }}
+            >
+              {devicesError}
+            </p>
+          )}
+
+          {devices === null && (
+            <p className="text-xs mt-2" style={{ color: "var(--c-text-muted)" }}>
+              Loading…
+            </p>
+          )}
+
+          {devices !== null && devices.length > 0 && (
+            <ul className="flex flex-col gap-2 mt-3" data-testid="devices-list">
+              {devices.map((device) => {
+                const isConfirming = confirmingDeviceId === device.device_id;
+                const isRevoking = revokingDeviceId === device.device_id;
+                const displayName = device.device_name ?? shortId(device.device_id);
+                return (
+                  <li
+                    key={device.device_id}
+                    data-testid={`device-${device.device_id}`}
+                    style={{
+                      background: "var(--c-surface)",
+                      border: "2px solid var(--c-border)",
+                      borderRadius: "0.5rem",
+                      padding: "0.75rem",
+                    }}
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <div
+                          className="text-xs font-bold truncate"
+                          style={{ color: "var(--c-text)" }}
+                        >
+                          {displayName}
+                          {device.is_current && (
+                            <span
+                              className="ml-2 text-xs"
+                              style={{ color: "var(--c-accent)" }}
+                            >
+                              (this device)
+                            </span>
+                          )}
+                        </div>
+                        <div
+                          className="text-xs mt-1"
+                          style={{ color: "var(--c-text-dim)" }}
+                        >
+                          Last seen {formatTimestamp(device.last_seen)}
+                        </div>
+                      </div>
+                      {!device.is_current && !isConfirming && (
+                        <Button
+                          data-testid={`revoke-${device.device_id}`}
+                          variant="secondary"
+                          size="sm"
+                          disabled={isRevoking}
+                          onClick={() => startConfirm(device.device_id)}
+                        >
+                          Revoke
+                        </Button>
+                      )}
+                    </div>
+
+                    {isConfirming && (
+                      <div className="mt-3 flex flex-col gap-2">
+                        <TextInput
+                          label={`Type "${displayName}" to confirm`}
+                          value={confirmInput}
+                          onChange={setConfirmInput}
+                          autoFocus
+                          data-testid={`revoke-confirm-input-${device.device_id}`}
+                        />
+                        <div className="flex gap-2">
+                          <Button
+                            data-testid={`revoke-confirm-${device.device_id}`}
+                            size="sm"
+                            disabled={confirmInput !== displayName || isRevoking}
+                            onClick={() => revoke(device)}
+                          >
+                            {isRevoking ? "Revoking…" : "Revoke device"}
+                          </Button>
+                          <Button
+                            variant="secondary"
+                            size="sm"
+                            disabled={isRevoking}
+                            onClick={cancelConfirm}
+                          >
+                            Cancel
+                          </Button>
+                        </div>
+                      </div>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
         </div>
 
         <div>

--- a/frontend/src/pages/SecurityPage.tsx
+++ b/frontend/src/pages/SecurityPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { PageShell } from "../components/Layout/PageShell";
 import { Button } from "../components/ui/Button";
 import { TextInput } from "../components/ui/TextInput";
+import { NavigableList } from "../components/ui/NavigableList";
 import { useAppStore } from "../stores/appStore";
 import * as api from "../services/api";
 
@@ -60,6 +61,13 @@ function formatTimestamp(iso: string): string {
   }
 }
 
+const sectionHeaderClass =
+  "text-xs font-mono font-medium uppercase tracking-widest pb-1 border-b";
+const sectionHeaderStyle: React.CSSProperties = {
+  color: "var(--c-text)",
+  borderColor: "var(--c-border)",
+};
+
 export const SecurityPage: React.FC = () => {
   const navigate = useNavigate();
   const { currentUser } = useAppStore();
@@ -68,9 +76,9 @@ export const SecurityPage: React.FC = () => {
 
   const [devices, setDevices] = useState<api.DeviceInfo[] | null>(null);
   const [devicesError, setDevicesError] = useState<string | null>(null);
-  const [confirmingDeviceId, setConfirmingDeviceId] = useState<string | null>(null);
+  const [confirmingDevice, setConfirmingDevice] = useState<api.DeviceInfo | null>(null);
   const [confirmInput, setConfirmInput] = useState("");
-  const [revokingDeviceId, setRevokingDeviceId] = useState<string | null>(null);
+  const [revoking, setRevoking] = useState(false);
 
   const loadDevices = React.useCallback(() => {
     if (!currentUser) {
@@ -109,258 +117,209 @@ export const SecurityPage: React.FC = () => {
     };
   }, [currentUser?.id, loadDevices]);
 
-  const startConfirm = (deviceId: string) => {
-    setConfirmingDeviceId(deviceId);
-    setConfirmInput("");
-    setDevicesError(null);
-  };
-
   const cancelConfirm = () => {
-    setConfirmingDeviceId(null);
+    setConfirmingDevice(null);
     setConfirmInput("");
   };
 
-  const revoke = async (device: api.DeviceInfo) => {
-    if (!currentUser) {
+  const revoke = async () => {
+    if (!currentUser || !confirmingDevice) {
       return;
     }
-    setRevokingDeviceId(device.device_id);
+    setRevoking(true);
     setDevicesError(null);
     try {
-      await api.revokeDevice(currentUser.id, device.device_id);
+      await api.revokeDevice(currentUser.id, confirmingDevice.device_id);
       cancelConfirm();
       loadDevices();
     } catch (err) {
       setDevicesError(err instanceof Error ? err.message : "Failed to revoke device");
     } finally {
-      setRevokingDeviceId(null);
+      setRevoking(false);
     }
   };
 
+  const deviceDisplayName = (device: api.DeviceInfo): string =>
+    device.device_name ?? shortId(device.device_id);
+
   return (
     <PageShell title="Security" scrollable>
-      <div
-        className="flex flex-col gap-4 p-4 font-mono"
-        data-testid="security-page"
-        style={{ color: "var(--c-text)" }}
-      >
-        <div>
-          <h2 className="text-sm font-bold" style={{ color: "var(--c-accent)" }}>
-            PIN
-          </h2>
-          <p
-            className="text-xs mt-1"
-            style={{ color: "var(--c-text-muted)", lineHeight: 1.5 }}
-          >
-            The local PIN unlocks Pollis on this device. It never leaves
-            the device and can't be recovered — use your Secret Key if
-            you forget it.
-          </p>
-          <Button
-            data-testid="change-pin-button"
-            className="mt-3"
-            onClick={() => navigate({ to: "/security/change-pin" })}
-          >
-            Change PIN
-          </Button>
-        </div>
-
-        <div>
-          <h2 className="text-sm font-bold" style={{ color: "var(--c-accent)" }}>
-            Devices
-          </h2>
-          <p
-            className="text-xs mt-1"
-            style={{ color: "var(--c-text-muted)", lineHeight: 1.5 }}
-          >
-            Every device signed in to your account. Revoke any you don't
-            recognise — the device loses access to all groups and DMs on
-            its next sync.
-          </p>
-
-          {devicesError && (
-            <p
-              data-testid="devices-error"
-              className="text-xs mt-2"
-              style={{ color: "#ff6b6b" }}
-            >
-              {devicesError}
+      <div className="flex justify-center px-6 py-8">
+        <div
+          className="flex flex-col gap-8 w-full max-w-md font-mono"
+          data-testid="security-page"
+        >
+          {/* PIN */}
+          <section className="flex flex-col gap-4 mb-12">
+            <h2 className={sectionHeaderClass} style={sectionHeaderStyle}>
+              PIN
+            </h2>
+            <p className="text-xs" style={{ color: "var(--c-text-muted)", lineHeight: 1.5 }}>
+              The local PIN unlocks Pollis on this device. It never leaves the
+              device and can't be recovered — use your Secret Key if you forget it.
             </p>
-          )}
+            <div className="self-start">
+              <Button
+                data-testid="change-pin-button"
+                onClick={() => navigate({ to: "/security/change-pin" })}
+              >
+                Change PIN
+              </Button>
+            </div>
+          </section>
 
-          {devices === null && (
-            <p className="text-xs mt-2" style={{ color: "var(--c-text-muted)" }}>
-              Loading…
+          {/* Devices */}
+          <section className="flex flex-col gap-4 mb-12">
+            <h2 className={sectionHeaderClass} style={sectionHeaderStyle}>
+              Devices
+            </h2>
+            <p className="text-xs" style={{ color: "var(--c-text-muted)", lineHeight: 1.5 }}>
+              Every device signed in to your account. Revoke any you don't
+              recognise — the device loses access to all groups and DMs on its
+              next sync.
             </p>
-          )}
 
-          {devices !== null && devices.length > 0 && (
-            <ul className="flex flex-col gap-2 mt-3" data-testid="devices-list">
-              {devices.map((device) => {
-                const isConfirming = confirmingDeviceId === device.device_id;
-                const isRevoking = revokingDeviceId === device.device_id;
-                const displayName = device.device_name ?? shortId(device.device_id);
-                return (
-                  <li
-                    key={device.device_id}
-                    data-testid={`device-${device.device_id}`}
-                    style={{
-                      background: "var(--c-surface)",
-                      border: "2px solid var(--c-border)",
-                      borderRadius: "0.5rem",
-                      padding: "0.75rem",
-                    }}
+            {devicesError && (
+              <p
+                data-testid="devices-error"
+                className="text-xs"
+                style={{ color: "#ff6b6b" }}
+              >
+                {devicesError}
+              </p>
+            )}
+
+            {confirmingDevice ? (
+              <div
+                className="flex flex-col gap-3"
+                data-testid="revoke-confirm"
+                style={{
+                  background: "var(--c-surface)",
+                  border: "2px solid var(--c-border)",
+                  borderRadius: "0.5rem",
+                  padding: "0.75rem",
+                }}
+              >
+                <p className="text-xs" style={{ color: "var(--c-text)" }}>
+                  Revoke <strong>{deviceDisplayName(confirmingDevice)}</strong>? This
+                  cannot be undone.
+                </p>
+                <TextInput
+                  label={`Type "${deviceDisplayName(confirmingDevice)}" to confirm`}
+                  value={confirmInput}
+                  onChange={setConfirmInput}
+                  autoFocus
+                  data-testid="revoke-confirm-input"
+                />
+                <div className="flex gap-2">
+                  <Button
+                    data-testid="revoke-confirm-submit"
+                    size="sm"
+                    disabled={
+                      confirmInput !== deviceDisplayName(confirmingDevice) || revoking
+                    }
+                    onClick={revoke}
                   >
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="min-w-0">
-                        <div
-                          className="text-xs font-bold truncate"
-                          style={{ color: "var(--c-text)" }}
-                        >
-                          {displayName}
-                          {device.is_current && (
-                            <span
-                              className="ml-2 text-xs"
-                              style={{ color: "var(--c-accent)" }}
-                            >
-                              (this device)
-                            </span>
-                          )}
-                        </div>
-                        <div
-                          className="text-xs mt-1"
-                          style={{ color: "var(--c-text-dim)" }}
-                        >
-                          Last seen {formatTimestamp(device.last_seen)}
-                        </div>
-                      </div>
-                      {!device.is_current && !isConfirming && (
+                    {revoking ? "Revoking…" : "Revoke device"}
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    disabled={revoking}
+                    onClick={cancelConfirm}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <NavigableList<api.DeviceInfo>
+                testId="devices-list"
+                items={devices ?? []}
+                isLoading={devices === null}
+                loadingLabel="Loading devices…"
+                emptyLabel="No devices registered."
+                getKey={(d) => d.device_id}
+                rowTestId={(d) => `device-${d.device_id}`}
+                renderRow={(d) => (
+                  <div className="min-w-0 flex flex-col">
+                    <span className="truncate" style={{ color: "var(--c-text)" }}>
+                      {deviceDisplayName(d)}
+                    </span>
+                    <span style={{ color: "var(--c-text-dim)" }}>
+                      Last seen {formatTimestamp(d.last_seen)}
+                    </span>
+                  </div>
+                )}
+                controls={(d) =>
+                  d.is_current
+                    ? []
+                    : [
                         <Button
-                          data-testid={`revoke-${device.device_id}`}
+                          key="revoke"
+                          data-testid={`revoke-${d.device_id}`}
                           variant="secondary"
                           size="sm"
-                          disabled={isRevoking}
-                          onClick={() => startConfirm(device.device_id)}
+                          onClick={() => {
+                            setConfirmingDevice(d);
+                            setConfirmInput("");
+                            setDevicesError(null);
+                          }}
                         >
                           Revoke
-                        </Button>
-                      )}
-                    </div>
+                        </Button>,
+                      ]
+                }
+              />
+            )}
+          </section>
 
-                    {isConfirming && (
-                      <div className="mt-3 flex flex-col gap-2">
-                        <TextInput
-                          label={`Type "${displayName}" to confirm`}
-                          value={confirmInput}
-                          onChange={setConfirmInput}
-                          autoFocus
-                          data-testid={`revoke-confirm-input-${device.device_id}`}
-                        />
-                        <div className="flex gap-2">
-                          <Button
-                            data-testid={`revoke-confirm-${device.device_id}`}
-                            size="sm"
-                            disabled={confirmInput !== displayName || isRevoking}
-                            onClick={() => revoke(device)}
-                          >
-                            {isRevoking ? "Revoking…" : "Revoke device"}
-                          </Button>
-                          <Button
-                            variant="secondary"
-                            size="sm"
-                            disabled={isRevoking}
-                            onClick={cancelConfirm}
-                          >
-                            Cancel
-                          </Button>
-                        </div>
-                      </div>
+          {/* Security events */}
+          <section className="flex flex-col gap-4 mb-12">
+            <h2 className={sectionHeaderClass} style={sectionHeaderStyle}>
+              Security events
+            </h2>
+            <p className="text-xs" style={{ color: "var(--c-text-muted)", lineHeight: 1.5 }}>
+              Every time a device is added to your account, an enrollment is
+              rejected, or your identity is reset, it shows up here. Check it if
+              you ever suspect someone has accessed your account.
+            </p>
+
+            {error && (
+              <p
+                data-testid="security-events-error"
+                className="text-xs"
+                style={{ color: "#ff6b6b" }}
+              >
+                {error}
+              </p>
+            )}
+
+            <NavigableList<api.SecurityEvent>
+              testId="security-events-list"
+              items={events ?? []}
+              isLoading={events === null}
+              loadingLabel="Loading…"
+              emptyLabel="No security events recorded yet."
+              getKey={(e) => e.id}
+              rowTestId={(e) => `security-event-${e.id}`}
+              renderRow={(event) => {
+                const { heading, detail } = describe(event);
+                return (
+                  <div className="min-w-0 flex flex-col">
+                    <span style={{ color: "var(--c-text)" }}>{heading}</span>
+                    {detail && (
+                      <span style={{ color: "var(--c-text-muted)" }}>{detail}</span>
                     )}
-                  </li>
+                    <span style={{ color: "var(--c-text-dim)" }}>
+                      {formatTimestamp(event.created_at)}
+                    </span>
+                  </div>
                 );
-              })}
-            </ul>
-          )}
+              }}
+            />
+          </section>
         </div>
-
-        <div>
-          <h2 className="text-sm font-bold" style={{ color: "var(--c-accent)" }}>
-            Security events
-          </h2>
-          <p
-            className="text-xs mt-1"
-            style={{ color: "var(--c-text-muted)", lineHeight: 1.5 }}
-          >
-            Every time a device is added to your account, an enrollment is
-            rejected, or your identity is reset, it shows up here. Check it
-            if you ever suspect someone has accessed your account.
-          </p>
-        </div>
-
-        {error && (
-          <p
-            data-testid="security-events-error"
-            className="text-xs"
-            style={{ color: "#ff6b6b" }}
-          >
-            {error}
-          </p>
-        )}
-
-        {events === null && (
-          <p className="text-xs" style={{ color: "var(--c-text-muted)" }}>
-            Loading…
-          </p>
-        )}
-
-        {events !== null && events.length === 0 && (
-          <p
-            data-testid="security-events-empty"
-            className="text-xs"
-            style={{ color: "var(--c-text-muted)" }}
-          >
-            No security events recorded yet.
-          </p>
-        )}
-
-        {events !== null && events.length > 0 && (
-          <ul className="flex flex-col gap-3" data-testid="security-events-list">
-            {events.map((event) => {
-              const { heading, detail } = describe(event);
-              return (
-                <li
-                  key={event.id}
-                  data-testid={`security-event-${event.id}`}
-                  style={{
-                    background: "var(--c-surface)",
-                    border: "2px solid var(--c-border)",
-                    borderRadius: "0.5rem",
-                    padding: "0.75rem",
-                  }}
-                >
-                  <div
-                    className="text-xs font-bold"
-                    style={{ color: "var(--c-text)" }}
-                  >
-                    {heading}
-                  </div>
-                  <div
-                    className="text-xs mt-1"
-                    style={{ color: "var(--c-text-muted)" }}
-                  >
-                    {detail}
-                  </div>
-                  <div
-                    className="text-xs mt-2"
-                    style={{ color: "var(--c-text-dim)" }}
-                  >
-                    {formatTimestamp(event.created_at)}
-                  </div>
-                </li>
-              );
-            })}
-          </ul>
-        )}
       </div>
     </PageShell>
   );

--- a/frontend/src/pages/VoiceSettingsPage.tsx
+++ b/frontend/src/pages/VoiceSettingsPage.tsx
@@ -183,7 +183,7 @@ export const VoiceSettingsPage: React.FC = () => {
   return (
     <PageShell title="Voice Settings" scrollable>
       <div className="flex justify-center px-6 py-8">
-      <div className="flex flex-col gap-8 w-full" style={{ maxWidth: 400 }}>
+      <div className="flex flex-col gap-8 w-full max-w-md">
 
         <section className="flex flex-col gap-4 mb-12">
           <h2

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -202,6 +202,10 @@ export async function listUserDevices(userId: string): Promise<DeviceInfo[]> {
   return invoke('list_user_devices', { userId });
 }
 
+export async function revokeDevice(userId: string, deviceId: string): Promise<void> {
+  await invoke('revoke_device', { userId, deviceId });
+}
+
 // ── User ───────────────────────────────────────────────────────────────────
 
 export interface UserProfileData {

--- a/src-tauri/gen/schemas/macOS-schema.json
+++ b/src-tauri/gen/schemas/macOS-schema.json
@@ -1160,10 +1160,22 @@
                         "markdownDescription": "Enables the size command without any pre-configured scope."
                       },
                       {
+                        "description": "Enables the start_accessing_security_scoped_resource command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-start-accessing-security-scoped-resource",
+                        "markdownDescription": "Enables the start_accessing_security_scoped_resource command without any pre-configured scope."
+                      },
+                      {
                         "description": "Enables the stat command without any pre-configured scope.",
                         "type": "string",
                         "const": "fs:allow-stat",
                         "markdownDescription": "Enables the stat command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Enables the stop_accessing_security_scoped_resource command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-stop-accessing-security-scoped-resource",
+                        "markdownDescription": "Enables the stop_accessing_security_scoped_resource command without any pre-configured scope."
                       },
                       {
                         "description": "Enables the truncate command without any pre-configured scope.",
@@ -1316,10 +1328,22 @@
                         "markdownDescription": "Denies the size command without any pre-configured scope."
                       },
                       {
+                        "description": "Denies the start_accessing_security_scoped_resource command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-start-accessing-security-scoped-resource",
+                        "markdownDescription": "Denies the start_accessing_security_scoped_resource command without any pre-configured scope."
+                      },
+                      {
                         "description": "Denies the stat command without any pre-configured scope.",
                         "type": "string",
                         "const": "fs:deny-stat",
                         "markdownDescription": "Denies the stat command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Denies the stop_accessing_security_scoped_resource command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-stop-accessing-security-scoped-resource",
+                        "markdownDescription": "Denies the stop_accessing_security_scoped_resource command without any pre-configured scope."
                       },
                       {
                         "description": "Denies the truncate command without any pre-configured scope.",
@@ -4233,22 +4257,22 @@
           "markdownDescription": "Denies the unminimize command without any pre-configured scope."
         },
         {
-          "description": "This permission set configures the types of dialogs\navailable from the dialog plugin.\n\n#### Granted Permissions\n\nAll dialog types are enabled.\n\n\n\n#### This default permission set includes:\n\n- `allow-ask`\n- `allow-confirm`\n- `allow-message`\n- `allow-save`\n- `allow-open`",
+          "description": "This permission set configures the types of dialogs\navailable from the dialog plugin.\n\n#### Granted Permissions\n\nAll dialog types are enabled.\n\n\n\n#### This default permission set includes:\n\n- `allow-message`\n- `allow-save`\n- `allow-open`",
           "type": "string",
           "const": "dialog:default",
-          "markdownDescription": "This permission set configures the types of dialogs\navailable from the dialog plugin.\n\n#### Granted Permissions\n\nAll dialog types are enabled.\n\n\n\n#### This default permission set includes:\n\n- `allow-ask`\n- `allow-confirm`\n- `allow-message`\n- `allow-save`\n- `allow-open`"
+          "markdownDescription": "This permission set configures the types of dialogs\navailable from the dialog plugin.\n\n#### Granted Permissions\n\nAll dialog types are enabled.\n\n\n\n#### This default permission set includes:\n\n- `allow-message`\n- `allow-save`\n- `allow-open`"
         },
         {
-          "description": "Enables the ask command without any pre-configured scope.",
+          "description": "Enables the ask command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `allow-message` and will be removed in v3)",
           "type": "string",
           "const": "dialog:allow-ask",
-          "markdownDescription": "Enables the ask command without any pre-configured scope."
+          "markdownDescription": "Enables the ask command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `allow-message` and will be removed in v3)"
         },
         {
-          "description": "Enables the confirm command without any pre-configured scope.",
+          "description": "Enables the confirm command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `allow-message` and will be removed in v3)",
           "type": "string",
           "const": "dialog:allow-confirm",
-          "markdownDescription": "Enables the confirm command without any pre-configured scope."
+          "markdownDescription": "Enables the confirm command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `allow-message` and will be removed in v3)"
         },
         {
           "description": "Enables the message command without any pre-configured scope.",
@@ -4269,16 +4293,16 @@
           "markdownDescription": "Enables the save command without any pre-configured scope."
         },
         {
-          "description": "Denies the ask command without any pre-configured scope.",
+          "description": "Denies the ask command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `deny-message` and will be removed in v3)",
           "type": "string",
           "const": "dialog:deny-ask",
-          "markdownDescription": "Denies the ask command without any pre-configured scope."
+          "markdownDescription": "Denies the ask command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `deny-message` and will be removed in v3)"
         },
         {
-          "description": "Denies the confirm command without any pre-configured scope.",
+          "description": "Denies the confirm command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `deny-message` and will be removed in v3)",
           "type": "string",
           "const": "dialog:deny-confirm",
-          "markdownDescription": "Denies the confirm command without any pre-configured scope."
+          "markdownDescription": "Denies the confirm command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `deny-message` and will be removed in v3)"
         },
         {
           "description": "Denies the message command without any pre-configured scope.",
@@ -5319,10 +5343,22 @@
           "markdownDescription": "Enables the size command without any pre-configured scope."
         },
         {
+          "description": "Enables the start_accessing_security_scoped_resource command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:allow-start-accessing-security-scoped-resource",
+          "markdownDescription": "Enables the start_accessing_security_scoped_resource command without any pre-configured scope."
+        },
+        {
           "description": "Enables the stat command without any pre-configured scope.",
           "type": "string",
           "const": "fs:allow-stat",
           "markdownDescription": "Enables the stat command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the stop_accessing_security_scoped_resource command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:allow-stop-accessing-security-scoped-resource",
+          "markdownDescription": "Enables the stop_accessing_security_scoped_resource command without any pre-configured scope."
         },
         {
           "description": "Enables the truncate command without any pre-configured scope.",
@@ -5475,10 +5511,22 @@
           "markdownDescription": "Denies the size command without any pre-configured scope."
         },
         {
+          "description": "Denies the start_accessing_security_scoped_resource command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:deny-start-accessing-security-scoped-resource",
+          "markdownDescription": "Denies the start_accessing_security_scoped_resource command without any pre-configured scope."
+        },
+        {
           "description": "Denies the stat command without any pre-configured scope.",
           "type": "string",
           "const": "fs:deny-stat",
           "markdownDescription": "Denies the stat command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the stop_accessing_security_scoped_resource command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:deny-stop-accessing-security-scoped-resource",
+          "markdownDescription": "Denies the stop_accessing_security_scoped_resource command without any pre-configured scope."
         },
         {
           "description": "Denies the truncate command without any pre-configured scope.",

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -893,6 +893,93 @@ pub async fn list_user_devices(
     Ok(devices)
 }
 
+/// Revoke one of the calling user's devices. Deletes the `user_device` row
+/// and any unclaimed key packages, then drives an MLS reconcile across
+/// every group + DM the user is in so the revoked device's leaf is
+/// removed from each tree. The current device cannot revoke itself —
+/// `logout(delete_data: true)` is the path for that.
+#[tauri::command]
+pub async fn revoke_device(
+    state: State<'_, Arc<AppState>>,
+    user_id: String,
+    device_id: String,
+) -> Result<()> {
+    let current_device_id = state.device_id.lock().await.clone();
+    if current_device_id.as_deref() == Some(device_id.as_str()) {
+        return Err(crate::error::Error::Other(anyhow::anyhow!(
+            "cannot revoke the current device — log out instead"
+        )));
+    }
+
+    let conn = state.remote_db.conn().await?;
+
+    // Confirm the device belongs to this user before touching anything.
+    let mut owner_rows = conn
+        .query(
+            "SELECT 1 FROM user_device WHERE device_id = ?1 AND user_id = ?2",
+            libsql::params![device_id.clone(), user_id.clone()],
+        )
+        .await?;
+    if owner_rows.next().await?.is_none() {
+        return Err(crate::error::Error::Other(anyhow::anyhow!(
+            "device not found for this user"
+        )));
+    }
+
+    // Drop the device row and its unclaimed key packages. Reconcile
+    // detects the missing row and prunes the leaf from each tree.
+    conn.execute(
+        "DELETE FROM mls_key_package WHERE user_id = ?1 AND device_id = ?2",
+        libsql::params![user_id.clone(), device_id.clone()],
+    )
+    .await?;
+    conn.execute(
+        "DELETE FROM user_device WHERE device_id = ?1 AND user_id = ?2",
+        libsql::params![device_id.clone(), user_id.clone()],
+    )
+    .await?;
+
+    // Collect every conversation the user belongs to (groups + DMs) so
+    // we can reconcile each one as the calling device.
+    let mut conversation_ids: Vec<String> = Vec::new();
+    {
+        let mut rows = conn
+            .query(
+                "SELECT group_id FROM group_member WHERE user_id = ?1",
+                libsql::params![user_id.clone()],
+            )
+            .await?;
+        while let Some(row) = rows.next().await? {
+            conversation_ids.push(row.get::<String>(0)?);
+        }
+    }
+    {
+        let mut rows = conn
+            .query(
+                "SELECT dm_channel_id FROM dm_channel_member WHERE user_id = ?1",
+                libsql::params![user_id.clone()],
+            )
+            .await?;
+        while let Some(row) = rows.next().await? {
+            conversation_ids.push(row.get::<String>(0)?);
+        }
+    }
+
+    for cid in &conversation_ids {
+        if let Err(e) = crate::commands::mls::reconcile_group_mls_impl(
+            state.inner(),
+            cid,
+            &user_id,
+        )
+        .await
+        {
+            eprintln!("[revoke_device] reconcile {cid} failed: {e}");
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use rusqlite::Connection;

--- a/src-tauri/src/commands/mls.rs
+++ b/src-tauri/src/commands/mls.rs
@@ -1508,6 +1508,7 @@ pub fn reconcile_group_mls_core_staged(
     available_kps: &[(String, String, KeyPackage)],
     actor_user_id: &str,
     actor_device_id: &str,
+    valid_devices: Option<&std::collections::HashSet<(String, String)>>,
 ) -> crate::error::Result<(ReconcileOutcome, Option<ReconcileCommitData>)> {
     use std::collections::{HashMap, HashSet};
 
@@ -1527,14 +1528,22 @@ pub fn reconcile_group_mls_core_staged(
         .iter()
         .map(|(uid, did, _)| (uid.clone(), did.clone()))
         .collect();
-    //    …UNION with existing tree members whose user is still in the roster.
+    //    …UNION with existing tree members whose user is still in the roster
+    //    AND whose device row still exists (when `valid_devices` is provided).
     //    This prevents removing the committer's own device (which consumed its
     //    KP on creation and has none left) or other devices that are already
-    //    correctly in the tree.
+    //    correctly in the tree, while still letting a `user_device` deletion
+    //    drive a leaf removal (used by device revocation).
     for (uid, did) in actual.keys() {
-        if roster_user_ids.contains(uid) {
-            desired.insert((uid.clone(), did.clone()));
+        if !roster_user_ids.contains(uid) {
+            continue;
         }
+        if let Some(valid) = valid_devices {
+            if !valid.contains(&(uid.clone(), did.clone())) {
+                continue;
+            }
+        }
+        desired.insert((uid.clone(), did.clone()));
     }
 
     // 3. Diff.
@@ -1673,6 +1682,7 @@ pub fn reconcile_group_mls_core(
     available_kps: &[(String, String, KeyPackage)],
     actor_user_id: &str,
     actor_device_id: &str,
+    valid_devices: Option<&std::collections::HashSet<(String, String)>>,
 ) -> crate::error::Result<(ReconcileOutcome, Option<ReconcileCommitData>)> {
     let (mut outcome, commit_data_opt) = reconcile_group_mls_core_staged(
         provider,
@@ -1682,6 +1692,7 @@ pub fn reconcile_group_mls_core(
         available_kps,
         actor_user_id,
         actor_device_id,
+        valid_devices,
     )?;
 
     // If a commit was staged, merge it locally. No-op runs leave the group
@@ -1768,6 +1779,29 @@ pub async fn reconcile_group_mls_impl(
             let mut rows = conn.query(&query, ()).await?;
             while let Some(row) = rows.next().await? {
                 device_pairs.push((row.get::<String>(0)?, row.get::<String>(1)?));
+            }
+        }
+    }
+
+    // 2b. Snapshot of every (user_id, device_id) pair still registered in
+    //     `user_device` for the current roster. Used by reconcile to drop
+    //     leaves whose device row was revoked even though the user is still
+    //     a roster member (single-device revoke flow).
+    let mut valid_devices: std::collections::HashSet<(String, String)> =
+        std::collections::HashSet::new();
+    {
+        let safe_ids: Vec<String> = roster_user_ids
+            .iter()
+            .map(|id| id.chars().filter(|c| c.is_alphanumeric() || *c == '-' || *c == '_').collect::<String>())
+            .collect();
+        if !safe_ids.is_empty() {
+            let in_clause = safe_ids.iter().map(|id| format!("'{id}'")).collect::<Vec<_>>().join(",");
+            let query = format!(
+                "SELECT user_id, device_id FROM user_device WHERE user_id IN ({in_clause})"
+            );
+            let mut rows = conn.query(&query, ()).await?;
+            while let Some(row) = rows.next().await? {
+                valid_devices.insert((row.get::<String>(0)?, row.get::<String>(1)?));
             }
         }
     }
@@ -1914,6 +1948,7 @@ pub async fn reconcile_group_mls_impl(
             &available_kps,
             &actor_user_id,
             &actor_device_id,
+            Some(&valid_devices),
         )?
     };
 
@@ -3241,6 +3276,7 @@ mod tests {
             &available_kps,
             actor_user_id,
             actor_device_id,
+            None,
         )
         .unwrap()
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -326,6 +326,7 @@ pub fn run() {
             commands::pin::lock,
             commands::pin::get_unlock_state,
             commands::auth::list_user_devices,
+            commands::auth::revoke_device,
             commands::device_enrollment::start_device_enrollment,
             commands::device_enrollment::poll_enrollment_status,
             commands::device_enrollment::list_pending_enrollment_requests,

--- a/src-tauri/src/test_harness.rs
+++ b/src-tauri/src/test_harness.rs
@@ -40,6 +40,7 @@ pub fn build_client_app(state: Arc<AppState>) -> Result<(App<MockRuntime>, Webvi
             crate::commands::auth::list_known_accounts,
             crate::commands::auth::wipe_local_data,
             crate::commands::auth::list_user_devices,
+            crate::commands::auth::revoke_device,
             crate::commands::pin::set_pin,
             crate::commands::pin::unlock,
             crate::commands::pin::lock,


### PR DESCRIPTION
Closes #209
Closes #210
Closes #191

- #209: gate admin highlighting on `selectedChannelId` so it doesn't bleed into DMs from a previously-selected group.
- #210: replace the raw `<button>` + unicode arrow in Preferences with the shared `Button` component.
- #191: new Devices section in Security page. Lists every registered device with last-seen and a "(this device)" badge; non-current devices have a Revoke button with typed-name confirmation. Backend `revoke_device` command deletes the `user_device` row + key packages and reconciles MLS across every group + DM the user is in. Reconcile now also drops leaves whose `user_device` row no longer exists (previously it only honored `group_member` removal), via an optional `valid_devices` set passed into `reconcile_group_mls_core_staged`. All 10 reconcile unit tests still pass.
- Polish: aligned Voice Settings / Security / Preferences page widths; ported Security page to NavigableList; switched TerminalMenu secondary action to a borderless cog.