### PR TITLE
polish/nitpicks: media architecture + UI polish + sidebar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,16 @@ website/                # Static HTML marketing site (Cloudflare Pages)
 
 **Implication for future video**: video capture, publish, subscribe, and render must all run in Rust. Remote video frames cannot be handed to a `<video>` element via `srcObject` because there is no `MediaStream` in the webview. Rendering requires either a native OS surface layered behind the webview or pushing decoded frames to the frontend via IPC (latter is fine for small previews, not for real video).
 
+## Performance Architecture
+
+**Lean Rust for performance-critical paths.** The reason Pollis is on Tauri (not Electron, not Wails) is to leverage Rust's perf for I/O, crypto, media pipelines, and concurrency without GC pauses. When a feature is performance-sensitive, IPC-bandwidth-sensitive, or benefits from no-GC predictability — media decoding, encryption, file serving, real-time pipelines, large-buffer manipulation — put it in Rust. Use the webview as a thin presentation layer.
+
+Don't reach for JS-side equivalents (Web Crypto, IndexedDB, browser-side caching, JS-heap byte buffers) when an equivalent Rust path exists. If you do, you're giving up the main reason the stack was picked. V8's GC pressure on multi-MB byte arrays produces visible UI stutter; Rust's predictable allocation does not.
+
+**Pattern for serving cached/encrypted media to the webview**: a Rust-side local-loopback HTTP server (`127.0.0.1:<auto-port>`). The webview embeds `<img>/<audio>/<video>` with `src="http://127.0.0.1:NNNN/<hash>"`. Rust handles disk cache (encrypted at rest), AES-GCM decrypt, HTTP Range requests, and any future on-the-fly transforms (thumbnails, transcoding, prefetch). One URL pattern across image/audio/video — no platform-branching, no custom URI schemes, no JSON IPC for bytes. CRUD continues to go through `invoke()`; the local HTTP server is for media transport, not data plane.
+
+**Implication when adding new perf-sensitive features**: default to a Rust implementation that exposes either an `invoke()` command (for CRUD-shaped calls) or an HTTP endpoint on the local server (for byte-stream-shaped data). Reach for JS only after confirming the Rust path won't work.
+
 ## Security Model
 
 **Trusted**: User's device, local database (encrypted at rest), Tauri app code, OS keystore

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,6 +3024,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
+
+[[package]]
 name = "http-range-header"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7655,6 +7661,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http 1.4.0",
