### PR TITLE
feat: MVP quick wins — auto-hangup, group rename, media link previews

### DIFF
--- a/frontend/src/components/Message/MediaLinkUnfurl.tsx
+++ b/frontend/src/components/Message/MediaLinkUnfurl.tsx
@@ -1,0 +1,130 @@
+import React, { useCallback, useMemo, useState } from "react";
+import { open } from "@tauri-apps/plugin-shell";
+
+const URL_REGEX = /(https?:\/\/[^\s<>"')\]]+|www\.[^\s<>"')\]]+\.[^\s<>"')\]]+)/gi;
+
+const IMAGE_EXTS = ["jpg", "jpeg", "png", "gif", "webp", "avif", "bmp", "svg"];
+const VIDEO_EXTS = ["mp4", "webm", "mov", "m4v", "ogv"];
+
+type MediaKind = "image" | "video";
+
+interface MediaLink {
+  url: string;
+  kind: MediaKind;
+}
+
+function ensureProtocol(url: string): string {
+  if (/^https?:\/\//i.test(url)) {
+    return url;
+  }
+  return `https://${url}`;
+}
+
+function classify(url: string): MediaKind | null {
+  let pathname: string;
+  try {
+    pathname = new URL(ensureProtocol(url)).pathname.toLowerCase();
+  } catch {
+    return null;
+  }
+  const dot = pathname.lastIndexOf(".");
+  if (dot < 0) {
+    return null;
+  }
+  const ext = pathname.slice(dot + 1);
+  if (IMAGE_EXTS.includes(ext)) {
+    return "image";
+  }
+  if (VIDEO_EXTS.includes(ext)) {
+    return "video";
+  }
+  return null;
+}
+
+function extractMediaLinks(text: string): MediaLink[] {
+  const out: MediaLink[] = [];
+  const seen = new Set<string>();
+  URL_REGEX.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = URL_REGEX.exec(text)) !== null) {
+    const url = match[0];
+    if (seen.has(url)) {
+      continue;
+    }
+    seen.add(url);
+    const kind = classify(url);
+    if (kind) {
+      out.push({ url, kind });
+    }
+  }
+  return out;
+}
+
+interface MediaLinkUnfurlProps {
+  text: string;
+}
+
+export const MediaLinkUnfurl: React.FC<MediaLinkUnfurlProps> = ({ text }) => {
+  const links = useMemo(() => extractMediaLinks(text), [text]);
+  const [hidden, setHidden] = useState<Set<string>>(() => new Set());
+
+  const handleClick = useCallback((url: string) => {
+    open(ensureProtocol(url));
+  }, []);
+
+  const visible = links.filter((l) => !hidden.has(l.url));
+  if (visible.length === 0) {
+    return null;
+  }
+
+  return (
+    <div data-testid="media-link-unfurl" className="mt-2 flex flex-col gap-2">
+      {visible.map((link) => {
+        const href = ensureProtocol(link.url);
+        if (link.kind === "image") {
+          return (
+            <button
+              key={link.url}
+              type="button"
+              onClick={() => handleClick(link.url)}
+              className="block max-w-sm cursor-pointer p-0 bg-transparent border-0"
+              title={href}
+              aria-label={`Open ${href}`}
+            >
+              <img
+                src={href}
+                alt=""
+                onError={() =>
+                  setHidden((prev) => {
+                    const next = new Set(prev);
+                    next.add(link.url);
+                    return next;
+                  })
+                }
+                className="max-w-full max-h-80 rounded"
+                style={{ border: "1px solid var(--c-border)" }}
+              />
+            </button>
+          );
+        }
+        return (
+          <video
+            key={link.url}
+            src={href}
+            controls
+            preload="metadata"
+            onError={() =>
+              setHidden((prev) => {
+                const next = new Set(prev);
+                next.add(link.url);
+                return next;
+              })
+            }
+            className="max-w-sm max-h-80 rounded"
+            style={{ border: "1px solid var(--c-border)" }}
+          />
+        );
+      })}
+    </div>
+  );
+};

