### PR TITLE
Let users change their email via single-OTP verification

### DIFF
--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -301,117 +301,6 @@ export const Settings: React.FC<SettingsProps> = ({ onDeleteAccount }) => {
                 />
                 <input data-testid="settings-username-input" type="hidden" value={username} readOnly />
 
-                {emailChangeStep === "idle" ? (
-                  <div className="flex flex-col gap-1.5">
-                    <TextInput
-                      label="Email"
-                      value={email}
-                      onChange={() => { /* read-only — change via the button below */ }}
-                      type="email"
-                      placeholder="you@example.com"
-                      id="settings-email"
-                      disabled
-                    />
-                    <input data-testid="settings-email-input" type="hidden" value={email} readOnly />
-                    <Button
-                      data-testid="settings-email-change-button"
-                      variant="secondary"
-                      size="sm"
-                      onClick={() => {
-                        setPendingNewEmail("");
-                        setEmailOtpCode("");
-                        setEmailChangeError(null);
-                        setEmailChangeStep("request");
-                      }}
-                      className="self-start"
-                    >
-                      Change Email
-                    </Button>
-                  </div>
-                ) : emailChangeStep === "request" ? (
-                  <div className="flex flex-col gap-2">
-                    <TextInput
-                      label="New email"
-                      value={pendingNewEmail}
-                      onChange={setPendingNewEmail}
-                      type="email"
-                      placeholder="you@example.com"
-                      id="settings-email-new"
-                      disabled={emailChangePending}
-                    />
-                    <input data-testid="settings-email-new-input" type="hidden" value={pendingNewEmail} readOnly />
-                    {emailChangeError && (
-                      <p data-testid="settings-email-change-error" className="text-xs font-mono" style={{ color: "#ff6b6b" }}>
-                        {emailChangeError}
-                      </p>
-                    )}
-                    <div className="flex gap-2">
-                      <Button
-                        data-testid="settings-email-send-code"
-                        size="sm"
-                        onClick={handleSendEmailChangeOtp}
-                        isLoading={emailChangePending}
-                        loadingText="Sending…"
-                      >
-                        Send Code
-                      </Button>
-                      <Button
-                        data-testid="settings-email-cancel"
-                        variant="ghost"
-                        size="sm"
-                        onClick={cancelEmailChange}
-                        disabled={emailChangePending}
-                      >
-                        Cancel
-                      </Button>
-                    </div>
-                  </div>
-                ) : (
-                  <div className="flex flex-col gap-2">
-                    <p className="text-xs font-mono" style={{ color: "var(--c-text-muted)" }}>
-                      Code sent to <span style={{ color: "var(--c-text)" }}>{pendingNewEmail}</span>.
-                    </p>
-                    <TextInput
-                      label="Verification code"
-                      value={emailOtpCode}
-                      onChange={setEmailOtpCode}
-                      placeholder="000000"
-                      id="settings-email-otp"
-                      disabled={emailChangePending}
-                    />
-                    <input data-testid="settings-email-otp-input" type="hidden" value={emailOtpCode} readOnly />
-                    {emailChangeError && (
-                      <p data-testid="settings-email-change-error" className="text-xs font-mono" style={{ color: "#ff6b6b" }}>
-                        {emailChangeError}
-                      </p>
-                    )}
-                    <div className="flex gap-2">
-                      <Button
-                        data-testid="settings-email-verify"
-                        size="sm"
-                        onClick={handleVerifyEmailChange}
-                        isLoading={emailChangePending}
-                        loadingText="Verifying…"
-                      >
-                        Verify
-                      </Button>
-                      <Button
-                        data-testid="settings-email-back"
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => {
-                          setEmailOtpCode("");
-                          setEmailChangeError(null);
-                          setEmailChangeStep("request");
-                        }}
-                        disabled={emailChangePending}
-                      >
-                        Back
-                      </Button>
-                    </div>
-                  </div>
-                )}
-
                 {/* Phone field hidden — not currently surfaced as a feature.
                     State and backend wiring are intentionally left in place
                     so re-enabling is a one-uncomment change.
@@ -450,6 +339,130 @@ export const Settings: React.FC<SettingsProps> = ({ onDeleteAccount }) => {
             >
               Save Changes
             </Button>
+          </section>
+
+          {/* Email is its own section so the user doesn't mistake it for
+              something the "Save Changes" button covers — email only mutates
+              via the OTP-verified flow below. */}
+          <section className="flex flex-col gap-4 mb-12">
+            <h2 className="text-xs font-mono font-medium uppercase tracking-widest pb-1 border-b" style={{ color: 'var(--c-text-dim)', borderColor: 'var(--c-border)' }}>
+              Email
+            </h2>
+
+            {isLoading ? (
+              <span className="text-xs font-mono" style={{ color: 'var(--c-text-muted)' }}>
+                Loading…
+              </span>
+            ) : emailChangeStep === "idle" ? (
+              <div className="flex flex-col gap-1.5">
+                <TextInput
+                  label="Email"
+                  value={email}
+                  onChange={() => { /* read-only — change via the button below */ }}
+                  type="email"
+                  placeholder="you@example.com"
+                  id="settings-email"
+                  disabled
+                />
+                <input data-testid="settings-email-input" type="hidden" value={email} readOnly />
+                <Button
+                  data-testid="settings-email-change-button"
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => {
+                    setPendingNewEmail("");
+                    setEmailOtpCode("");
+                    setEmailChangeError(null);
+                    setEmailChangeStep("request");
+                  }}
+                  className="self-start mt-3"
+                >
+                  Change Email
+                </Button>
+              </div>
+            ) : emailChangeStep === "request" ? (
+              <div className="flex flex-col gap-2">
+                <TextInput
+                  label="New email"
+                  value={pendingNewEmail}
+                  onChange={setPendingNewEmail}
+                  type="email"
+                  placeholder="you@example.com"
+                  id="settings-email-new"
+                  disabled={emailChangePending}
+                />
+                <input data-testid="settings-email-new-input" type="hidden" value={pendingNewEmail} readOnly />
+                {emailChangeError && (
+                  <p data-testid="settings-email-change-error" className="text-xs font-mono" style={{ color: "#ff6b6b" }}>
+                    {emailChangeError}
+                  </p>
+                )}
+                <div className="flex gap-2">
+                  <Button
+                    data-testid="settings-email-send-code"
+                    size="sm"
+                    onClick={handleSendEmailChangeOtp}
+                    isLoading={emailChangePending}
+                    loadingText="Sending…"
+                  >
+                    Send Code
+                  </Button>
+                  <Button
+                    data-testid="settings-email-cancel"
+                    variant="ghost"
+                    size="sm"
+                    onClick={cancelEmailChange}
+                    disabled={emailChangePending}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <div className="flex flex-col gap-2">
+                <p className="text-xs font-mono" style={{ color: "var(--c-text-muted)" }}>
+                  Code sent to <span style={{ color: "var(--c-text)" }}>{pendingNewEmail}</span>.
+                </p>
+                <TextInput
+                  label="Verification code"
+                  value={emailOtpCode}
+                  onChange={setEmailOtpCode}
+                  placeholder="000000"
+                  id="settings-email-otp"
+                  disabled={emailChangePending}
+                />
+                <input data-testid="settings-email-otp-input" type="hidden" value={emailOtpCode} readOnly />
+                {emailChangeError && (
+                  <p data-testid="settings-email-change-error" className="text-xs font-mono" style={{ color: "#ff6b6b" }}>
+                    {emailChangeError}
+                  </p>
+                )}
+                <div className="flex gap-2">
+                  <Button
+                    data-testid="settings-email-verify"
+                    size="sm"
+                    onClick={handleVerifyEmailChange}
+                    isLoading={emailChangePending}
+                    loadingText="Verifying…"
+                  >
+                    Verify
+                  </Button>
+                  <Button
+                    data-testid="settings-email-back"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => {
+                      setEmailOtpCode("");
+                      setEmailChangeError(null);
+                      setEmailChangeStep("request");
+                    }}
+                    disabled={emailChangePending}
+                  >
+                    Back
+                  </Button>
+                </div>
+              </div>
+            )}
           </section>
 
           {/* Avatar */}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
 import { Upload, User } from "lucide-react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useAppStore } from "../stores/appStore";
 import { uploadAvatar } from "../services/r2-upload";
 import { resizeImage } from "../utils/imageProcessing";
