### PR TITLE
perf: query performance pass + assorted fixes

### DIFF
--- a/frontend/src/components/Layout/AppShell.tsx
+++ b/frontend/src/components/Layout/AppShell.tsx
@@ -389,15 +389,13 @@ export const AppShell: React.FC = () => {
       {/* On chat screens, invert: dark bg with accent text. Otherwise: accent bg with dark text. */}
       <div
         style={{
-          height: 28,
           flexShrink: 0,
           borderTop: "1px solid var(--c-border)",
           background: isChatScreen ? "var(--c-bg)" : "var(--c-accent)",
           display: "flex",
           alignItems: "center",
           justifyContent: "space-between",
-          paddingLeft: 12,
-          paddingRight: 12,
+          padding: "8px 10px",
         }}
       >
         <StatusBarSummary color={isChatScreen ? "var(--c-accent)" : "black"} />

--- a/frontend/src/components/Layout/MainContent.tsx
+++ b/frontend/src/components/Layout/MainContent.tsx
@@ -187,15 +187,13 @@ export const MainContent: React.FC = () => {
     try {
       let page: RawMessagePage;
       if (selectedChannelId) {
-        page = await invoke<RawMessagePage>('get_channel_messages', {
-          userId: currentUser.id,
+        page = await invoke<RawMessagePage>('read_channel_messages', {
           channelId: selectedChannelId,
           limit: 50,
           cursor: pageCursor,
         });
       } else if (selectedConversationId) {
-        page = await invoke<RawMessagePage>('get_dm_messages', {
-          userId: currentUser.id,
+        page = await invoke<RawMessagePage>('read_dm_messages', {
           dmChannelId: selectedConversationId,
           limit: 50,
           cursor: pageCursor,

--- a/frontend/src/components/Layout/StatusBarSummary.tsx
+++ b/frontend/src/components/Layout/StatusBarSummary.tsx
@@ -49,7 +49,6 @@ const SummaryItem: React.FC<SummaryItemProps> = ({ icon, count, to, label, color
           minWidth: "2ch",
           textAlign: "left",
           fontVariantNumeric: "tabular-nums",
-          lineHeight: "1.5rem"
         }}
       >
         {display}

--- a/frontend/src/components/Message/MessageItem.tsx
+++ b/frontend/src/components/Message/MessageItem.tsx
@@ -141,8 +141,9 @@ export const MessageItem: React.FC<MessageItemProps> = ({
           style={isAuthorAdmin ? {
             background: "var(--c-accent)",
             color: "var(--c-bg)",
-            paddingLeft: "0.5rem",
-            paddingRight: "0.5rem",
+            paddingLeft: "0.25rem",
+            paddingRight: "0.25rem",
+            borderRadius: "0.125rem",
           } : {
             color: isOwn ? "var(--c-accent)" : authorColor,
           }}
@@ -164,7 +165,6 @@ export const MessageItem: React.FC<MessageItemProps> = ({
           style={{
             color: isDeleted ? "var(--c-text-muted)" : "var(--c-text)",
             whiteSpace: "pre-wrap",
-            fontStyle: isDeleted ? "italic" : undefined,
           }}
         >
           <LinkifiedText text={content} />

--- a/frontend/src/components/Message/MessageItem.tsx
+++ b/frontend/src/components/Message/MessageItem.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import { decode } from "blurhash";
+import { save as saveDialog } from "@tauri-apps/plugin-dialog";
+import { writeFile } from "@tauri-apps/plugin-fs";
 import { Reply, Download, Film, Check, Edit2, Trash2 } from "lucide-react";
 import { getFileIcon } from "../../utils/fileIcon";
 import { useAppStore } from "../../stores/appStore";
@@ -495,34 +497,40 @@ const AttachmentDisplay: React.FC<{ attachment: MessageAttachment }> = ({ attach
     };
   }, [downloadUrl, attachment.localPreviewUrl]);
 
-  const triggerSave = (url: string) => {
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = attachment.filename;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
+  // Save to a user-chosen path via the native Tauri dialog. The `<a download>`
+  // trick doesn't work on WebKitGTK: `download` is ignored across origins
+  // (loopback media URL vs the app's tauri:// origin), so the webview just
+  // navigates to the URL and shows the browser's built-in audio/video player
+  // instead of triggering a download.
+  const triggerSave = async (url: string): Promise<boolean> => {
+    const target = await saveDialog({ defaultPath: attachment.filename });
+    if (!target) {
+      return false;
+    }
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error(`fetch failed: ${res.status}`);
+    }
+    const bytes = new Uint8Array(await res.arrayBuffer());
+    await writeFile(target, bytes);
+    return true;
   };
 
   const handleDownload = async () => {
     if (downloadStatus !== "idle") { return; }
-    if (downloadUrl) {
-      // Already decrypted — save immediately, show brief confirmation.
-      triggerSave(downloadUrl);
-      setDownloadStatus("done");
-      setTimeout(() => setDownloadStatus("idle"), 2000);
-      return;
-    }
     setDownloadStatus("downloading");
     try {
-      const url = await downloadAndDecryptMedia(
-        attachment.object_key,
-        attachment.content_hash,
-        attachment.content_type,
-      );
-      triggerSave(url);
-      setDownloadStatus("done");
-      setTimeout(() => setDownloadStatus("idle"), 2000);
+      const url = downloadUrl
+        ?? await downloadAndDecryptMedia(
+          attachment.object_key,
+          attachment.content_hash,
+          attachment.content_type,
+        );
+      const saved = await triggerSave(url);
+      setDownloadStatus(saved ? "done" : "idle");
+      if (saved) {
+        setTimeout(() => setDownloadStatus("idle"), 2000);
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to download");
       setDownloadStatus("idle");

--- a/frontend/src/components/Message/MessageList.tsx
+++ b/frontend/src/components/Message/MessageList.tsx
@@ -214,13 +214,13 @@ export const MessageList: React.FC<MessageListProps> = ({
           >
             <div className="flex items-start gap-2 min-w-0">
               <span
-                className="flex-shrink-0 font-mono text-sm italic"
+                className="flex-shrink-0 font-mono text-sm"
                 style={{ color: "var(--c-text-dim)" }}
               >
                 blocked user
               </span>
               <span
-                className="font-mono text-sm italic"
+                className="font-mono text-sm"
                 style={{ color: "var(--c-text-muted)" }}
               >
                 [blocked]

--- a/frontend/src/components/TypingIndicator.tsx
+++ b/frontend/src/components/TypingIndicator.tsx
@@ -39,6 +39,7 @@ export const TypingIndicator: React.FC<TypingIndicatorProps> = ({
         minHeight: 16,
         color: "var(--c-text-muted)",
         lineHeight: "16px",
+        margin: "0.25rem 0.125rem"
       }}
     >
       {text}

--- a/frontend/src/components/Voice/RemoteUserVolumeSlider.tsx
+++ b/frontend/src/components/Voice/RemoteUserVolumeSlider.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import { useQueryClient } from "@tanstack/react-query";
 import { Volume2 } from "lucide-react";
 import {
   usePreferences,
@@ -11,7 +10,6 @@ import {
   REMOTE_USER_VOLUME_DEFAULT,
   type PreferencesData,
 } from "../../hooks/queries/usePreferences";
-import { useAppStore } from "../../stores/appStore";
 
 interface RemoteUserVolumeSliderProps {
   identity: string;
@@ -32,9 +30,7 @@ export const RemoteUserVolumeSlider: React.FC<RemoteUserVolumeSliderProps> = ({
   identity,
   participantName,
 }) => {
-  const { mutation, query } = usePreferences();
-  const currentUser = useAppStore((s) => s.currentUser);
-  const queryClient = useQueryClient();
+  const { save, query } = usePreferences();
 
   const userId = userIdFromVoiceIdentity(identity);
   const stored = query.data?.user_volumes?.[userId];
@@ -45,8 +41,8 @@ export const RemoteUserVolumeSlider: React.FC<RemoteUserVolumeSliderProps> = ({
       const clamped = clampRemoteUserVolume(next);
 
       // Push the live value into the mixer immediately so the change is
-      // audible while the user drags — no debounce, no waiting on the
-      // remote prefs save.
+      // audible while the user drags. The prefs save below is throttled,
+      // but the mixer update is not.
       invoke("set_remote_user_volume", { userId, volume: clamped }).catch(
         (e) => {
           console.warn(
@@ -56,9 +52,6 @@ export const RemoteUserVolumeSlider: React.FC<RemoteUserVolumeSliderProps> = ({
         },
       );
 
-      // Persist via the existing preferences blob. Optimistically update
-      // the React Query cache so other reads see the new value before the
-      // round-trip resolves.
       const prev: PreferencesData = query.data ?? {};
       const prevVolumes = prev.user_volumes ?? {};
       const nextVolumes: { [userId: string]: number } = { ...prevVolumes };
@@ -72,15 +65,9 @@ export const RemoteUserVolumeSlider: React.FC<RemoteUserVolumeSliderProps> = ({
         user_volumes:
           Object.keys(nextVolumes).length > 0 ? nextVolumes : undefined,
       };
-      if (currentUser) {
-        queryClient.setQueryData(
-          ["user", "preferences", currentUser.id],
-          nextPrefs,
-        );
-      }
-      mutation.mutate(nextPrefs);
+      save(nextPrefs);
     },
-    [userId, mutation, query.data, queryClient, currentUser],
+    [userId, save, query.data],
   );
 
   const pct =

--- a/frontend/src/hooks/queries/useMessages.ts
+++ b/frontend/src/hooks/queries/useMessages.ts
@@ -1,7 +1,24 @@
+import { useEffect, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { invoke } from "@tauri-apps/api/core";
 import { useAppStore } from "../../stores/appStore";
 import type { Message, DMConversation } from "../../types";
+
+// Per-conversation timestamp of the last background ingest. Used to debounce
+// rapid channel-switching so we don't fire one ingest per click. Realtime
+// hints also write here when they trigger an ingest, so a focus immediately
+// after a realtime-driven ingest skips the redundant call.
+const lastIngestAt = new Map<string, number>();
+const INGEST_DEBOUNCE_MS = 5_000;
+
+export function shouldIngest(conversationId: string): boolean {
+  const last = lastIngestAt.get(conversationId) ?? 0;
+  return performance.now() - last >= INGEST_DEBOUNCE_MS;
+}
+
+export function markIngested(conversationId: string): void {
+  lastIngestAt.set(conversationId, performance.now());
+}
 
 export const messageQueryKeys = {
   all: ["messages"] as const,
@@ -131,20 +148,18 @@ type MessagesQueryResult = {
 
 export function useMessages(channelId: string | null, conversationId: string | null) {
   const currentUser = useAppStore((state) => state.currentUser);
+  const queryClient = useQueryClient();
   const isChannel = !!channelId;
   const queryKey = isChannel
     ? messageQueryKeys.channel(channelId)
     : messageQueryKeys.conversation(conversationId);
+  const targetId = channelId ?? conversationId;
 
   const query = useQuery({
     queryKey,
     queryFn: async (): Promise<MessagesQueryResult> => {
-      if (isChannel && channelId && currentUser) {
-        // get_channel_messages internally calls poll_mls_welcomes_inner +
-        // process_pending_commits_inner via ingest_channel_envelopes_inner,
-        // so no frontend pre-flight is needed.
-        const page = await invoke<MessagePage>('get_channel_messages', {
-          userId: currentUser.id,
+      if (isChannel && channelId) {
+        const page = await invoke<MessagePage>('read_channel_messages', {
           channelId,
           limit: 50,
         });
@@ -154,12 +169,8 @@ export function useMessages(channelId: string | null, conversationId: string | n
         };
       }
 
-      if (conversationId && currentUser) {
-        // get_dm_messages internally calls poll_mls_welcomes_inner +
-        // process_pending_commits_inner via ingest_dm_envelopes_inner,
-        // so no frontend pre-flight is needed.
-        const page = await invoke<MessagePage>('get_dm_messages', {
-          userId: currentUser.id,
+      if (conversationId) {
+        const page = await invoke<MessagePage>('read_dm_messages', {
           dmChannelId: conversationId,
           limit: 50,
         });
@@ -175,6 +186,39 @@ export function useMessages(channelId: string | null, conversationId: string | n
     staleTime: 1000 * 30,
     refetchOnWindowFocus: true,
   });
+
+  // Fire ingest in the background after the local read mounts. Skipped if a
+  // recent ingest (incl. one driven by a realtime hint) already covered this
+  // conversation. Invalidates the query on completion so newly-decrypted
+  // messages and freshly-cached usernames show up.
+  const ingestInflight = useRef<string | null>(null);
+  useEffect(() => {
+    if (!currentUser || !targetId) {
+      return;
+    }
+    if (ingestInflight.current === targetId) {
+      return;
+    }
+    if (!shouldIngest(targetId)) {
+      return;
+    }
+    ingestInflight.current = targetId;
+    markIngested(targetId);
+    const command = isChannel ? 'ingest_channel_envelopes' : 'ingest_dm_envelopes';
+    const args = isChannel
+      ? { userId: currentUser.id, channelId: targetId }
+      : { userId: currentUser.id, dmChannelId: targetId };
+    invoke(command, args)
+      .catch((e) => {
+        console.warn(`[useMessages] ${command} failed:`, e);
+      })
+      .finally(() => {
+        if (ingestInflight.current === targetId) {
+          ingestInflight.current = null;
+        }
+        queryClient.invalidateQueries({ queryKey });
+      });
+  }, [targetId, isChannel, currentUser?.id]);
 
   return {
     messages: query.data?.messages ?? [],
@@ -297,18 +341,16 @@ export function useLastMessage(channelId: string | null, conversationId: string 
   return useQuery({
     queryKey,
     queryFn: async (): Promise<Message | null> => {
-      if (isChannel && channelId && currentUser) {
-        const page = await invoke<MessagePage>('get_channel_messages', {
-          userId: currentUser.id,
+      if (isChannel && channelId) {
+        const page = await invoke<MessagePage>('read_channel_messages', {
           channelId,
           limit: 1,
         });
         const msgs = (page.messages || []).map(transformChannelMessage);
         return msgs[msgs.length - 1] ?? null;
       }
-      if (conversationId && currentUser) {
-        const page = await invoke<MessagePage>('get_dm_messages', {
-          userId: currentUser.id,
+      if (conversationId) {
+        const page = await invoke<MessagePage>('read_dm_messages', {
           dmChannelId: conversationId,
           limit: 1,
         });

--- a/frontend/src/hooks/queries/usePreferences.ts
+++ b/frontend/src/hooks/queries/usePreferences.ts
@@ -1,5 +1,5 @@
-import { useEffect } from "react";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useEffect } from "react";
+import { useQuery, useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { invoke } from "@tauri-apps/api/core";
 import { useAppStore } from "../../stores/appStore";
 import {
@@ -156,6 +156,64 @@ export function getPreference<T>(json: string, key: string, defaultValue: T): T 
 
 const prefsKey = (userId: string | null) => ["user", "preferences", userId] as const;
 
+// Remote write throttle window. The local React Query cache update + any
+// callsite-side live effects (CSS vars, mixer state) fire on every call;
+// only the actual `invoke("save_preferences")` is rate-limited. Leading +
+// trailing edges always fire; sustained calls during the window collapse
+// to one intermediate fire every SAVE_THROTTLE_MS.
+const SAVE_THROTTLE_MS = 500;
+
+interface PendingSave {
+  userId: string;
+  prefs: PreferencesData;
+}
+
+let pendingSave: PendingSave | null = null;
+let saveThrottleTimer: ReturnType<typeof setTimeout> | null = null;
+let lastSaveInvokeAt = 0;
+
+async function flushPendingSave(): Promise<void> {
+  if (saveThrottleTimer !== null) {
+    clearTimeout(saveThrottleTimer);
+    saveThrottleTimer = null;
+  }
+  const job = pendingSave;
+  pendingSave = null;
+  if (!job) {
+    return;
+  }
+  lastSaveInvokeAt = performance.now();
+  try {
+    await invoke("save_preferences", {
+      userId: job.userId,
+      preferencesJson: JSON.stringify(job.prefs),
+    });
+  } catch (e) {
+    console.warn("[prefs] save_preferences failed", e);
+  }
+}
+
+function scheduleSave(
+  userId: string,
+  prefs: PreferencesData,
+  queryClient: QueryClient,
+): void {
+  queryClient.setQueryData(prefsKey(userId), prefs);
+  pendingSave = { userId, prefs };
+
+  const elapsed = performance.now() - lastSaveInvokeAt;
+  if (elapsed >= SAVE_THROTTLE_MS) {
+    void flushPendingSave();
+    return;
+  }
+  if (saveThrottleTimer === null) {
+    saveThrottleTimer = setTimeout(() => {
+      saveThrottleTimer = null;
+      void flushPendingSave();
+    }, SAVE_THROTTLE_MS - elapsed);
+  }
+}
+
 export function usePreferences() {
   const currentUser = useAppStore((state) => state.currentUser);
   const queryClient = useQueryClient();
@@ -196,23 +254,17 @@ export function usePreferences() {
     staleTime: 1000 * 60 * 5,
   });
 
-  const mutation = useMutation({
-    mutationFn: async (prefs: PreferencesData) => {
-      if (!currentUser) { return; }
-      await invoke("save_preferences", {
-        userId: currentUser.id,
-        preferencesJson: JSON.stringify(prefs),
-      });
-      return prefs;
-    },
-    onSuccess: (prefs) => {
-      if (prefs) {
-        queryClient.setQueryData(prefsKey(currentUser?.id ?? null), prefs);
+  const save = useCallback(
+    (prefs: PreferencesData) => {
+      if (!currentUser) {
+        return;
       }
+      scheduleSave(currentUser.id, prefs, queryClient);
     },
-  });
+    [currentUser, queryClient],
+  );
 
-  return { query, mutation };
+  return { query, save };
 }
 
 /**

--- a/frontend/src/hooks/useLiveKitRealtime.ts
+++ b/frontend/src/hooks/useLiveKitRealtime.ts
@@ -352,6 +352,12 @@ export function useLiveKitRealtime() {
         // Wipe stale presence for the reconnected room — Rust will re-emit
         // a fresh participant snapshot right after.
         usePresenceStore.getState().resetRoom(event.room_id);
+        // Catch up on welcomes that may have arrived during the outage so
+        // new-group invites apply without waiting for the user to open a
+        // channel from one of those groups.
+        invoke('poll_mls_welcomes', { userId: currentUser.id }).catch((err) => {
+          console.warn('[realtime] reconnect: poll_mls_welcomes failed:', err);
+        });
         return;
       }
 
@@ -487,4 +493,16 @@ export function useLiveKitRealtime() {
       console.error('[realtime] connect_rooms failed:', err);
     });
   }, [isTauriReady, allRoomIds, currentUser?.id, currentUser?.username, networkStatus]);
+
+  // One-time welcome poll on sign-in / app-ready. Catches welcomes for
+  // groups the user was invited to while offline so new-group invites
+  // apply without requiring them to open a channel from each group first.
+  useEffect(() => {
+    if (!isTauriReady || !currentUser || networkStatus === 'kill-switch') {
+      return;
+    }
+    invoke('poll_mls_welcomes', { userId: currentUser.id }).catch((err) => {
+      console.warn('[realtime] startup poll_mls_welcomes failed:', err);
+    });
+  }, [isTauriReady, currentUser?.id, networkStatus]);
 }

--- a/frontend/src/hooks/useLiveKitRealtime.ts
+++ b/frontend/src/hooks/useLiveKitRealtime.ts
@@ -3,7 +3,7 @@ import { Channel, invoke } from '@tauri-apps/api/core';
 import { useQueryClient } from '@tanstack/react-query';
 import { useAppStore } from '../stores/appStore';
 import { useTauriReady } from './useTauriReady';
-import { messageQueryKeys, useDMConversations } from './queries/useMessages';
+import { messageQueryKeys, useDMConversations, markIngested } from './queries/useMessages';
 import { usePreferences } from './queries/usePreferences';
 import { groupQueryKeys, useUserGroupsWithChannels } from './queries/useGroups';
 import { notify, setNotifyPrefs, loadDeviceCallRingtone } from '../utils/notify';
@@ -216,6 +216,37 @@ export function useLiveKitRealtime() {
 
     const channel = new Channel<RealtimeEvent>();
 
+    // Pull new envelopes for a conversation, then invalidate so the local
+    // read picks them up. The local-first read path no longer runs ingest
+    // inside the queryFn, so realtime hints must drive it explicitly.
+    const ingestAndInvalidate = (
+      channelId: string | null,
+      conversationId: string | null,
+    ) => {
+      const targetId = channelId ?? conversationId;
+      if (!targetId) {
+        return;
+      }
+      const command = channelId ? 'ingest_channel_envelopes' : 'ingest_dm_envelopes';
+      const args = channelId
+        ? { userId: currentUser.id, channelId }
+        : { userId: currentUser.id, dmChannelId: conversationId };
+      markIngested(targetId);
+      invoke(command, args)
+        .catch((err) => {
+          console.warn(`[realtime] ${command} failed:`, err);
+        })
+        .finally(() => {
+          if (channelId) {
+            queryClientRef.current.invalidateQueries({ queryKey: messageQueryKeys.channel(channelId) });
+            queryClientRef.current.invalidateQueries({ queryKey: ['last-message', 'channel', channelId] });
+          } else if (conversationId) {
+            queryClientRef.current.invalidateQueries({ queryKey: messageQueryKeys.conversation(conversationId) });
+            queryClientRef.current.invalidateQueries({ queryKey: ['last-message', 'conversation', conversationId] });
+          }
+        });
+    };
+
     channel.onmessage = (event) => {
       if (event.type === 'dm_created') {
         queryClientRef.current.invalidateQueries({
@@ -301,27 +332,14 @@ export function useLiveKitRealtime() {
       }
 
       if (event.type === 'edited_message') {
-        const channelId = event.channel_id;
-        const conversationId = event.conversation_id;
-        if (channelId) {
-          queryClientRef.current.invalidateQueries({ queryKey: messageQueryKeys.channel(channelId) });
-        } else if (conversationId) {
-          queryClientRef.current.invalidateQueries({ queryKey: messageQueryKeys.conversation(conversationId) });
-        }
+        ingestAndInvalidate(event.channel_id, event.conversation_id);
         return;
       }
 
       if (event.type === 'deleted_message') {
-        // Refetching the channel triggers ingest, which applies the
-        // type='delete' tombstone envelope as a soft-delete on the local
-        // row. The MessageList then renders it as "[deleted]".
-        const channelId = event.channel_id;
-        const conversationId = event.conversation_id;
-        if (channelId) {
-          queryClientRef.current.invalidateQueries({ queryKey: messageQueryKeys.channel(channelId) });
-        } else if (conversationId) {
-          queryClientRef.current.invalidateQueries({ queryKey: messageQueryKeys.conversation(conversationId) });
-        }
+        // Ingest applies the type='delete' tombstone envelope as a
+        // soft-delete on the local row; MessageList renders [deleted].
+        ingestAndInvalidate(event.channel_id, event.conversation_id);
         queryClientRef.current.invalidateQueries({ queryKey: ['last-message'] });
         return;
       }
@@ -418,23 +436,9 @@ export function useLiveKitRealtime() {
       // conversation data but never trigger notifications or unread badges.
       const isOwnMessage = event.sender_id === currentUserIdRef.current;
 
-      // Always invalidate the affected room's query so re-entering the channel
-      // shows the new message immediately. For currently-selected rooms this
-      // triggers an immediate refetch; for others it just marks stale for next
-      // mount. Without this, React Query's staleTime serves cached pages that
-      // omit messages received while the user was elsewhere.
-      if (channelId) {
-        queryClientRef.current.invalidateQueries({ queryKey: messageQueryKeys.channel(channelId) });
-      } else if (conversationId) {
-        queryClientRef.current.invalidateQueries({ queryKey: messageQueryKeys.conversation(conversationId) });
-      }
-
-      // Always update the last-message preview regardless of which channel is selected
-      if (channelId) {
-        queryClientRef.current.invalidateQueries({ queryKey: ["last-message", "channel", channelId] });
-      } else if (conversationId) {
-        queryClientRef.current.invalidateQueries({ queryKey: ["last-message", "conversation", conversationId] });
-      }
+      // Ingest the new envelope, then invalidate the affected room's
+      // query and last-message preview so they pick the new message up.
+      ingestAndInvalidate(channelId, conversationId);
 
       const isSelected =
         (channelId && channelId === selectedChannelIdRef.current) ||

--- a/frontend/src/pages/Channel.tsx
+++ b/frontend/src/pages/Channel.tsx
@@ -51,7 +51,7 @@ export const ChannelPage: React.FC = () => {
               data-testid="rename-channel-trigger"
               onClick={() => navigate({ to: "/groups/$groupId/channels/$channelId/rename", params: { groupId, channelId } })}
               aria-label="Rename channel"
-              className="icon-btn-sm flex-shrink-0"
+              className="icon-btn-sm flex-shrink-0 padding-0"
             >
               <Pencil size={14} aria-hidden="true" />
             </button>
@@ -59,7 +59,7 @@ export const ChannelPage: React.FC = () => {
               data-testid="delete-channel-trigger"
               onClick={() => setPendingDeleteChannelId(channelId)}
               aria-label="Delete channel"
-              className="icon-btn-sm flex-shrink-0"
+              className="icon-btn-sm flex-shrink-0 padding-0"
             >
               <Trash2 size={14} aria-hidden="true" />
             </button>

--- a/frontend/src/pages/Channel.tsx
+++ b/frontend/src/pages/Channel.tsx
@@ -9,13 +9,20 @@ export const ChannelPage: React.FC = () => {
   const navigate = useNavigate();
   const { groupId, channelId } = useParams({ from: "/groups/$groupId/channels/$channelId" });
   const setSelectedChannelId = useAppStore((s) => s.setSelectedChannelId);
+  const setSelectedGroupId = useAppStore((s) => s.setSelectedGroupId);
   const pendingDeleteChannelId = useAppStore((s) => s.pendingDeleteChannelId);
   const setPendingDeleteChannelId = useAppStore((s) => s.setPendingDeleteChannelId);
 
   useEffect(() => {
+    // selectedGroupId drives the LiveKit room id used by the typing
+    // publisher; without it, this client's typing events never go out.
+    // setSelectedGroupId also nulls channelId, so set the group first.
+    if (useAppStore.getState().selectedGroupId !== groupId) {
+      setSelectedGroupId(groupId);
+    }
     setSelectedChannelId(channelId);
     return () => { setSelectedChannelId(null); };
-  }, [channelId, setSelectedChannelId]);
+  }, [groupId, channelId, setSelectedGroupId, setSelectedChannelId]);
 
   useEffect(() => {
     return () => { setPendingDeleteChannelId(null); };

--- a/frontend/src/pages/Preferences.tsx
+++ b/frontend/src/pages/Preferences.tsx
@@ -46,7 +46,7 @@ export const Preferences: React.FC = () => {
   const [accentHexInput, setAccentHexInput] = useState<string>(() => hslToHex(38, 90, 62));
   const [bgHexInput, setBgHexInput] = useState<string>(() => hslToHex(38, 20, 4));
 
-  const { query, mutation } = usePreferences();
+  const { query, save: savePrefs } = usePreferences();
 
   // Apply saved preferences on first load
   useEffect(() => {
@@ -115,7 +115,7 @@ export const Preferences: React.FC = () => {
     // local value back to the remote on every save.
     const { font_size: _legacyFontSize, ...rest } = query.data ?? {};
     void _legacyFontSize;
-    mutation.mutate({
+    savePrefs({
       ...rest,
       accent_color: accentHex,
       background_color: bgHex,
@@ -123,7 +123,7 @@ export const Preferences: React.FC = () => {
       allow_sound_effects: sfx,
       sidebar_open_by_default: sidebar,
     });
-  }, [mutation, query.data, hue, saturation, bgHue, bgSaturation, bgLightness, allowDesktopNotifications, allowSoundEffects, sidebarOpenByDefault]);
+  }, [savePrefs, query.data, hue, saturation, bgHue, bgSaturation, bgLightness, allowDesktopNotifications, allowSoundEffects, sidebarOpenByDefault]);
 
   const handleAccentColor = (hex: string) => {
     const [h, s] = hexToHsl(hex);

--- a/frontend/src/pages/VoiceSettingsPage.tsx
+++ b/frontend/src/pages/VoiceSettingsPage.tsx
@@ -164,7 +164,7 @@ export const VoiceSettingsPage: React.FC = () => {
    */
   const savePrefsAndPushApm = (patch: Partial<PreferencesData>) => {
     const next: PreferencesData = { ...preferences.query.data, ...patch };
-    preferences.mutation.mutate(next);
+    preferences.save(next);
     void pushApmConfig(preferencesToApmConfig(next));
   };
 
@@ -177,7 +177,7 @@ export const VoiceSettingsPage: React.FC = () => {
 
   const autoJoinVoice = preferences.query.data?.auto_join_voice ?? false;
   const handleAutoJoinVoice = (enabled: boolean) => {
-    preferences.mutation.mutate({ ...preferences.query.data, auto_join_voice: enabled });
+    preferences.save({ ...preferences.query.data, auto_join_voice: enabled });
   };
 
   return (

--- a/pollis-core/src/commands/messages.rs
+++ b/pollis-core/src/commands/messages.rs
@@ -371,11 +371,16 @@ pub async fn ingest_channel_envelopes_inner(
 ) -> Result<()> {
     let conn = state.remote_db.conn().await?;
 
-    // Resolve mls_group_id — all channels in a group share one MLS group.
+    // Single round-trip: resolve mls_group_id AND confirm membership. Returns
+    // a row only when the channel exists and the user is a member; otherwise
+    // short-circuit so the read path falls back to whatever is local.
     let mls_group_id: String = {
         let mut rows = conn.query(
-            "SELECT group_id FROM channels WHERE id = ?1",
-            libsql::params![channel_id.to_string()],
+            "SELECT c.group_id FROM channels c
+             JOIN group_member gm ON gm.group_id = c.group_id
+             WHERE c.id = ?1 AND gm.user_id = ?2
+             LIMIT 1",
+            libsql::params![channel_id.to_string(), user_id.to_string()],
         ).await?;
         match rows.next().await? {
             Some(row) => row.get::<String>(0)?,
@@ -383,46 +388,37 @@ pub async fn ingest_channel_envelopes_inner(
         }
     };
 
-    // Non-members have no MLS key material, no business creating a watermark
-    // row, and would just block cleanup. Short-circuit here so the read path
-    // falls back to whatever is already in local.
-    let is_member: bool = {
-        let mut rows = conn.query(
-            "SELECT 1 FROM group_member
-             WHERE group_id = ?1 AND user_id = ?2
-             LIMIT 1",
-            libsql::params![mls_group_id.clone(), user_id.to_string()],
-        ).await?;
-        rows.next().await?.is_some()
-    };
-    if !is_member {
-        return Ok(());
-    }
+    let device_id = state.device_id.lock().await.clone();
 
     // Advance MLS epoch before decryption so pre-ingest-window commits apply.
-    {
-        let device_id = state.device_id.lock().await.clone();
-        if let Some(did) = device_id {
-            if let Err(e) = crate::commands::mls::poll_mls_welcomes_inner(state, user_id, &did).await {
-                eprintln!("[ingest] poll_mls_welcomes for {mls_group_id}: {e}");
-            }
+    if let Some(ref did) = device_id {
+        if let Err(e) = crate::commands::mls::poll_mls_welcomes_inner(state, user_id, did).await {
+            eprintln!("[ingest] poll_mls_welcomes for {mls_group_id}: {e}");
         }
     }
     if let Err(e) = crate::commands::mls::process_pending_commits_inner(state, &mls_group_id, user_id).await {
         eprintln!("[ingest] process_pending_commits for {mls_group_id}: {e}");
     }
 
-    // Pull every envelope for this conversation (message + edit), oldest-first.
-    // Ordering is critical so MLS decryption sees epochs in the order they were
-    // committed and the watermark stops at the first decrypt failure.
+    // Pull only envelopes past this device's watermark. Steady state returns
+    // zero rows. Empty-string COALESCE handles the no-watermark-yet case
+    // (first ingest for this conversation on this device). Ordering by
+    // sent_at ASC is critical so MLS decryption sees epochs in commit order
+    // and the watermark stops at the first decrypt failure.
     let envelopes: Vec<(String, String, String, Option<String>, Option<String>, String, String)> = {
         let mut out = Vec::new();
+        let did_param = device_id.clone().unwrap_or_default();
         let mut rows = conn.query(
             "SELECT id, sender_id, ciphertext, reply_to_id, target_message_id, sent_at, type
              FROM message_envelope
              WHERE conversation_id = ?1
+               AND sent_at > COALESCE(
+                   (SELECT last_fetched_at FROM conversation_watermark
+                    WHERE conversation_id = ?1 AND user_id = ?2 AND device_id = ?3),
+                   ''
+               )
              ORDER BY sent_at ASC, id ASC",
-            libsql::params![channel_id.to_string()],
+            libsql::params![channel_id.to_string(), user_id.to_string(), did_param],
         ).await?;
         while let Some(row) = rows.next().await? {
             out.push((
@@ -445,18 +441,15 @@ pub async fn ingest_channel_envelopes_inner(
         &envelopes,
     ).await?;
 
-    if let Some(ts) = watermark_ts {
-        let device_id = state.device_id.lock().await.clone();
-        if let Some(did) = device_id {
-            if let Err(e) = conn.execute(
-                "INSERT INTO conversation_watermark (conversation_id, user_id, device_id, last_fetched_at)
-                 VALUES (?1, ?2, ?3, ?4)
-                 ON CONFLICT(conversation_id, user_id, device_id) DO UPDATE SET
-                   last_fetched_at = MAX(last_fetched_at, excluded.last_fetched_at)",
-                libsql::params![channel_id.to_string(), user_id.to_string(), did, ts],
-            ).await {
-                eprintln!("[watermark] ingest_channel: upsert failed: {e}");
-            }
+    if let (Some(ts), Some(did)) = (watermark_ts, device_id.as_ref()) {
+        if let Err(e) = conn.execute(
+            "INSERT INTO conversation_watermark (conversation_id, user_id, device_id, last_fetched_at)
+             VALUES (?1, ?2, ?3, ?4)
+             ON CONFLICT(conversation_id, user_id, device_id) DO UPDATE SET
+               last_fetched_at = MAX(last_fetched_at, excluded.last_fetched_at)",
+            libsql::params![channel_id.to_string(), user_id.to_string(), did.clone(), ts],
+        ).await {
+            eprintln!("[watermark] ingest_channel: upsert failed: {e}");
         }
     }
 
@@ -931,26 +924,32 @@ pub async fn ingest_dm_envelopes_inner(
         return Ok(());
     }
 
-    {
-        let device_id = state.device_id.lock().await.clone();
-        if let Some(did) = device_id {
-            if let Err(e) = crate::commands::mls::poll_mls_welcomes_inner(state, user_id, &did).await {
-                eprintln!("[ingest] poll_mls_welcomes for DM {dm_channel_id}: {e}");
-            }
+    let device_id = state.device_id.lock().await.clone();
+
+    if let Some(ref did) = device_id {
+        if let Err(e) = crate::commands::mls::poll_mls_welcomes_inner(state, user_id, did).await {
+            eprintln!("[ingest] poll_mls_welcomes for DM {dm_channel_id}: {e}");
         }
     }
     if let Err(e) = crate::commands::mls::process_pending_commits_inner(state, dm_channel_id, user_id).await {
         eprintln!("[ingest] process_pending_commits for DM {dm_channel_id}: {e}");
     }
 
+    // Watermark-filtered envelope read — see ingest_channel_envelopes_inner.
     let envelopes: Vec<(String, String, String, Option<String>, Option<String>, String, String)> = {
         let mut out = Vec::new();
+        let did_param = device_id.clone().unwrap_or_default();
         let mut rows = conn.query(
             "SELECT id, sender_id, ciphertext, reply_to_id, target_message_id, sent_at, type
              FROM message_envelope
              WHERE conversation_id = ?1
+               AND sent_at > COALESCE(
+                   (SELECT last_fetched_at FROM conversation_watermark
+                    WHERE conversation_id = ?1 AND user_id = ?2 AND device_id = ?3),
+                   ''
+               )
              ORDER BY sent_at ASC, id ASC",
-            libsql::params![dm_channel_id.to_string()],
+            libsql::params![dm_channel_id.to_string(), user_id.to_string(), did_param],
         ).await?;
         while let Some(row) = rows.next().await? {
             out.push((
@@ -973,18 +972,15 @@ pub async fn ingest_dm_envelopes_inner(
         &envelopes,
     ).await?;
 
-    if let Some(ts) = watermark_ts {
-        let device_id = state.device_id.lock().await.clone();
-        if let Some(did) = device_id {
-            if let Err(e) = conn.execute(
-                "INSERT INTO conversation_watermark (conversation_id, user_id, device_id, last_fetched_at)
-                 VALUES (?1, ?2, ?3, ?4)
-                 ON CONFLICT(conversation_id, user_id, device_id) DO UPDATE SET
-                   last_fetched_at = MAX(last_fetched_at, excluded.last_fetched_at)",
-                libsql::params![dm_channel_id.to_string(), user_id.to_string(), did, ts],
-            ).await {
-                eprintln!("[watermark] ingest_dm: upsert failed: {e}");
-            }
+    if let (Some(ts), Some(did)) = (watermark_ts, device_id.as_ref()) {
+        if let Err(e) = conn.execute(
+            "INSERT INTO conversation_watermark (conversation_id, user_id, device_id, last_fetched_at)
+             VALUES (?1, ?2, ?3, ?4)
+             ON CONFLICT(conversation_id, user_id, device_id) DO UPDATE SET
+               last_fetched_at = MAX(last_fetched_at, excluded.last_fetched_at)",
+            libsql::params![dm_channel_id.to_string(), user_id.to_string(), did.clone(), ts],
+        ).await {
+            eprintln!("[watermark] ingest_dm: upsert failed: {e}");
         }
     }
 

--- a/pollis-core/src/commands/messages.rs
+++ b/pollis-core/src/commands/messages.rs
@@ -708,6 +708,142 @@ async fn attach_sender_usernames(
     Ok(())
 }
 
+/// Attach sender usernames from the local `user_cache` table; for any
+/// sender_ids missing from the cache, do one batched remote fetch and
+/// write the results back. After the first read of a channel/DM, the
+/// cache is warm and subsequent reads are zero-remote.
+async fn attach_sender_usernames_local(
+    state: &Arc<AppState>,
+    messages: &mut [ChannelMessage],
+) -> Result<()> {
+    if messages.is_empty() {
+        return Ok(());
+    }
+
+    let mut ids: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for m in messages.iter() {
+        ids.insert(m.sender_id.clone());
+    }
+    let ids_vec: Vec<String> = ids.into_iter().collect();
+
+    let mut found: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+    let missing: Vec<String> = {
+        let guard = state.local_db.lock().await;
+        let db = guard.as_ref().ok_or_else(|| crate::error::Error::Other(anyhow::anyhow!("Not signed in")))?;
+        let placeholders = (1..=ids_vec.len())
+            .map(|i| format!("?{i}"))
+            .collect::<Vec<_>>()
+            .join(",");
+        let sql = format!("SELECT id, username FROM user_cache WHERE id IN ({placeholders})");
+        let mut stmt = db.conn().prepare(&sql)?;
+        let mapped = stmt.query_map(rusqlite::params_from_iter(ids_vec.iter()), |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?;
+        for r in mapped {
+            if let Ok((id, name)) = r {
+                found.insert(id, name);
+            }
+        }
+        ids_vec.iter().filter(|i| !found.contains_key(*i)).cloned().collect()
+    };
+
+    if !missing.is_empty() {
+        let placeholders = (1..=missing.len())
+            .map(|i| format!("?{i}"))
+            .collect::<Vec<_>>()
+            .join(",");
+        let sql = format!("SELECT id, username FROM users WHERE id IN ({placeholders})");
+        let params: Vec<libsql::Value> = missing
+            .iter()
+            .map(|s| libsql::Value::Text(s.clone()))
+            .collect();
+        let conn = state.remote_db.conn().await?;
+        match conn.query(&sql, libsql::params_from_iter(params)).await {
+            Ok(mut rows) => {
+                let mut fetched: Vec<(String, String)> = Vec::new();
+                while let Some(row) = rows.next().await? {
+                    let id: String = row.get(0)?;
+                    let name: String = row.get(1)?;
+                    fetched.push((id.clone(), name.clone()));
+                    found.insert(id, name);
+                }
+                drop(rows);
+                if !fetched.is_empty() {
+                    let guard = state.local_db.lock().await;
+                    if let Some(db) = guard.as_ref() {
+                        for (id, name) in &fetched {
+                            let _ = db.conn().execute(
+                                "INSERT INTO user_cache (id, username, updated_at) VALUES (?1, ?2, datetime('now'))
+                                 ON CONFLICT(id) DO UPDATE SET username = ?2, updated_at = datetime('now')",
+                                rusqlite::params![id, name],
+                            );
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                // Offline or transient — leave the missing names as None.
+                // Next ingest / read while online will fill them in.
+                eprintln!("[messages] attach_sender_usernames_local: remote fallback failed: {e}");
+            }
+        }
+    }
+
+    for m in messages.iter_mut() {
+        m.sender_username = found.get(&m.sender_id).cloned();
+    }
+    Ok(())
+}
+
+/// Local-only read of a channel page. Does NOT trigger ingest — callers
+/// fire `ingest_channel_envelopes` separately, off the critical render
+/// path. Usernames come from the local `user_cache` (with a one-shot
+/// remote fallback for cache misses, see `attach_sender_usernames_local`).
+pub async fn read_channel_messages(
+    channel_id: String,
+    limit: Option<i64>,
+    cursor: Option<MessageCursor>,
+    state: &Arc<AppState>,
+) -> Result<MessagePage> {
+    let limit = limit.unwrap_or(50);
+    let mut messages = read_local_channel_page(state, &channel_id, &cursor, limit).await?;
+    attach_sender_usernames_local(state, &mut messages).await?;
+
+    let next_cursor = if messages.len() == limit as usize {
+        messages.last().map(|m| MessageCursor {
+            sent_at: m.sent_at.clone(),
+            id: m.id.clone(),
+        })
+    } else {
+        None
+    };
+
+    Ok(MessagePage { messages, next_cursor })
+}
+
+/// Local-only read of a DM page. Mirrors `read_channel_messages`.
+pub async fn read_dm_messages(
+    dm_channel_id: String,
+    limit: Option<i64>,
+    cursor: Option<MessageCursor>,
+    state: &Arc<AppState>,
+) -> Result<MessagePage> {
+    let limit = limit.unwrap_or(50);
+    let mut messages = read_local_channel_page(state, &dm_channel_id, &cursor, limit).await?;
+    attach_sender_usernames_local(state, &mut messages).await?;
+
+    let next_cursor = if messages.len() == limit as usize {
+        messages.last().map(|m| MessageCursor {
+            sent_at: m.sent_at.clone(),
+            id: m.id.clone(),
+        })
+    } else {
+        None
+    };
+
+    Ok(MessagePage { messages, next_cursor })
+}
+
 /// Frontend-triggerable ingest for a channel. Used by LiveKit real-time hints
 /// and channel-focus pre-warm paths that want to persist new envelopes without
 /// reading a page.

--- a/pollis-core/src/commands/r2.rs
+++ b/pollis-core/src/commands/r2.rs
@@ -34,6 +34,20 @@ pub const MEDIA_CACHE_MAX_FILE_BYTES: u64 = 100 * 1024 * 1024;
 /// Set once at app startup from the Tauri shim (`app_data_dir()`).
 static MEDIA_CACHE_DIR: OnceLock<PathBuf> = OnceLock::new();
 
+/// Per-user scope for the cache. Two clients on the same machine each have
+/// their own `db_key`; without per-user scoping they'd share `MEDIA_CACHE_DIR`
+/// and try (and fail) to decrypt each other's entries — 500 from the media
+/// server. Set after sign-in via `set_cache_user(Some(user_id))`, cleared on
+/// logout via `set_cache_user(None)`. The pre-signin window falls back to a
+/// shared "_anon" bucket.
+static CURRENT_CACHE_USER: StdMutex<Option<String>> = StdMutex::new(None);
+
+pub fn set_cache_user(user_id: Option<&str>) {
+    if let Ok(mut guard) = CURRENT_CACHE_USER.lock() {
+        *guard = user_id.map(|s| s.to_string());
+    }
+}
+
 /// Per-hash locks so concurrent callers for the same content_hash share one
 /// download instead of racing to write the same file. The outer mutex guards
 /// the map; the inner `Arc<TokioMutex>` is the actual gate.
@@ -50,11 +64,18 @@ pub fn set_media_cache_dir(path: PathBuf) {
     let _ = MEDIA_CACHE_DIR.set(path);
 }
 
-fn media_cache_dir() -> Result<&'static Path> {
-    MEDIA_CACHE_DIR
+fn media_cache_dir() -> Result<PathBuf> {
+    let root = MEDIA_CACHE_DIR
         .get()
-        .map(|p| p.as_path())
-        .ok_or_else(|| Error::Other(anyhow::anyhow!("media cache dir not initialised")))
+        .ok_or_else(|| Error::Other(anyhow::anyhow!("media cache dir not initialised")))?;
+    let user = CURRENT_CACHE_USER
+        .lock()
+        .ok()
+        .and_then(|g| g.clone())
+        .unwrap_or_else(|| "_anon".to_string());
+    let path = root.join(user);
+    let _ = std::fs::create_dir_all(&path);
+    Ok(path)
 }
 
 /// Map a MIME type to a file extension. Falls back to `bin`. Kept small —
@@ -117,8 +138,8 @@ pub fn content_type_for_ext(ext: &str) -> &'static str {
 /// caller can derive a Content-Type. `None` if no file with this hash
 /// exists in the cache.
 pub fn find_cached_file(content_hash: &str) -> Option<(PathBuf, String)> {
-    let dir = MEDIA_CACHE_DIR.get()?;
-    let entries = std::fs::read_dir(dir).ok()?;
+    let dir = media_cache_dir().ok()?;
+    let entries = std::fs::read_dir(&dir).ok()?;
     let prefix = format!("{content_hash}.");
     for entry in entries.flatten() {
         let path = entry.path();
@@ -192,19 +213,19 @@ fn enforce_cache_cap_to(dir: &Path, target_bytes: u64) {
 /// Public re-evaluation entry point — call from app focus to defend
 /// against external file copies / mtime tampering / cap-config changes.
 pub fn enforce_cache_cap_now() {
-    if let Some(dir) = MEDIA_CACHE_DIR.get() {
-        enforce_cache_cap(dir);
+    if let Ok(dir) = media_cache_dir() {
+        enforce_cache_cap(&dir);
     }
 }
 
 /// Sum of all cached file sizes. Used to gate downloads against the cap
 /// *before* writing new bytes, so the cache never peaks above the cap.
 pub fn cache_total_bytes() -> u64 {
-    let dir = match MEDIA_CACHE_DIR.get() {
-        Some(d) => d,
-        None => return 0,
+    let dir = match media_cache_dir() {
+        Ok(d) => d,
+        Err(_) => return 0,
     };
-    let entries = match std::fs::read_dir(dir) {
+    let entries = match std::fs::read_dir(&dir) {
         Ok(rd) => rd,
         Err(_) => return 0,
     };
@@ -225,11 +246,11 @@ pub fn cache_total_bytes() -> u64 {
 /// lifecycle as the keystore unlock. The directory itself stays so a
 /// subsequent re-login doesn't have to re-create it.
 pub fn clear_media_cache() {
-    let dir = match MEDIA_CACHE_DIR.get() {
-        Some(d) => d,
-        None => return,
+    let dir = match media_cache_dir() {
+        Ok(d) => d,
+        Err(_) => return,
     };
-    let entries = match std::fs::read_dir(dir) {
+    let entries = match std::fs::read_dir(&dir) {
         Ok(rd) => rd,
         Err(_) => return,
     };
@@ -578,7 +599,7 @@ pub async fn get_media_url(
     }
 
     let dir = media_cache_dir()?;
-    if let Err(e) = std::fs::create_dir_all(dir) {
+    if let Err(e) = std::fs::create_dir_all(&dir) {
         in_flight().lock().expect("in-flight map poisoned").remove(&content_hash);
         return Err(Error::Other(anyhow::anyhow!("create cache dir: {e}")));
     }
@@ -610,7 +631,7 @@ pub async fn get_media_url(
     let new_size = encrypted.len() as u64;
     let total = cache_total_bytes();
     if total.saturating_add(new_size) > MEDIA_CACHE_MAX_BYTES {
-        enforce_cache_cap_to(dir, MEDIA_CACHE_MAX_BYTES.saturating_sub(new_size));
+        enforce_cache_cap_to(&dir, MEDIA_CACHE_MAX_BYTES.saturating_sub(new_size));
     }
 
     // Atomic write: <hash>.<ext>.enc.tmp → rename → <hash>.<ext>.enc.
@@ -631,7 +652,7 @@ pub async fn get_media_url(
         return Err(Error::Other(anyhow::anyhow!("rename cache tmp: {e}")));
     }
 
-    enforce_cache_cap(dir);
+    enforce_cache_cap(&dir);
 
     in_flight().lock().expect("in-flight map poisoned").remove(&content_hash);
     Ok(url)

--- a/pollis-core/src/commands/voice.rs
+++ b/pollis-core/src/commands/voice.rs
@@ -1330,16 +1330,22 @@ pub async fn join_voice_channel(
     // subscribed tracks once the event loop drains buffered events, and
     // attaching twice creates competing draining tasks.
     let local_avatar_url = lookup_avatar_url(&state, &user_id).await;
-    let existing_remote: Vec<(String, String)> = room
+    let existing_remote: Vec<(String, String, bool)> = room
         .remote_participants()
         .into_iter()
-        .map(|(_id, p)| (p.identity().to_string(), p.name()))
+        .map(|(_id, p)| {
+            // Seed mute state from current publications — TrackMuted only
+            // fires on transitions, so a participant who muted before we
+            // joined would otherwise render as unmuted indefinitely.
+            let is_muted = p.track_publications().values().any(|pub_| pub_.is_muted());
+            (p.identity().to_string(), p.name(), is_muted)
+        })
         .collect();
-    let mut existing_with_avatars: Vec<(String, String, Option<String>)> =
+    let mut existing_with_avatars: Vec<(String, String, bool, Option<String>)> =
         Vec::with_capacity(existing_remote.len());
-    for (identity, name) in existing_remote {
+    for (identity, name, is_muted) in existing_remote {
         let avatar = lookup_avatar_url_for_identity(&state, &identity).await;
-        existing_with_avatars.push((identity, name, avatar));
+        existing_with_avatars.push((identity, name, is_muted, avatar));
     }
     {
         let voice = state.voice.lock().await;
@@ -1350,12 +1356,12 @@ pub async fn join_voice_channel(
                 is_muted: false,
                 avatar_url: local_avatar_url,
             });
-            for (identity, name, avatar_url) in existing_with_avatars {
-                eprintln!("[voice] existing participant: {}", identity);
+            for (identity, name, is_muted, avatar_url) in existing_with_avatars {
+                eprintln!("[voice] existing participant: {} muted={}", identity, is_muted);
                 let _ = ch.send(VoiceEvent::ParticipantJoined {
                     identity,
                     name,
-                    is_muted: false,
+                    is_muted,
                     avatar_url,
                 });
             }
@@ -1371,6 +1377,7 @@ pub async fn join_voice_channel(
                 RoomEvent::ParticipantConnected(p) => {
                     eprintln!("[voice] participant joined: {}", p.identity());
                     let identity = p.identity().to_string();
+                    let is_muted = p.track_publications().values().any(|pub_| pub_.is_muted());
                     let avatar_url =
                         lookup_avatar_url_for_identity(&state_for_room, &identity).await;
                     let voice = voice_arc.lock().await;
@@ -1378,7 +1385,7 @@ pub async fn join_voice_channel(
                         let _ = ch.send(VoiceEvent::ParticipantJoined {
                             identity,
                             name: p.name(),
-                            is_muted: false,
+                            is_muted,
                             avatar_url,
                         });
                     }
@@ -1419,6 +1426,21 @@ pub async fn join_voice_channel(
                         drop(pb);
                         drop(voice);
                         buffers_arc.lock().unwrap().remove(&track_key);
+                    }
+                }
+
+                RoomEvent::TrackMuted { participant, publication: _ } => {
+                    let identity = participant.identity().to_string();
+                    let voice = voice_arc.lock().await;
+                    if let Some(ch) = &voice.channel {
+                        let _ = ch.send(VoiceEvent::Muted { identity });
+                    }
+                }
+                RoomEvent::TrackUnmuted { participant, publication: _ } => {
+                    let identity = participant.identity().to_string();
+                    let voice = voice_arc.lock().await;
+                    if let Some(ch) = &voice.channel {
+                        let _ = ch.send(VoiceEvent::Unmuted { identity });
                     }
                 }
 

--- a/pollis-core/src/db/local_schema.sql
+++ b/pollis-core/src/db/local_schema.sql
@@ -65,3 +65,9 @@ CREATE TABLE IF NOT EXISTS mls_kv (
     PRIMARY KEY (scope, key)
 );
 
+CREATE TABLE IF NOT EXISTS user_cache (
+    id         TEXT PRIMARY KEY,
+    username   TEXT NOT NULL,
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+

--- a/pollis-core/src/db/migrations/000002_index_gm_user_and_channels_group.sql
+++ b/pollis-core/src/db/migrations/000002_index_gm_user_and_channels_group.sql
@@ -1,0 +1,2 @@
+CREATE INDEX idx_gm_user ON group_member(user_id);
+CREATE INDEX idx_channels_group ON channels(group_id);

--- a/pollis-core/src/db/mod.rs
+++ b/pollis-core/src/db/mod.rs
@@ -15,6 +15,11 @@ pub const POST_BASELINE_MIGRATIONS: &[(u32, &str, &str)] = &[
         "user_preferred_name",
         include_str!("migrations/000001_user_preferred_name.sql"),
     ),
+    (
+        2,
+        "index_gm_user_and_channels_group",
+        include_str!("migrations/000002_index_gm_user_and_channels_group.sql"),
+    ),
 ];
 
 pub mod queries {

--- a/pollis-core/src/state.rs
+++ b/pollis-core/src/state.rs
@@ -154,12 +154,18 @@ impl AppState {
         }
 
         *self.local_db.lock().await = Some(db);
+        // Scope the media cache to this user. Two clients on the same machine
+        // (dev workflow) otherwise share `app_data_dir/media-cache` but each
+        // has its own db_key, so client B can't decrypt client A's cache
+        // entries and the media server returns 500.
+        crate::commands::r2::set_cache_user(Some(user_id));
         Ok(())
     }
 
     /// Close the current user's database (called on logout).
     pub async fn unload_user_db(&self) {
         *self.local_db.lock().await = None;
+        crate::commands::r2::set_cache_user(None);
     }
 
     pub fn check_not_outdated(&self) -> crate::error::Result<()> {

--- a/src-tauri/src/commands/messages.rs
+++ b/src-tauri/src/commands/messages.rs
@@ -29,6 +29,16 @@ pub async fn get_dm_messages(user_id: String, dm_channel_id: String, limit: Opti
 }
 
 #[tauri::command]
+pub async fn read_channel_messages(channel_id: String, limit: Option<i64>, cursor: Option<MessageCursor>, state: State<'_, Arc<AppState>>) -> Result<MessagePage> {
+    pollis_core::commands::messages::read_channel_messages(channel_id, limit, cursor, &state).await
+}
+
+#[tauri::command]
+pub async fn read_dm_messages(dm_channel_id: String, limit: Option<i64>, cursor: Option<MessageCursor>, state: State<'_, Arc<AppState>>) -> Result<MessagePage> {
+    pollis_core::commands::messages::read_dm_messages(dm_channel_id, limit, cursor, &state).await
+}
+
+#[tauri::command]
 pub async fn ingest_channel_envelopes(user_id: String, channel_id: String, state: State<'_, Arc<AppState>>) -> Result<()> {
     pollis_core::commands::messages::ingest_channel_envelopes(user_id, channel_id, &state).await
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -408,6 +408,8 @@ pub fn run() {
             commands::messages::send_message,
             commands::messages::get_channel_messages,
             commands::messages::get_dm_messages,
+            commands::messages::read_channel_messages,
+            commands::messages::read_dm_messages,
             commands::messages::ingest_channel_envelopes,
             commands::messages::ingest_dm_envelopes,
             commands::messages::list_messages_by_sender,

--- a/src-tauri/src/test_harness.rs
+++ b/src-tauri/src/test_harness.rs
@@ -97,6 +97,8 @@ pub fn build_client_app(state: Arc<AppState>) -> Result<(App<MockRuntime>, Webvi
             crate::commands::messages::send_message,
             crate::commands::messages::get_channel_messages,
             crate::commands::messages::get_dm_messages,
+            crate::commands::messages::read_channel_messages,
+            crate::commands::messages::read_dm_messages,
             crate::commands::messages::list_messages_by_sender,
             crate::commands::messages::list_channel_previews,
             crate::commands::messages::search_messages,


### PR DESCRIPTION
## Summary

Query-performance pass (Phases 1–3) plus a handful of bugs found along the way.

### Performance

- **`save_preferences` throttle** (`b72d3ac`) — slider drags were firing ~77 remote UPSERTs per drag. Leading + 500ms-throttled + trailing pattern; local cache and live effects still fire on every change.
- **Indexes for the hot homepage query** (`5af31fa`) — `idx_gm_user` + `idx_channels_group` for `list_user_groups_with_channels` and `list_group_channels`.
- **Render channel/DM page from local, ingest in background** (`2ee79f2`) — `read_channel_messages` / `read_dm_messages` commands plus a per-conversation ingest debounce. Critical path drops from ~7 serial Turso round-trips to 0.
- **Watermark-filter envelope read + collapsed channel/member lookup** (`3c1be6a`) — `ingest_*_envelopes_inner` now filters by `conversation_watermark.last_fetched_at` so steady-state ingest returns zero rows, and the channels + group_member round-trips are merged into one.
- **MLS welcome poll on startup + reconnect** (`973a9be`) — catches welcomes from groups the user was invited to while offline without needing to open a channel from each.

### Fixes

- **Typing indicator** (`b4618a1`) — `ChannelPage` was setting `selectedChannelId` but not `selectedGroupId`, so direct channel navigation (deep link, refresh, notification) left `typingRoomId` null and `publish_typing` short-circuited.
- **Voice mute state** (`b713a76`) — `RoomEvent::TrackMuted` / `TrackUnmuted` were never matched in the room event loop, so remote mute toggles never reached the frontend. Also seed initial mute state from `track_publications().is_muted()` so already-muted participants aren't shown as unmuted.
- **Bottom-bar height** (`2819b52`) — match the sidebar Close button via padding instead of a fixed 28px.
- **Attachment download on Linux** (`cf2cc89`) — `<a download>` is ignored across origins by WebKitGTK, so the webview was navigating to the loopback media URL and showing the browser's built-in audio player. Replaced with `plugin-dialog` `save()` + `plugin-fs` `writeFile()`.
- **Media cache per user** (`ed5b469`) — `app_data_dir/media-cache` was shared, but each user has their own `db_key`, so client B's media-server returned 500 trying to decrypt client A's cache entries. Now scoped to `<root>/<user_id>/`.

## Test plan

- [x] `cargo test --features test-harness --test flows` — all 24 pass
- [x] `cargo check --workspace` clean
- [x] `tsc --noEmit` clean
- [ ] Apply the schema-migration index by hand against dev Turso before testing (`000002_index_gm_user_and_channels_group.sql`)
- [ ] Click into a chat → first frame renders fast, no 500ms+ block waiting on Turso
- [ ] Direct-navigate to a channel URL → typing indicator works both directions
- [ ] Toggle mic mute on remote participant → other client's UI updates
- [ ] Download an audio attachment → save dialog appears, file lands at chosen path
- [ ] Two dev clients on same machine → both can play the same audio file