### PR TITLE
fix: voice leave cleanup, concurrent-join guard, PIN entry polish

### DIFF
--- a/frontend/src/components/Auth/PinCreateScreen.tsx
+++ b/frontend/src/components/Auth/PinCreateScreen.tsx
@@ -128,6 +128,7 @@ export const PinCreateScreen: React.FC<PinCreateScreenProps> = ({
                 }}
                 disabled={isLoading}
                 autoFocus
+                mask
               />
               <input
                 data-testid="pin-create-input"

--- a/frontend/src/components/Auth/PinEntryScreen.tsx
+++ b/frontend/src/components/Auth/PinEntryScreen.tsx
@@ -110,6 +110,7 @@ export const PinEntryScreen: React.FC<PinEntryScreenProps> = ({
                 }}
                 disabled={isLoading}
                 autoFocus
+                mask
               />
               <input
                 data-testid="pin-entry-input"

--- a/frontend/src/components/ui/InputOtp.tsx
+++ b/frontend/src/components/ui/InputOtp.tsx
@@ -6,6 +6,7 @@ interface InputOtpProps {
   onChange: (value: string) => void;
   disabled?: boolean;
   autoFocus?: boolean;
+  mask?: boolean;
 }
 
 export const InputOtp: React.FC<InputOtpProps> = ({
@@ -14,6 +15,7 @@ export const InputOtp: React.FC<InputOtpProps> = ({
   onChange,
   disabled = false,
   autoFocus = false,
+  mask = false,
 }) => {
   const [focusedIndex, setFocusedIndex] = useState<number | null>(null);
   const inputsRef = useRef<(HTMLInputElement | null)[]>([]);
@@ -82,7 +84,7 @@ export const InputOtp: React.FC<InputOtpProps> = ({
           <input
             key={index}
             ref={(el) => { inputsRef.current[index] = el; }}
-            type="text"
+            type={mask ? "password" : "text"}
             inputMode="numeric"
             maxLength={1}
             value={digit}

--- a/frontend/src/pages/ChangePinPage.tsx
+++ b/frontend/src/pages/ChangePinPage.tsx
@@ -72,8 +72,9 @@ export const ChangePinPage: React.FC = () => {
 
   return (
     <PageShell title="Change PIN" scrollable>
+      <div className="flex justify-center px-6 py-8">
       <div
-        className="flex flex-col gap-4 p-4 font-mono"
+        className="flex flex-col gap-4 w-full max-w-md font-mono"
         data-testid="change-pin-page"
         style={{ color: "var(--c-text)" }}
       >
@@ -127,6 +128,7 @@ export const ChangePinPage: React.FC = () => {
                 }}
                 disabled={isLoading}
                 autoFocus
+                mask
               />
               <input
                 data-testid="change-pin-input"
@@ -145,6 +147,7 @@ export const ChangePinPage: React.FC = () => {
             </Button>
           </div>
         )}
+      </div>
       </div>
     </PageShell>
   );

--- a/src-tauri/src/commands/voice.rs
+++ b/src-tauri/src/commands/voice.rs
@@ -73,6 +73,17 @@ pub(crate) struct SendableStream(pub(crate) cpal::Stream);
 unsafe impl Send for SendableStream {}
 unsafe impl Sync for SendableStream {}
 
+impl Drop for SendableStream {
+    fn drop(&mut self) {
+        // cpal::Stream::Drop alone doesn't reliably stop the backend audio
+        // thread — on ALSA the I/O thread can be parked in snd_pcm_readi and
+        // miss the drop signal, leaving the OS mic-in-use indicator on until
+        // the process exits. Explicit pause() wakes the backend and releases
+        // the device promptly.
+        let _ = self.0.pause();
+    }
+}
+
 // ── Events pushed to the frontend ─────────────────────────────────────────
 
 #[derive(Clone, Serialize, Deserialize)]

--- a/src-tauri/src/commands/voice.rs
+++ b/src-tauri/src/commands/voice.rs
@@ -240,6 +240,10 @@ pub struct VoiceState {
     pub room_task: Option<tokio::task::JoinHandle<()>>,
     pub playback: Arc<Mutex<PlaybackState>>,
     pub is_muted: Arc<AtomicBool>,
+    /// Set while a `join_voice_channel` call is in flight. Blocks a second
+    /// concurrent invocation from racing the first and tripping LiveKit's
+    /// DuplicateIdentity eviction (which would disconnect both attempts).
+    pub joining: Arc<AtomicBool>,
     pub current_input_device: Option<String>,
     /// APM stage for the current voice session. Owns the WebRTC AudioProcessing
     /// `Processor` and its config. `None` outside a call.
@@ -270,6 +274,7 @@ impl VoiceState {
             room_task: None,
             playback: Arc::new(Mutex::new(PlaybackState::new())),
             is_muted: Arc::new(AtomicBool::new(false)),
+            joining: Arc::new(AtomicBool::new(false)),
             current_input_device: None,
             apm: None,
             denoiser: Arc::new(Mutex::new(None)),
@@ -1033,6 +1038,28 @@ pub async fn join_voice_channel(
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis() as u64)
         .unwrap_or(0);
+
+    // Refuse re-entry if a join is already in flight or a room is already
+    // connected. Two concurrent joins with the same identity (`voice-{user_id}`)
+    // race LiveKit's session bookkeeping and trigger DuplicateIdentity, which
+    // disconnects the surviving session shortly after Connected. Holds the
+    // voice lock just long enough to swap the flag, then releases.
+    let _join_guard = {
+        let voice = state.voice.lock().await;
+        if voice.room.is_some() {
+            return Err(anyhow::anyhow!("already connected to a voice channel").into());
+        }
+        if voice.joining.swap(true, Ordering::AcqRel) {
+            return Err(anyhow::anyhow!("voice channel join already in progress").into());
+        }
+        struct JoinGuard(Arc<AtomicBool>);
+        impl Drop for JoinGuard {
+            fn drop(&mut self) {
+                self.0.store(false, Ordering::Release);
+            }
+        }
+        JoinGuard(Arc::clone(&voice.joining))
+    };
 
     let url = state.config.livekit_url.clone();
     if url.is_empty() {


### PR DESCRIPTION
## Summary
- Closes #238 — `SendableStream::Drop` now calls `pause()` so cpal releases the mic device on leave (mic indicator no longer stays on until app close)
- Closes #239 — `join_voice_channel` guards against concurrent invocations that triggered LiveKit `DuplicateIdentity` disconnects
- Closes #235 — PIN entry digits are masked (`type="password"`) and Change PIN page now uses the standard `max-w-md` centered column

## Test plan
- [x] Join → leave a voice channel; OS mic indicator clears within ~1s
- [x] Spam-click Join; only one connect happens, no DuplicateIdentity
- [x] PIN entry / create / change render dots, layout matches Security/Preferences pages