--- a/frontend/src/components/Message/MessageItem.tsx
+++ b/frontend/src/components/Message/MessageItem.tsx
@@ -5,6 +5,7 @@ import { getFileIcon } from "../../utils/fileIcon";
 import { useAppStore } from "../../stores/appStore";
 import { downloadAndDecryptMedia } from "../../services/r2-upload";
 import { LinkifiedText } from "../ui/LinkifiedText";
+import { MediaLinkUnfurl } from "./MediaLinkUnfurl";
 import { LoadingSpinner } from "../ui/LoaderSpinner";
 import { InlineAudioPlayer } from "../ui/InlineAudioPlayer";
 import { AudioPlayer } from "../ui/AudioPlayer";
@@ -220,6 +221,9 @@ export const MessageItem: React.FC<MessageItemProps> = ({
           </div>
         )}
       </div>
+
+      {/* Inline previews for media URLs typed in the message body */}
+      {!isDeleted && <MediaLinkUnfurl text={content} />}
 
       {/* Attachments — each on its own row */}
       {sortedAttachments && (

--- a/frontend/src/hooks/queries/useGroups.ts
+++ b/frontend/src/hooks/queries/useGroups.ts
@@ -140,6 +140,42 @@ export function useJoinGroup() {
   });
 }
 
+export function useUpdateGroup() {
+  const queryClient = useQueryClient();
+  const currentUser = useAppStore((state) => state.currentUser);
+
+  return useMutation({
+    mutationFn: async ({
+      groupId,
+      name,
+      description,
+    }: {
+      groupId: string;
+      name?: string;
+      description?: string | null;
+    }) => {
+      if (!currentUser) {
+        throw new Error("No current user");
+      }
+      await invoke("update_group", {
+        groupId,
+        requesterId: currentUser.id,
+        name: name ?? null,
+        description: description ?? null,
+        iconUrl: null,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: groupQueryKeys.userGroups(currentUser?.id ?? null),
+      });
+      queryClient.invalidateQueries({
+        queryKey: groupQueryKeys.userGroupsWithChannels(currentUser?.id ?? null),
+      });
+    },
+  });
+}
+
 export function useUpdateGroupIcon() {
   const queryClient = useQueryClient();
   const currentUser = useAppStore((state) => state.currentUser);

--- a/frontend/src/pages/Call.tsx
+++ b/frontend/src/pages/Call.tsx
@@ -18,11 +18,14 @@ import { voiceSession } from "../voice";
  * - Callee accepts an incoming-call alert in the bottom status bar → AppShell
  *   does the same.
  */
+const RINGING_TIMEOUT_MS = 30_000;
+
 export const CallPage: React.FC = () => {
   const navigate = useNavigate();
   const { callId } = useParams({ from: "/call/$callId" });
   const roomName = `call-${callId}`;
   const activeVoiceChannelId = useAppStore((s) => s.activeVoiceChannelId);
+  const voiceParticipants = useAppStore((s) => s.voiceParticipants);
 
   // Direct navigation to /call/<id> with no active voice → bounce back. Joining
   // is initiated by the caller's DM page or the callee's accept button; we
@@ -44,6 +47,21 @@ export const CallPage: React.FC = () => {
       navigate({ to: "/dms" });
     }
   }, [activeVoiceChannelId, roomName, navigate]);