-import { useUserProfile, useUpdateProfile, useUpdateAvatar, useUserAvatar } from "../hooks/queries";
+import { useUserProfile, useUpdateProfile, useUpdateAvatar, useUserAvatar, userQueryKeys } from "../hooks/queries";
 import { TextInput } from "../components/ui/TextInput";
 import { Button } from "../components/ui/Button";
 import { getVersion } from "@tauri-apps/api/app";
@@ -34,6 +35,18 @@ export const Settings: React.FC<SettingsProps> = ({ onDeleteAccount }) => {
   const [username, setUsername] = useState("");
   const [email, setEmail] = useState("");
   const [phone, setPhone] = useState("");
+
+  // Email-change flow lives entirely in this component:
+  //   'idle'    → display current email + "Change" button
+  //   'request' → input new address, send OTP
+  //   'verify'  → input the OTP, swap email
+  // Distinct mutations would obscure the linear UX, so we hold state locally.
+  const [emailChangeStep, setEmailChangeStep] = useState<"idle" | "request" | "verify">("idle");
+  const [pendingNewEmail, setPendingNewEmail] = useState("");
+  const [emailOtpCode, setEmailOtpCode] = useState("");
+  const [emailChangeError, setEmailChangeError] = useState<string | null>(null);
+  const [emailChangePending, setEmailChangePending] = useState(false);
+  const queryClient = useQueryClient();
   const [fileInputKey, setFileInputKey] = useState(0);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [saveSuccess, setSaveSuccess] = useState(false);
@@ -145,6 +158,56 @@ export const Settings: React.FC<SettingsProps> = ({ onDeleteAccount }) => {
     }
   };
 