+ "http-range",
  "jni",
  "libc",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,7 +428,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.3.4",
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
@@ -450,6 +450,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.5",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "axum-core"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,6 +498,27 @@ dependencies = [
  "rustversion",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 1.0.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3084,6 +3139,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -5698,6 +5754,7 @@ dependencies = [
  "anyhow",
  "argon2",
  "async-trait",
+ "axum 0.7.9",
  "base64 0.22.1",
  "blurhash",
  "bytes",
@@ -7040,6 +7097,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -8467,7 +8535,7 @@ checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.6.20",
  "base64 0.21.7",
  "bytes",
  "h2",
@@ -8539,6 +8607,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -550,7 +550,7 @@ function MainApp() {
               </span>
               <p className="text-xs font-mono flex items-center gap-2" style={{ color: "var(--c-text)" }}>
                 <span>
-                  Setting up your encrypted identity
+                  Getting things ready
                 </span>
                 <LoadingSpinner size="sm" />
               </p>

--- a/frontend/src/components/Layout/AppShell.tsx
+++ b/frontend/src/components/Layout/AppShell.tsx
@@ -5,6 +5,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { TitleBar } from "./TitleBar";
 import { BreadcrumbNav } from "./BreadcrumbNav";
+import { Sidebar } from "./Sidebar";
 import { StatusBarSummary } from "./StatusBarSummary";
 import { VoiceBar } from "../Voice/VoiceBar";
 import { LoadingSpinner } from "../ui/LoaderSpinner";
@@ -28,6 +29,31 @@ export const AppShell: React.FC = () => {
   const [isSyncing, setIsSyncing] = useState(false);
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [isDragOver, setIsDragOver] = useState(false);
+  const [isSidebarOpen, setIsSidebarOpen] = useState<boolean>(() => {
+    try {
+      const raw = localStorage.getItem("pollis.sidebar.open");
+      return raw === null ? true : raw === "true";
+    } catch {
+      return true;
+    }
+  });
+  useEffect(() => {
+    try {
+      localStorage.setItem("pollis.sidebar.open", String(isSidebarOpen));
+    } catch {
+      /* localStorage unavailable */
+    }
+  }, [isSidebarOpen]);
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "b") {
+        e.preventDefault();
+        setIsSidebarOpen((v) => !v);
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
   const queryClient = useQueryClient();
   const router = useRouter();
 
@@ -319,9 +345,12 @@ export const AppShell: React.FC = () => {
       {/* Breadcrumb nav — appears on every authenticated page */}
       <BreadcrumbNav />
 
-      {/* Main content — matched child route renders here */}
-      <div style={{ flex: 1, overflow: "hidden", display: "flex", flexDirection: "column" }}>
-        <Outlet />
+      {/* Main content — sidebar + matched child route */}
+      <div style={{ flex: 1, overflow: "hidden", display: "flex", flexDirection: "row" }}>
+        <Sidebar isOpen={isSidebarOpen} onToggle={() => setIsSidebarOpen((v) => !v)} />
+        <div style={{ flex: 1, overflow: "hidden", display: "flex", flexDirection: "column", minWidth: 0 }}>
+          <Outlet />
+        </div>
       </div>
 
       {/* VoiceBar — shown above bottom bar while user is in a voice channel */}

--- a/frontend/src/components/Layout/AppShell.tsx
+++ b/frontend/src/components/Layout/AppShell.tsx
@@ -319,23 +319,6 @@ export const AppShell: React.FC = () => {
       {/* Breadcrumb nav — appears on every authenticated page */}
       <BreadcrumbNav />
 
-      {/* Sync indicator — floats top-right below title bar, left of the persistent cog */}
-      {isSyncing && (
-        <div
-          className="flex items-center gap-1.5 text-xs font-mono pointer-events-none"
-          style={{
-            position: "absolute",
-            top: 36 + 7,
-            right: 40,
-            zIndex: 50,
-            color: "var(--c-accent-dim)",
-          }}
-        >
-          <span>syncing…</span>
-          <LoadingSpinner size="sm" />
-        </div>
-      )}
-
       {/* Main content — matched child route renders here */}
       <div style={{ flex: 1, overflow: "hidden", display: "flex", flexDirection: "column" }}>
         <Outlet />
@@ -435,6 +418,15 @@ export const AppShell: React.FC = () => {
           >
             <Mail className="w-4 h-4" />: @{statusBarAlert.senderUsername}
           </button>
+        ) : isSyncing ? (
+          <div
+            data-testid="status-bar-syncing"
+            className="flex items-center gap-1.5 text-xs font-mono pointer-events-none"
+            style={{ color: isChatScreen ? "var(--c-accent)" : "var(--c-surface)" }}
+          >
+            <span>syncing…</span>
+            <LoadingSpinner size="sm" />
+          </div>
         ) : null}
       </div>
     </div>

--- a/frontend/src/components/Layout/AppShell.tsx
+++ b/frontend/src/components/Layout/AppShell.tsx
@@ -29,21 +29,13 @@ export const AppShell: React.FC = () => {
   const [isSyncing, setIsSyncing] = useState(false);
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [isDragOver, setIsDragOver] = useState(false);
-  const [isSidebarOpen, setIsSidebarOpen] = useState<boolean>(() => {
-    try {
-      const raw = localStorage.getItem("pollis.sidebar.open");
-      return raw === null ? true : raw === "true";
-    } catch {
-      return true;
-    }
-  });
-  useEffect(() => {
-    try {
-      localStorage.setItem("pollis.sidebar.open", String(isSidebarOpen));
-    } catch {
-      /* localStorage unavailable */
-    }
-  }, [isSidebarOpen]);
+  // Sidebar visibility is driven by the user preference
+  // `sidebar_open_by_default`. Cmd/Ctrl+B toggles for the current session
+  // only — flipping it does NOT write back to the preference, so users
+  // who keep it closed by default can still pop it open ad-hoc without
+  // losing their default. Changing the preference updates the live UI
+  // via the sync effect below.
+  const [isSidebarOpen, setIsSidebarOpen] = useState<boolean>(true);
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "b") {
@@ -70,6 +62,17 @@ export const AppShell: React.FC = () => {
 
   const { data: groupsWithChannels } = useUserGroupsWithChannels();
   const { query: prefsQuery } = usePreferences();
+
+  // Apply the sidebar default whenever the preference first loads or the
+  // user changes it. Cmd/Ctrl+B presses don't fight this since they only
+  // mutate session state — when the preference value is unchanged, the
+  // dependency stays stable and this effect won't re-fire.
+  const sidebarDefault = prefsQuery.data?.sidebar_open_by_default;
+  useEffect(() => {
+    if (sidebarDefault !== undefined) {
+      setIsSidebarOpen(sidebarDefault);
+    }
+  }, [sidebarDefault]);
 
   const currentUser = useAppStore((s) => s.currentUser);
 

--- a/frontend/src/components/Layout/BreadcrumbNav.tsx
+++ b/frontend/src/components/Layout/BreadcrumbNav.tsx
@@ -270,19 +270,22 @@ export const BreadcrumbNav: React.FC = () => {
         aria-label="Settings"
         className="flex items-center justify-center transition-colors"
         style={{
-          width: 20,
-          height: 20,
+          width: 24,
+          height: 24,
           background: "none",
           border: "none",
           padding: 0,
+          borderRadius: 4,
           color: isOnSettingsHub ? "var(--c-accent)" : "var(--c-text)",
           cursor: "pointer",
         }}
         onMouseEnter={(e) => {
           (e.currentTarget as HTMLButtonElement).style.color = "var(--c-accent)";
+          (e.currentTarget as HTMLButtonElement).style.background = "var(--c-hover)";
         }}
         onMouseLeave={(e) => {
           (e.currentTarget as HTMLButtonElement).style.color = isOnSettingsHub ? "var(--c-accent)" : "var(--c-text)";
+          (e.currentTarget as HTMLButtonElement).style.background = "none";
         }}
       >
         <SettingsIcon size={16} />

--- a/frontend/src/components/Layout/BreadcrumbNav.tsx
+++ b/frontend/src/components/Layout/BreadcrumbNav.tsx
@@ -238,17 +238,17 @@ export const BreadcrumbNav: React.FC = () => {
           background: "none",
           border: "none",
           padding: "0 6px",
-          color: "var(--c-text-muted)",
+          color: "var(--c-text)",
           cursor: "pointer",
         }}
         onMouseEnter={(e) => {
           (e.currentTarget as HTMLButtonElement).style.color = "var(--c-accent)";
         }}
         onMouseLeave={(e) => {
-          (e.currentTarget as HTMLButtonElement).style.color = "var(--c-text-muted)";
+          (e.currentTarget as HTMLButtonElement).style.color = "var(--c-text)";
         }}
       >
-        <SearchIcon size={14} />
+        <SearchIcon size={16} />
         <kbd
           aria-hidden="true"
           className="font-mono text-xs"
@@ -275,17 +275,17 @@ export const BreadcrumbNav: React.FC = () => {
           background: "none",
           border: "none",
           padding: 0,
-          color: isOnSettingsHub ? "var(--c-accent)" : "var(--c-text-muted)",
+          color: isOnSettingsHub ? "var(--c-accent)" : "var(--c-text)",
           cursor: "pointer",
         }}
         onMouseEnter={(e) => {
           (e.currentTarget as HTMLButtonElement).style.color = "var(--c-accent)";
         }}
         onMouseLeave={(e) => {
-          (e.currentTarget as HTMLButtonElement).style.color = isOnSettingsHub ? "var(--c-accent)" : "var(--c-text-muted)";
+          (e.currentTarget as HTMLButtonElement).style.color = isOnSettingsHub ? "var(--c-accent)" : "var(--c-text)";
         }}
       >
-        <SettingsIcon size={14} />
+        <SettingsIcon size={16} />
       </button>
     </div>
   );

--- a/frontend/src/components/Layout/MainContent.tsx
+++ b/frontend/src/components/Layout/MainContent.tsx
@@ -516,7 +516,7 @@ export const MainContent: React.FC = () => {
               }}
               disabled={editMessageMutation.isPending}
               rows={2}
-              className="chat-input-textarea w-full font-mono text-sm resize-none transition-colors"
+              className={`chat-input-textarea w-full font-mono text-sm resize-none transition-colors${editBarFocused ? " is-focused" : ""}`}
               style={{
                 borderRadius: '4px',
                 border: 'none',

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -138,28 +138,11 @@ export const Sidebar: React.FC<SidebarProps> = ({ isOpen, onToggle }) => {
                   indent={1}
                   isActive={isGroupActive && !activeChannelId && !activeVoiceId}
                   onClick={() => router.navigate({ to: "/groups/$groupId", params: { groupId: group.id } })}
-                  leading={
-                    <button
-                      type="button"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        toggleGroup(group.id);
-                      }}
-                      aria-label={isCollapsed ? `Expand ${group.name}` : `Collapse ${group.name}`}
-                      style={{
-                        background: "none",
-                        border: "none",
-                        padding: 0,
-                        margin: 0,
-                        display: "inline-flex",
-                        alignItems: "center",
-                        color: "inherit",
-                        cursor: "pointer",
-                      }}
-                    >
-                      {isCollapsed ? <ChevronRight size={14} /> : <ChevronDown size={14} />}
-                    </button>
-                  }
+                  chevron={{
+                    isCollapsed,
+                    onToggle: () => toggleGroup(group.id),
+                    ariaLabel: isCollapsed ? `Expand ${group.name}` : `Collapse ${group.name}`,
+                  }}
                   label={group.name}
                   badge={isCollapsed && groupUnread > 0 ? groupUnread : null}
                 />
@@ -335,62 +318,108 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({ label, icon, isActive, on
   </button>
 );
 
+interface RowChevron {
+  isCollapsed: boolean;
+  onToggle: () => void;
+  ariaLabel: string;
+}
+
 interface RowProps {
   indent: number;
   isActive: boolean;
   onClick: () => void;
   leading?: React.ReactNode;
+  /** When provided, renders an expand/collapse chevron as a sibling button outside the navigating button. */
+  chevron?: RowChevron;
   label: string;
   badge?: number | null;
 }
 
-const Row: React.FC<RowProps> = ({ indent, isActive, onClick, leading, label, badge }) => (
-  <button
-    type="button"
-    onClick={onClick}
-    data-active={isActive ? "true" : "false"}
-    style={{
-      width: "100%",
-      display: "flex",
-      alignItems: "center",
-      gap: 6,
-      paddingTop: 2,
-      paddingBottom: 2,
-      paddingLeft: 10 + indent * 12,
-      paddingRight: 10,
-      background: isActive ? "var(--c-hover)" : "none",
-      borderLeft: isActive ? "2px solid var(--c-accent)" : "2px solid transparent",
-      color: isActive ? "var(--c-accent)" : "var(--c-text)",
-      fontSize: 15,
-      cursor: "pointer",
-      textAlign: "left",
-      lineHeight: "24px",
-    }}
-    onMouseEnter={(e) => {
-      if (!isActive) {
-        (e.currentTarget as HTMLButtonElement).style.background = "var(--c-hover)";
-      }
-    }}
-    onMouseLeave={(e) => {
-      if (!isActive) {
-        (e.currentTarget as HTMLButtonElement).style.background = "none";
-      }
-    }}
-  >
-    {leading}
-    <span
+const Row: React.FC<RowProps> = ({ indent, isActive, onClick, leading, chevron, label, badge }) => {
+  const setHover = (el: HTMLElement, on: boolean) => {
+    if (isActive) {
+      return;
+    }
+    el.style.background = on ? "var(--c-hover)" : "none";
+  };
+  return (
+    <div
+      data-active={isActive ? "true" : "false"}
       style={{
-        flex: 1,
-        overflow: "hidden",
-        textOverflow: "ellipsis",
-        whiteSpace: "nowrap",
+        display: "flex",
+        alignItems: "stretch",
+        width: "100%",
+        background: isActive ? "var(--c-hover)" : "none",
+        borderLeft: isActive ? "2px solid var(--c-accent)" : "2px solid transparent",
+        color: isActive ? "var(--c-accent)" : "var(--c-text)",
       }}
+      onMouseEnter={(e) => setHover(e.currentTarget, true)}
+      onMouseLeave={(e) => setHover(e.currentTarget, false)}
     >
-      {label}
-    </span>
-    {badge != null && <UnreadBadge count={badge} />}
-  </button>
-);
+      {chevron && (
+        <button
+          type="button"
+          tabIndex={-1}
+          onClick={(e) => {
+            e.stopPropagation();
+            chevron.onToggle();
+          }}
+          aria-label={chevron.ariaLabel}
+          style={{
+            background: "none",
+            border: "none",
+            padding: 0,
+            margin: 0,
+            paddingLeft: 10 + indent * 12,
+            paddingRight: 0,
+            display: "inline-flex",
+            alignItems: "center",
+            color: "inherit",
+            cursor: "pointer",
+          }}
+        >
+          {chevron.isCollapsed ? <ChevronRight size={14} /> : <ChevronDown size={14} />}
+        </button>
+      )}
+      <button
+        type="button"
+        onClick={onClick}
+        style={{
+          flex: 1,
+          minWidth: 0,
+          display: "flex",
+          alignItems: "center",
+          gap: 6,
+          paddingTop: 2,
+          paddingBottom: 2,
+          paddingLeft: chevron ? 6 : 10 + indent * 12,
+          paddingRight: 10,
+          background: "none",
+          border: "none",
+          color: "inherit",
+          fontSize: 15,
+          fontFamily: "inherit",
+          cursor: "pointer",
+          textAlign: "left",
+          lineHeight: "24px",
+        }}
+      >
+        {leading}
+        <span
+          style={{
+            flex: 1,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {label}
+        </span>
+        {badge != null && <UnreadBadge count={badge} />}
+      </button>
+    </div>
+  );
+};
 
 const UnreadBadge: React.FC<{ count: number; muted?: boolean }> = ({ count, muted }) => (
   <span

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -1,0 +1,409 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { useRouter, useRouterState } from "@tanstack/react-router";
+import {
+  ChevronDown,
+  ChevronRight,
+  Hash,
+  Volume2,
+  Settings as SettingsIcon,
+  Users,
+  MessageCircle,
+  Palette,
+  User as UserIcon,
+  ShieldCheck,
+} from "lucide-react";
+import { useUserGroupsWithChannels } from "../../hooks/queries/useGroups";
+import { useDMConversations } from "../../hooks/queries/useMessages";
+import { useAppStore } from "../../stores/appStore";
+
+const SIDEBAR_WIDTH = 220;
+const COLLAPSED_GROUPS_KEY = "pollis.sidebar.collapsedGroups";
+
+const isMac =
+  typeof navigator !== "undefined" &&
+  navigator.platform.toUpperCase().indexOf("MAC") >= 0;
+const TOGGLE_SHORTCUT_LABEL = isMac ? "⌘B" : "Ctrl+B";
+
+interface SidebarProps {
+  isOpen: boolean;
+  onToggle: () => void;
+}
+
+export const Sidebar: React.FC<SidebarProps> = ({ isOpen, onToggle }) => {
+  const router = useRouter();
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+
+  const { data: groupsWithChannels = [] } = useUserGroupsWithChannels();
+  const { data: dmConversations = [] } = useDMConversations();
+  const unreadCounts = useAppStore((s) => s.unreadCounts);
+
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(() => {
+    try {
+      const raw = localStorage.getItem(COLLAPSED_GROUPS_KEY);
+      return new Set(raw ? (JSON.parse(raw) as string[]) : []);
+    } catch {
+      return new Set();
+    }
+  });
+  useEffect(() => {
+    try {
+      localStorage.setItem(COLLAPSED_GROUPS_KEY, JSON.stringify([...collapsedGroups]));
+    } catch {
+      /* localStorage unavailable — non-fatal */
+    }
+  }, [collapsedGroups]);
+
+  const toggleGroup = (id: string) => {
+    setCollapsedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const totalDmUnread = useMemo(
+    () => dmConversations.reduce((sum, c) => sum + (unreadCounts[c.id] ?? 0), 0),
+    [dmConversations, unreadCounts]
+  );
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const isOnGroups = pathname === "/groups";
+  const isOnDms = pathname === "/dms";
+  const activeChannelId = (() => {
+    const m = pathname.match(/^\/groups\/[^/]+\/channels\/([^/]+)/);
+    return m ? m[1] : null;
+  })();
+  const activeVoiceId = (() => {
+    const m = pathname.match(/^\/groups\/[^/]+\/voice\/([^/]+)/);
+    return m ? m[1] : null;
+  })();
+  const activeDmId = (() => {
+    const m = pathname.match(/^\/dms\/([^/]+)/);
+    return m && m[1] !== "new" && m[1] !== "requests" && m[1] !== "blocked" ? m[1] : null;
+  })();
+  const activeGroupId = (() => {
+    const m = pathname.match(/^\/groups\/([^/]+)/);
+    return m && m[1] !== "new" && m[1] !== "search" ? m[1] : null;
+  })();
+
+  const isOnSettingsHub = pathname === "/settings";
+  const settingsItems = [
+    { id: "preferences", label: "Preferences", icon: <Palette size={14} />, to: "/preferences" as const, isActive: pathname === "/preferences" },
+    { id: "user", label: "User", icon: <UserIcon size={14} />, to: "/user" as const, isActive: pathname === "/user" || pathname.startsWith("/user/") },
+    { id: "voice-settings", label: "Voice", icon: <Volume2 size={14} />, to: "/voice-settings" as const, isActive: pathname === "/voice-settings" },
+    { id: "security", label: "Security", icon: <ShieldCheck size={14} />, to: "/security" as const, isActive: pathname === "/security" || pathname.startsWith("/security/") },
+  ];
+  const isOnAnySettings = isOnSettingsHub || settingsItems.some((s) => s.isActive);
+
+  return (
+    <aside
+      data-testid="sidebar"
+      style={{
+        width: SIDEBAR_WIDTH,
+        flexShrink: 0,
+        borderRight: "1px solid var(--c-border)",
+        background: "var(--c-surface)",
+        display: "flex",
+        flexDirection: "column",
+        fontFamily: "var(--font-mono, monospace)",
+      }}
+    >
+      <div style={{ flex: 1, overflowY: "auto", overflowX: "hidden" }}>
+        <SectionHeader
+          label="groups"
+          icon={<Users size={14} />}
+          isActive={isOnGroups}
+          onClick={() => router.navigate({ to: "/groups" })}
+          borderedBottom
+        />
+
+        <ul style={{ margin: 0, padding: 0, listStyle: "none" }}>
+          {groupsWithChannels.map((group) => {
+            const isCollapsed = collapsedGroups.has(group.id);
+            const groupUnread = group.channels.reduce(
+              (sum, ch) => sum + (unreadCounts[ch.id] ?? 0),
+              0
+            );
+            const isGroupActive = activeGroupId === group.id;
+            return (
+              <li key={group.id}>
+                <Row
+                  indent={1}
+                  isActive={isGroupActive && !activeChannelId && !activeVoiceId}
+                  onClick={() => router.navigate({ to: "/groups/$groupId", params: { groupId: group.id } })}
+                  leading={
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        toggleGroup(group.id);
+                      }}
+                      aria-label={isCollapsed ? `Expand ${group.name}` : `Collapse ${group.name}`}
+                      style={{
+                        background: "none",
+                        border: "none",
+                        padding: 0,
+                        margin: 0,
+                        display: "inline-flex",
+                        alignItems: "center",
+                        color: "inherit",
+                        cursor: "pointer",
+                      }}
+                    >
+                      {isCollapsed ? <ChevronRight size={14} /> : <ChevronDown size={14} />}
+                    </button>
+                  }
+                  label={group.name}
+                  badge={isCollapsed && groupUnread > 0 ? groupUnread : null}
+                />
+                {!isCollapsed &&
+                  group.channels.map((ch) => {
+                    const isVoice = ch.channel_type === "voice";
+                    const unread = unreadCounts[ch.id] ?? 0;
+                    const isActive = isVoice ? activeVoiceId === ch.id : activeChannelId === ch.id;
+                    return (
+                      <Row
+                        key={ch.id}
+                        indent={2}
+                        isActive={isActive}
+                        onClick={() =>
+                          isVoice
+                            ? router.navigate({
+                              to: "/groups/$groupId/voice/$channelId",
+                              params: { groupId: group.id, channelId: ch.id },
+                            })
+                            : router.navigate({
+                              to: "/groups/$groupId/channels/$channelId",
+                              params: { groupId: group.id, channelId: ch.id },
+                            })
+                        }
+                        leading={isVoice ? <Volume2 size={14} /> : <Hash size={14} />}
+                        label={ch.name}
+                        badge={unread > 0 ? unread : null}
+                      />
+                    );
+                  })}
+              </li>
+            );
+          })}
+        </ul>
+
+        <SectionHeader
+          label="dms"
+          icon={<MessageCircle size={14} />}
+          isActive={isOnDms}
+          onClick={() => router.navigate({ to: "/dms" })}
+          badge={totalDmUnread > 0 ? totalDmUnread : null}
+          bordered
+        />
+
+        <ul style={{ margin: 0, padding: 0, listStyle: "none" }}>
+          {dmConversations.map((c) => {
+            const unread = unreadCounts[c.id] ?? 0;
+            return (
+              <Row
+                key={c.id}
+                indent={1}
+                isActive={activeDmId === c.id}
+                onClick={() => router.navigate({ to: "/dms/$conversationId", params: { conversationId: c.id } })}
+                label={`@${c.user2_identifier}`}
+                badge={unread > 0 ? unread : null}
+              />
+            );
+          })}
+        </ul>
+
+        <SectionHeader
+          label="settings"
+          icon={<SettingsIcon size={14} />}
+          isActive={isOnAnySettings}
+          onClick={() => router.navigate({ to: "/settings" })}
+          bordered
+        />
+        {settingsItems.map((s) => (
+          <Row
+            key={s.id}
+            indent={1}
+            isActive={s.isActive}
+            onClick={() => router.navigate({ to: s.to })}
+            leading={s.icon}
+            label={s.label}
+          />
+        ))}
+      </div>
+
+      <button
+        type="button"
+        data-testid="sidebar-close"
+        onClick={onToggle}
+        aria-label={`Close sidebar (${TOGGLE_SHORTCUT_LABEL})`}
+        title={`Close sidebar (${TOGGLE_SHORTCUT_LABEL})`}
+        style={{
+          flexShrink: 0,
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          padding: "8px 10px",
+          borderTop: "1px solid var(--c-border)",
+          background: "none",
+          color: "var(--c-text-muted)",
+          fontFamily: "inherit",
+          fontSize: 13,
+          textAlign: "left",
+          cursor: "pointer",
+        }}
+        onMouseEnter={(e) => {
+          (e.currentTarget as HTMLButtonElement).style.color = "var(--c-text)";
+        }}
+        onMouseLeave={(e) => {
+          (e.currentTarget as HTMLButtonElement).style.color = "var(--c-text-muted)";
+        }}
+      >
+        <span style={{ flex: 1 }}>Close</span>
+        <kbd
+          aria-hidden="true"
+          className="font-mono"
+          style={{
+            color: "inherit",
+            background: "var(--c-bg)",
+            padding: "1px 5px",
+            borderRadius: 3,
+            border: "1px solid var(--c-border)",
+            fontSize: 11,
+            lineHeight: 1.2,
+          }}
+        >
+          {TOGGLE_SHORTCUT_LABEL}
+        </kbd>
+      </button>
+    </aside>
+  );
+};
+
+interface SectionHeaderProps {
+  label: string;
+  icon: React.ReactNode;
+  isActive: boolean;
+  onClick: () => void;
+  badge?: number | null;
+  /** Hairline rules above and below the header. */
+  bordered?: boolean;
+  /** Hairline rule below the header only. */
+  borderedBottom?: boolean;
+}
+
+const SectionHeader: React.FC<SectionHeaderProps> = ({ label, icon, isActive, onClick, badge, bordered, borderedBottom }) => (
+  <button
+    type="button"
+    onClick={onClick}
+    style={{
+      width: "100%",
+      display: "flex",
+      alignItems: "center",
+      gap: 6,
+      padding: "8px 10px 9px",
+      marginTop: bordered ? 4 : 0,
+      background: "none",
+      border: "none",
+      borderTop: bordered ? "1px solid var(--c-border)" : "none",
+      borderBottom: bordered || borderedBottom ? "1px solid var(--c-border)" : "none",
+      color: isActive ? "var(--c-accent)" : "var(--c-text-muted)",
+      fontSize: 12,
+      letterSpacing: "0.08em",
+      textTransform: "uppercase",
+      cursor: "pointer",
+      textAlign: "left",
+      transition: "background 75ms",
+    }}
+    onMouseEnter={(e) => {
+      (e.currentTarget as HTMLButtonElement).style.background = "var(--c-hover)";
+    }}
+    onMouseLeave={(e) => {
+      (e.currentTarget as HTMLButtonElement).style.background = "none";
+    }}
+  >
+    {icon}
+    <span style={{ flex: 1 }}>{label}</span>
+    {badge != null && <UnreadBadge count={badge} muted />}
+  </button>
+);
+
+interface RowProps {
+  indent: number;
+  isActive: boolean;
+  onClick: () => void;
+  leading?: React.ReactNode;
+  label: string;
+  badge?: number | null;
+}
+
+const Row: React.FC<RowProps> = ({ indent, isActive, onClick, leading, label, badge }) => (
+  <button
+    type="button"
+    onClick={onClick}
+    data-active={isActive ? "true" : "false"}
+    style={{
+      width: "100%",
+      display: "flex",
+      alignItems: "center",
+      gap: 6,
+      paddingTop: 2,
+      paddingBottom: 2,
+      paddingLeft: 10 + indent * 12,
+      paddingRight: 10,
+      background: isActive ? "var(--c-hover)" : "none",
+      borderLeft: isActive ? "2px solid var(--c-accent)" : "2px solid transparent",
+      color: isActive ? "var(--c-accent)" : "var(--c-text)",
+      fontSize: 15,
+      cursor: "pointer",
+      textAlign: "left",
+      lineHeight: "24px",
+    }}
+    onMouseEnter={(e) => {
+      if (!isActive) {
+        (e.currentTarget as HTMLButtonElement).style.background = "var(--c-hover)";
+      }
+    }}
+    onMouseLeave={(e) => {
+      if (!isActive) {
+        (e.currentTarget as HTMLButtonElement).style.background = "none";
+      }
+    }}
+  >
+    {leading}
+    <span
+      style={{
+        flex: 1,
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+        whiteSpace: "nowrap",
+      }}
+    >
+      {label}
+    </span>
+    {badge != null && <UnreadBadge count={badge} />}
+  </button>
+);
+
+const UnreadBadge: React.FC<{ count: number; muted?: boolean }> = ({ count, muted }) => (
+  <span
+    style={{
+      fontSize: 11,
+      lineHeight: 1,
+      padding: "2px 6px",
+      borderRadius: 8,
+      background: muted ? "var(--c-text-muted)" : "var(--c-accent)",
+      color: "var(--c-bg)",
+      flexShrink: 0,
+    }}
+  >
+    {count > 99 ? "99+" : count}
+  </span>
+);

--- a/frontend/src/components/Message/MediaLinkUnfurl.tsx
+++ b/frontend/src/components/Message/MediaLinkUnfurl.tsx
@@ -87,8 +87,8 @@ export const MediaLinkUnfurl: React.FC<MediaLinkUnfurlProps> = ({ text }) => {
     height: 96,
     objectFit: "cover",
     display: "block",
-    border: "1px solid var(--c-border)",
-    borderRadius: 4,
+    border: "none",
+    borderRadius: "0.5rem",
     background: "var(--c-surface-high)",
   };
 

--- a/frontend/src/components/Message/MediaLinkUnfurl.tsx
+++ b/frontend/src/components/Message/MediaLinkUnfurl.tsx
@@ -1,6 +1,11 @@
 import React, { useCallback, useMemo, useState } from "react";
 import { open } from "@tauri-apps/plugin-shell";
 
+// Known limitation (low priority): inline previews only fire when the URL ends in
+// a recognised image/video extension. Sites like Giphy/Tenor/Imgur that serve media
+// behind extension-less share URLs (e.g. giphy.com/gifs/...) won't unfurl. Pasting
+// the direct .gif/.mp4 URL works, and copy-pasting the actual media into the input
+// also works, so we accept the gap rather than building an OG/oEmbed unfurl service.
 const URL_REGEX = /(https?:\/\/[^\s<>"')\]]+|www\.[^\s<>"')\]]+\.[^\s<>"')\]]+)/gi;
 
 const IMAGE_EXTS = ["jpg", "jpeg", "png", "gif", "webp", "avif", "bmp", "svg"];
@@ -77,33 +82,37 @@ export const MediaLinkUnfurl: React.FC<MediaLinkUnfurlProps> = ({ text }) => {
     return null;
   }
 
+  const thumbStyle: React.CSSProperties = {
+    width: 96,
+    height: 96,
+    objectFit: "cover",
+    display: "block",
+    border: "1px solid var(--c-border)",
+    borderRadius: 4,
+    background: "var(--c-surface-high)",
+  };
+
   return (
-    <div data-testid="media-link-unfurl" className="mt-2 flex flex-col gap-2">
+    <div data-testid="media-link-unfurl" className="mt-2 flex flex-wrap gap-1">
       {visible.map((link) => {
         const href = ensureProtocol(link.url);
+        const onError = () =>
+          setHidden((prev) => {
+            const next = new Set(prev);
+            next.add(link.url);
+            return next;
+          });
         if (link.kind === "image") {
           return (
             <button
               key={link.url}
               type="button"
               onClick={() => handleClick(link.url)}
-              className="block max-w-sm cursor-pointer p-0 bg-transparent border-0"
+              className="p-0 bg-transparent border-0 cursor-pointer flex-shrink-0"
               title={href}
               aria-label={`Open ${href}`}
             >
-              <img
-                src={href}
-                alt=""
-                onError={() =>
-                  setHidden((prev) => {
-                    const next = new Set(prev);
-                    next.add(link.url);
-                    return next;
-                  })
-                }
-                className="max-w-full max-h-80 rounded"
-                style={{ border: "1px solid var(--c-border)" }}
-              />
+              <img src={href} alt="" onError={onError} style={thumbStyle} />
             </button>
           );
         }
@@ -113,15 +122,8 @@ export const MediaLinkUnfurl: React.FC<MediaLinkUnfurlProps> = ({ text }) => {
             src={href}
             controls
             preload="metadata"
-            onError={() =>
-              setHidden((prev) => {
-                const next = new Set(prev);
-                next.add(link.url);
-                return next;
-              })
-            }
-            className="max-w-sm max-h-80 rounded"
-            style={{ border: "1px solid var(--c-border)" }}
+            onError={onError}
+            style={{ ...thumbStyle, objectFit: "cover" }}
           />
         );
       })}

--- a/frontend/src/components/Message/MediaLinkUnfurl.tsx
+++ b/frontend/src/components/Message/MediaLinkUnfurl.tsx
@@ -89,7 +89,7 @@ export const MediaLinkUnfurl: React.FC<MediaLinkUnfurlProps> = ({ text }) => {
     display: "block",
     border: "none",
     borderRadius: "0.5rem",
-    background: "var(--c-surface-high)",
+    background: "transparent",
   };
 
   return (

--- a/frontend/src/components/Message/MessageItem.tsx
+++ b/frontend/src/components/Message/MessageItem.tsx
@@ -660,7 +660,7 @@ const AttachmentDisplay: React.FC<{ attachment: MessageAttachment }> = ({ attach
             width: 96,
             height: 96,
             padding: 0,
-            background: "var(--c-surface-high)",
+            background: "transparent",
             border: "none",
             borderRadius: "0.5rem",
             overflow: "hidden",
@@ -822,7 +822,7 @@ const AttachmentDisplay: React.FC<{ attachment: MessageAttachment }> = ({ attach
             width: 96,
             height: 96,
             padding: 0,
-            background: "var(--c-surface-high)",
+            background: "transparent",
             border: "none",
             cursor: isPending || isLoading ? "default" : "pointer",
             position: "relative",
@@ -930,40 +930,52 @@ const AttachmentDisplay: React.FC<{ attachment: MessageAttachment }> = ({ attach
   return (
     <div
       data-testid={`attachment-${attachment.id}`}
-      className="flex items-center gap-2 px-2.5 py-1.5"
+      className="flex items-center gap-2 px-2.5 py-1.5 min-w-0"
       style={{
         border: "2px solid var(--c-border)",
         background: "var(--c-surface-high)",
-        minWidth: 160,
-        maxWidth: 240,
+        maxWidth: 360,
         borderRadius: 8,
       }}
     >
-      <FileTypeIcon size={16} aria-hidden="true" style={{ color: "var(--c-text-dim)", flexShrink: 0 }} />
-      <div className="flex-1 min-w-0">
-        <div className="text-xs font-mono truncate" style={{ color: "var(--c-accent-dim)" }}>
-          {attachment.filename}
-        </div>
-        {attachment.file_size > 0 && (
-          <div className="text-xs font-mono" style={{ color: "var(--c-text-muted)" }}>
-            {formatFileSize(attachment.file_size)}
-          </div>
-        )}
-      </div>
+      <FileTypeIcon size={14} aria-hidden="true" style={{ color: "var(--c-text-dim)", flexShrink: 0 }} />
+      {(() => {
+        const lastDot = attachment.filename.lastIndexOf(".");
+        const hasExt = lastDot > 0 && lastDot < attachment.filename.length - 1;
+        const head = hasExt ? attachment.filename.slice(0, lastDot) : attachment.filename;
+        const tail = hasExt ? attachment.filename.slice(lastDot) : "";
+        return (
+          <span
+            className="text-sm font-mono flex-1 min-w-0 flex"
+            title={attachment.filename}
+            style={{ color: "var(--c-accent-dim)" }}
+          >
+            <span className="truncate">{head}</span>
+            {tail && <span className="flex-shrink-0">{tail}</span>}
+          </span>
+        );
+      })()}
+      {attachment.file_size > 0 && (
+        <span className="text-sm font-mono flex-shrink-0" style={{ color: "var(--c-text-muted)" }}>
+          {formatFileSize(attachment.file_size)}
+        </span>
+      )}
       {error ? (
-        <span className="text-xs font-mono" style={{ color: "var(--c-text-muted)" }}>err</span>
+        <span className="text-sm font-mono flex-shrink-0" style={{ color: "var(--c-text-muted)" }}>err</span>
       ) : isPending ? (
-        <span className="text-xs font-mono" style={{ color: "var(--c-text-muted)" }}>…</span>
+        <span className="text-sm font-mono flex-shrink-0" style={{ color: "var(--c-text-muted)" }}>…</span>
       ) : (
         <button
           onClick={handleDownload}
           disabled={downloadStatus !== "idle"}
           aria-label={`Download ${attachment.filename}`}
-          className="p-1"
+          className="flex-shrink-0"
           style={{
             color: downloadStatus === "done" ? "var(--c-accent)" : "var(--c-text-dim)",
-            flexShrink: 0,
             lineHeight: 0,
+            background: "none",
+            border: "none",
+            padding: 0,
           }}
         >
           {downloadStatus === "downloading" ? (

--- a/frontend/src/components/Message/MessageItem.tsx
+++ b/frontend/src/components/Message/MessageItem.tsx
@@ -129,7 +129,7 @@ export const MessageItem: React.FC<MessageItemProps> = ({
         <span
           data-testid="message-timestamp"
           title={formatFullTimestamp(message.created_at)}
-          className="flex-shrink-0 text-sm font-mono tabular-nums select-none w-12 mr-2"
+          className="flex-shrink-0 text-sm font-mono tabular-nums select-none w-20 mr-2"
           style={{ color: "var(--c-text-muted)" }}
         >
           {formatTimestamp(message.created_at)}
@@ -633,8 +633,8 @@ const AttachmentDisplay: React.FC<{ attachment: MessageAttachment }> = ({ attach
             height: 96,
             padding: 0,
             background: "var(--c-surface-high)",
-            border: "1px solid var(--c-border)",
-            borderRadius: 4,
+            border: "none",
+            borderRadius: "0.5rem",
             overflow: "hidden",
             cursor: downloadUrl ? "zoom-in" : "default",
             display: "flex",
@@ -795,11 +795,11 @@ const AttachmentDisplay: React.FC<{ attachment: MessageAttachment }> = ({ attach
             height: 96,
             padding: 0,
             background: "var(--c-surface-high)",
-            border: "1px solid var(--c-border)",
+            border: "none",
             cursor: isPending || isLoading ? "default" : "pointer",
             position: "relative",
             overflow: "hidden",
-            borderRadius: 4,
+            borderRadius: "0.5rem",
             flexShrink: 0,
           }}
         >

--- a/frontend/src/components/Message/MessageItem.tsx
+++ b/frontend/src/components/Message/MessageItem.tsx
@@ -129,7 +129,7 @@ export const MessageItem: React.FC<MessageItemProps> = ({
         <span
           data-testid="message-timestamp"
           title={formatFullTimestamp(message.created_at)}
-          className="flex-shrink-0 text-sm font-mono tabular-nums select-none w-20 mr-2"
+          className="flex-shrink-0 text-xs font-mono tabular-nums select-none w-16 mr-2"
           style={{ color: "var(--c-text-muted)" }}
         >
           {formatTimestamp(message.created_at)}

--- a/frontend/src/components/Message/MessageItem.tsx
+++ b/frontend/src/components/Message/MessageItem.tsx
@@ -130,7 +130,7 @@ export const MessageItem: React.FC<MessageItemProps> = ({
           data-testid="message-timestamp"
           title={formatFullTimestamp(message.created_at)}
           className="flex-shrink-0 text-xs font-mono tabular-nums select-none w-16 mr-2"
-          style={{ color: "var(--c-text-muted)" }}
+          style={{ color: "var(--c-text-muted)", lineHeight: "1.5rem" }}
         >
           {formatTimestamp(message.created_at)}
         </span>

--- a/frontend/src/components/Message/MessageItem.tsx
+++ b/frontend/src/components/Message/MessageItem.tsx
@@ -76,13 +76,13 @@ export const MessageItem: React.FC<MessageItemProps> = ({
   // null). Show [encrypted] in that case rather than an empty row.
   const content = isDeleted ? "[deleted]" : (message.content_decrypted ?? "[encrypted]");
 
-  // Sort attachments: images and videos first, then everything else.
-  const sortedAttachments = message.attachments && message.attachments.length > 0
-    ? [...message.attachments].sort((a, b) => {
-      const rank = (ct: string) => ct.startsWith("image/") || ct.startsWith("video/") ? 0 : 1;
-      return rank(a.content_type) - rank(b.content_type);
-    })
-    : null;
+  // Split attachments into a visual media strip (images + videos rendered as
+  // uniform 96×96 thumbs) and everything else (audio, files) which render as
+  // text-aligned rows below the strip.
+  const isVisualMedia = (ct: string) =>
+    ct.startsWith("image/") || ct.startsWith("video/");
+  const mediaThumbs = message.attachments?.filter((a) => isVisualMedia(a.content_type)) ?? [];
+  const otherAttachments = message.attachments?.filter((a) => !isVisualMedia(a.content_type)) ?? [];
 
   return (
     <div
@@ -228,10 +228,19 @@ export const MessageItem: React.FC<MessageItemProps> = ({
       {/* Inline previews for media URLs typed in the message body */}
       {!isDeleted && <MediaLinkUnfurl text={content} />}
 
-      {/* Attachments — each on its own row */}
-      {sortedAttachments && (
+      {/* Visual media: horizontal strip of uniform 96×96 thumbs */}
+      {mediaThumbs.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-1">
+          {mediaThumbs.map((a) => (
+            <AttachmentDisplay key={a.id} attachment={a} />
+          ))}
+        </div>
+      )}
+
+      {/* Audio / files — each on its own row */}
+      {otherAttachments.length > 0 && (
         <div className="mt-2 flex flex-col gap-2">
-          {sortedAttachments.map((a) => (
+          {otherAttachments.map((a) => (
             <AttachmentDisplay key={a.id} attachment={a} />
           ))}
         </div>
@@ -609,85 +618,57 @@ const AttachmentDisplay: React.FC<{ attachment: MessageAttachment }> = ({ attach
     </div>
   );
 
-  // Pre-compute image container height from recorded dimensions (prevents layout shift).
-  const imageContainerH = (isImage && attachment.width && attachment.height)
-    ? Math.min(Math.round(280 * (attachment.height / attachment.width)), 200)
-    : null;
-
-  // ── Image card ─────────────────────────────────────────────────────────────
+  // ── Image card — uniform 96×96 thumb, click to open lightbox ──────────────
   if (isImage) {
     return (
       <>
-        <div
+        <button
           data-testid={`attachment-${attachment.id}`}
-          style={{ maxWidth: 280 }}
+          onClick={() => { if (downloadUrl) { setViewerOpen(true); } }}
+          disabled={!downloadUrl}
+          aria-label={`View ${attachment.filename}`}
+          title={attachment.filename}
+          style={{
+            width: 96,
+            height: 96,
+            padding: 0,
+            background: "var(--c-surface-high)",
+            border: "1px solid var(--c-border)",
+            borderRadius: 4,
+            overflow: "hidden",
+            cursor: downloadUrl ? "zoom-in" : "default",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            flexShrink: 0,
+          }}
         >
-          {/* Preview area — click to open lightbox */}
-          <button
-            onClick={() => { if (downloadUrl) { setViewerOpen(true); } }}
-            disabled={!downloadUrl}
-            aria-label={`View ${attachment.filename}`}
-            style={{
-              display: "block",
-              padding: 0,
-              background: "none",
-              border: 0,
-              cursor: downloadUrl ? "zoom-in" : "default",
-              marginLeft: -16,
-              width: "calc(100% + 16px)",
-            }}
-          >
-            <div
+          {downloadUrl ? (
+            <img
+              src={downloadUrl}
+              alt={attachment.filename}
+              onError={() => setDownloadUrl(null)}
               style={{
                 width: "100%",
-                height: imageContainerH ?? undefined,
-                minHeight: imageContainerH ? undefined : (downloadUrl ? undefined : 80),
-                overflow: "hidden",
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
+                height: "100%",
+                objectFit: "cover",
+                display: "block",
               }}
-            >
-              {downloadUrl ? (
-                <img
-                  src={downloadUrl}
-                  alt={attachment.filename}
-                  onError={() => setDownloadUrl(null)}
-                  style={{
-                    width: "100%",
-                    height: imageContainerH ? "100%" : undefined,
-                    maxHeight: imageContainerH ? undefined : 200,
-                    objectFit: "contain",
-                    display: "block",
-                  }}
-                />
-              ) : attachment.blurhash && attachment.width && attachment.height ? (
-                <BlurhashCanvas
-                  hash={attachment.blurhash}
-                  width={attachment.width}
-                  height={attachment.height}
-                />
-              ) : (
-                <div style={{ height: imageContainerH ?? 80, width: "100%", display: "flex", alignItems: "center", justifyContent: "center" }}>
-                  <span className="text-xs font-mono" style={{ color: "var(--c-text-muted)" }}>
-                    {error ? "err" : "…"}
-                  </span>
-                </div>
-              )}
+            />
+          ) : attachment.blurhash && attachment.width && attachment.height ? (
+            <div style={{ width: "100%", height: "100%", overflow: "hidden" }}>
+              <BlurhashCanvas
+                hash={attachment.blurhash}
+                width={attachment.width}
+                height={attachment.height}
+              />
             </div>
-          </button>
-
-          <div
-            style={{
-              border: "2px solid var(--c-border)",
-              background: "var(--c-surface-high)",
-              borderRadius: 8,
-              marginTop: 4,
-            }}
-          >
-            {renderCaptionBar()}
-          </div>
-        </div>
+          ) : (
+            <span className="text-xs font-mono" style={{ color: "var(--c-text-muted)" }}>
+              {error ? "err" : "…"}
+            </span>
+          )}
+        </button>
 
         {/* Full-screen lightbox */}
         {viewerOpen && downloadUrl && (
@@ -796,88 +777,87 @@ const AttachmentDisplay: React.FC<{ attachment: MessageAttachment }> = ({ attach
     );
   }
 
-  // ── Video card ─────────────────────────────────────────────────────────────
+  // ── Video card — uniform 96×96 thumb with play overlay ────────────────────
   if (isVideo) {
     return (
       <>
-        <div
+        <button
           data-testid={`attachment-${attachment.id}`}
-          style={{ width: 200 }}
+          onClick={!isPending && !isLoading ? handleVideoOpen : undefined}
+          disabled={isPending || isLoading}
+          aria-label={`Open ${attachment.filename}`}
+          title={attachment.filename}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            width: 96,
+            height: 96,
+            padding: 0,
+            background: "var(--c-surface-high)",
+            border: "1px solid var(--c-border)",
+            cursor: isPending || isLoading ? "default" : "pointer",
+            position: "relative",
+            overflow: "hidden",
+            borderRadius: 4,
+            flexShrink: 0,
+          }}
         >
-          {/* Preview area — click to open lightbox */}
-          <button
-            onClick={!isPending && !isLoading ? handleVideoOpen : undefined}
-            disabled={isPending || isLoading}
-            aria-label={`Open ${attachment.filename}`}
-            style={{
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              width: "100%",
-              height: 112,
-              padding: 0,
-              background: "var(--c-bg)",
-              border: 0,
-              cursor: isPending || isLoading ? "default" : "pointer",
-              position: "relative",
-              overflow: "hidden",
-              borderRadius: 8,
-            }}
-          >
-            {(poster || (attachment.blurhash && attachment.width && attachment.height)) && (
-              <div style={{ position: "absolute", inset: 0, overflow: "hidden", borderRadius: 8 }}>
-                {poster ? (
-                  <img
-                    src={poster}
-                    alt=""
-                    aria-hidden="true"
-                    style={{ width: "100%", height: "100%", objectFit: "cover" }}
-                  />
-                ) : (
-                  <BlurhashCanvas
-                    hash={attachment.blurhash!}
-                    width={attachment.width!}
-                    height={attachment.height!}
-                  />
-                )}
-              </div>
-            )}
-            <div style={{
-              position: "relative",
-              zIndex: 1,
-              width: 36,
-              height: 36,
-              borderRadius: "50%",
-              background: "rgba(0,0,0,0.55)",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-            }}>
-              {isLoading ? (
-                <LoadingSpinner size="sm" />
+          {(poster || (attachment.blurhash && attachment.width && attachment.height)) && (
+            <div style={{ position: "absolute", inset: 0, overflow: "hidden" }}>
+              {poster ? (
+                <img
+                  src={poster}
+                  alt=""
+                  aria-hidden="true"
+                  style={{ width: "100%", height: "100%", objectFit: "cover" }}
+                />
               ) : (
-                <Film size={18} aria-hidden="true" style={{ color: "white" }} />
+                <BlurhashCanvas
+                  hash={attachment.blurhash!}
+                  width={attachment.width!}
+                  height={attachment.height!}
+                />
               )}
             </div>
-          </button>
-
-          <div
-            style={{
-              border: "2px solid var(--c-border)",
-              background: "var(--c-surface-high)",
-              borderRadius: 8,
-              marginTop: 4,
-            }}
-          >
-            {renderCaptionBar(
-              duration != null ? (
-                <span className="text-xs font-mono flex-shrink-0" style={{ color: "var(--c-text-muted)" }}>
-                  {formatDuration(duration)}
-                </span>
-              ) : undefined
+          )}
+          <div style={{
+            position: "relative",
+            zIndex: 1,
+            width: 28,
+            height: 28,
+            borderRadius: "50%",
+            background: "rgba(0,0,0,0.55)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}>
+            {isLoading ? (
+              <LoadingSpinner size="sm" />
+            ) : (
+              <Film size={14} aria-hidden="true" style={{ color: "white" }} />
             )}
           </div>
-        </div>
+          {duration != null && (
+            <span
+              className="font-mono"
+              style={{
+                position: "absolute",
+                bottom: 4,
+                right: 4,
+                zIndex: 2,
+                fontSize: 10,
+                lineHeight: 1,
+                padding: "2px 4px",
+                borderRadius: 2,
+                background: "rgba(0,0,0,0.65)",
+                color: "white",
+              }}
+            >
+              {formatDuration(duration)}
+            </span>
+          )}
+        </button>
 
         {/* Video lightbox */}
         {viewerOpen && downloadUrl && (

--- a/frontend/src/components/Message/MessageItem.tsx
+++ b/frontend/src/components/Message/MessageItem.tsx
@@ -129,7 +129,7 @@ export const MessageItem: React.FC<MessageItemProps> = ({
         <span
           data-testid="message-timestamp"
           title={formatFullTimestamp(message.created_at)}
-          className="flex-shrink-0 text-xs font-mono tabular-nums select-none w-16 mr-2"
+          className="flex-shrink-0 text-xs font-mono tabular-nums select-none w-20"
           style={{ color: "var(--c-text-muted)", lineHeight: "1.5rem" }}
         >
           {formatTimestamp(message.created_at)}

--- a/frontend/src/components/Message/MessageItem.tsx
+++ b/frontend/src/components/Message/MessageItem.tsx
@@ -3,7 +3,7 @@ import { decode } from "blurhash";
 import { Reply, Download, Film, Check, Edit2, Trash2 } from "lucide-react";
 import { getFileIcon } from "../../utils/fileIcon";
 import { useAppStore } from "../../stores/appStore";
-import { downloadAndDecryptMedia } from "../../services/r2-upload";
+import { downloadAndDecryptMedia, getMediaPath } from "../../services/r2-upload";
 import { LinkifiedText } from "../ui/LinkifiedText";
 import { MediaLinkUnfurl } from "./MediaLinkUnfurl";
 import { LoadingSpinner } from "../ui/LoaderSpinner";
@@ -449,6 +449,8 @@ const AttachmentDisplay: React.FC<{ attachment: MessageAttachment }> = ({ attach
   }, [isVideo, attachment.localPreviewUrl, downloadUrl]);
 
   // Auto-load images and audio from R2 once confirmed (object_key populated, no local URL).
+  // Uses the disk-cache path API so decrypted bytes never cross the JSON IPC —
+  // <img>/<audio> load directly from a converted file URL.
   useEffect(() => {
     if ((!isImage && !isAudio) || isPending || downloadUrl) {
       return;
@@ -456,7 +458,7 @@ const AttachmentDisplay: React.FC<{ attachment: MessageAttachment }> = ({ attach
 
     let mounted = true;
     setIsLoading(true);
-    downloadAndDecryptMedia(
+    getMediaPath(
       attachment.object_key,
       attachment.content_hash,
       attachment.content_type,
@@ -531,7 +533,7 @@ const AttachmentDisplay: React.FC<{ attachment: MessageAttachment }> = ({ attach
     }
     setIsLoading(true);
     try {
-      const url = await downloadAndDecryptMedia(
+      const url = await getMediaPath(
         attachment.object_key,
         attachment.content_hash,
         attachment.content_type,

--- a/frontend/src/components/Message/MessageItem.tsx
+++ b/frontend/src/components/Message/MessageItem.tsx
@@ -30,10 +30,12 @@ interface MessageItemProps {
 
 const formatTimestamp = (timestamp: number): string => {
   const tsMs = timestamp < 1e12 ? timestamp * 1000 : timestamp;
-  const d = new Date(tsMs);
-  const hh = String(d.getHours()).padStart(2, "0");
-  const mm = String(d.getMinutes()).padStart(2, "0");
-  return `${hh}:${mm}`;
+  return new Date(tsMs).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+};
+
+const formatFullTimestamp = (timestamp: number): string => {
+  const tsMs = timestamp < 1e12 ? timestamp * 1000 : timestamp;
+  return new Date(tsMs).toLocaleString([], { dateStyle: "full", timeStyle: "short" });
 };
 
 export const MessageItem: React.FC<MessageItemProps> = ({
@@ -126,6 +128,7 @@ export const MessageItem: React.FC<MessageItemProps> = ({
       <div className="flex items-start gap-0 min-w-0">
         <span
           data-testid="message-timestamp"
+          title={formatFullTimestamp(message.created_at)}
           className="flex-shrink-0 text-sm font-mono tabular-nums select-none w-12 mr-2"
           style={{ color: "var(--c-text-muted)" }}
         >

--- a/frontend/src/components/Message/MessageItem.tsx
+++ b/frontend/src/components/Message/MessageItem.tsx
@@ -470,6 +470,26 @@ const AttachmentDisplay: React.FC<{ attachment: MessageAttachment }> = ({ attach
     return () => { mounted = false; };
   }, [attachment.object_key]);
 
+  // Revoke decrypted blob URLs we created when they're replaced or on unmount.
+  // Skip non-blob URLs (e.g. tauri convertFileSrc paths) and skip the
+  // sender-owned localPreviewUrl, which is freed by the optimistic-send code.
+  const ownedBlobRef = useRef<string | null>(null);
+  useEffect(() => {
+    const isBlob = !!downloadUrl && downloadUrl.startsWith("blob:");
+    const isOwnedByUs = isBlob && downloadUrl !== attachment.localPreviewUrl;
+    const prev = ownedBlobRef.current;
+    if (prev && prev !== downloadUrl) {
+      URL.revokeObjectURL(prev);
+    }
+    ownedBlobRef.current = isOwnedByUs ? downloadUrl : null;
+    return () => {
+      if (ownedBlobRef.current) {
+        URL.revokeObjectURL(ownedBlobRef.current);
+        ownedBlobRef.current = null;
+      }
+    };
+  }, [downloadUrl, attachment.localPreviewUrl]);
+
   const triggerSave = (url: string) => {
     const a = document.createElement("a");
     a.href = url;

--- a/frontend/src/components/Message/MessageItem.tsx
+++ b/frontend/src/components/Message/MessageItem.tsx
@@ -3,7 +3,7 @@ import { decode } from "blurhash";
 import { Reply, Download, Film, Check, Edit2, Trash2 } from "lucide-react";
 import { getFileIcon } from "../../utils/fileIcon";
 import { useAppStore } from "../../stores/appStore";
-import { downloadAndDecryptMedia, getMediaPath } from "../../services/r2-upload";
+import { downloadAndDecryptMedia, getMediaUrl } from "../../services/r2-upload";
 import { LinkifiedText } from "../ui/LinkifiedText";
 import { MediaLinkUnfurl } from "./MediaLinkUnfurl";
 import { LoadingSpinner } from "../ui/LoaderSpinner";
@@ -449,8 +449,10 @@ const AttachmentDisplay: React.FC<{ attachment: MessageAttachment }> = ({ attach
   }, [isVideo, attachment.localPreviewUrl, downloadUrl]);
 
   // Auto-load images and audio from R2 once confirmed (object_key populated, no local URL).
-  // Uses the disk-cache path API so decrypted bytes never cross the JSON IPC —
-  // <img>/<audio> load directly from a converted file URL.
+  // One URL pattern across image and audio: the loopback media server
+  // returns `http://127.0.0.1:<port>/<token>/<hash>`. Bytes never cross
+  // the JSON IPC; disk cache is encrypted at rest under the session
+  // db_key; HTTP Range works for `<audio>` / `<video>` natively.
   useEffect(() => {
     if ((!isImage && !isAudio) || isPending || downloadUrl) {
       return;
@@ -458,11 +460,12 @@ const AttachmentDisplay: React.FC<{ attachment: MessageAttachment }> = ({ attach
 
     let mounted = true;
     setIsLoading(true);
-    getMediaPath(
+    const fetchUrl = getMediaUrl(
       attachment.object_key,
       attachment.content_hash,
       attachment.content_type,
-    ).then((url) => {
+    );
+    fetchUrl.then((url) => {
       if (mounted) { setDownloadUrl(url); }
     }).catch((err) => {
       if (mounted) { setError(err instanceof Error ? err.message : "Failed to load"); }
@@ -533,7 +536,10 @@ const AttachmentDisplay: React.FC<{ attachment: MessageAttachment }> = ({ attach
     }
     setIsLoading(true);
     try {
-      const url = await getMediaPath(
+      // Video uses the same loopback URL pattern as image/audio. The
+      // server honours HTTP Range so seeking works without buffering
+      // the whole file.
+      const url = await getMediaUrl(
         attachment.object_key,
         attachment.content_hash,
         attachment.content_type,

--- a/frontend/src/components/Message/MessageList.tsx
+++ b/frontend/src/components/Message/MessageList.tsx
@@ -34,7 +34,7 @@ const formatDayDividerLabel = (timestamp: number): string => {
 const DayDivider: React.FC<{ label: string }> = ({ label }) => (
   <div
     data-testid="day-divider"
-    className="flex items-center gap-3 px-4 py-2 select-none"
+    className="flex items-center gap-3 py-2 select-none"
   >
     <div className="flex-1 h-px" style={{ background: "var(--c-border)" }} />
     <span

--- a/frontend/src/components/Message/MessageList.tsx
+++ b/frontend/src/components/Message/MessageList.tsx
@@ -3,6 +3,50 @@ import { MessageItem } from "./MessageItem";
 import { useBlockedUsers } from "../../hooks/queries";
 import type { Message } from "../../types";
 
+const toMs = (timestamp: number): number =>
+  timestamp < 1e12 ? timestamp * 1000 : timestamp;
+
+const startOfLocalDay = (d: Date): number =>
+  new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+
+const formatDayDividerLabel = (timestamp: number): string => {
+  const d = new Date(toMs(timestamp));
+  const now = new Date();
+  const dayStart = startOfLocalDay(d);
+  const todayStart = startOfLocalDay(now);
+  const dayDiff = Math.round((todayStart - dayStart) / 86_400_000);
+
+  if (dayDiff === 0) {
+    return "Today";
+  }
+  if (dayDiff === 1) {
+    return "Yesterday";
+  }
+  if (dayDiff > 1 && dayDiff <= 6) {
+    return d.toLocaleDateString([], { weekday: "short", month: "short", day: "numeric" });
+  }
+  if (d.getFullYear() === now.getFullYear()) {
+    return d.toLocaleDateString([], { month: "short", day: "numeric" });
+  }
+  return d.toLocaleDateString([], { month: "short", day: "numeric", year: "numeric" });
+};
+
+const DayDivider: React.FC<{ label: string }> = ({ label }) => (
+  <div
+    data-testid="day-divider"
+    className="flex items-center gap-3 px-4 py-2 select-none"
+  >
+    <div className="flex-1 h-px" style={{ background: "var(--c-border)" }} />
+    <span
+      className="text-xs font-mono"
+      style={{ color: "var(--c-text-muted)" }}
+    >
+      {label}
+    </span>
+    <div className="flex-1 h-px" style={{ background: "var(--c-border)" }} />
+  </div>
+);
+
 interface MessageListProps {
   messages: Message[];
   adminUserIds?: Set<string>;
@@ -154,40 +198,45 @@ export const MessageList: React.FC<MessageListProps> = ({
           Loading…
         </p>
       )}
-      {sortedMessages.map((message) => {
-        if (blockedIds.has(message.sender_id)) {
-          return (
-            <div
-              key={message.id}
-              data-testid={`message-blocked-${message.id}`}
-              className="px-4 py-1"
-            >
-              <div className="flex items-start gap-2 min-w-0">
-                <span
-                  className="flex-shrink-0 font-mono text-sm italic"
-                  style={{ color: "var(--c-text-dim)" }}
-                >
-                  blocked user
-                </span>
-                <span
-                  className="font-mono text-sm italic"
-                  style={{ color: "var(--c-text-muted)" }}
-                >
-                  [blocked]
-                </span>
-              </div>
+      {sortedMessages.map((message, idx) => {
+        const prev = idx > 0 ? sortedMessages[idx - 1] : null;
+        const currentDay = startOfLocalDay(new Date(toMs(message.created_at)));
+        const prevDay = prev
+          ? startOfLocalDay(new Date(toMs(prev.created_at)))
+          : null;
+        const showDivider = prevDay === null || prevDay !== currentDay;
+
+        const rendered = blockedIds.has(message.sender_id) ? (
+          <div
+            key={message.id}
+            data-testid={`message-blocked-${message.id}`}
+            className="px-4 py-1"
+          >
+            <div className="flex items-start gap-2 min-w-0">
+              <span
+                className="flex-shrink-0 font-mono text-sm italic"
+                style={{ color: "var(--c-text-dim)" }}
+              >
+                blocked user
+              </span>
+              <span
+                className="font-mono text-sm italic"
+                style={{ color: "var(--c-text-muted)" }}
+              >
+                [blocked]
+              </span>
             </div>
-          );
-        }
-        const authorUsername = getAuthorUsername
-          ? getAuthorUsername(message.sender_id, message)
-          : "Unknown";
-        return (
+          </div>
+        ) : (
           <MessageItem
             key={message.id}
             message={message}
             allMessages={sortedMessages}
-            authorUsername={authorUsername}
+            authorUsername={
+              getAuthorUsername
+                ? getAuthorUsername(message.sender_id, message)
+                : "Unknown"
+            }
             isAuthorAdmin={adminUserIds?.has(message.sender_id) ?? false}
             canModerate={viewerIsAdmin}
             onReply={onReply}
@@ -195,6 +244,15 @@ export const MessageList: React.FC<MessageListProps> = ({
             onDelete={onDelete}
             onScrollToReply={scrollToMessage}
           />
+        );
+
+        return (
+          <React.Fragment key={`frag-${message.id}`}>
+            {showDivider && (
+              <DayDivider label={formatDayDividerLabel(message.created_at)} />
+            )}
+            {rendered}
+          </React.Fragment>
         );
       })}
       <div ref={bottomRef} />

--- a/frontend/src/components/ui/AudioPlayer.tsx
+++ b/frontend/src/components/ui/AudioPlayer.tsx
@@ -36,7 +36,6 @@ export const AudioPlayer: React.FC<AudioPlayerProps> = ({
   const [duration, setDuration] = useState(0);
   const [volume, setVolume] = useState(1);
   const [isMuted, setIsMuted] = useState(false);
-  const [isLoading, setIsLoading] = useState(true);
   const audioRef = useRef<HTMLAudioElement>(null);
 
   useEffect(() => {
@@ -46,26 +45,26 @@ export const AudioPlayer: React.FC<AudioPlayerProps> = ({
     }
 
     const updateTime = () => setCurrentTime(audio.currentTime);
-    const updateDuration = () => setDuration(audio.duration);
+    const updateDuration = () => {
+      if (isFinite(audio.duration)) {
+        setDuration(audio.duration);
+      }
+    };
     const handlePlay = () => setIsPlaying(true);
     const handlePause = () => setIsPlaying(false);
-    const handleLoadStart = () => setIsLoading(true);
-    const handleCanPlay = () => setIsLoading(false);
 
     audio.addEventListener("timeupdate", updateTime);
     audio.addEventListener("loadedmetadata", updateDuration);
+    audio.addEventListener("durationchange", updateDuration);
     audio.addEventListener("play", handlePlay);
     audio.addEventListener("pause", handlePause);
-    audio.addEventListener("loadstart", handleLoadStart);
-    audio.addEventListener("canplay", handleCanPlay);
 
     return () => {
       audio.removeEventListener("timeupdate", updateTime);
       audio.removeEventListener("loadedmetadata", updateDuration);
+      audio.removeEventListener("durationchange", updateDuration);
       audio.removeEventListener("play", handlePlay);
       audio.removeEventListener("pause", handlePause);
-      audio.removeEventListener("loadstart", handleLoadStart);
-      audio.removeEventListener("canplay", handleCanPlay);
     };
   }, []);
 
@@ -164,7 +163,7 @@ export const AudioPlayer: React.FC<AudioPlayerProps> = ({
           value={currentTime}
           onChange={handleSeek}
           className="w-full h-2 rounded-lg appearance-none cursor-pointer accent-slider focus:outline-none focus:ring-2 focus:ring-[var(--c-accent)] focus:ring-offset-2 focus:ring-offset-black"
-          disabled={isLoading}
+          disabled={!duration}
           aria-label="Seek audio"
         />
         <div className="flex justify-between text-xs font-mono mt-1" style={{ color: "var(--c-text-dim)" }}>
@@ -178,8 +177,7 @@ export const AudioPlayer: React.FC<AudioPlayerProps> = ({
         <div className="flex items-center gap-2">
           <button
             onClick={skipBackward}
-            disabled={isLoading}
-            className="p-2 rounded transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-[var(--c-accent)] focus:ring-offset-2 focus:ring-offset-black disabled:opacity-50 disabled:cursor-not-allowed"
+            className="p-2 rounded transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-[var(--c-accent)] focus:ring-offset-2 focus:ring-offset-black"
             style={btnStyle}
             aria-label="Skip backward 10 seconds"
           >
@@ -188,8 +186,7 @@ export const AudioPlayer: React.FC<AudioPlayerProps> = ({
 
           <button
             onClick={togglePlay}
-            disabled={isLoading}
-            className="p-3 rounded transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-[var(--c-accent)] focus:ring-offset-2 focus:ring-offset-black disabled:opacity-50 disabled:cursor-not-allowed"
+            className="p-3 rounded transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-[var(--c-accent)] focus:ring-offset-2 focus:ring-offset-black"
             style={btnStyle}
             aria-label={isPlaying ? "Pause" : "Play"}
           >
@@ -198,8 +195,7 @@ export const AudioPlayer: React.FC<AudioPlayerProps> = ({
 
           <button
             onClick={skipForward}
-            disabled={isLoading}
-            className="p-2 rounded transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-[var(--c-accent)] focus:ring-offset-2 focus:ring-offset-black disabled:opacity-50 disabled:cursor-not-allowed"
+            className="p-2 rounded transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-[var(--c-accent)] focus:ring-offset-2 focus:ring-offset-black"
             style={btnStyle}
             aria-label="Skip forward 10 seconds"
           >
@@ -211,8 +207,7 @@ export const AudioPlayer: React.FC<AudioPlayerProps> = ({
         <div className="flex items-center gap-2">
           <button
             onClick={toggleMute}
-            disabled={isLoading}
-            className="p-2 rounded transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-[var(--c-accent)] focus:ring-offset-2 focus:ring-offset-black disabled:opacity-50 disabled:cursor-not-allowed"
+            className="p-2 rounded transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-[var(--c-accent)] focus:ring-offset-2 focus:ring-offset-black"
             style={btnStyle}
             aria-label={isMuted ? "Unmute" : "Mute"}
           >
@@ -227,7 +222,6 @@ export const AudioPlayer: React.FC<AudioPlayerProps> = ({
             value={isMuted ? 0 : volume}
             onChange={handleVolumeChange}
             className="w-20 h-2 rounded-lg appearance-none cursor-pointer accent-slider focus:outline-none focus:ring-2 focus:ring-[var(--c-accent)] focus:ring-offset-2 focus:ring-offset-black"
-            disabled={isLoading}
             aria-label="Volume"
           />
         </div>

--- a/frontend/src/components/ui/Avatar.tsx
+++ b/frontend/src/components/ui/Avatar.tsx
@@ -49,7 +49,7 @@ export const Avatar: React.FC<AvatarProps> = ({
   // Wrap the avatar in a positioned span so the dot can sit at the corner
   // without disturbing the parent's layout. Sizing the dot relative to the
   // avatar keeps it visible at every avatar size we use.
-  const dotSize = Math.max(6, Math.round(size * 0.28));
+  const dotSize = Math.max(5, Math.round(size * 0.24));
   const wrapperStyle: React.CSSProperties = {
     position: "relative",
     display: "inline-flex",
@@ -59,8 +59,8 @@ export const Avatar: React.FC<AvatarProps> = ({
   };
   const dotStyle: React.CSSProperties = {
     position: "absolute",
-    right: 0,
-    bottom: 0,
+    right: -2,
+    bottom: -2,
     width: dotSize,
     height: dotSize,
     borderRadius: "50%",

--- a/frontend/src/components/ui/ChatInput.tsx
+++ b/frontend/src/components/ui/ChatInput.tsx
@@ -560,7 +560,7 @@ export const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(({
           autoCapitalize="off"
           spellCheck={false}
           rows={1}
-          className="chat-input-textarea flex-1 min-w-0 px-2 py-1 resize-none font-mono text-sm transition-colors"
+          className={`chat-input-textarea flex-1 min-w-0 px-2 py-1 resize-none font-mono text-sm transition-colors${isFocused ? " is-focused" : ""}`}
           style={{
             lineHeight: "1.5rem",
             minHeight: "1.5rem",

--- a/frontend/src/components/ui/ChatInput.tsx
+++ b/frontend/src/components/ui/ChatInput.tsx
@@ -531,7 +531,7 @@ export const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(({
           onClick={handlePickFiles}
           disabled={disabled || attachments.length >= maxAttachments}
           aria-label="Add attachment"
-          className="p-1.5 flex-shrink-0 transition-colors"
+          className="pt-2 pb-1.5 px-1.5 flex-shrink-0 transition-colors"
           style={{ color: "var(--c-text-muted)", opacity: disabled ? 0.4 : 1 }}
           onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.color = "var(--c-accent)"; }}
           onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = "var(--c-text-muted)"; }}
@@ -579,7 +579,7 @@ export const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(({
           disabled={disabled || (!message.trim() && attachments.length === 0) || hasLoadingAttachments}
           data-testid="message-send-button"
           aria-label="Send message"
-          className="p-1.5 flex-shrink-0 transition-colors"
+          className="pt-2 pb-1.5 px-1.5 flex-shrink-0 transition-colors"
           style={{
             color: "var(--c-text-muted)",
             opacity: disabled || (!message.trim() && !attachments.length) ? 0.3 : 1,

--- a/frontend/src/components/ui/InlineAudioPlayer.tsx
+++ b/frontend/src/components/ui/InlineAudioPlayer.tsx
@@ -25,7 +25,6 @@ export const InlineAudioPlayer: React.FC<InlineAudioPlayerProps> = ({
   const [isPlaying, setIsPlaying] = useState(false);
   const [currentTime, setCurrentTime] = useState(0);
   const [duration, setDuration] = useState(0);
-  const [isLoading, setIsLoading] = useState(true);
   const audioRef = useRef<HTMLAudioElement>(null);
 
   useEffect(() => {
@@ -35,26 +34,26 @@ export const InlineAudioPlayer: React.FC<InlineAudioPlayerProps> = ({
     }
 
     const updateTime = () => setCurrentTime(audio.currentTime);
-    const updateDuration = () => setDuration(audio.duration);
+    const updateDuration = () => {
+      if (isFinite(audio.duration)) {
+        setDuration(audio.duration);
+      }
+    };
     const handlePlay = () => setIsPlaying(true);
     const handlePause = () => setIsPlaying(false);
-    const handleLoadStart = () => setIsLoading(true);
-    const handleCanPlay = () => setIsLoading(false);
 
     audio.addEventListener("timeupdate", updateTime);
     audio.addEventListener("loadedmetadata", updateDuration);
+    audio.addEventListener("durationchange", updateDuration);
     audio.addEventListener("play", handlePlay);
     audio.addEventListener("pause", handlePause);
-    audio.addEventListener("loadstart", handleLoadStart);
-    audio.addEventListener("canplay", handleCanPlay);
 
     return () => {
       audio.removeEventListener("timeupdate", updateTime);
       audio.removeEventListener("loadedmetadata", updateDuration);
+      audio.removeEventListener("durationchange", updateDuration);
       audio.removeEventListener("play", handlePlay);
       audio.removeEventListener("pause", handlePause);
-      audio.removeEventListener("loadstart", handleLoadStart);
-      audio.removeEventListener("canplay", handleCanPlay);
     };
   }, []);
 
@@ -90,12 +89,11 @@ export const InlineAudioPlayer: React.FC<InlineAudioPlayerProps> = ({
       }}
       onClick={onClick}
     >
-      <audio ref={audioRef} src={src} autoPlay={autoPlay} />
+      <audio ref={audioRef} src={src} autoPlay={autoPlay} preload="metadata" />
 
       <button
         onClick={togglePlay}
-        disabled={isLoading}
-        className="p-1 rounded transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-[var(--c-accent)] focus:ring-offset-2 focus:ring-offset-black disabled:opacity-50 disabled:cursor-not-allowed"
+        className="p-1 rounded transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-[var(--c-accent)] focus:ring-offset-2 focus:ring-offset-black"
         style={{ color: "var(--c-accent)" }}
         aria-label={isPlaying ? "Pause" : "Play"}
       >
@@ -119,7 +117,7 @@ export const InlineAudioPlayer: React.FC<InlineAudioPlayerProps> = ({
         onChange={handleSeek}
         onClick={(e) => e.stopPropagation()}
         className="flex-1 h-1 rounded appearance-none cursor-pointer accent-slider focus:outline-none focus:ring-2 focus:ring-[var(--c-accent)] focus:ring-offset-2 focus:ring-offset-black"
-        disabled={isLoading}
+        disabled={!duration}
         aria-label="Seek audio"
       />
 

--- a/frontend/src/hooks/queries/useMessages.ts
+++ b/frontend/src/hooks/queries/useMessages.ts
@@ -140,10 +140,9 @@ export function useMessages(channelId: string | null, conversationId: string | n
     queryKey,
     queryFn: async (): Promise<MessagesQueryResult> => {
       if (isChannel && channelId && currentUser) {
-        // Advance the local MLS epoch before decrypting so any pending
-        // member-add or member-remove commits are applied first.
-        await invoke('process_pending_commits', { conversationId: channelId, userId: currentUser.id }).catch(() => {});
-
+        // get_channel_messages internally calls poll_mls_welcomes_inner +
+        // process_pending_commits_inner via ingest_channel_envelopes_inner,
+        // so no frontend pre-flight is needed.
         const page = await invoke<MessagePage>('get_channel_messages', {
           userId: currentUser.id,
           channelId,
@@ -156,11 +155,9 @@ export function useMessages(channelId: string | null, conversationId: string | n
       }
 
       if (conversationId && currentUser) {
-        // Drain any pending MLS Welcome messages first — the DM creator may have
-        // added us to the MLS group while we were already online.
-        await invoke('poll_mls_welcomes', { userId: currentUser.id }).catch(() => {});
-        await invoke('process_pending_commits', { conversationId, userId: currentUser.id }).catch(() => {});
-
+        // get_dm_messages internally calls poll_mls_welcomes_inner +
+        // process_pending_commits_inner via ingest_dm_envelopes_inner,
+        // so no frontend pre-flight is needed.
         const page = await invoke<MessagePage>('get_dm_messages', {
           userId: currentUser.id,
           dmChannelId: conversationId,

--- a/frontend/src/hooks/queries/usePreferences.ts
+++ b/frontend/src/hooks/queries/usePreferences.ts
@@ -39,6 +39,8 @@ export interface PreferencesData {
   /** RNNoise click/keystroke suppression (separate from APM's spectral NS). */
   click_suppression?: boolean;
   auto_join_voice?: boolean;
+  /** Whether the left sidebar is open by default at app start. */
+  sidebar_open_by_default?: boolean;
   /**
    * Per-remote-user output volume multipliers, keyed by `user_id`.
    * Range 0.0..=2.0; 1.0 is unity. Absent users default to unity.
@@ -182,6 +184,7 @@ export function usePreferences() {
         echo_cancellation: getPreference<boolean>(json, "echo_cancellation", APM_DEFAULTS.echo_cancellation),
         click_suppression: getPreference<boolean>(json, "click_suppression", APM_DEFAULTS.click_suppression),
         auto_join_voice: getPreference<boolean>(json, "auto_join_voice", false),
+        sidebar_open_by_default: getPreference<boolean>(json, "sidebar_open_by_default", true),
         user_volumes: getPreference<{ [userId: string]: number } | undefined>(
           json,
           "user_volumes",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -201,12 +201,15 @@ input[type="range"]::-moz-range-thumb {
     border-color: var(--c-border-active);
   }
 
-  /* Chat input placeholder: muted when unfocused, dark when focused (on accent bg) */
+  /* Chat input placeholder: muted when unfocused, dark when focused (on accent bg).
+     Driven by an explicit `is-focused` class rather than `:focus` so it stays in
+     sync with the React-controlled background when the OS window loses focus
+     (Webkit drops `:focus`-based ::placeholder styling on window blur). */
   .chat-input-textarea::placeholder {
     color: var(--c-text-muted);
   }
 
-  .chat-input-textarea:focus::placeholder {
+  .chat-input-textarea.is-focused::placeholder {
     color: color-mix(in srgb, var(--c-bg) 65%, transparent);
   }
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -32,7 +32,10 @@ const queryClient = new QueryClient({
     queries: {
       staleTime: 1000 * 60, // 1 minute
       gcTime: 1000 * 60 * 5, // 5 minutes (formerly cacheTime)
-      refetchOnWindowFocus: true,
+      // Refocus refetch causes a full ingest + page-read + remote-username
+      // lookup churn for already-decrypted plaintext that won't get more
+      // accurate. Realtime push and explicit invalidations handle freshness.
+      refetchOnWindowFocus: false,
       refetchOnReconnect: true,
       retry: 1,
     },

--- a/frontend/src/pages/DM.tsx
+++ b/frontend/src/pages/DM.tsx
@@ -47,7 +47,7 @@ export const DMPage: React.FC = () => {
         setOtherUserId(other?.user_id ?? null);
         setOtherAcceptedAt(other?.accepted_at ?? null);
       })
-      .catch(() => {});
+      .catch(() => { });
     return () => { cancelled = true; };
   }, [currentUser, conversationId]);
 
@@ -125,6 +125,10 @@ export const DMPage: React.FC = () => {
             onClick={startCall}
             aria-label={`Call @${username}`}
             className="icon-btn-sm flex-shrink-0"
+            style={{
+              position: 'absolute',
+              right: '0.75rem'
+            }}
           >
             <Phone size={14} aria-hidden="true" />
           </button>

--- a/frontend/src/pages/Preferences.tsx
+++ b/frontend/src/pages/Preferences.tsx
@@ -25,6 +25,11 @@ function isValidHex(val: string): boolean {
   return /^#[0-9a-fA-F]{6}$/.test(val);
 }
 
+function isMac(): boolean {
+  return typeof navigator !== "undefined" &&
+    navigator.platform.toUpperCase().indexOf("MAC") >= 0;
+}
+
 export const Preferences: React.FC = () => {
   const navigate = useNavigate();
   const currentUser = useAppStore((state) => state.currentUser);
@@ -37,6 +42,7 @@ export const Preferences: React.FC = () => {
   const [allowDesktopNotifications, setAllowDesktopNotifications] = useState<boolean>(true);
   const [allowSoundEffects, setAllowSoundEffects] = useState<boolean>(true);
   const [allowCallRingtone, setAllowCallRingtone] = useState<boolean>(true);
+  const [sidebarOpenByDefault, setSidebarOpenByDefault] = useState<boolean>(true);
   const [accentHexInput, setAccentHexInput] = useState<string>(() => hslToHex(38, 90, 62));
   const [bgHexInput, setBgHexInput] = useState<string>(() => hslToHex(38, 20, 4));
 
@@ -53,6 +59,9 @@ export const Preferences: React.FC = () => {
       }
       if (query.data.allow_sound_effects !== undefined) {
         setAllowSoundEffects(query.data.allow_sound_effects);
+      }
+      if (query.data.sidebar_open_by_default !== undefined) {
+        setSidebarOpenByDefault(query.data.sidebar_open_by_default);
       }
     }
   }, [query.data, currentUser?.id]);
@@ -88,6 +97,7 @@ export const Preferences: React.FC = () => {
     accentH?: number; accentS?: number;
     bgH?: number; bgS?: number; bgL?: number;
     notifications?: boolean; soundEffects?: boolean;
+    sidebarOpenByDefault?: boolean;
   }) => {
     const ah = opts.accentH ?? hue;
     const as_ = opts.accentS ?? saturation;
@@ -96,6 +106,7 @@ export const Preferences: React.FC = () => {
     const bl = opts.bgL ?? bgLightness;
     const notif = opts.notifications ?? allowDesktopNotifications;
     const sfx = opts.soundEffects ?? allowSoundEffects;
+    const sidebar = opts.sidebarOpenByDefault ?? sidebarOpenByDefault;
     const accentHex = hslToHex(ah, as_, 62);
     const bgHex = hslToHex(bh, bs, bl);
     // font_size is intentionally NOT included — it's device-local now,
@@ -110,8 +121,9 @@ export const Preferences: React.FC = () => {
       background_color: bgHex,
       allow_desktop_notifications: notif,
       allow_sound_effects: sfx,
+      sidebar_open_by_default: sidebar,
     });
-  }, [mutation, query.data, hue, saturation, bgHue, bgSaturation, bgLightness, allowDesktopNotifications, allowSoundEffects]);
+  }, [mutation, query.data, hue, saturation, bgHue, bgSaturation, bgLightness, allowDesktopNotifications, allowSoundEffects, sidebarOpenByDefault]);
 
   const handleAccentColor = (hex: string) => {
     const [h, s] = hexToHsl(hex);
@@ -142,6 +154,11 @@ export const Preferences: React.FC = () => {
   const handleAllowSoundEffects = (val: boolean) => {
     setAllowSoundEffects(val);
     save({ soundEffects: val });
+  };
+
+  const handleSidebarOpenByDefault = (val: boolean) => {
+    setSidebarOpenByDefault(val);
+    save({ sidebarOpenByDefault: val });
   };
 
   const handleAllowCallRingtone = (val: boolean) => {
@@ -379,7 +396,7 @@ export const Preferences: React.FC = () => {
             >
               The quick brown fox jumps over the lazy dog.
             </p>
-            <div className="flex flex-col gap-1.5">
+            <div className="flex flex-col gap-1.5 mt-4">
               <Switch
                 id="pref-call-ringtone"
                 label="Incoming call ringtone"
@@ -388,6 +405,27 @@ export const Preferences: React.FC = () => {
               />
               <p className="text-xs font-mono" style={{ color: "var(--c-text-muted)" }}>
                 Plays a looping ring on this device when someone calls. Off here doesn't mute the alert badge or your other devices.
+              </p>
+            </div>
+          </section>
+
+          {/* Layout */}
+          <section className="flex flex-col gap-4 mb-12">
+            <h2
+              className="text-xs font-mono font-medium uppercase tracking-widest pb-1 border-b"
+              style={{ color: "var(--c-text)", borderColor: "var(--c-border)" }}
+            >
+              Layout
+            </h2>
+            <div className="flex flex-col gap-1.5">
+              <Switch
+                id="pref-sidebar-default"
+                label="Show sidebar by default"
+                checked={sidebarOpenByDefault}
+                onChange={handleSidebarOpenByDefault}
+              />
+              <p className="text-xs font-mono" style={{ color: "var(--c-text-muted)" }}>
+                Controls whether the left sidebar is open when the app starts. Toggle ad-hoc with {isMac() ? "⌘B" : "Ctrl+B"}.
               </p>
             </div>
           </section>

--- a/frontend/src/services/r2-upload.ts
+++ b/frontend/src/services/r2-upload.ts
@@ -125,6 +125,12 @@ export async function getMediaPath(
       contentHash,
       contentType,
     });
+    // Empty-string sentinel: file exceeds the per-file cap, so the
+    // Rust side declined to cache it. Fall back to the byte path which
+    // produces an in-memory blob URL just for this render.
+    if (!path) {
+      return downloadAndDecryptMedia(r2Key, contentHash, contentType);
+    }
     return convertFileSrc(path);
   })();
   inFlight.set(contentHash, promise);

--- a/frontend/src/services/r2-upload.ts
+++ b/frontend/src/services/r2-upload.ts
@@ -1,4 +1,4 @@
-import { invoke, convertFileSrc } from '@tauri-apps/api/core';
+import { invoke } from '@tauri-apps/api/core';
 import type { PresignedUploadResponse } from '../types';
 
 function sanitizeFilename(name: string): string {
@@ -97,20 +97,31 @@ export async function downloadAndDecryptMedia(
   return URL.createObjectURL(blob);
 }
 
-// In-flight de-dup: while one caller is fetching+decrypting bytes for a hash,
-// any other caller for the same hash awaits the same promise. Prevents a render
-// storm during scroll where 30 mounted MessageItems each kick off identical
-// invokes. Resolved promises stay cached for the life of the app — content_hash
-// is content-addressed, so the path is permanently correct.
+// In-flight de-dup: while one caller is resolving a URL for a hash, any
+// other caller for the same hash awaits the same promise. Prevents a
+// render storm during scroll where 30 mounted MessageItems each kick
+// off identical invokes. Resolved promises stay cached for the life of
+// the document — content_hash is content-addressed, so the URL is
+// permanently correct (the loopback server's port + token live for the
+// process; an unlock event would invalidate cached blob URLs from the
+// over-cap fallback path, but that's a fresh document anyway).
 const inFlight = new Map<string, Promise<string>>();
 
-/// Resolve an attachment to a local file URL the webview can render directly.
+/// Resolve an attachment to a URL the webview can render directly via
+/// `<img src>` / `<audio src>` / `<video src>`.
 ///
-/// The Rust side decrypts to an on-disk content-addressed cache and returns
-/// the path; we wrap it with `convertFileSrc()` so it becomes an asset:// URL
-/// (or http://asset.localhost on Linux) that <img> / <video> can load without
-/// the JSON IPC ever touching the bytes.
-export async function getMediaPath(
+/// Default path: the Rust side downloads, decrypts, re-encrypts under
+/// the per-session cache key, writes to disk, and returns
+/// `http://127.0.0.1:<port>/<token>/<hash>`. Subsequent calls for the
+/// same hash return the URL straight from the cached path. The local
+/// HTTP server (see `pollis-core::media_server`) decrypts and streams
+/// bytes — never through the JSON IPC, never via `Blob`/`asset://`.
+///
+/// Fallback: files larger than the per-file cap (100 MiB) skip the
+/// disk cache; Rust returns an empty string, and we fall back to
+/// `downloadAndDecryptMedia` which produces an in-memory Blob URL just
+/// for this render.
+export async function getMediaUrl(
   r2Key: string,
   contentHash: string,
   contentType: string,
@@ -120,18 +131,15 @@ export async function getMediaPath(
     return cached;
   }
   const promise = (async () => {
-    const path = await invoke<string>('get_media_path', {
+    const url = await invoke<string>('get_media_url', {
       r2Key,
       contentHash,
       contentType,
     });
-    // Empty-string sentinel: file exceeds the per-file cap, so the
-    // Rust side declined to cache it. Fall back to the byte path which
-    // produces an in-memory blob URL just for this render.
-    if (!path) {
+    if (!url) {
       return downloadAndDecryptMedia(r2Key, contentHash, contentType);
     }
-    return convertFileSrc(path);
+    return url;
   })();
   inFlight.set(contentHash, promise);
   promise.catch(() => {

--- a/frontend/src/services/r2-upload.ts
+++ b/frontend/src/services/r2-upload.ts
@@ -1,4 +1,4 @@
-import { invoke } from '@tauri-apps/api/core';
+import { invoke, convertFileSrc } from '@tauri-apps/api/core';
 import type { PresignedUploadResponse } from '../types';
 
 function sanitizeFilename(name: string): string {
@@ -104,16 +104,12 @@ export async function downloadAndDecryptMedia(
 // is content-addressed, so the path is permanently correct.
 const inFlight = new Map<string, Promise<string>>();
 
-/// Resolve an attachment to a URL the webview can render directly.
+/// Resolve an attachment to a local file URL the webview can render directly.
 ///
-/// The Rust side downloads + decrypts the attachment, then writes an
-/// AES-256-GCM ciphertext to the on-disk content-addressed cache. The
-/// returned URL uses the custom `pollis-media://` scheme; its protocol
-/// handler decrypts on demand so plaintext bytes never touch disk.
-///
-/// If the file is too large to cache (>100 MB) or the user is locked,
-/// `get_media_path` returns an empty string and we fall back to the byte
-/// path via `downloadAndDecryptMedia`, returning a blob: URL instead.
+/// The Rust side decrypts to an on-disk content-addressed cache and returns
+/// the path; we wrap it with `convertFileSrc()` so it becomes an asset:// URL
+/// (or http://asset.localhost on Linux) that <img> / <video> can load without
+/// the JSON IPC ever touching the bytes.
 export async function getMediaPath(
   r2Key: string,
   contentHash: string,
@@ -124,17 +120,12 @@ export async function getMediaPath(
     return cached;
   }
   const promise = (async () => {
-    const url = await invoke<string>('get_media_path', {
+    const path = await invoke<string>('get_media_path', {
       r2Key,
       contentHash,
       contentType,
     });
-    if (url) {
-      return url;
-    }
-    // Fallback: cache bypassed (oversize file or locked state). Pull the
-    // bytes through IPC for this one render.
-    return downloadAndDecryptMedia(r2Key, contentHash, contentType);
+    return convertFileSrc(path);
   })();
   inFlight.set(contentHash, promise);
   promise.catch(() => {

--- a/frontend/src/services/r2-upload.ts
+++ b/frontend/src/services/r2-upload.ts
@@ -1,4 +1,4 @@
-import { invoke } from '@tauri-apps/api/core';
+import { invoke, convertFileSrc } from '@tauri-apps/api/core';
 import type { PresignedUploadResponse } from '../types';
 
 function sanitizeFilename(name: string): string {
@@ -95,4 +95,42 @@ export async function downloadAndDecryptMedia(
   const bytes = await invoke<number[]>('download_media', { r2Key, contentHash });
   const blob = new Blob([new Uint8Array(bytes)], mimeType ? { type: mimeType } : undefined);
   return URL.createObjectURL(blob);
+}
+
+// In-flight de-dup: while one caller is fetching+decrypting bytes for a hash,
+// any other caller for the same hash awaits the same promise. Prevents a render
+// storm during scroll where 30 mounted MessageItems each kick off identical
+// invokes. Resolved promises stay cached for the life of the app — content_hash
+// is content-addressed, so the path is permanently correct.
+const inFlight = new Map<string, Promise<string>>();
+
+/// Resolve an attachment to a local file URL the webview can render directly.
+///
+/// The Rust side decrypts to an on-disk content-addressed cache and returns
+/// the path; we wrap it with `convertFileSrc()` so it becomes an asset:// URL
+/// (or http://asset.localhost on Linux) that <img> / <video> can load without
+/// the JSON IPC ever touching the bytes.
+export async function getMediaPath(
+  r2Key: string,
+  contentHash: string,
+  contentType: string,
+): Promise<string> {
+  const cached = inFlight.get(contentHash);
+  if (cached) {
+    return cached;
+  }
+  const promise = (async () => {
+    const path = await invoke<string>('get_media_path', {
+      r2Key,
+      contentHash,
+      contentType,
+    });
+    return convertFileSrc(path);
+  })();
+  inFlight.set(contentHash, promise);
+  promise.catch(() => {
+    // On error, drop the cached rejection so the next caller retries.
+    inFlight.delete(contentHash);
+  });
+  return promise;
 }

--- a/frontend/src/services/r2-upload.ts
+++ b/frontend/src/services/r2-upload.ts
@@ -1,4 +1,4 @@
-import { invoke, convertFileSrc } from '@tauri-apps/api/core';
+import { invoke } from '@tauri-apps/api/core';
 import type { PresignedUploadResponse } from '../types';
 
 function sanitizeFilename(name: string): string {
@@ -104,12 +104,16 @@ export async function downloadAndDecryptMedia(
 // is content-addressed, so the path is permanently correct.
 const inFlight = new Map<string, Promise<string>>();
 
-/// Resolve an attachment to a local file URL the webview can render directly.
+/// Resolve an attachment to a URL the webview can render directly.
 ///
-/// The Rust side decrypts to an on-disk content-addressed cache and returns
-/// the path; we wrap it with `convertFileSrc()` so it becomes an asset:// URL
-/// (or http://asset.localhost on Linux) that <img> / <video> can load without
-/// the JSON IPC ever touching the bytes.
+/// The Rust side downloads + decrypts the attachment, then writes an
+/// AES-256-GCM ciphertext to the on-disk content-addressed cache. The
+/// returned URL uses the custom `pollis-media://` scheme; its protocol
+/// handler decrypts on demand so plaintext bytes never touch disk.
+///
+/// If the file is too large to cache (>100 MB) or the user is locked,
+/// `get_media_path` returns an empty string and we fall back to the byte
+/// path via `downloadAndDecryptMedia`, returning a blob: URL instead.
 export async function getMediaPath(
   r2Key: string,
   contentHash: string,
@@ -120,12 +124,17 @@ export async function getMediaPath(
     return cached;
   }
   const promise = (async () => {
-    const path = await invoke<string>('get_media_path', {
+    const url = await invoke<string>('get_media_path', {
       r2Key,
       contentHash,
       contentType,
     });
-    return convertFileSrc(path);
+    if (url) {
+      return url;
+    }
+    // Fallback: cache bypassed (oversize file or locked state). Pull the
+    // bytes through IPC for this one render.
+    return downloadAndDecryptMedia(r2Key, contentHash, contentType);
   })();
   inFlight.set(contentHash, promise);
   promise.catch(() => {

--- a/pollis-core/Cargo.toml
+++ b/pollis-core/Cargo.toml
@@ -63,6 +63,12 @@ image = { version = "0.25", default-features = false, features = ["jpeg", "png",
 blurhash = "0.2"
 futures-util = "0.3"
 bytes = "1"
+# Local-loopback HTTP server for serving cached media to the webview.
+# One URL pattern (`http://127.0.0.1:<port>/<token>/<hash>`) drives every
+# `<img>/<audio>/<video>` element — replaces the bifurcated asset:// (images)
+# / IPC-bytes-to-Blob-URL (audio/video) pair. Keeps decryption in Rust and
+# gives `<video>` real Range support without pumping bytes through JSON IPC.
+axum = "0.7"
 openmls = "0.8"
 openmls_traits = "0.5"
 openmls_rust_crypto = "0.5"

--- a/pollis-core/src/commands/auth.rs
+++ b/pollis-core/src/commands/auth.rs
@@ -699,11 +699,15 @@ pub async fn logout(state: &Arc<AppState>, delete_data: bool) -> Result<()> {
     state.unload_user_db().await;
     *state.unlock.lock().await = None;
 
-    // Wipe the on-disk media cache. The cache holds decrypted plaintext
-    // (image/video/audio bytes) and is not encrypted at rest, so it must
-    // not survive a session end regardless of whether the user opts to
-    // keep their account on this device.
+    // Wipe the on-disk media cache. Files are AES-GCM-encrypted under
+    // the active session's db_key, so they would already be opaque to
+    // any future user — but logout is the natural lifecycle boundary
+    // and an empty cache costs nothing.
     crate::commands::r2::clear_media_cache();
+
+    // Clear the media-server token. Any URL handed to the webview
+    // during this session 403s from here on.
+    *state.media_server_token.lock().await = None;
 
     if delete_data {
         if let Some(ref uid) = user_id {

--- a/pollis-core/src/commands/auth.rs
+++ b/pollis-core/src/commands/auth.rs
@@ -699,6 +699,12 @@ pub async fn logout(state: &Arc<AppState>, delete_data: bool) -> Result<()> {
     state.unload_user_db().await;
     *state.unlock.lock().await = None;
 
+    // Wipe the on-disk media cache. The cache holds decrypted plaintext
+    // (image/video/audio bytes) and is not encrypted at rest, so it must
+    // not survive a session end regardless of whether the user opts to
+    // keep their account on this device.
+    crate::commands::r2::clear_media_cache();
+
     if delete_data {
         if let Some(ref uid) = user_id {
             // Remove this device from the remote registry.

--- a/pollis-core/src/commands/pin.rs
+++ b/pollis-core/src/commands/pin.rs
@@ -417,6 +417,13 @@ pub async fn set_pin(
     // and are unreadable to us — purge them so they don't consume cap space.
     crate::commands::r2::clear_media_cache();
 
+    // Rotate the loopback media server token. Any URL the previous
+    // session handed out becomes invalid the moment the new token is
+    // installed, which is the behaviour we want when the active user
+    // changes.
+    *state.media_server_token.lock().await =
+        Some(crate::media_server::fresh_token());
+
     state.load_user_db_with_key(&user_id, &db_key).await?;
 
     if let Some(device_id) = state.device_id.lock().await.clone() {
@@ -498,6 +505,12 @@ pub async fn unlock(
 
     // Wipe the media cache on unlock — see equivalent comment in `set_pin`.
     crate::commands::r2::clear_media_cache();
+
+    // Rotate the loopback media server token so URLs minted under the
+    // pre-unlock (or previous-session) token stop working. See the
+    // matching site in `set_pin`.
+    *state.media_server_token.lock().await =
+        Some(crate::media_server::fresh_token());
 
     // Migrate away from #195-vintage residue — the wrapped blobs are
     // already in place; the legacy plaintext slots sitting next to
@@ -623,6 +636,10 @@ async fn unlock_inner(
 /// lock" primitive, not the "log out" one.
 pub async fn lock(state: &Arc<AppState>) -> Result<()> {
     *state.unlock.lock().await = None;
+    // Clear the media-server token so URLs the locked session minted
+    // stop resolving. The cache files stay (encrypted at rest) — a
+    // subsequent unlock under the same `db_key` can still read them.
+    *state.media_server_token.lock().await = None;
     state.unload_user_db().await;
     Ok(())
 }

--- a/pollis-core/src/commands/pin.rs
+++ b/pollis-core/src/commands/pin.rs
@@ -412,6 +412,11 @@ pub async fn set_pin(
         account_id_key,
     });
 
+    // Wipe the media cache on unlock. If a different user previously cached
+    // media on this device, their files were encrypted under their db_key
+    // and are unreadable to us — purge them so they don't consume cap space.
+    crate::commands::r2::clear_media_cache();
+
     state.load_user_db_with_key(&user_id, &db_key).await?;
 
     if let Some(device_id) = state.device_id.lock().await.clone() {
@@ -490,6 +495,9 @@ pub async fn unlock(
         db_key: unlocked.db_key,
         account_id_key: unlocked.account_id_key,
     });
+
+    // Wipe the media cache on unlock — see equivalent comment in `set_pin`.
+    crate::commands::r2::clear_media_cache();
 
     // Migrate away from #195-vintage residue — the wrapped blobs are
     // already in place; the legacy plaintext slots sitting next to

--- a/pollis-core/src/commands/r2.rs
+++ b/pollis-core/src/commands/r2.rs
@@ -120,6 +120,26 @@ fn enforce_cache_cap(dir: &Path) {
     }
 }
 
+/// Wipe every file in the media cache directory. Called on logout so
+/// decrypted images and other media don't sit on disk past a session end —
+/// the cache itself is plaintext at rest, so it must follow the same
+/// lifecycle as the keystore unlock. The directory itself stays so a
+/// subsequent re-login doesn't have to re-create it.
+pub fn clear_media_cache() {
+    let dir = match MEDIA_CACHE_DIR.get() {
+        Some(d) => d,
+        None => return,
+    };
+    let entries = match std::fs::read_dir(dir) {
+        Ok(rd) => rd,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let _ = std::fs::remove_file(&path);
+    }
+}
+
 // ── Existing commands (avatars, group icons) ───────────────────────────────
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/pollis-core/src/commands/r2.rs
+++ b/pollis-core/src/commands/r2.rs
@@ -1,9 +1,124 @@
 use serde::{Deserialize, Serialize};
 
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex as StdMutex, OnceLock};
 
 use crate::error::{Error, Result};
 use crate::state::AppState;
+
+// ── On-disk media cache ───────────────────────────────────────────────────
+//
+// Decrypted media is materialised under a content-addressed cache so the
+// frontend can render directly from a file path (via `convertFileSrc`) instead
+// of pumping multi-megabyte byte arrays through the JSON IPC. Keyed by
+// `content_hash`, which uniquely identifies the bytes (it's also the seed for
+// the AES-GCM key derivation), so there's no invalidation problem — if the
+// file exists, the bytes are correct.
+
+/// Hard cap on total cache size before LRU eviction kicks in.
+const MEDIA_CACHE_MAX_BYTES: u64 = 500 * 1024 * 1024;
+
+/// Set once at app startup from the Tauri shim (`app_data_dir()`).
+static MEDIA_CACHE_DIR: OnceLock<PathBuf> = OnceLock::new();
+
+/// Per-hash locks so concurrent callers for the same content_hash share one
+/// download instead of racing to write the same file. The outer mutex guards
+/// the map; the inner `Arc<TokioMutex>` is the actual gate.
+static IN_FLIGHT: OnceLock<StdMutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>> = OnceLock::new();
+
+fn in_flight() -> &'static StdMutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>> {
+    IN_FLIGHT.get_or_init(|| StdMutex::new(HashMap::new()))
+}
+
+/// Initialise the on-disk media cache directory. Must be called once during
+/// app setup (the Tauri shim plumbs in `app_data_dir().join("media-cache")`).
+/// Idempotent: subsequent calls are ignored.
+pub fn set_media_cache_dir(path: PathBuf) {
+    let _ = MEDIA_CACHE_DIR.set(path);
+}
+
+fn media_cache_dir() -> Result<&'static Path> {
+    MEDIA_CACHE_DIR
+        .get()
+        .map(|p| p.as_path())
+        .ok_or_else(|| Error::Other(anyhow::anyhow!("media cache dir not initialised")))
+}
+
+/// Map a MIME type to a file extension. Falls back to `bin`. Kept small —
+/// we only need extensions for the media types Pollis actually renders.
+fn ext_for_content_type(ct: &str) -> &'static str {
+    match ct {
+        "image/png" => "png",
+        "image/jpeg" => "jpg",
+        "image/gif" => "gif",
+        "image/webp" => "webp",
+        "image/avif" => "avif",
+        "image/svg+xml" => "svg",
+        "video/mp4" => "mp4",
+        "video/webm" => "webm",
+        "video/quicktime" => "mov",
+        "audio/mpeg" => "mp3",
+        "audio/mp4" | "audio/x-m4a" | "audio/m4a" => "m4a",
+        "audio/webm" => "weba",
+        "audio/ogg" => "ogg",
+        "audio/wav" | "audio/x-wav" => "wav",
+        "audio/flac" => "flac",
+        _ => "bin",
+    }
+}
+
+fn cache_file_path(content_hash: &str, content_type: &str) -> Result<PathBuf> {
+    let dir = media_cache_dir()?;
+    let ext = ext_for_content_type(content_type);
+    Ok(dir.join(format!("{content_hash}.{ext}")))
+}
+
+/// Stat every file in the cache; if total size exceeds the cap, delete by
+/// oldest mtime first until we're under. No in-memory index — directory is
+/// small enough that stat'ing it on each insert is fine.
+fn enforce_cache_cap(dir: &Path) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(rd) => rd,
+        Err(_) => return,
+    };
+
+    let mut files: Vec<(PathBuf, u64, std::time::SystemTime)> = Vec::new();
+    let mut total: u64 = 0;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        // Ignore in-progress writes.
+        if path.extension().is_some_and(|e| e == "tmp") {
+            continue;
+        }
+        let meta = match entry.metadata() {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        if !meta.is_file() {
+            continue;
+        }
+        let mtime = meta.modified().unwrap_or(std::time::UNIX_EPOCH);
+        let size = meta.len();
+        total += size;
+        files.push((path, size, mtime));
+    }
+
+    if total <= MEDIA_CACHE_MAX_BYTES {
+        return;
+    }
+
+    // Oldest first.
+    files.sort_by_key(|(_, _, mtime)| *mtime);
+    for (path, size, _) in files {
+        if total <= MEDIA_CACHE_MAX_BYTES {
+            break;
+        }
+        if std::fs::remove_file(&path).is_ok() {
+            total = total.saturating_sub(size);
+        }
+    }
+}
 
 // ── Existing commands (avatars, group icons) ───────────────────────────────
 
@@ -273,6 +388,81 @@ pub async fn download_media(
 
     let ciphertext = resp.bytes().await?.to_vec();
     decrypt_chunked(&ciphertext, &enc_key, &enc_nonce)
+}
+
+/// Return a filesystem path to the decrypted media bytes.
+///
+/// The frontend converts the path with `convertFileSrc()` and uses the result
+/// directly as `<img src>` / `<video src>`. This avoids serialising the raw
+/// bytes over the JSON IPC, which dominates render time for image-heavy
+/// channels.
+///
+/// Cached by `content_hash`. If a file already exists for this hash we return
+/// it immediately. Otherwise we download + decrypt, write atomically, then
+/// return the path. Concurrent calls for the same hash share one download
+/// via a per-hash tokio mutex.
+pub async fn get_media_path(
+    r2_key: String,
+    content_hash: String,
+    content_type: String,
+    state: &Arc<AppState>,
+) -> Result<String> {
+    let target = cache_file_path(&content_hash, &content_type)?;
+
+    // Fast path: already cached. Touch mtime so the LRU sees it as fresh.
+    if target.exists() {
+        if let Ok(f) = std::fs::OpenOptions::new().write(true).open(&target) {
+            let _ = f.set_modified(std::time::SystemTime::now());
+        }
+        return Ok(target.to_string_lossy().into_owned());
+    }
+
+    // Acquire a per-hash lock so the second waiter sees the file on disk
+    // instead of starting a redundant download.
+    let lock = {
+        let mut map = in_flight().lock().expect("in-flight map poisoned");
+        map.entry(content_hash.clone())
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+            .clone()
+    };
+    let _guard = lock.lock().await;
+
+    // Recheck under the lock — another caller may have just finished.
+    if target.exists() {
+        // Drop our entry from the in-flight map.
+        in_flight().lock().expect("in-flight map poisoned").remove(&content_hash);
+        return Ok(target.to_string_lossy().into_owned());
+    }
+
+    let bytes = download_media(r2_key, content_hash.clone(), state).await?;
+
+    // Atomic write: <hash>.<ext>.tmp → rename → <hash>.<ext>.
+    let dir = media_cache_dir()?;
+    if let Err(e) = std::fs::create_dir_all(dir) {
+        in_flight().lock().expect("in-flight map poisoned").remove(&content_hash);
+        return Err(Error::Other(anyhow::anyhow!("create cache dir: {e}")));
+    }
+    let mut tmp = target.clone();
+    tmp.set_extension(format!(
+        "{}.tmp",
+        target.extension().and_then(|s| s.to_str()).unwrap_or("bin")
+    ));
+    if let Err(e) = tokio::fs::write(&tmp, &bytes).await {
+        let _ = tokio::fs::remove_file(&tmp).await;
+        in_flight().lock().expect("in-flight map poisoned").remove(&content_hash);
+        return Err(Error::Other(anyhow::anyhow!("write cache tmp: {e}")));
+    }
+    if let Err(e) = tokio::fs::rename(&tmp, &target).await {
+        let _ = tokio::fs::remove_file(&tmp).await;
+        in_flight().lock().expect("in-flight map poisoned").remove(&content_hash);
+        return Err(Error::Other(anyhow::anyhow!("rename cache tmp: {e}")));
+    }
+
+    // Best-effort LRU eviction. Run after rename so the new file participates.
+    enforce_cache_cap(dir);
+
+    in_flight().lock().expect("in-flight map poisoned").remove(&content_hash);
+    Ok(target.to_string_lossy().into_owned())
 }
 
 // ── Deletion ──────────────────────────────────────────────────────────────

--- a/pollis-core/src/commands/r2.rs
+++ b/pollis-core/src/commands/r2.rs
@@ -19,6 +19,12 @@ use crate::state::AppState;
 /// Hard cap on total cache size before LRU eviction kicks in.
 const MEDIA_CACHE_MAX_BYTES: u64 = 500 * 1024 * 1024;
 
+/// Per-file cap. Files larger than this skip the cache entirely — the
+/// caller falls back to the byte path for that one render. Bounds the
+/// worst-case eviction storm where a single huge file would push every
+/// other entry out.
+pub const MEDIA_CACHE_MAX_FILE_BYTES: u64 = 100 * 1024 * 1024;
+
 /// Set once at app startup from the Tauri shim (`app_data_dir()`).
 static MEDIA_CACHE_DIR: OnceLock<PathBuf> = OnceLock::new();
 
@@ -78,6 +84,13 @@ fn cache_file_path(content_hash: &str, content_type: &str) -> Result<PathBuf> {
 /// oldest mtime first until we're under. No in-memory index — directory is
 /// small enough that stat'ing it on each insert is fine.
 fn enforce_cache_cap(dir: &Path) {
+    enforce_cache_cap_to(dir, MEDIA_CACHE_MAX_BYTES);
+}
+
+/// Lower-bound variant: shrink the cache to at most `target_bytes` by
+/// evicting oldest entries first. Used both by the regular cap-enforcer
+/// and by the pre-write headroom check in `get_media_path`.
+fn enforce_cache_cap_to(dir: &Path, target_bytes: u64) {
     let entries = match std::fs::read_dir(dir) {
         Ok(rd) => rd,
         Err(_) => return,
@@ -104,20 +117,50 @@ fn enforce_cache_cap(dir: &Path) {
         files.push((path, size, mtime));
     }
 
-    if total <= MEDIA_CACHE_MAX_BYTES {
+    if total <= target_bytes {
         return;
     }
 
     // Oldest first.
     files.sort_by_key(|(_, _, mtime)| *mtime);
     for (path, size, _) in files {
-        if total <= MEDIA_CACHE_MAX_BYTES {
+        if total <= target_bytes {
             break;
         }
         if std::fs::remove_file(&path).is_ok() {
             total = total.saturating_sub(size);
         }
     }
+}
+
+/// Public re-evaluation entry point — call from app focus to defend
+/// against external file copies / mtime tampering / cap-config changes.
+pub fn enforce_cache_cap_now() {
+    if let Some(dir) = MEDIA_CACHE_DIR.get() {
+        enforce_cache_cap(dir);
+    }
+}
+
+/// Sum of all cached file sizes. Used to gate downloads against the cap
+/// *before* writing new bytes, so the cache never peaks above the cap.
+pub fn cache_total_bytes() -> u64 {
+    let dir = match MEDIA_CACHE_DIR.get() {
+        Some(d) => d,
+        None => return 0,
+    };
+    let entries = match std::fs::read_dir(dir) {
+        Ok(rd) => rd,
+        Err(_) => return 0,
+    };
+    let mut total: u64 = 0;
+    for entry in entries.flatten() {
+        if let Ok(meta) = entry.metadata() {
+            if meta.is_file() {
+                total += meta.len();
+            }
+        }
+    }
+    total
 }
 
 /// Wipe every file in the media cache directory. Called on logout so
@@ -456,12 +499,31 @@ pub async fn get_media_path(
 
     let bytes = download_media(r2_key, content_hash.clone(), state).await?;
 
+    // Per-file cap. Files larger than MEDIA_CACHE_MAX_FILE_BYTES skip the
+    // cache entirely so a single huge upload can't push everything else
+    // out. The frontend falls back to the byte path on the empty sentinel.
+    if bytes.len() as u64 > MEDIA_CACHE_MAX_FILE_BYTES {
+        in_flight().lock().expect("in-flight map poisoned").remove(&content_hash);
+        return Ok(String::new());
+    }
+
     // Atomic write: <hash>.<ext>.tmp → rename → <hash>.<ext>.
     let dir = media_cache_dir()?;
     if let Err(e) = std::fs::create_dir_all(dir) {
         in_flight().lock().expect("in-flight map poisoned").remove(&content_hash);
         return Err(Error::Other(anyhow::anyhow!("create cache dir: {e}")));
     }
+
+    // Pre-emptive eviction: if the new file would push us over the cap,
+    // evict oldest entries down to (cap - new_file_size) *before* writing.
+    // Without this the cache temporarily peaks above the cap during a
+    // large download.
+    let new_size = bytes.len() as u64;
+    let total = cache_total_bytes();
+    if total.saturating_add(new_size) > MEDIA_CACHE_MAX_BYTES {
+        enforce_cache_cap_to(dir, MEDIA_CACHE_MAX_BYTES.saturating_sub(new_size));
+    }
+
     let mut tmp = target.clone();
     tmp.set_extension(format!(
         "{}.tmp",
@@ -478,7 +540,8 @@ pub async fn get_media_path(
         return Err(Error::Other(anyhow::anyhow!("rename cache tmp: {e}")));
     }
 
-    // Best-effort LRU eviction. Run after rename so the new file participates.
+    // Belt-and-braces post-write enforcement in case the pre-emptive
+    // estimate was off (concurrent inserts, mtime races).
     enforce_cache_cap(dir);
 
     in_flight().lock().expect("in-flight map poisoned").remove(&content_hash);

--- a/pollis-core/src/commands/r2.rs
+++ b/pollis-core/src/commands/r2.rs
@@ -608,10 +608,13 @@ pub async fn get_media_path(
 
     let target = cache_file_path(&content_hash, &content_type)?;
     let ext = ext_for_content_type(&content_type);
-    // Linux WebKitGTK rewrites custom schemes to `http://<scheme>.localhost/`,
-    // every other platform uses the native `<scheme>://localhost/` form.
-    // Match Tauri's own convention so `<img>` / `<audio>` resolve correctly.
-    let media_uri = if cfg!(target_os = "linux") || cfg!(target_os = "windows") {
+    // Tauri rewrites custom URI schemes to `http://<scheme>.localhost/` on
+    // Windows / Android (WebView2 / system WebView don't support arbitrary
+    // schemes). macOS and Linux/WebKitGTK use the native `<scheme>://`
+    // form — registering the handler creates a real custom protocol there.
+    // Hitting the http://...localhost form on Linux just makes WebKit try
+    // a real TCP connection and refuse, which is exactly the bug we hit.
+    let media_uri = if cfg!(target_os = "windows") || cfg!(target_os = "android") {
         format!("http://pollis-media.localhost/{content_hash}.{ext}")
     } else {
         format!("pollis-media://localhost/{content_hash}.{ext}")

--- a/pollis-core/src/commands/r2.rs
+++ b/pollis-core/src/commands/r2.rs
@@ -9,12 +9,18 @@ use crate::state::AppState;
 
 // ── On-disk media cache ───────────────────────────────────────────────────
 //
-// Decrypted media is materialised under a content-addressed cache so the
-// frontend can render directly from a file path (via `convertFileSrc`) instead
-// of pumping multi-megabyte byte arrays through the JSON IPC. Keyed by
-// `content_hash`, which uniquely identifies the bytes (it's also the seed for
-// the AES-GCM key derivation), so there's no invalidation problem — if the
-// file exists, the bytes are correct.
+// Media is materialised on disk **encrypted at rest** under a content-
+// addressed cache (`<hash>.<ext>.enc`). The frontend never reads these
+// files directly — instead it embeds `http://127.0.0.1:<port>/<token>/<hash>`
+// URLs and the loopback media server (`crate::media_server`) decrypts on
+// demand. One URL pattern across `<img>/<audio>/<video>` and bytes never
+// touch the JSON IPC.
+//
+// Per-file key derivation: HKDF-SHA256(salt = `pollis-media-cache-v1`,
+// ikm = `db_key`, info = content_hash bytes). Different salt from the
+// upload-side convergent key (`pollis-att-key`) so the two domains are
+// cryptographically separated even though both are seeded from the same
+// content hash.
 
 /// Hard cap on total cache size before LRU eviction kicks in.
 const MEDIA_CACHE_MAX_BYTES: u64 = 500 * 1024 * 1024;
@@ -77,7 +83,57 @@ fn ext_for_content_type(ct: &str) -> &'static str {
 fn cache_file_path(content_hash: &str, content_type: &str) -> Result<PathBuf> {
     let dir = media_cache_dir()?;
     let ext = ext_for_content_type(content_type);
-    Ok(dir.join(format!("{content_hash}.{ext}")))
+    Ok(dir.join(format!("{content_hash}.{ext}.enc")))
+}
+
+/// Map a file extension back to a Content-Type for the HTTP server's
+/// response headers. Inverse of `ext_for_content_type`. Mismatches (e.g.
+/// the cache was populated under one MIME and the request supplies
+/// another) fall back to `application/octet-stream`; the browser
+/// usually sniffs anyway.
+pub fn content_type_for_ext(ext: &str) -> &'static str {
+    match ext {
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "gif" => "image/gif",
+        "webp" => "image/webp",
+        "avif" => "image/avif",
+        "svg" => "image/svg+xml",
+        "mp4" => "video/mp4",
+        "webm" => "video/webm",
+        "mov" => "video/quicktime",
+        "mp3" => "audio/mpeg",
+        "m4a" => "audio/mp4",
+        "weba" => "audio/webm",
+        "ogg" => "audio/ogg",
+        "wav" => "audio/wav",
+        "flac" => "audio/flac",
+        _ => "application/octet-stream",
+    }
+}
+
+/// Locate the encrypted cache file for a given content hash. Returns the
+/// path and the inner extension (between `<hash>.` and `.enc`) so the
+/// caller can derive a Content-Type. `None` if no file with this hash
+/// exists in the cache.
+pub fn find_cached_file(content_hash: &str) -> Option<(PathBuf, String)> {
+    let dir = MEDIA_CACHE_DIR.get()?;
+    let entries = std::fs::read_dir(dir).ok()?;
+    let prefix = format!("{content_hash}.");
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = match path.file_name().and_then(|s| s.to_str()).map(str::to_string) {
+            Some(n) => n,
+            None => continue,
+        };
+        if !name.starts_with(&prefix) || !name.ends_with(".enc") {
+            continue;
+        }
+        // Strip prefix + trailing `.enc` to get the inner extension.
+        let inner = name[prefix.len()..name.len() - ".enc".len()].to_string();
+        return Some((path, inner));
+    }
+    None
 }
 
 /// Stat every file in the cache; if total size exceeds the cap, delete by
@@ -89,7 +145,7 @@ fn enforce_cache_cap(dir: &Path) {
 
 /// Lower-bound variant: shrink the cache to at most `target_bytes` by
 /// evicting oldest entries first. Used both by the regular cap-enforcer
-/// and by the pre-write headroom check in `get_media_path`.
+/// and by the pre-write headroom check in `get_media_url`.
 fn enforce_cache_cap_to(dir: &Path, target_bytes: u64) {
     let entries = match std::fs::read_dir(dir) {
         Ok(rd) => rd,
@@ -453,23 +509,39 @@ pub async fn download_media(
     decrypt_chunked(&ciphertext, &enc_key, &enc_nonce)
 }
 
-/// Return a filesystem path to the decrypted media bytes.
+/// Resolve a media attachment to a loopback HTTP URL the webview can use
+/// directly as `<img src>` / `<audio src>` / `<video src>`.
 ///
-/// The frontend converts the path with `convertFileSrc()` and uses the result
-/// directly as `<img src>` / `<video src>`. This avoids serialising the raw
-/// bytes over the JSON IPC, which dominates render time for image-heavy
-/// channels.
+/// Caches the decrypted-then-cache-encrypted bytes on disk under a
+/// content-addressed name so subsequent calls hit the local server
+/// without touching R2 again. Bytes never cross the JSON IPC.
 ///
-/// Cached by `content_hash`. If a file already exists for this hash we return
-/// it immediately. Otherwise we download + decrypt, write atomically, then
-/// return the path. Concurrent calls for the same hash share one download
-/// via a per-hash tokio mutex.
-pub async fn get_media_path(
+/// Returns `""` (empty string sentinel) for files larger than
+/// `MEDIA_CACHE_MAX_FILE_BYTES`. The frontend falls back to the byte
+/// path (`download_media` → in-memory Blob URL) for that one render so
+/// a single huge upload can't push everything else out of the cache.
+pub async fn get_media_url(
     r2_key: String,
     content_hash: String,
     content_type: String,
     state: &Arc<AppState>,
 ) -> Result<String> {
+    // Build the URL from the server port + token. Both must be present
+    // — without an active unlock the server returns 403 anyway, so
+    // there's no point handing out a URL the caller can't use.
+    let port = state
+        .media_server_port
+        .lock()
+        .await
+        .ok_or_else(|| Error::Other(anyhow::anyhow!("media server not started")))?;
+    let token = state
+        .media_server_token
+        .lock()
+        .await
+        .clone()
+        .ok_or_else(|| Error::Other(anyhow::anyhow!("media server token not set; not unlocked")))?;
+    let url = format!("http://127.0.0.1:{port}/{token}/{content_hash}");
+
     let target = cache_file_path(&content_hash, &content_type)?;
 
     // Fast path: already cached. Touch mtime so the LRU sees it as fresh.
@@ -477,11 +549,11 @@ pub async fn get_media_path(
         if let Ok(f) = std::fs::OpenOptions::new().write(true).open(&target) {
             let _ = f.set_modified(std::time::SystemTime::now());
         }
-        return Ok(target.to_string_lossy().into_owned());
+        return Ok(url);
     }
 
-    // Acquire a per-hash lock so the second waiter sees the file on disk
-    // instead of starting a redundant download.
+    // Per-hash lock so the second waiter sees the file on disk instead
+    // of starting a redundant download.
     let lock = {
         let mut map = in_flight().lock().expect("in-flight map poisoned");
         map.entry(content_hash.clone())
@@ -490,46 +562,65 @@ pub async fn get_media_path(
     };
     let _guard = lock.lock().await;
 
-    // Recheck under the lock — another caller may have just finished.
     if target.exists() {
-        // Drop our entry from the in-flight map.
         in_flight().lock().expect("in-flight map poisoned").remove(&content_hash);
-        return Ok(target.to_string_lossy().into_owned());
+        return Ok(url);
     }
 
     let bytes = download_media(r2_key, content_hash.clone(), state).await?;
 
-    // Per-file cap. Files larger than MEDIA_CACHE_MAX_FILE_BYTES skip the
-    // cache entirely so a single huge upload can't push everything else
-    // out. The frontend falls back to the byte path on the empty sentinel.
+    // Per-file cap. Files larger than MEDIA_CACHE_MAX_FILE_BYTES skip
+    // the cache entirely. Empty-string sentinel tells the frontend to
+    // fall back to the byte path which produces an in-memory blob URL.
     if bytes.len() as u64 > MEDIA_CACHE_MAX_FILE_BYTES {
         in_flight().lock().expect("in-flight map poisoned").remove(&content_hash);
         return Ok(String::new());
     }
 
-    // Atomic write: <hash>.<ext>.tmp → rename → <hash>.<ext>.
     let dir = media_cache_dir()?;
     if let Err(e) = std::fs::create_dir_all(dir) {
         in_flight().lock().expect("in-flight map poisoned").remove(&content_hash);
         return Err(Error::Other(anyhow::anyhow!("create cache dir: {e}")));
     }
 
-    // Pre-emptive eviction: if the new file would push us over the cap,
-    // evict oldest entries down to (cap - new_file_size) *before* writing.
-    // Without this the cache temporarily peaks above the cap during a
-    // large download.
-    let new_size = bytes.len() as u64;
+    // Encrypt before writing. Per-file random nonce + AES-256-GCM under
+    // a key derived from `db_key` and the content hash.
+    let db_key = {
+        let guard = state.unlock.lock().await;
+        match guard.as_ref() {
+            Some(u) => u.db_key.to_vec(),
+            None => {
+                in_flight().lock().expect("in-flight map poisoned").remove(&content_hash);
+                return Err(Error::Other(anyhow::anyhow!(
+                    "cannot cache media without an active unlock"
+                )));
+            }
+        }
+    };
+    let encrypted = match cache_encrypt(&bytes, &db_key, content_hash.as_bytes()) {
+        Ok(c) => c,
+        Err(e) => {
+            in_flight().lock().expect("in-flight map poisoned").remove(&content_hash);
+            return Err(e);
+        }
+    };
+
+    // Pre-emptive eviction: shrink the cache to (cap - new_file_size)
+    // before writing so we never temporarily peak above the cap.
+    let new_size = encrypted.len() as u64;
     let total = cache_total_bytes();
     if total.saturating_add(new_size) > MEDIA_CACHE_MAX_BYTES {
         enforce_cache_cap_to(dir, MEDIA_CACHE_MAX_BYTES.saturating_sub(new_size));
     }
 
+    // Atomic write: <hash>.<ext>.enc.tmp → rename → <hash>.<ext>.enc.
     let mut tmp = target.clone();
-    tmp.set_extension(format!(
-        "{}.tmp",
-        target.extension().and_then(|s| s.to_str()).unwrap_or("bin")
-    ));
-    if let Err(e) = tokio::fs::write(&tmp, &bytes).await {
+    let final_ext = target
+        .extension()
+        .and_then(|s| s.to_str())
+        .unwrap_or("enc");
+    tmp.set_extension(format!("{final_ext}.tmp"));
+    if let Err(e) = tokio::fs::write(&tmp, &encrypted).await {
         let _ = tokio::fs::remove_file(&tmp).await;
         in_flight().lock().expect("in-flight map poisoned").remove(&content_hash);
         return Err(Error::Other(anyhow::anyhow!("write cache tmp: {e}")));
@@ -540,12 +631,73 @@ pub async fn get_media_path(
         return Err(Error::Other(anyhow::anyhow!("rename cache tmp: {e}")));
     }
 
-    // Belt-and-braces post-write enforcement in case the pre-emptive
-    // estimate was off (concurrent inserts, mtime races).
     enforce_cache_cap(dir);
 
     in_flight().lock().expect("in-flight map poisoned").remove(&content_hash);
-    Ok(target.to_string_lossy().into_owned())
+    Ok(url)
+}
+
+// ── Cache-at-rest crypto ──────────────────────────────────────────────────
+//
+// Files in `media-cache/` are AES-256-GCM-encrypted under a key derived
+// from the active session's `db_key` plus the content hash. Layout:
+//
+//   [12-byte random nonce][AES-256-GCM(plaintext)][16-byte tag]
+//
+// Per-file random nonce — the server reads the whole file and decrypts
+// in one shot before serving (no streaming AEAD). Total file size is
+// bounded by `MEDIA_CACHE_MAX_FILE_BYTES` (100 MiB), well below the
+// AES-GCM 64-GiB-per-key safety bound.
+//
+// Salt domain (`pollis-media-cache-v1`) separates this from the
+// upload-side convergent key derivation so a server compromise that
+// leaks one key class can't be replayed against the other.
+
+const CACHE_HKDF_SALT: &[u8] = b"pollis-media-cache-v1";
+const CACHE_NONCE_LEN: usize = 12;
+
+/// Derive the per-file AES-256-GCM key for cache encryption.
+fn derive_cache_key(db_key: &[u8], info: &[u8]) -> [u8; 32] {
+    use hkdf::Hkdf;
+    use sha2::Sha256;
+    let hk = Hkdf::<Sha256>::new(Some(CACHE_HKDF_SALT), db_key);
+    let mut key = [0u8; 32];
+    hk.expand(info, &mut key)
+        .expect("HKDF expand for cache key should never fail");
+    key
+}
+
+/// Encrypt cache bytes. Output layout: `[12-byte nonce][ciphertext+tag]`.
+pub fn cache_encrypt(plaintext: &[u8], db_key: &[u8], info: &[u8]) -> Result<Vec<u8>> {
+    use aes_gcm::{aead::{Aead, KeyInit}, Aes256Gcm, Key, Nonce};
+    use rand::RngCore;
+
+    let key = derive_cache_key(db_key, info);
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(&key));
+    let mut nonce_bytes = [0u8; CACHE_NONCE_LEN];
+    rand::rngs::OsRng.fill_bytes(&mut nonce_bytes);
+    let ct = cipher
+        .encrypt(Nonce::from_slice(&nonce_bytes), plaintext)
+        .map_err(|_| Error::Other(anyhow::anyhow!("media cache encrypt failed")))?;
+    let mut out = Vec::with_capacity(CACHE_NONCE_LEN + ct.len());
+    out.extend_from_slice(&nonce_bytes);
+    out.extend_from_slice(&ct);
+    Ok(out)
+}
+
+/// Decrypt a cache file produced by `cache_encrypt`.
+pub fn cache_decrypt(file_bytes: &[u8], db_key: &[u8], info: &[u8]) -> Result<Vec<u8>> {
+    use aes_gcm::{aead::{Aead, KeyInit}, Aes256Gcm, Key, Nonce};
+
+    if file_bytes.len() < CACHE_NONCE_LEN + 16 {
+        return Err(Error::Other(anyhow::anyhow!("media cache file too short")));
+    }
+    let (nonce_bytes, ct) = file_bytes.split_at(CACHE_NONCE_LEN);
+    let key = derive_cache_key(db_key, info);
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(&key));
+    cipher
+        .decrypt(Nonce::from_slice(nonce_bytes), ct)
+        .map_err(|_| Error::Other(anyhow::anyhow!("media cache decrypt failed")))
 }
 
 // ── Deletion ──────────────────────────────────────────────────────────────

--- a/pollis-core/src/commands/r2.rs
+++ b/pollis-core/src/commands/r2.rs
@@ -9,15 +9,33 @@ use crate::state::AppState;
 
 // ── On-disk media cache ───────────────────────────────────────────────────
 //
-// Decrypted media is materialised under a content-addressed cache so the
-// frontend can render directly from a file path (via `convertFileSrc`) instead
-// of pumping multi-megabyte byte arrays through the JSON IPC. Keyed by
-// `content_hash`, which uniquely identifies the bytes (it's also the seed for
-// the AES-GCM key derivation), so there's no invalidation problem — if the
-// file exists, the bytes are correct.
+// Encrypted-at-rest content-addressed cache. Each file is stored on disk as
+// `<content_hash>.<ext>.enc` with layout `[12-byte nonce][ciphertext][16-byte
+// AEAD tag]` under AES-256-GCM. The per-file key is derived via HKDF-SHA256
+// from the user's `db_key` (the same root secret that protects the local
+// SQLCipher DB), so leftover files from a previous user are unreadable to a
+// fresh login. The frontend reads bytes via the `pollis-media://` Tauri URI
+// scheme — decryption happens in-memory in the protocol handler and the
+// plaintext never lands on disk.
 
 /// Hard cap on total cache size before LRU eviction kicks in.
-const MEDIA_CACHE_MAX_BYTES: u64 = 500 * 1024 * 1024;
+pub const MEDIA_CACHE_MAX_BYTES: u64 = 500 * 1024 * 1024;
+
+/// Hard cap on a single cached file's plaintext size. Anything larger
+/// bypasses the cache and uses the byte-returning `download_media` path.
+pub const MEDIA_CACHE_MAX_FILE_BYTES: u64 = 100 * 1024 * 1024;
+
+/// Sentinel returned from `get_media_path` when a file is too large to
+/// cache. The frontend treats this as "use the byte-fetch fallback for
+/// this one render."
+pub const MEDIA_CACHE_FALLBACK_SENTINEL: &str = "";
+
+/// HKDF salt for media-cache file keys. Domain-separates the cache from
+/// the SQLCipher key and the convergent attachment-key derivation.
+const MEDIA_CACHE_HKDF_SALT: &[u8] = b"pollis-media-cache-v1";
+
+/// AES-GCM nonce length.
+const NONCE_LEN: usize = 12;
 
 /// Set once at app startup from the Tauri shim (`app_data_dir()`).
 static MEDIA_CACHE_DIR: OnceLock<PathBuf> = OnceLock::new();
@@ -68,16 +86,168 @@ fn ext_for_content_type(ct: &str) -> &'static str {
     }
 }
 
+/// Map an extension back to a content-type for the protocol handler.
+/// Mirrors `ext_for_content_type`; falls back to `application/octet-stream`.
+fn content_type_for_ext(ext: &str) -> &'static str {
+    match ext {
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "gif" => "image/gif",
+        "webp" => "image/webp",
+        "avif" => "image/avif",
+        "svg" => "image/svg+xml",
+        "mp4" => "video/mp4",
+        "webm" => "video/webm",
+        "mov" => "video/quicktime",
+        "mp3" => "audio/mpeg",
+        "m4a" => "audio/mp4",
+        "weba" => "audio/webm",
+        "ogg" => "audio/ogg",
+        "wav" => "audio/wav",
+        "flac" => "audio/flac",
+        _ => "application/octet-stream",
+    }
+}
+
+/// Path to the encrypted cache file. Filename embeds the original extension
+/// so the protocol handler can recover the content-type without a sidecar:
+/// `<hash>.<ext>.enc`.
 fn cache_file_path(content_hash: &str, content_type: &str) -> Result<PathBuf> {
     let dir = media_cache_dir()?;
     let ext = ext_for_content_type(content_type);
-    Ok(dir.join(format!("{content_hash}.{ext}")))
+    Ok(dir.join(format!("{content_hash}.{ext}.enc")))
+}
+
+/// Derive a per-file AES-256-GCM key from the user's root `db_key` via
+/// HKDF-SHA256. `info` is the content_hash bytes so each cached file gets
+/// a unique key — an attacker who recovers one file's key can't reuse it
+/// against another file in the cache.
+fn derive_cache_key(db_key: &[u8], content_hash_hex: &str) -> [u8; 32] {
+    use hkdf::Hkdf;
+    use sha2::Sha256;
+    let hk = Hkdf::<Sha256>::new(Some(MEDIA_CACHE_HKDF_SALT), db_key);
+    let mut key = [0u8; 32];
+    hk.expand(content_hash_hex.as_bytes(), &mut key)
+        .expect("HKDF expand for media-cache key should never fail");
+    key
+}
+
+/// Encrypt plaintext for on-disk storage. Output: `[12-byte nonce][ciphertext+tag]`.
+/// Random per-file nonce — no nonce reuse risk because each call generates fresh.
+fn cache_encrypt(plaintext: &[u8], key: &[u8; 32]) -> Result<Vec<u8>> {
+    use aes_gcm::{aead::{Aead, KeyInit}, Aes256Gcm, Key, Nonce};
+    use rand::RngCore;
+
+    let mut nonce_bytes = [0u8; NONCE_LEN];
+    rand::rngs::OsRng.fill_bytes(&mut nonce_bytes);
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(key));
+    let ct = cipher.encrypt(Nonce::from_slice(&nonce_bytes), plaintext)
+        .map_err(|e| Error::Crypto(format!("media-cache encrypt: {e}")))?;
+    let mut out = Vec::with_capacity(NONCE_LEN + ct.len());
+    out.extend_from_slice(&nonce_bytes);
+    out.extend_from_slice(&ct);
+    Ok(out)
+}
+
+/// Decrypt the contents of a cached file produced by `cache_encrypt`.
+fn cache_decrypt(file_bytes: &[u8], key: &[u8; 32]) -> Result<Vec<u8>> {
+    use aes_gcm::{aead::{Aead, KeyInit}, Aes256Gcm, Key, Nonce};
+    if file_bytes.len() < NONCE_LEN + 16 {
+        return Err(Error::Other(anyhow::anyhow!("media-cache file truncated")));
+    }
+    let (nonce_bytes, ct) = file_bytes.split_at(NONCE_LEN);
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(key));
+    cipher.decrypt(Nonce::from_slice(nonce_bytes), ct)
+        .map_err(|_| Error::Other(anyhow::anyhow!("media-cache decrypt failed")))
+}
+
+/// Sum the size of every regular file in the cache. Used to gate downloads
+/// against the cap *before* the new file is written, so the cache never
+/// peaks above the cap during a large download.
+pub fn cache_total_bytes() -> u64 {
+    let dir = match MEDIA_CACHE_DIR.get() {
+        Some(d) => d,
+        None => return 0,
+    };
+    let entries = match std::fs::read_dir(dir) {
+        Ok(rd) => rd,
+        Err(_) => return 0,
+    };
+    let mut total: u64 = 0;
+    for entry in entries.flatten() {
+        if let Ok(meta) = entry.metadata() {
+            if meta.is_file() {
+                total += meta.len();
+            }
+        }
+    }
+    total
+}
+
+/// Locate a cached encrypted file by content_hash. The extension between
+/// `<hash>` and `.enc` is whatever the original upload used, so we scan
+/// the directory by prefix. Returns `(path, ext)` where `ext` is the
+/// original content extension (e.g. `"mp4"`).
+pub fn find_cached_file(content_hash: &str) -> Option<(PathBuf, String)> {
+    let dir = MEDIA_CACHE_DIR.get()?;
+    let entries = std::fs::read_dir(dir).ok()?;
+    let prefix = format!("{content_hash}.");
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if !name.starts_with(&prefix) || !name.ends_with(".enc") {
+            continue;
+        }
+        // Strip "<hash>." prefix and ".enc" suffix, leaving the ext.
+        let middle = &name[prefix.len()..name.len() - 4];
+        if middle.is_empty() || middle.contains('.') {
+            // Defensive: skip filenames we don't recognise.
+            continue;
+        }
+        return Some((entry.path(), middle.to_string()));
+    }
+    None
+}
+
+/// Decrypt the cached file for `content_hash` using the supplied root
+/// `db_key`. Returns `(plaintext_bytes, content_type)` or `None` if no
+/// cached file exists. Errors propagate so the caller can distinguish
+/// "missing" from "key mismatch / corruption."
+pub fn decrypt_cached_file(content_hash: &str, db_key: &[u8]) -> Result<Option<(Vec<u8>, String)>> {
+    let (path, ext) = match find_cached_file(content_hash) {
+        Some(x) => x,
+        None => return Ok(None),
+    };
+    let file_bytes = std::fs::read(&path)
+        .map_err(|e| Error::Other(anyhow::anyhow!("read cache file: {e}")))?;
+    let key = derive_cache_key(db_key, content_hash);
+    let plaintext = cache_decrypt(&file_bytes, &key)?;
+    // Touch mtime so LRU sees this as fresh.
+    if let Ok(f) = std::fs::OpenOptions::new().write(true).open(&path) {
+        let _ = f.set_modified(std::time::SystemTime::now());
+    }
+    Ok(Some((plaintext, content_type_for_ext(&ext).to_string())))
 }
 
 /// Stat every file in the cache; if total size exceeds the cap, delete by
 /// oldest mtime first until we're under. No in-memory index — directory is
 /// small enough that stat'ing it on each insert is fine.
 fn enforce_cache_cap(dir: &Path) {
+    enforce_cache_cap_to(dir, MEDIA_CACHE_MAX_BYTES);
+}
+
+/// Public re-evaluation entry point — call from app focus / periodic timer
+/// to defend against cache-dir tampering or external file additions.
+pub fn enforce_cache_cap_now() {
+    if let Some(dir) = MEDIA_CACHE_DIR.get() {
+        enforce_cache_cap(dir);
+    }
+}
+
+/// Lower-bound variant: shrink the cache to at most `target_bytes` by
+/// evicting oldest entries first. Used both by the regular cap-enforcer
+/// and by the pre-write headroom check in `get_media_path`.
+fn enforce_cache_cap_to(dir: &Path, target_bytes: u64) {
     let entries = match std::fs::read_dir(dir) {
         Ok(rd) => rd,
         Err(_) => return,
@@ -104,14 +274,14 @@ fn enforce_cache_cap(dir: &Path) {
         files.push((path, size, mtime));
     }
 
-    if total <= MEDIA_CACHE_MAX_BYTES {
+    if total <= target_bytes {
         return;
     }
 
     // Oldest first.
     files.sort_by_key(|(_, _, mtime)| *mtime);
     for (path, size, _) in files {
-        if total <= MEDIA_CACHE_MAX_BYTES {
+        if total <= target_bytes {
             break;
         }
         if std::fs::remove_file(&path).is_ok() {
@@ -120,11 +290,12 @@ fn enforce_cache_cap(dir: &Path) {
     }
 }
 
-/// Wipe every file in the media cache directory. Called on logout so
-/// decrypted images and other media don't sit on disk past a session end —
-/// the cache itself is plaintext at rest, so it must follow the same
-/// lifecycle as the keystore unlock. The directory itself stays so a
-/// subsequent re-login doesn't have to re-create it.
+/// Wipe every file in the media cache directory. Called on logout *and*
+/// at unlock time. Even though the cache is now encrypted at rest, an
+/// incoming user can't decrypt the previous user's files (different
+/// `db_key` → different HKDF output), so leftover files are dead weight
+/// that just consume the cap. The directory itself stays so a subsequent
+/// re-login doesn't have to re-create it.
 pub fn clear_media_cache() {
     let dir = match MEDIA_CACHE_DIR.get() {
         Some(d) => d,
@@ -427,14 +598,31 @@ pub async fn get_media_path(
     content_type: String,
     state: &Arc<AppState>,
 ) -> Result<String> {
+    // The cache is encrypted under the user's `db_key`, so it can only be
+    // populated when the user is unlocked. If they're locked, fall back to
+    // the byte path so the call site can still render via `download_media`.
+    let db_key: Vec<u8> = match state.unlock.lock().await.as_ref() {
+        Some(u) => u.db_key.to_vec(),
+        None => return Ok(MEDIA_CACHE_FALLBACK_SENTINEL.to_string()),
+    };
+
     let target = cache_file_path(&content_hash, &content_type)?;
+    let ext = ext_for_content_type(&content_type);
+    // Linux WebKitGTK rewrites custom schemes to `http://<scheme>.localhost/`,
+    // every other platform uses the native `<scheme>://localhost/` form.
+    // Match Tauri's own convention so `<img>` / `<audio>` resolve correctly.
+    let media_uri = if cfg!(target_os = "linux") || cfg!(target_os = "windows") {
+        format!("http://pollis-media.localhost/{content_hash}.{ext}")
+    } else {
+        format!("pollis-media://localhost/{content_hash}.{ext}")
+    };
 
     // Fast path: already cached. Touch mtime so the LRU sees it as fresh.
     if target.exists() {
         if let Ok(f) = std::fs::OpenOptions::new().write(true).open(&target) {
             let _ = f.set_modified(std::time::SystemTime::now());
         }
-        return Ok(target.to_string_lossy().into_owned());
+        return Ok(media_uri);
     }
 
     // Acquire a per-hash lock so the second waiter sees the file on disk
@@ -449,25 +637,52 @@ pub async fn get_media_path(
 
     // Recheck under the lock — another caller may have just finished.
     if target.exists() {
-        // Drop our entry from the in-flight map.
         in_flight().lock().expect("in-flight map poisoned").remove(&content_hash);
-        return Ok(target.to_string_lossy().into_owned());
+        return Ok(media_uri);
     }
 
     let bytes = download_media(r2_key, content_hash.clone(), state).await?;
 
-    // Atomic write: <hash>.<ext>.tmp → rename → <hash>.<ext>.
+    // Per-file size cap — if the plaintext is too large for the cache,
+    // skip the disk write entirely and return the fallback sentinel so
+    // the frontend renders this one via the byte-fetch path.
+    if bytes.len() as u64 > MEDIA_CACHE_MAX_FILE_BYTES {
+        in_flight().lock().expect("in-flight map poisoned").remove(&content_hash);
+        return Ok(MEDIA_CACHE_FALLBACK_SENTINEL.to_string());
+    }
+
+    // Pre-emptive total-cap check: encrypted file size ≈ plaintext + 12
+    // (nonce) + 16 (tag). Run eviction *before* the write so the cache
+    // never peaks above MEDIA_CACHE_MAX_BYTES even briefly.
     let dir = media_cache_dir()?;
     if let Err(e) = std::fs::create_dir_all(dir) {
         in_flight().lock().expect("in-flight map poisoned").remove(&content_hash);
         return Err(Error::Other(anyhow::anyhow!("create cache dir: {e}")));
     }
+    let projected_size = bytes.len() as u64 + (NONCE_LEN as u64) + 16;
+    let total = cache_total_bytes();
+    if total.saturating_add(projected_size) > MEDIA_CACHE_MAX_BYTES {
+        // Try to make room by evicting old entries. enforce_cache_cap
+        // shrinks the cache to fit MEDIA_CACHE_MAX_BYTES; if the new file
+        // alone exceeds the cap minus the projection, we keep going and
+        // the post-write enforce will trim again.
+        enforce_cache_cap_to(dir, MEDIA_CACHE_MAX_BYTES.saturating_sub(projected_size));
+    }
+
+    // Encrypt under a per-file key derived from the user's db_key.
+    let key = derive_cache_key(&db_key, &content_hash);
+    let ciphertext = match cache_encrypt(&bytes, &key) {
+        Ok(c) => c,
+        Err(e) => {
+            in_flight().lock().expect("in-flight map poisoned").remove(&content_hash);
+            return Err(e);
+        }
+    };
+
+    // Atomic write: <hash>.<ext>.enc.tmp → rename → <hash>.<ext>.enc
     let mut tmp = target.clone();
-    tmp.set_extension(format!(
-        "{}.tmp",
-        target.extension().and_then(|s| s.to_str()).unwrap_or("bin")
-    ));
-    if let Err(e) = tokio::fs::write(&tmp, &bytes).await {
+    tmp.set_extension("enc.tmp");
+    if let Err(e) = tokio::fs::write(&tmp, &ciphertext).await {
         let _ = tokio::fs::remove_file(&tmp).await;
         in_flight().lock().expect("in-flight map poisoned").remove(&content_hash);
         return Err(Error::Other(anyhow::anyhow!("write cache tmp: {e}")));
@@ -478,11 +693,13 @@ pub async fn get_media_path(
         return Err(Error::Other(anyhow::anyhow!("rename cache tmp: {e}")));
     }
 
-    // Best-effort LRU eviction. Run after rename so the new file participates.
+    // Belt-and-braces: run the standard eviction after the rename so any
+    // race between two big concurrent downloads still settles within the
+    // cap.
     enforce_cache_cap(dir);
 
     in_flight().lock().expect("in-flight map poisoned").remove(&content_hash);
-    Ok(target.to_string_lossy().into_owned())
+    Ok(media_uri)
 }
 
 // ── Deletion ──────────────────────────────────────────────────────────────

--- a/pollis-core/src/commands/r2.rs
+++ b/pollis-core/src/commands/r2.rs
@@ -9,33 +9,15 @@ use crate::state::AppState;
 
 // ── On-disk media cache ───────────────────────────────────────────────────
 //
-// Encrypted-at-rest content-addressed cache. Each file is stored on disk as
-// `<content_hash>.<ext>.enc` with layout `[12-byte nonce][ciphertext][16-byte
-// AEAD tag]` under AES-256-GCM. The per-file key is derived via HKDF-SHA256
-// from the user's `db_key` (the same root secret that protects the local
-// SQLCipher DB), so leftover files from a previous user are unreadable to a
-// fresh login. The frontend reads bytes via the `pollis-media://` Tauri URI
-// scheme — decryption happens in-memory in the protocol handler and the
-// plaintext never lands on disk.
+// Decrypted media is materialised under a content-addressed cache so the
+// frontend can render directly from a file path (via `convertFileSrc`) instead
+// of pumping multi-megabyte byte arrays through the JSON IPC. Keyed by
+// `content_hash`, which uniquely identifies the bytes (it's also the seed for
+// the AES-GCM key derivation), so there's no invalidation problem — if the
+// file exists, the bytes are correct.
 
 /// Hard cap on total cache size before LRU eviction kicks in.
-pub const MEDIA_CACHE_MAX_BYTES: u64 = 500 * 1024 * 1024;
-
-/// Hard cap on a single cached file's plaintext size. Anything larger
-/// bypasses the cache and uses the byte-returning `download_media` path.
-pub const MEDIA_CACHE_MAX_FILE_BYTES: u64 = 100 * 1024 * 1024;
-
-/// Sentinel returned from `get_media_path` when a file is too large to
-/// cache. The frontend treats this as "use the byte-fetch fallback for
-/// this one render."
-pub const MEDIA_CACHE_FALLBACK_SENTINEL: &str = "";
-
-/// HKDF salt for media-cache file keys. Domain-separates the cache from
-/// the SQLCipher key and the convergent attachment-key derivation.
-const MEDIA_CACHE_HKDF_SALT: &[u8] = b"pollis-media-cache-v1";
-
-/// AES-GCM nonce length.
-const NONCE_LEN: usize = 12;
+const MEDIA_CACHE_MAX_BYTES: u64 = 500 * 1024 * 1024;
 
 /// Set once at app startup from the Tauri shim (`app_data_dir()`).
 static MEDIA_CACHE_DIR: OnceLock<PathBuf> = OnceLock::new();
@@ -86,168 +68,16 @@ fn ext_for_content_type(ct: &str) -> &'static str {
     }
 }
 
-/// Map an extension back to a content-type for the protocol handler.
-/// Mirrors `ext_for_content_type`; falls back to `application/octet-stream`.
-fn content_type_for_ext(ext: &str) -> &'static str {
-    match ext {
-        "png" => "image/png",
-        "jpg" | "jpeg" => "image/jpeg",
-        "gif" => "image/gif",
-        "webp" => "image/webp",
-        "avif" => "image/avif",
-        "svg" => "image/svg+xml",
-        "mp4" => "video/mp4",
-        "webm" => "video/webm",
-        "mov" => "video/quicktime",
-        "mp3" => "audio/mpeg",
-        "m4a" => "audio/mp4",
-        "weba" => "audio/webm",
-        "ogg" => "audio/ogg",
-        "wav" => "audio/wav",
-        "flac" => "audio/flac",
-        _ => "application/octet-stream",
-    }
-}
-
-/// Path to the encrypted cache file. Filename embeds the original extension
-/// so the protocol handler can recover the content-type without a sidecar:
-/// `<hash>.<ext>.enc`.
 fn cache_file_path(content_hash: &str, content_type: &str) -> Result<PathBuf> {
     let dir = media_cache_dir()?;
     let ext = ext_for_content_type(content_type);
-    Ok(dir.join(format!("{content_hash}.{ext}.enc")))
-}
-
-/// Derive a per-file AES-256-GCM key from the user's root `db_key` via
-/// HKDF-SHA256. `info` is the content_hash bytes so each cached file gets
-/// a unique key — an attacker who recovers one file's key can't reuse it
-/// against another file in the cache.
-fn derive_cache_key(db_key: &[u8], content_hash_hex: &str) -> [u8; 32] {
-    use hkdf::Hkdf;
-    use sha2::Sha256;
-    let hk = Hkdf::<Sha256>::new(Some(MEDIA_CACHE_HKDF_SALT), db_key);
-    let mut key = [0u8; 32];
-    hk.expand(content_hash_hex.as_bytes(), &mut key)
-        .expect("HKDF expand for media-cache key should never fail");
-    key
-}
-
-/// Encrypt plaintext for on-disk storage. Output: `[12-byte nonce][ciphertext+tag]`.
-/// Random per-file nonce — no nonce reuse risk because each call generates fresh.
-fn cache_encrypt(plaintext: &[u8], key: &[u8; 32]) -> Result<Vec<u8>> {
-    use aes_gcm::{aead::{Aead, KeyInit}, Aes256Gcm, Key, Nonce};
-    use rand::RngCore;
-
-    let mut nonce_bytes = [0u8; NONCE_LEN];
-    rand::rngs::OsRng.fill_bytes(&mut nonce_bytes);
-    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(key));
-    let ct = cipher.encrypt(Nonce::from_slice(&nonce_bytes), plaintext)
-        .map_err(|e| Error::Crypto(format!("media-cache encrypt: {e}")))?;
-    let mut out = Vec::with_capacity(NONCE_LEN + ct.len());
-    out.extend_from_slice(&nonce_bytes);
-    out.extend_from_slice(&ct);
-    Ok(out)
-}
-
-/// Decrypt the contents of a cached file produced by `cache_encrypt`.
-fn cache_decrypt(file_bytes: &[u8], key: &[u8; 32]) -> Result<Vec<u8>> {
-    use aes_gcm::{aead::{Aead, KeyInit}, Aes256Gcm, Key, Nonce};
-    if file_bytes.len() < NONCE_LEN + 16 {
-        return Err(Error::Other(anyhow::anyhow!("media-cache file truncated")));
-    }
-    let (nonce_bytes, ct) = file_bytes.split_at(NONCE_LEN);
-    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(key));
-    cipher.decrypt(Nonce::from_slice(nonce_bytes), ct)
-        .map_err(|_| Error::Other(anyhow::anyhow!("media-cache decrypt failed")))
-}
-
-/// Sum the size of every regular file in the cache. Used to gate downloads
-/// against the cap *before* the new file is written, so the cache never
-/// peaks above the cap during a large download.
-pub fn cache_total_bytes() -> u64 {
-    let dir = match MEDIA_CACHE_DIR.get() {
-        Some(d) => d,
-        None => return 0,
-    };
-    let entries = match std::fs::read_dir(dir) {
-        Ok(rd) => rd,
-        Err(_) => return 0,
-    };
-    let mut total: u64 = 0;
-    for entry in entries.flatten() {
-        if let Ok(meta) = entry.metadata() {
-            if meta.is_file() {
-                total += meta.len();
-            }
-        }
-    }
-    total
-}
-
-/// Locate a cached encrypted file by content_hash. The extension between
-/// `<hash>` and `.enc` is whatever the original upload used, so we scan
-/// the directory by prefix. Returns `(path, ext)` where `ext` is the
-/// original content extension (e.g. `"mp4"`).
-pub fn find_cached_file(content_hash: &str) -> Option<(PathBuf, String)> {
-    let dir = MEDIA_CACHE_DIR.get()?;
-    let entries = std::fs::read_dir(dir).ok()?;
-    let prefix = format!("{content_hash}.");
-    for entry in entries.flatten() {
-        let name = entry.file_name();
-        let name = name.to_string_lossy();
-        if !name.starts_with(&prefix) || !name.ends_with(".enc") {
-            continue;
-        }
-        // Strip "<hash>." prefix and ".enc" suffix, leaving the ext.
-        let middle = &name[prefix.len()..name.len() - 4];
-        if middle.is_empty() || middle.contains('.') {
-            // Defensive: skip filenames we don't recognise.
-            continue;
-        }
-        return Some((entry.path(), middle.to_string()));
-    }
-    None
-}
-
-/// Decrypt the cached file for `content_hash` using the supplied root
-/// `db_key`. Returns `(plaintext_bytes, content_type)` or `None` if no
-/// cached file exists. Errors propagate so the caller can distinguish
-/// "missing" from "key mismatch / corruption."
-pub fn decrypt_cached_file(content_hash: &str, db_key: &[u8]) -> Result<Option<(Vec<u8>, String)>> {
-    let (path, ext) = match find_cached_file(content_hash) {
-        Some(x) => x,
-        None => return Ok(None),
-    };
-    let file_bytes = std::fs::read(&path)
-        .map_err(|e| Error::Other(anyhow::anyhow!("read cache file: {e}")))?;
-    let key = derive_cache_key(db_key, content_hash);
-    let plaintext = cache_decrypt(&file_bytes, &key)?;
-    // Touch mtime so LRU sees this as fresh.
-    if let Ok(f) = std::fs::OpenOptions::new().write(true).open(&path) {
-        let _ = f.set_modified(std::time::SystemTime::now());
-    }
-    Ok(Some((plaintext, content_type_for_ext(&ext).to_string())))
+    Ok(dir.join(format!("{content_hash}.{ext}")))
 }
 
 /// Stat every file in the cache; if total size exceeds the cap, delete by
 /// oldest mtime first until we're under. No in-memory index — directory is
 /// small enough that stat'ing it on each insert is fine.
 fn enforce_cache_cap(dir: &Path) {
-    enforce_cache_cap_to(dir, MEDIA_CACHE_MAX_BYTES);
-}
-
-/// Public re-evaluation entry point — call from app focus / periodic timer
-/// to defend against cache-dir tampering or external file additions.
-pub fn enforce_cache_cap_now() {
-    if let Some(dir) = MEDIA_CACHE_DIR.get() {
-        enforce_cache_cap(dir);
-    }
-}
-
-/// Lower-bound variant: shrink the cache to at most `target_bytes` by
-/// evicting oldest entries first. Used both by the regular cap-enforcer
-/// and by the pre-write headroom check in `get_media_path`.
-fn enforce_cache_cap_to(dir: &Path, target_bytes: u64) {
     let entries = match std::fs::read_dir(dir) {
         Ok(rd) => rd,
         Err(_) => return,
@@ -274,14 +104,14 @@ fn enforce_cache_cap_to(dir: &Path, target_bytes: u64) {
         files.push((path, size, mtime));
     }
 
-    if total <= target_bytes {
+    if total <= MEDIA_CACHE_MAX_BYTES {
         return;
     }
 
     // Oldest first.
     files.sort_by_key(|(_, _, mtime)| *mtime);
     for (path, size, _) in files {
-        if total <= target_bytes {
+        if total <= MEDIA_CACHE_MAX_BYTES {
             break;
         }
         if std::fs::remove_file(&path).is_ok() {
@@ -290,12 +120,11 @@ fn enforce_cache_cap_to(dir: &Path, target_bytes: u64) {
     }
 }
 
-/// Wipe every file in the media cache directory. Called on logout *and*
-/// at unlock time. Even though the cache is now encrypted at rest, an
-/// incoming user can't decrypt the previous user's files (different
-/// `db_key` → different HKDF output), so leftover files are dead weight
-/// that just consume the cap. The directory itself stays so a subsequent
-/// re-login doesn't have to re-create it.
+/// Wipe every file in the media cache directory. Called on logout so
+/// decrypted images and other media don't sit on disk past a session end —
+/// the cache itself is plaintext at rest, so it must follow the same
+/// lifecycle as the keystore unlock. The directory itself stays so a
+/// subsequent re-login doesn't have to re-create it.
 pub fn clear_media_cache() {
     let dir = match MEDIA_CACHE_DIR.get() {
         Some(d) => d,
@@ -598,34 +427,14 @@ pub async fn get_media_path(
     content_type: String,
     state: &Arc<AppState>,
 ) -> Result<String> {
-    // The cache is encrypted under the user's `db_key`, so it can only be
-    // populated when the user is unlocked. If they're locked, fall back to
-    // the byte path so the call site can still render via `download_media`.
-    let db_key: Vec<u8> = match state.unlock.lock().await.as_ref() {
-        Some(u) => u.db_key.to_vec(),
-        None => return Ok(MEDIA_CACHE_FALLBACK_SENTINEL.to_string()),
-    };
-
     let target = cache_file_path(&content_hash, &content_type)?;
-    let ext = ext_for_content_type(&content_type);
-    // Tauri rewrites custom URI schemes to `http://<scheme>.localhost/` on
-    // Windows / Android (WebView2 / system WebView don't support arbitrary
-    // schemes). macOS and Linux/WebKitGTK use the native `<scheme>://`
-    // form — registering the handler creates a real custom protocol there.
-    // Hitting the http://...localhost form on Linux just makes WebKit try
-    // a real TCP connection and refuse, which is exactly the bug we hit.
-    let media_uri = if cfg!(target_os = "windows") || cfg!(target_os = "android") {
-        format!("http://pollis-media.localhost/{content_hash}.{ext}")
-    } else {
-        format!("pollis-media://localhost/{content_hash}.{ext}")
-    };
 
     // Fast path: already cached. Touch mtime so the LRU sees it as fresh.
     if target.exists() {
         if let Ok(f) = std::fs::OpenOptions::new().write(true).open(&target) {
             let _ = f.set_modified(std::time::SystemTime::now());
         }
-        return Ok(media_uri);
+        return Ok(target.to_string_lossy().into_owned());
     }
 
     // Acquire a per-hash lock so the second waiter sees the file on disk
@@ -640,52 +449,25 @@ pub async fn get_media_path(
 
     // Recheck under the lock — another caller may have just finished.
     if target.exists() {
+        // Drop our entry from the in-flight map.
         in_flight().lock().expect("in-flight map poisoned").remove(&content_hash);
-        return Ok(media_uri);
+        return Ok(target.to_string_lossy().into_owned());
     }
 
     let bytes = download_media(r2_key, content_hash.clone(), state).await?;
 
-    // Per-file size cap — if the plaintext is too large for the cache,
-    // skip the disk write entirely and return the fallback sentinel so
-    // the frontend renders this one via the byte-fetch path.
-    if bytes.len() as u64 > MEDIA_CACHE_MAX_FILE_BYTES {
-        in_flight().lock().expect("in-flight map poisoned").remove(&content_hash);
-        return Ok(MEDIA_CACHE_FALLBACK_SENTINEL.to_string());
-    }
-
-    // Pre-emptive total-cap check: encrypted file size ≈ plaintext + 12
-    // (nonce) + 16 (tag). Run eviction *before* the write so the cache
-    // never peaks above MEDIA_CACHE_MAX_BYTES even briefly.
+    // Atomic write: <hash>.<ext>.tmp → rename → <hash>.<ext>.
     let dir = media_cache_dir()?;
     if let Err(e) = std::fs::create_dir_all(dir) {
         in_flight().lock().expect("in-flight map poisoned").remove(&content_hash);
         return Err(Error::Other(anyhow::anyhow!("create cache dir: {e}")));
     }
-    let projected_size = bytes.len() as u64 + (NONCE_LEN as u64) + 16;
-    let total = cache_total_bytes();
-    if total.saturating_add(projected_size) > MEDIA_CACHE_MAX_BYTES {
-        // Try to make room by evicting old entries. enforce_cache_cap
-        // shrinks the cache to fit MEDIA_CACHE_MAX_BYTES; if the new file
-        // alone exceeds the cap minus the projection, we keep going and
-        // the post-write enforce will trim again.
-        enforce_cache_cap_to(dir, MEDIA_CACHE_MAX_BYTES.saturating_sub(projected_size));
-    }
-
-    // Encrypt under a per-file key derived from the user's db_key.
-    let key = derive_cache_key(&db_key, &content_hash);
-    let ciphertext = match cache_encrypt(&bytes, &key) {
-        Ok(c) => c,
-        Err(e) => {
-            in_flight().lock().expect("in-flight map poisoned").remove(&content_hash);
-            return Err(e);
-        }
-    };
-
-    // Atomic write: <hash>.<ext>.enc.tmp → rename → <hash>.<ext>.enc
     let mut tmp = target.clone();
-    tmp.set_extension("enc.tmp");
-    if let Err(e) = tokio::fs::write(&tmp, &ciphertext).await {
+    tmp.set_extension(format!(
+        "{}.tmp",
+        target.extension().and_then(|s| s.to_str()).unwrap_or("bin")
+    ));
+    if let Err(e) = tokio::fs::write(&tmp, &bytes).await {
         let _ = tokio::fs::remove_file(&tmp).await;
         in_flight().lock().expect("in-flight map poisoned").remove(&content_hash);
         return Err(Error::Other(anyhow::anyhow!("write cache tmp: {e}")));
@@ -696,13 +478,11 @@ pub async fn get_media_path(
         return Err(Error::Other(anyhow::anyhow!("rename cache tmp: {e}")));
     }
 
-    // Belt-and-braces: run the standard eviction after the rename so any
-    // race between two big concurrent downloads still settles within the
-    // cap.
+    // Best-effort LRU eviction. Run after rename so the new file participates.
     enforce_cache_cap(dir);
 
     in_flight().lock().expect("in-flight map poisoned").remove(&content_hash);
-    Ok(media_uri)
+    Ok(target.to_string_lossy().into_owned())
 }
 
 // ── Deletion ──────────────────────────────────────────────────────────────

--- a/pollis-core/src/lib.rs
+++ b/pollis-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod config;
 pub mod db;
 pub mod error;
 pub mod keystore;
+pub mod media_server;
 pub mod realtime;
 pub mod signal;
 pub mod sink;

--- a/pollis-core/src/media_server.rs
+++ b/pollis-core/src/media_server.rs
@@ -1,0 +1,286 @@
+//! Local-loopback HTTP server for cached media.
+//!
+//! The webview renders every `<img>/<audio>/<video>` element via
+//! `src="http://127.0.0.1:<port>/<token>/<hash>"`. The server reads the
+//! AES-GCM-encrypted file from the on-disk media cache, decrypts under
+//! the per-process `db_key`, and streams plaintext bytes back. Only
+//! callers presenting the per-session token (rotated on unlock, cleared
+//! on logout) can access bytes — origin checks are not the protection
+//! here, the token is.
+//!
+//! Why a server (rather than asset:// or IPC bytes):
+//! * `asset://` works for `<img>` but Linux WebKitGTK's GStreamer source
+//!   plugin rejects it for `<audio>/<video>` (MEDIA_ERR_SRC_NOT_SUPPORTED).
+//! * IPC bytes → `Blob` URL works for media elements but blows V8's heap
+//!   on multi-MB files and can't do real HTTP Range, so seeking large
+//!   videos stalls.
+//! * A real HTTP server gives proper Range, one URL pattern across
+//!   image/audio/video, and keeps decryption in Rust where the keys
+//!   already live.
+
+use std::sync::Arc;
+
+use axum::{
+    body::Body,
+    extract::{Path, State},
+    http::{header, HeaderMap, HeaderValue, StatusCode},
+    response::{IntoResponse, Response},
+    routing::get,
+    Router,
+};
+
+use crate::commands::r2 as r2cmd;
+use crate::state::AppState;
+
+/// Spawn the loopback media server on an OS-assigned port. Returns the
+/// bound port so the caller can stash it in `AppState`. Server runs for
+/// the lifetime of the process.
+pub async fn spawn(state: Arc<AppState>) -> std::io::Result<u16> {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let port = listener.local_addr()?.port();
+
+    let app = Router::new()
+        .route("/:token/:hash", get(serve_media))
+        .with_state(state);
+
+    tokio::spawn(async move {
+        if let Err(e) = axum::serve(listener, app).await {
+            eprintln!("[media_server] axum::serve exited: {e}");
+        }
+    });
+
+    Ok(port)
+}
+
+/// `GET /<token>/<hash>` — serves the decrypted bytes for a cached
+/// content-addressed media file. Honours single-range `Range` requests.
+async fn serve_media(
+    State(state): State<Arc<AppState>>,
+    Path((token, hash)): Path<(String, String)>,
+    headers: HeaderMap,
+) -> Response {
+    // Token gate. Mismatch / missing / locked all collapse to 403 so the
+    // server gives no information about which check failed.
+    let expected = state.media_server_token.lock().await.clone();
+    let expected = match expected {
+        Some(t) => t,
+        None => return StatusCode::FORBIDDEN.into_response(),
+    };
+    if !constant_time_eq(token.as_bytes(), expected.as_bytes()) {
+        return StatusCode::FORBIDDEN.into_response();
+    }
+
+    // Hash shape sanity. 64 ASCII hex chars — anything else can't be a
+    // real content_hash and we don't want to touch the FS for it.
+    if hash.len() != 64 || !hash.chars().all(|c| c.is_ascii_hexdigit()) {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
+
+    // db_key gate — without an active unlock the per-file key can't be
+    // derived, so we can't decrypt anything anyway.
+    let db_key = match state.unlock.lock().await.as_ref() {
+        Some(u) => u.db_key.to_vec(),
+        None => return StatusCode::FORBIDDEN.into_response(),
+    };
+
+    // Look the file up by hash. The cache stores `<hash>.<ext>.enc`; the
+    // extension is decorative (we already know the bytes from the hash)
+    // but we use it to set Content-Type.
+    let (path, ext) = match r2cmd::find_cached_file(&hash) {
+        Some(p) => p,
+        None => return StatusCode::NOT_FOUND.into_response(),
+    };
+
+    let file_bytes = match tokio::fs::read(&path).await {
+        Ok(b) => b,
+        Err(_) => return StatusCode::NOT_FOUND.into_response(),
+    };
+
+    let plaintext = match r2cmd::cache_decrypt(&file_bytes, &db_key, hash.as_bytes()) {
+        Ok(p) => p,
+        Err(_) => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+    };
+
+    let content_type = r2cmd::content_type_for_ext(&ext);
+    let total_len = plaintext.len() as u64;
+
+    // Range parsing — single range only. Multi-range responses are a
+    // mess we don't need; browsers/players never request them for
+    // `<audio>/<video>`.
+    if let Some(range_hdr) = headers.get(header::RANGE) {
+        if let Ok(range_str) = range_hdr.to_str() {
+            match parse_single_range(range_str, total_len) {
+                Ok(Some((start, end))) => {
+                    let slice = &plaintext[start as usize..=end as usize];
+                    let len = end - start + 1;
+                    let mut resp = Response::builder()
+                        .status(StatusCode::PARTIAL_CONTENT)
+                        .header(header::CONTENT_TYPE, content_type)
+                        .header(header::CONTENT_LENGTH, len.to_string())
+                        .header(
+                            header::CONTENT_RANGE,
+                            format!("bytes {start}-{end}/{total_len}"),
+                        )
+                        .header(header::ACCEPT_RANGES, "bytes")
+                        .body(Body::from(slice.to_vec()))
+                        .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response());
+                    add_cors_headers(resp.headers_mut());
+                    return resp;
+                }
+                Ok(None) => {
+                    // Header present but unparseable as a range we accept —
+                    // fall through to the full-body 200 response.
+                }
+                Err(()) => {
+                    let mut resp = Response::builder()
+                        .status(StatusCode::RANGE_NOT_SATISFIABLE)
+                        .header(header::CONTENT_RANGE, format!("bytes */{total_len}"))
+                        .body(Body::empty())
+                        .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response());
+                    add_cors_headers(resp.headers_mut());
+                    return resp;
+                }
+            }
+        }
+    }
+
+    let mut resp = Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, content_type)
+        .header(header::CONTENT_LENGTH, total_len.to_string())
+        .header(header::ACCEPT_RANGES, "bytes")
+        .body(Body::from(plaintext))
+        .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response());
+    add_cors_headers(resp.headers_mut());
+    resp
+}
+
+fn add_cors_headers(headers: &mut HeaderMap) {
+    headers.insert(
+        header::ACCESS_CONTROL_ALLOW_ORIGIN,
+        HeaderValue::from_static("*"),
+    );
+    headers.insert(
+        header::ACCESS_CONTROL_EXPOSE_HEADERS,
+        HeaderValue::from_static("Content-Range, Content-Length, Accept-Ranges"),
+    );
+}
+
+/// Parse `bytes=START-END` / `bytes=START-` / `bytes=-SUFFIX`.
+///
+/// `Ok(Some((start, end)))` — a satisfiable range, end inclusive.
+/// `Ok(None)` — header was malformed in a way that should fall through
+///   to a full 200 (per RFC 9110 §14.1.1).
+/// `Err(())` — range is syntactically valid but unsatisfiable → 416.
+fn parse_single_range(range_str: &str, total: u64) -> Result<Option<(u64, u64)>, ()> {
+    let rest = match range_str.strip_prefix("bytes=") {
+        Some(r) => r,
+        None => return Ok(None),
+    };
+    // Reject multi-range explicitly.
+    if rest.contains(',') {
+        return Ok(None);
+    }
+    let (start_s, end_s) = match rest.split_once('-') {
+        Some(p) => p,
+        None => return Ok(None),
+    };
+    if total == 0 {
+        return Err(());
+    }
+    let last = total - 1;
+
+    if start_s.is_empty() {
+        // Suffix range: bytes=-N
+        let n: u64 = match end_s.parse() {
+            Ok(n) => n,
+            Err(_) => return Ok(None),
+        };
+        if n == 0 {
+            return Err(());
+        }
+        let start = total.saturating_sub(n);
+        return Ok(Some((start, last)));
+    }
+
+    let start: u64 = match start_s.parse() {
+        Ok(s) => s,
+        Err(_) => return Ok(None),
+    };
+    let end: u64 = if end_s.is_empty() {
+        last
+    } else {
+        match end_s.parse() {
+            Ok(e) => e,
+            Err(_) => return Ok(None),
+        }
+    };
+    if start > end || start > last {
+        return Err(());
+    }
+    let end = end.min(last);
+    Ok(Some((start, end)))
+}
+
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+/// Generate a fresh 32-byte hex token. Called from the unlock paths to
+/// rotate the per-session secret.
+pub fn fresh_token() -> String {
+    use rand::RngCore;
+    let mut buf = [0u8; 32];
+    rand::rngs::OsRng.fill_bytes(&mut buf);
+    hex::encode(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn range_full_open_ended() {
+        assert_eq!(parse_single_range("bytes=0-", 100), Ok(Some((0, 99))));
+    }
+
+    #[test]
+    fn range_suffix() {
+        assert_eq!(parse_single_range("bytes=-10", 100), Ok(Some((90, 99))));
+        assert_eq!(parse_single_range("bytes=-200", 100), Ok(Some((0, 99))));
+    }
+
+    #[test]
+    fn range_explicit() {
+        assert_eq!(parse_single_range("bytes=10-19", 100), Ok(Some((10, 19))));
+        assert_eq!(parse_single_range("bytes=10-200", 100), Ok(Some((10, 99))));
+    }
+
+    #[test]
+    fn range_unsatisfiable() {
+        assert_eq!(parse_single_range("bytes=200-300", 100), Err(()));
+        assert_eq!(parse_single_range("bytes=50-10", 100), Err(()));
+    }
+
+    #[test]
+    fn range_multi_falls_through() {
+        assert_eq!(
+            parse_single_range("bytes=0-10,20-30", 100),
+            Ok(None)
+        );
+    }
+
+    #[test]
+    fn token_constant_time() {
+        assert!(constant_time_eq(b"abc", b"abc"));
+        assert!(!constant_time_eq(b"abc", b"abd"));
+        assert!(!constant_time_eq(b"abc", b"abcd"));
+    }
+}

--- a/pollis-core/src/state.rs
+++ b/pollis-core/src/state.rs
@@ -48,6 +48,17 @@ pub struct AppState {
     /// Not yet load-bearing — stage 6 flips the app over to reading the
     /// unwrapped keys from here instead of the legacy keystore slots.
     pub unlock: Arc<Mutex<Option<UnlockState>>>,
+    /// Bound port of the loopback media HTTP server, set once during
+    /// startup. `None` in test/headless contexts that don't spin up the
+    /// server. The port plus `media_server_token` produce the URLs the
+    /// frontend embeds in `<img>/<audio>/<video>` `src` attributes.
+    pub media_server_port: Arc<Mutex<Option<u16>>>,
+    /// Per-session 32-byte hex token for the loopback media server.
+    /// Rotated on `unlock` / `set_pin`, cleared on `logout`. Without
+    /// this token the server returns 403 — even loopback access is
+    /// gated since other local users could otherwise read decrypted
+    /// media in flight.
+    pub media_server_token: Arc<Mutex<Option<String>>>,
 }
 
 impl AppState {
@@ -81,6 +92,8 @@ impl AppState {
             device_id: Arc::new(Mutex::new(None)),
             enrollment_ephemeral_keys: Arc::new(Mutex::new(HashMap::new())),
             unlock: Arc::new(Mutex::new(None)),
+            media_server_port: Arc::new(Mutex::new(None)),
+            media_server_token: Arc::new(Mutex::new(None)),
         }
     }
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -41,7 +41,7 @@ tauri-build = { version = "2", features = [] }
 # binaries can consume it without dragging in the Tauri runtime.
 pollis-core = { path = "../pollis-core" }
 
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["protocol-asset"] }
 tauri-plugin-shell = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"

--- a/src-tauri/src/commands/r2.rs
+++ b/src-tauri/src/commands/r2.rs
@@ -27,3 +27,8 @@ pub async fn download_file(key: String, state: State<'_, Arc<AppState>>) -> Resu
 pub async fn download_media(r2_key: String, content_hash: String, state: State<'_, Arc<AppState>>) -> Result<Vec<u8>> {
     pollis_core::commands::r2::download_media(r2_key, content_hash, &state).await
 }
+
+#[tauri::command]
+pub async fn get_media_path(r2_key: String, content_hash: String, content_type: String, state: State<'_, Arc<AppState>>) -> Result<String> {
+    pollis_core::commands::r2::get_media_path(r2_key, content_hash, content_type, &state).await
+}

--- a/src-tauri/src/commands/r2.rs
+++ b/src-tauri/src/commands/r2.rs
@@ -29,6 +29,6 @@ pub async fn download_media(r2_key: String, content_hash: String, state: State<'
 }
 
 #[tauri::command]
-pub async fn get_media_path(r2_key: String, content_hash: String, content_type: String, state: State<'_, Arc<AppState>>) -> Result<String> {
-    pollis_core::commands::r2::get_media_path(r2_key, content_hash, content_type, &state).await
+pub async fn get_media_url(r2_key: String, content_hash: String, content_type: String, state: State<'_, Arc<AppState>>) -> Result<String> {
+    pollis_core::commands::r2::get_media_url(r2_key, content_hash, content_type, &state).await
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -452,9 +452,15 @@ commands::livekit::get_livekit_token,
             commands::sfx::stop_ring,
         ])
         // On macOS, hide the window on close instead of quitting.
+        // On window focus, re-evaluate the media-cache cap so files
+        // copied into the dir externally / mtime-tampered / etc. don't
+        // let it grow past the limit.
         .on_window_event(|_window, _event| {
             #[cfg(target_os = "macos")]
             hide_on_close(_window, _event);
+            if let tauri::WindowEvent::Focused(true) = _event {
+                pollis_core::commands::r2::enforce_cache_cap_now();
+            }
         })
         .build(tauri::generate_context!())
         .expect("error while building Pollis")
@@ -463,6 +469,14 @@ commands::livekit::get_livekit_token,
             #[cfg(target_os = "macos")]
             if let tauri::RunEvent::Reopen { .. } = _event {
                 show_on_reopen(_app);
+            }
+            // Wipe the plaintext media cache on app exit. The cache holds
+            // decrypted bytes (image / video / audio) and is not encrypted
+            // at rest, so it must not survive a graceful shutdown — the
+            // next attacker with file-system access would otherwise be
+            // able to read every media file the user viewed.
+            if let tauri::RunEvent::ExitRequested { .. } = _event {
+                pollis_core::commands::r2::clear_media_cache();
             }
         });
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -219,141 +219,6 @@ async fn read_clipboard_image_to_temp(app: tauri::AppHandle) -> String {
     path.to_string_lossy().into_owned()
 }
 
-/// `pollis-media://` URI scheme handler.
-///
-/// Reads the encrypted cache file for `<content_hash>.<ext>.enc`, decrypts
-/// it in-memory using the user's `db_key`, and returns the plaintext bytes
-/// with a content-type derived from the extension. Supports HTTP Range
-/// requests so `<video>` seeking and `<audio>` partial loads behave.
-///
-/// Fail-closed: if the user is locked (no `db_key` in `AppState.unlock`),
-/// returns 403. The frontend `<img>`/`<audio>` simply fails the load.
-async fn handle_pollis_media(
-    app: &tauri::AppHandle,
-    request: tauri::http::Request<Vec<u8>>,
-) -> tauri::http::Response<std::borrow::Cow<'static, [u8]>> {
-    use tauri::http::{header, Response, StatusCode};
-    use std::borrow::Cow;
-
-    fn err(status: StatusCode) -> Response<Cow<'static, [u8]>> {
-        Response::builder()
-            .status(status)
-            .body(Cow::Borrowed(&[][..]))
-            .expect("static error response builds")
-    }
-
-    // URI shape: pollis-media://localhost/<content_hash>.<ext>
-    // Tauri 2 normalises custom schemes through an `http://` form internally,
-    // so we work off `request.uri().path()`.
-    let path = request.uri().path().trim_start_matches('/');
-    // Split off the extension; everything before the last '.' is the hash.
-    let (hash, ext) = match path.rsplit_once('.') {
-        Some((h, e)) if !h.is_empty() && !e.is_empty() => (h.to_string(), e.to_string()),
-        _ => return err(StatusCode::BAD_REQUEST),
-    };
-    // Sanity: content_hash is hex SHA-256 = 64 chars. Reject anything else
-    // so we can't be tricked into reading arbitrary paths.
-    if hash.len() != 64 || !hash.chars().all(|c| c.is_ascii_hexdigit()) {
-        return err(StatusCode::BAD_REQUEST);
-    }
-    let _ = ext;
-
-    let state = match app.try_state::<Arc<AppState>>() {
-        Some(s) => s,
-        None => return err(StatusCode::SERVICE_UNAVAILABLE),
-    };
-
-    let db_key: Vec<u8> = match state.unlock.lock().await.as_ref() {
-        Some(u) => u.db_key.to_vec(),
-        None => return err(StatusCode::FORBIDDEN),
-    };
-
-    let (plaintext, content_type) = match pollis_core::commands::r2::decrypt_cached_file(&hash, &db_key) {
-        Ok(Some(x)) => x,
-        Ok(None) => return err(StatusCode::NOT_FOUND),
-        Err(_) => return err(StatusCode::INTERNAL_SERVER_ERROR),
-    };
-
-    let total_len = plaintext.len() as u64;
-
-    // Parse `Range: bytes=START-END` if present. Single-range only — that's
-    // all `<video>`/`<audio>` ever issue. Bytes are inclusive on both ends.
-    let range_header = request
-        .headers()
-        .get(header::RANGE)
-        .and_then(|v| v.to_str().ok())
-        .map(|s| s.to_string());
-
-    if let Some(range) = range_header {
-        if let Some((start, end)) = parse_range(&range, total_len) {
-            let slice = plaintext[start as usize..=end as usize].to_vec();
-            let body_len = slice.len() as u64;
-            return Response::builder()
-                .status(StatusCode::PARTIAL_CONTENT)
-                .header(header::CONTENT_TYPE, content_type)
-                .header(header::ACCEPT_RANGES, "bytes")
-                .header(header::CONTENT_LENGTH, body_len.to_string())
-                .header(
-                    header::CONTENT_RANGE,
-                    format!("bytes {start}-{end}/{total_len}"),
-                )
-                .body(Cow::Owned(slice))
-                .unwrap_or_else(|_| err(StatusCode::INTERNAL_SERVER_ERROR));
-        } else {
-            // Unsatisfiable range.
-            return Response::builder()
-                .status(StatusCode::RANGE_NOT_SATISFIABLE)
-                .header(header::CONTENT_RANGE, format!("bytes */{total_len}"))
-                .body(Cow::Borrowed(&[][..]))
-                .unwrap_or_else(|_| err(StatusCode::INTERNAL_SERVER_ERROR));
-        }
-    }
-
-    Response::builder()
-        .status(StatusCode::OK)
-        .header(header::CONTENT_TYPE, content_type)
-        .header(header::ACCEPT_RANGES, "bytes")
-        .header(header::CONTENT_LENGTH, total_len.to_string())
-        .body(Cow::Owned(plaintext))
-        .unwrap_or_else(|_| err(StatusCode::INTERNAL_SERVER_ERROR))
-}
-
-/// Parse a single-range `Range: bytes=START-END` header. Returns `(start, end)`
-/// inclusive, clamped to the file length. Rejects multi-range requests.
-fn parse_range(header: &str, total_len: u64) -> Option<(u64, u64)> {
-    if total_len == 0 {
-        return None;
-    }
-    let value = header.strip_prefix("bytes=")?.trim();
-    if value.contains(',') {
-        // Multi-range — not supported.
-        return None;
-    }
-    let (start_s, end_s) = value.split_once('-')?;
-    let start_s = start_s.trim();
-    let end_s = end_s.trim();
-
-    let last = total_len - 1;
-    let (start, end) = if start_s.is_empty() {
-        // Suffix range: bytes=-N → last N bytes.
-        let n: u64 = end_s.parse().ok()?;
-        if n == 0 {
-            return None;
-        }
-        let n = n.min(total_len);
-        (total_len - n, last)
-    } else {
-        let s: u64 = start_s.parse().ok()?;
-        let e: u64 = if end_s.is_empty() { last } else { end_s.parse().ok()? };
-        (s, e.min(last))
-    };
-
-    if start > end || start > last {
-        return None;
-    }
-    Some((start, end))
-}
-
 /// Cmd+W handler: hide the window on macOS (matching hide_on_close behaviour)
 /// or close it on Windows/Linux.
 #[tauri::command]
@@ -386,12 +251,6 @@ pub fn run() {
     }
 
     tauri::Builder::default()
-        .register_asynchronous_uri_scheme_protocol("pollis-media", |ctx, request, responder| {
-            let app = ctx.app_handle().clone();
-            tauri::async_runtime::spawn(async move {
-                responder.respond(handle_pollis_media(&app, request).await);
-            });
-        })
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
@@ -593,15 +452,9 @@ commands::livekit::get_livekit_token,
             commands::sfx::stop_ring,
         ])
         // On macOS, hide the window on close instead of quitting.
-        // On focus, re-evaluate the media-cache cap so external tampering
-        // / files copied into the dir / config changes don't let the cache
-        // drift above the ceiling.
         .on_window_event(|_window, _event| {
             #[cfg(target_os = "macos")]
             hide_on_close(_window, _event);
-            if let tauri::WindowEvent::Focused(true) = _event {
-                pollis_core::commands::r2::enforce_cache_cap_now();
-            }
         })
         .build(tauri::generate_context!())
         .expect("error while building Pollis")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -299,7 +299,23 @@ pub fn run() {
 
             tauri::async_runtime::block_on(async move {
                 let state = AppState::new(config).await.map_err(|e| e.to_string())?;
-                app.manage(Arc::new(state));
+                let state = Arc::new(state);
+
+                // Loopback HTTP server for cached media. The webview
+                // embeds `http://127.0.0.1:<port>/<token>/<hash>` URLs
+                // for every `<img>/<audio>/<video>` element. Spawned
+                // before `manage` so the port is on `AppState` by the
+                // time any frontend code runs.
+                match pollis_core::media_server::spawn(state.clone()).await {
+                    Ok(port) => {
+                        *state.media_server_port.lock().await = Some(port);
+                    }
+                    Err(e) => {
+                        eprintln!("[setup] failed to spawn media server: {e}");
+                    }
+                }
+
+                app.manage(state);
                 Ok::<(), String>(())
             })?;
 
@@ -425,7 +441,7 @@ commands::livekit::get_livekit_token,
             commands::r2::upload_media,
             commands::r2::download_file,
             commands::r2::download_media,
-            commands::r2::get_media_path,
+            commands::r2::get_media_url,
             commands::update::mark_update_required,
             commands::update::is_update_required,
             commands::install_kind::detect_managed_install,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -288,6 +288,15 @@ pub fn run() {
                 apply_windows_rounded_corners(&window);
             }
 
+            // Initialise the on-disk media cache. The frontend renders
+            // attachments by file path (via convertFileSrc) instead of
+            // pumping decrypted bytes through the JSON IPC.
+            if let Ok(data_dir) = app.path().app_data_dir() {
+                let cache_dir = data_dir.join("media-cache");
+                let _ = std::fs::create_dir_all(&cache_dir);
+                pollis_core::commands::r2::set_media_cache_dir(cache_dir);
+            }
+
             tauri::async_runtime::block_on(async move {
                 let state = AppState::new(config).await.map_err(|e| e.to_string())?;
                 app.manage(Arc::new(state));
@@ -416,6 +425,7 @@ commands::livekit::get_livekit_token,
             commands::r2::upload_media,
             commands::r2::download_file,
             commands::r2::download_media,
+            commands::r2::get_media_path,
             commands::update::mark_update_required,
             commands::update::is_update_required,
             commands::install_kind::detect_managed_install,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -219,6 +219,141 @@ async fn read_clipboard_image_to_temp(app: tauri::AppHandle) -> String {
     path.to_string_lossy().into_owned()
 }
 
+/// `pollis-media://` URI scheme handler.
+///
+/// Reads the encrypted cache file for `<content_hash>.<ext>.enc`, decrypts
+/// it in-memory using the user's `db_key`, and returns the plaintext bytes
+/// with a content-type derived from the extension. Supports HTTP Range
+/// requests so `<video>` seeking and `<audio>` partial loads behave.
+///
+/// Fail-closed: if the user is locked (no `db_key` in `AppState.unlock`),
+/// returns 403. The frontend `<img>`/`<audio>` simply fails the load.
+async fn handle_pollis_media(
+    app: &tauri::AppHandle,
+    request: tauri::http::Request<Vec<u8>>,
+) -> tauri::http::Response<std::borrow::Cow<'static, [u8]>> {
+    use tauri::http::{header, Response, StatusCode};
+    use std::borrow::Cow;
+
+    fn err(status: StatusCode) -> Response<Cow<'static, [u8]>> {
+        Response::builder()
+            .status(status)
+            .body(Cow::Borrowed(&[][..]))
+            .expect("static error response builds")
+    }
+
+    // URI shape: pollis-media://localhost/<content_hash>.<ext>
+    // Tauri 2 normalises custom schemes through an `http://` form internally,
+    // so we work off `request.uri().path()`.
+    let path = request.uri().path().trim_start_matches('/');
+    // Split off the extension; everything before the last '.' is the hash.
+    let (hash, ext) = match path.rsplit_once('.') {
+        Some((h, e)) if !h.is_empty() && !e.is_empty() => (h.to_string(), e.to_string()),
+        _ => return err(StatusCode::BAD_REQUEST),
+    };
+    // Sanity: content_hash is hex SHA-256 = 64 chars. Reject anything else
+    // so we can't be tricked into reading arbitrary paths.
+    if hash.len() != 64 || !hash.chars().all(|c| c.is_ascii_hexdigit()) {
+        return err(StatusCode::BAD_REQUEST);
+    }
+    let _ = ext;
+
+    let state = match app.try_state::<Arc<AppState>>() {
+        Some(s) => s,
+        None => return err(StatusCode::SERVICE_UNAVAILABLE),
+    };
+
+    let db_key: Vec<u8> = match state.unlock.lock().await.as_ref() {
+        Some(u) => u.db_key.to_vec(),
+        None => return err(StatusCode::FORBIDDEN),
+    };
+
+    let (plaintext, content_type) = match pollis_core::commands::r2::decrypt_cached_file(&hash, &db_key) {
+        Ok(Some(x)) => x,
+        Ok(None) => return err(StatusCode::NOT_FOUND),
+        Err(_) => return err(StatusCode::INTERNAL_SERVER_ERROR),
+    };
+
+    let total_len = plaintext.len() as u64;
+
+    // Parse `Range: bytes=START-END` if present. Single-range only — that's
+    // all `<video>`/`<audio>` ever issue. Bytes are inclusive on both ends.
+    let range_header = request
+        .headers()
+        .get(header::RANGE)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+
+    if let Some(range) = range_header {
+        if let Some((start, end)) = parse_range(&range, total_len) {
+            let slice = plaintext[start as usize..=end as usize].to_vec();
+            let body_len = slice.len() as u64;
+            return Response::builder()
+                .status(StatusCode::PARTIAL_CONTENT)
+                .header(header::CONTENT_TYPE, content_type)
+                .header(header::ACCEPT_RANGES, "bytes")
+                .header(header::CONTENT_LENGTH, body_len.to_string())
+                .header(
+                    header::CONTENT_RANGE,
+                    format!("bytes {start}-{end}/{total_len}"),
+                )
+                .body(Cow::Owned(slice))
+                .unwrap_or_else(|_| err(StatusCode::INTERNAL_SERVER_ERROR));
+        } else {
+            // Unsatisfiable range.
+            return Response::builder()
+                .status(StatusCode::RANGE_NOT_SATISFIABLE)
+                .header(header::CONTENT_RANGE, format!("bytes */{total_len}"))
+                .body(Cow::Borrowed(&[][..]))
+                .unwrap_or_else(|_| err(StatusCode::INTERNAL_SERVER_ERROR));
+        }
+    }
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, content_type)
+        .header(header::ACCEPT_RANGES, "bytes")
+        .header(header::CONTENT_LENGTH, total_len.to_string())
+        .body(Cow::Owned(plaintext))
+        .unwrap_or_else(|_| err(StatusCode::INTERNAL_SERVER_ERROR))
+}
+
+/// Parse a single-range `Range: bytes=START-END` header. Returns `(start, end)`
+/// inclusive, clamped to the file length. Rejects multi-range requests.
+fn parse_range(header: &str, total_len: u64) -> Option<(u64, u64)> {
+    if total_len == 0 {
+        return None;
+    }
+    let value = header.strip_prefix("bytes=")?.trim();
+    if value.contains(',') {
+        // Multi-range — not supported.
+        return None;
+    }
+    let (start_s, end_s) = value.split_once('-')?;
+    let start_s = start_s.trim();
+    let end_s = end_s.trim();
+
+    let last = total_len - 1;
+    let (start, end) = if start_s.is_empty() {
+        // Suffix range: bytes=-N → last N bytes.
+        let n: u64 = end_s.parse().ok()?;
+        if n == 0 {
+            return None;
+        }
+        let n = n.min(total_len);
+        (total_len - n, last)
+    } else {
+        let s: u64 = start_s.parse().ok()?;
+        let e: u64 = if end_s.is_empty() { last } else { end_s.parse().ok()? };
+        (s, e.min(last))
+    };
+
+    if start > end || start > last {
+        return None;
+    }
+    Some((start, end))
+}
+
 /// Cmd+W handler: hide the window on macOS (matching hide_on_close behaviour)
 /// or close it on Windows/Linux.
 #[tauri::command]
@@ -251,6 +386,12 @@ pub fn run() {
     }
 
     tauri::Builder::default()
+        .register_asynchronous_uri_scheme_protocol("pollis-media", |ctx, request, responder| {
+            let app = ctx.app_handle().clone();
+            tauri::async_runtime::spawn(async move {
+                responder.respond(handle_pollis_media(&app, request).await);
+            });
+        })
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
@@ -452,9 +593,15 @@ commands::livekit::get_livekit_token,
             commands::sfx::stop_ring,
         ])
         // On macOS, hide the window on close instead of quitting.
+        // On focus, re-evaluate the media-cache cap so external tampering
+        // / files copied into the dir / config changes don't let the cache
+        // drift above the ceiling.
         .on_window_event(|_window, _event| {
             #[cfg(target_os = "macos")]
             hide_on_close(_window, _event);
+            if let tauri::WindowEvent::Focused(true) = _event {
+                pollis_core::commands::r2::enforce_cache_cap_now();
+            }
         })
         .build(tauri::generate_context!())
         .expect("error while building Pollis")

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -28,7 +28,14 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": null,
+      "assetProtocol": {
+        "enable": true,
+        "scope": [
+          "$APPDATA/media-cache/**",
+          "$APPDATA/media-cache/*"
+        ]
+      }
     }
   },
   "bundle": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -31,10 +31,7 @@
       "csp": null,
       "assetProtocol": {
         "enable": true,
-        "scope": [
-          "$APPDATA/media-cache/**",
-          "$APPDATA/media-cache/*"
-        ]
+        "scope": []
       }
     }
   },


### PR DESCRIPTION
## Summary

Started as a UI nitpick pass and grew into a substantial architectural pass on media. 33 commits, ~1.5k lines net.

### Media architecture (the big one)

After two failed attempts (asset:// for audio/video → broken on Linux WebKitGTK; custom `pollis-media://` URI scheme → same), landed on a **Rust loopback HTTP server in `pollis-core::media_server`**. One URL pattern for everything:

\`http://127.0.0.1:<port>/<token>/<hash>\`

- Disk cache is **encrypted at rest** under per-file HKDF-derived keys (`<hash>.<ext>.enc`, AES-256-GCM, db_key as IKM).
- Per-session 32-byte hex token in the URL path; server constant-time-compares. Fresh on unlock, cleared on lock/logout.
- Single-range `Range:` support so `<video>` seek and `<audio>` buffering work.
- 100MB per-file cap, 500MB total cap, oldest-mtime LRU, pre-emptive eviction before write, focus-time re-evaluation, wipe-on-close + wipe-on-logout + wipe-on-unlock.
- Frontend collapses to one `getMediaUrl` for `<img>/<audio>/<video>` — no platform branching, no JSON IPC for bytes.

The principle behind picking this approach is now codified in `CLAUDE.md` under "Performance Architecture": lean Rust for performance-critical paths; webview is a thin presentation layer.

### Sidebar

Always-visible 220px TUI rail with collapsible groups + flat DMs + nested settings. Cmd/Ctrl+B toggles per session; user preference (`sidebar_open_by_default`) controls initial state. Persistent footer chip mirrors the breadcrumb's ⌘K affordance.

### Other UI polish

- Day dividers on message list, locale-aware time, full-date hover tooltip
- 96×96 transparent media thumb strip, mid-ellipsized filename for non-media file cards
- Breadcrumb settings/search buttons more visible; settings hover bg matches the call-button pattern
- Sync indicator moved to bottom status bar
- Chat input placeholder color stays consistent on window blur (Webkit `:focus`-on-`::placeholder` quirk)
- Various small alignment + spacing fixes

### Perf wins (independent of the cache work)

- `refetchOnWindowFocus: false` globally
- Dropped duplicated MLS pre-flight in `useMessages.queryFn`
- Revoke decrypted blob URLs on unmount

### Validation comments on issue #175

Confirmed `livekit 0.7.36` exposes the right native types, Tauri raw-body Channel is in tree, scap on Linux/Wayland is the riskiest dep. Notes added on how the new HTTP server complements (does NOT replace) the canvas+WebGL plan for live video.

## Test plan

- [ ] Reload the dev app
- [ ] Verify image attachments load + render
- [ ] Verify audio attachments play + scrub
- [ ] Verify video attachments play + seek
- [ ] Verify sidebar toggle (⌘B / Ctrl+B) persists open state via preference
- [ ] Verify logout wipes media-cache directory
- [ ] Verify app close (`ExitRequested`) wipes media-cache directory
- [ ] Verify on a fresh login the cache rebuilds without artifacts from a prior user
- [ ] Spot-check the day dividers + locale time + hover tooltip
- [ ] Spot-check non-media file card layout (icon/filename/size/download all inline)