+
+  // Ringing timeout: if nobody else is in the room after 30s, auto-hang-up so
+  // we stop publishing mic audio (and burning per-participant minutes) into
+  // an empty room. Applies to both sides — caller waiting for an unanswered
+  // ring, callee whose peer dropped before their join completed.
+  const hasRemoteParticipant = voiceParticipants.some((p) => !p.isLocal);
+  useEffect(() => {
+    if (hasRemoteParticipant || activeVoiceChannelId !== roomName) {
+      return;
+    }
+    const timer = setTimeout(() => {
+      voiceSession.leave();
+    }, RINGING_TIMEOUT_MS);
+    return () => clearTimeout(timer);
+  }, [hasRemoteParticipant, activeVoiceChannelId, roomName]);
 
   const hangUp = () => {
     voiceSession.leave();

--- a/frontend/src/pages/Group.tsx
+++ b/frontend/src/pages/Group.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from "react";
 import { useNavigate, useParams } from "@tanstack/react-router";
-import { ArrowLeft, Hash, Plus, Volume2, Users, UserPlus, Inbox, LogOut } from "lucide-react";
+import { ArrowLeft, Hash, Plus, Volume2, Users, UserPlus, Inbox, LogOut, Pencil } from "lucide-react";
 import { TerminalMenu, type TerminalMenuItem } from "../components/ui/TerminalMenu";
 import { useAppStore } from "../stores/appStore";
 import { useUserGroupsWithChannels, useGroupJoinRequests } from "../hooks/queries/useGroups";
@@ -106,6 +106,14 @@ export const GroupPage: React.FC = () => {
       testId: "menu-item-members",
     },
     ...(isAdmin ? [
+      {
+        id: "rename-group",
+        label: "Rename Group",
+        icon: <Pencil size={14} />,
+        action: () => navigate({ to: "/groups/$groupId/rename", params: { groupId } }),
+        type: "system" as const,
+        testId: "menu-item-rename-group",
+      },
       {
         id: "create-channel",
         label: "New Channel",

--- a/frontend/src/pages/RenameGroup.tsx
+++ b/frontend/src/pages/RenameGroup.tsx
@@ -1,0 +1,135 @@
+import React, { useEffect, useState } from "react";
+import { useAppStore } from "../stores/appStore";
+import { useUpdateGroup, useUserGroupsWithChannels } from "../hooks/queries/useGroups";
+import { TextInput } from "../components/ui/TextInput";
+import { TextArea } from "../components/ui/TextArea";
+import { Button } from "../components/ui/Button";
+
+interface RenameGroupProps {
+  groupId: string;
+  onSuccess?: () => void;
+}
+
+export const RenameGroup: React.FC<RenameGroupProps> = ({ groupId, onSuccess }) => {
+  const { currentUser } = useAppStore();
+  const { data: groupsWithChannels } = useUserGroupsWithChannels();
+  const updateGroup = useUpdateGroup();
+
+  const group = groupsWithChannels?.find((g) => g.id === groupId);
+
+  const [name, setName] = useState(group?.name ?? "");
+  const [description, setDescription] = useState(group?.description ?? "");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (group) {
+      setName(group.name);
+      setDescription(group.description ?? "");
+    }
+  }, [group?.id]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    if (!name.trim()) {
+      setError("Name is required");
+      return;
+    }
+    if (!currentUser) {
+      setError("User not found");
+      return;
+    }
+    if (!group) {
+      setError("Group not found");
+      return;
+    }
+    const trimmedName = name.trim();
+    const trimmedDescription = description.trim();
+    const nameChanged = trimmedName !== group.name;
+    const descriptionChanged = trimmedDescription !== (group.description ?? "");
+    if (!nameChanged && !descriptionChanged) {
+      onSuccess?.();
+      return;
+    }
+    try {
+      await updateGroup.mutateAsync({
+        groupId,
+        name: nameChanged ? trimmedName : undefined,
+        description: descriptionChanged ? trimmedDescription : undefined,
+      });
+      onSuccess?.();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to rename group");
+    }
+  };
+
+  if (!currentUser) {
+    return (
+      <div data-testid="rename-group-no-user" className="flex items-center justify-center flex-1" style={{ background: "var(--c-bg)" }}>
+        <p className="text-xs font-mono" style={{ color: "var(--c-text-muted)" }}>Please sign in</p>
+      </div>
+    );
+  }
+
+  if (!group) {
+    return (
+      <div data-testid="rename-group-not-found" className="flex items-center justify-center flex-1" style={{ background: "var(--c-bg)" }}>
+        <p className="text-xs font-mono" style={{ color: "var(--c-text-muted)" }}>Group not found</p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-testid="rename-group-page"
+      className="flex-1 flex flex-col overflow-auto"
+      style={{ background: "var(--c-bg)" }}
+    >
+      <div data-testid="rename-group-content" className="flex-1 flex justify-center overflow-auto px-6 py-8">
+        <form
+          data-testid="rename-group-form"
+          onSubmit={handleSubmit}
+          className="w-full max-w-md flex flex-col gap-5"
+        >
+          <TextInput
+            label="Group Name"
+            value={name}
+            onChange={setName}
+            placeholder="My Group"
+            disabled={updateGroup.isPending}
+            id="rename-group-name"
+            required
+          />
+          <input data-testid="rename-group-name-input" type="hidden" value={name} readOnly />
+
+          <TextArea
+            label="Description"
+            value={description}
+            onChange={setDescription}
+            placeholder="Optional description…"
+            disabled={updateGroup.isPending}
+            rows={2}
+            id="rename-group-description"
+          />
+          <input data-testid="rename-group-description-input" type="hidden" value={description} readOnly />
+
+          {error && (
+            <p data-testid="rename-group-error" className="text-xs font-mono" style={{ color: "#ff6b6b" }}>
+              {error}
+            </p>
+          )}
+
+          <Button
+            data-testid="rename-group-submit-button"
+            type="submit"
+            isLoading={updateGroup.isPending}
+            loadingText="Saving…"
+            className="w-full"
+          >
+            Save
+          </Button>
+        </form>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/pages/RenameGroupPage.tsx
+++ b/frontend/src/pages/RenameGroupPage.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { useNavigate, useParams } from "@tanstack/react-router";
+import { PageShell } from "../components/Layout/PageShell";
+import { RenameGroup } from "./RenameGroup";
+
+export const RenameGroupPage: React.FC = () => {
+  const navigate = useNavigate();
+  const { groupId } = useParams({ from: "/groups/$groupId/rename" });
+
+  return (
+    <PageShell title="Rename Group">
+      <RenameGroup
+        groupId={groupId}
+        onSuccess={() => {
+          navigate({ to: "/groups/$groupId", params: { groupId } });
+        }}
+      />
+    </PageShell>
+  );
+};

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -37,6 +37,7 @@ import { RequestsPage } from "./pages/RequestsPage";
 import { BlockedPage } from "./pages/BlockedPage";
 import { CallPage } from "./pages/Call";
 import { RenameChannelPage } from "./pages/RenameChannelPage";
+import { RenameGroupPage } from "./pages/RenameGroupPage";
 
 // Re-export RouterContext so callers can import from either location.
 export type { RouterContext };
@@ -98,6 +99,12 @@ const renameChannelRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/groups/$groupId/channels/$channelId/rename",
   component: RenameChannelPage,
+});
+
+const renameGroupRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/groups/$groupId/rename",
+  component: RenameGroupPage,
 });
 
 const membersRoute = createRoute({
@@ -250,6 +257,7 @@ const routeTree = rootRoute.addChildren([
   channelRoute,
   createChannelRoute,
   renameChannelRoute,
+  renameGroupRoute,
   membersRoute,
   kickMemberRoute,
   joinRequestsRoute,


### PR DESCRIPTION
Three small MVP-expected features, each in its own commit.

- **#232** — `Call.tsx` auto-hangs-up after 30s if no remote participant is in the room, so the caller stops publishing mic into an empty LiveKit room. Applied to both sides because `incomingCall` is cleared on accept, making caller-vs-callee detection unreliable on the call page; "alone for 30s → leave" is the correct behavior either way.
- **#204** — Admin-only "Rename Group" flow. Backend `update_group` already enforced the admin role; this wires up `useUpdateGroup`, a `RenameGroup` page mirroring the channel-rename pattern, route `/groups/$groupId/rename`, and a menu entry in `Group.tsx`.
- **#178** — New `MediaLinkUnfurl` renders inline `<img>` / `<video>` previews for URLs whose path ends in a known image/video extension, with `onError` fallback to hide bad previews. Render-time only — no upload pipeline.

Closes #232, closes #204, closes #178.