+  const cancelEmailChange = () => {
+    setEmailChangeStep("idle");
+    setPendingNewEmail("");
+    setEmailOtpCode("");
+    setEmailChangeError(null);
+  };
+
+  const handleSendEmailChangeOtp = async () => {
+    if (!currentUser) { return; }
+    const target = pendingNewEmail.trim();
+    if (!target) {
+      setEmailChangeError("Enter a new email address.");
+      return;
+    }
+    setEmailChangePending(true);
+    setEmailChangeError(null);
+    try {
+      await invoke("request_email_change_otp", { userId: currentUser.id, newEmail: target });
+      setEmailChangeStep("verify");
+    } catch (err) {
+      setEmailChangeError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setEmailChangePending(false);
+    }
+  };
+
+  const handleVerifyEmailChange = async () => {
+    if (!currentUser) { return; }
+    if (!emailOtpCode.trim()) {
+      setEmailChangeError("Enter the code from your email.");
+      return;
+    }
+    setEmailChangePending(true);
+    setEmailChangeError(null);
+    try {
+      await invoke("verify_email_change", {
+        userId: currentUser.id,
+        newEmail: pendingNewEmail.trim(),
+        code: emailOtpCode.trim(),
+      });
+      // Refetch the profile so the displayed email updates without a reload.
+      await queryClient.invalidateQueries({ queryKey: userQueryKeys.profile(currentUser.id) });
+      cancelEmailChange();
+    } catch (err) {
+      setEmailChangeError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setEmailChangePending(false);
+    }
+  };
+
   const handleDeleteAccount = useCallback(async () => {
     if (!currentUser) {
       return;
@@ -238,16 +301,120 @@ export const Settings: React.FC<SettingsProps> = ({ onDeleteAccount }) => {
                 />
                 <input data-testid="settings-username-input" type="hidden" value={username} readOnly />
 
-                <TextInput
-                  label="Email"
-                  value={email}
-                  onChange={setEmail}
-                  type="email"
-                  placeholder="you@example.com"
-                  id="settings-email"
-                />
-                <input data-testid="settings-email-input" type="hidden" value={email} readOnly />
+                {emailChangeStep === "idle" ? (
+                  <div className="flex flex-col gap-1.5">
+                    <TextInput
+                      label="Email"
+                      value={email}
+                      onChange={() => { /* read-only — change via the button below */ }}
+                      type="email"
+                      placeholder="you@example.com"
+                      id="settings-email"
+                      disabled
+                    />
+                    <input data-testid="settings-email-input" type="hidden" value={email} readOnly />
+                    <Button
+                      data-testid="settings-email-change-button"
+                      variant="secondary"
+                      size="sm"
+                      onClick={() => {
+                        setPendingNewEmail("");
+                        setEmailOtpCode("");
+                        setEmailChangeError(null);
+                        setEmailChangeStep("request");
+                      }}
+                      className="self-start"
+                    >
+                      Change Email
+                    </Button>
+                  </div>
+                ) : emailChangeStep === "request" ? (
+                  <div className="flex flex-col gap-2">
+                    <TextInput
+                      label="New email"
+                      value={pendingNewEmail}
+                      onChange={setPendingNewEmail}
+                      type="email"
+                      placeholder="you@example.com"
+                      id="settings-email-new"
+                      disabled={emailChangePending}
+                    />
+                    <input data-testid="settings-email-new-input" type="hidden" value={pendingNewEmail} readOnly />
+                    {emailChangeError && (
+                      <p data-testid="settings-email-change-error" className="text-xs font-mono" style={{ color: "#ff6b6b" }}>
+                        {emailChangeError}
+                      </p>
+                    )}
+                    <div className="flex gap-2">
+                      <Button
+                        data-testid="settings-email-send-code"
+                        size="sm"
+                        onClick={handleSendEmailChangeOtp}
+                        isLoading={emailChangePending}
+                        loadingText="Sending…"
+                      >
+                        Send Code
+                      </Button>
+                      <Button
+                        data-testid="settings-email-cancel"
+                        variant="ghost"
+                        size="sm"
+                        onClick={cancelEmailChange}
+                        disabled={emailChangePending}
+                      >
+                        Cancel
+                      </Button>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="flex flex-col gap-2">
+                    <p className="text-xs font-mono" style={{ color: "var(--c-text-muted)" }}>
+                      Code sent to <span style={{ color: "var(--c-text)" }}>{pendingNewEmail}</span>.
+                    </p>
+                    <TextInput
+                      label="Verification code"
+                      value={emailOtpCode}
+                      onChange={setEmailOtpCode}
+                      placeholder="000000"
+                      id="settings-email-otp"
+                      disabled={emailChangePending}
+                    />
+                    <input data-testid="settings-email-otp-input" type="hidden" value={emailOtpCode} readOnly />
+                    {emailChangeError && (
+                      <p data-testid="settings-email-change-error" className="text-xs font-mono" style={{ color: "#ff6b6b" }}>
+                        {emailChangeError}
+                      </p>
+                    )}
+                    <div className="flex gap-2">
+                      <Button
+                        data-testid="settings-email-verify"
+                        size="sm"
+                        onClick={handleVerifyEmailChange}
+                        isLoading={emailChangePending}
+                        loadingText="Verifying…"
+                      >
+                        Verify
+                      </Button>
+                      <Button
+                        data-testid="settings-email-back"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => {
+                          setEmailOtpCode("");
+                          setEmailChangeError(null);
+                          setEmailChangeStep("request");
+                        }}
+                        disabled={emailChangePending}
+                      >
+                        Back
+                      </Button>
+                    </div>
+                  </div>
+                )}
 
+                {/* Phone field hidden — not currently surfaced as a feature.
+                    State and backend wiring are intentionally left in place
+                    so re-enabling is a one-uncomment change.
                 <TextInput
                   label="Phone"
                   value={phone}
@@ -256,6 +423,7 @@ export const Settings: React.FC<SettingsProps> = ({ onDeleteAccount }) => {
                   id="settings-phone"
                 />
                 <input data-testid="settings-phone-input" type="hidden" value={phone} readOnly />
+                */}
               </div>
             )}
 

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -278,6 +278,125 @@ pub async fn verify_otp(
     Ok(profile)
 }
 
+/// Send an OTP to a new email address as part of the email-change flow.
+/// Reuses the regular `request_otp` machinery — the OTP is stored keyed on
+/// the *new* email, and `verify_email_change` consumes it on success.
+///
+/// Pre-checks uniqueness so the user gets an immediate "already in use"
+/// error instead of waiting until verify time. A second uniqueness check
+/// runs at verify time to close the race.
+#[tauri::command]
+pub async fn request_email_change_otp(
+    state: State<'_, Arc<AppState>>,
+    user_id: String,
+    new_email: String,
+) -> Result<()> {
+    let trimmed = new_email.trim().to_string();
+    if trimmed.is_empty() {
+        return Err(anyhow::anyhow!("Email is required.").into());
+    }
+
+    let conn = state.remote_db.conn().await?;
+    let mut rows = conn
+        .query(
+            "SELECT id FROM users WHERE email = ?1",
+            libsql::params![trimmed.clone()],
+        )
+        .await?;
+    if let Some(row) = rows.next().await? {
+        let owner: String = row.get(0)?;
+        if owner == user_id {
+            return Err(anyhow::anyhow!("That's already your email address.").into());
+        }
+        return Err(anyhow::anyhow!("That email is already in use.").into());
+    }
+
+    request_otp(state, trimmed).await
+}
+
+/// Verify the OTP sent to a new email address and atomically swap
+/// `users.email` for the calling user. The OTP proves the caller controls
+/// the new mailbox; the device's keystore identity proves they're the one
+/// asking. We re-check uniqueness right before the UPDATE to close the
+/// window between request and verify.
+#[tauri::command]
+pub async fn verify_email_change(
+    state: State<'_, Arc<AppState>>,
+    user_id: String,
+    new_email: String,
+    code: String,
+) -> Result<()> {
+    use sha2::{Digest, Sha256};
+
+    let trimmed = new_email.trim().to_string();
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+
+    let entry = {
+        let store = state.otp_store.lock().await;
+        store.get(&trimmed).cloned()
+    }
+    .ok_or_else(|| {
+        anyhow::anyhow!("No verification request for that email. Request a new code.")
+    })?;
+
+    if now > entry.expires_at {
+        return Err(anyhow::anyhow!("This code has expired. Request a new one.").into());
+    }
+
+    let mut hasher = Sha256::new();
+    hasher.update(code.trim().as_bytes());
+    let provided = format!("{:x}", hasher.finalize());
+    if provided != entry.hash {
+        return Err(anyhow::anyhow!("Invalid code. Please check and try again.").into());
+    }
+
+    {
+        let mut store = state.otp_store.lock().await;
+        store.remove(&trimmed);
+    }
+
+    let conn = state.remote_db.conn().await?;
+
+    // Race-close: between request and verify, someone else could have
+    // claimed this email. Reject if so — the user gets a clear error.
+    let mut rows = conn
+        .query(
+            "SELECT 1 FROM users WHERE email = ?1 AND id != ?2",
+            libsql::params![trimmed.clone(), user_id.clone()],
+        )
+        .await?;
+    if rows.next().await?.is_some() {
+        return Err(anyhow::anyhow!("That email was just claimed by another account.").into());
+    }
+
+    conn.execute(
+        "UPDATE users SET email = ?1 WHERE id = ?2",
+        libsql::params![trimmed.clone(), user_id.clone()],
+    )
+    .await?;
+
+    // Mirror the new email into the local accounts index so the login
+    // screen's "continue as" picker shows the new address.
+    let mut name_rows = conn
+        .query(
+            "SELECT username FROM users WHERE id = ?1",
+            libsql::params![user_id.clone()],
+        )
+        .await?;
+    if let Some(row) = name_rows.next().await? {
+        let username: String = row.get(0)?;
+        if let Err(e) = crate::accounts::upsert_account(&user_id, &username, Some(&trimmed), None) {
+            eprintln!("[auth] email-change accounts.json mirror failed: {e}");
+        }
+    }
+
+    Ok(())
+}
+
 /// Dev-only: bypass OTP and log in directly with an email address.
 /// Returns an error in release builds so this can never be used in production.
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -315,6 +315,8 @@ pub fn run() {
             commands::auth::get_identity,
             commands::auth::request_otp,
             commands::auth::verify_otp,
+            commands::auth::request_email_change_otp,
+            commands::auth::verify_email_change,
             commands::auth::dev_login,
             commands::auth::get_session,
             commands::auth::logout,


### PR DESCRIPTION
## Summary

- New backend commands `request_email_change_otp` and `verify_email_change` mirror the existing OTP flow: pre-check uniqueness, send OTP to the new address, then on verify re-check uniqueness to close the request→verify race, swap `users.email` atomically, and mirror the new address into the local accounts index.
- Settings replaces the silently-no-op editable email TextInput with a three-step inline flow (read-only display + Change → new-email + Send Code → OTP + Verify), invalidating the profile query on success so the displayed email updates without a reload.
- Email lives in its own `Email` section under Account so users can't mistake it for something the Save Changes button covers.
- Hides the unused Phone field from Settings (state + `users.phone` column intentionally left intact).

No schema changes. Email is just metadata on `users` — MLS identity is the Ed25519 keypair, so existing sessions remain valid for the user across the swap.

## Test plan

- [ ] Open Settings, confirm email shows read-only with a Change button and lives under its own section
- [ ] Click Change → enter a new email → Send Code → confirm OTP arrives at the new address
- [ ] Enter the code → Verify → confirm the displayed email updates without reload
- [ ] Try to change to an email that already belongs to another account — error surfaces in the form, no DB write
- [ ] Try to change to your own current email — error surfaces, no OTP sent
- [ ] Save Changes (with username edit) does not affect the email value
- [ ] After change, sign out and sign in via the new email — works; old email no longer accepts OTP