### PR TITLE
fix(startup): raise RLIMIT_NOFILE; macOS device fallback validates direction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5718,6 +5718,7 @@ dependencies = [
  "cocoa",
  "dotenvy",
  "image",
+ "libc",
  "libsql",
  "objc",
  "openmls",

--- a/pollis-core/src/commands/voice.rs
+++ b/pollis-core/src/commands/voice.rs
@@ -425,30 +425,39 @@ fn macos_first_device(host: &cpal::Host, is_input: bool) -> Option<cpal::Device>
 
 #[cfg(target_os = "macos")]
 fn macos_lookup_any_scope(host: &cpal::Host, name: &str, is_input: bool) -> Option<cpal::Device> {
-    // Scope-agnostic scan first. cpal's scoped enumeration filters by
-    // supported_*_configs() — that's exactly the filter that already
-    // excluded the device, so don't re-apply it here. Return the device
-    // by name and let the stream-build attempt produce a real error if
-    // the device truly can't service this direction.
+    // Multiple AudioObjects can share a name (system-level objects, aggregate
+    // devices, BlackHole virtual devices). Returning the first name-match
+    // unconditionally can hand back a stub Device that hangs inside
+    // default_input_config() / default_output_config(). Direction-validate
+    // each candidate via supported_*_configs() and skip anything that
+    // doesn't report a usable stream for the requested scope.
+    let supports = |d: &cpal::Device| -> bool {
+        if is_input {
+            d.supported_input_configs().map(|mut c| c.next().is_some()).unwrap_or(false)
+        } else {
+            d.supported_output_configs().map(|mut c| c.next().is_some()).unwrap_or(false)
+        }
+    };
     if let Ok(all) = host.devices() {
         for d in all {
-            if d.name().ok().as_deref() == Some(name) {
+            if d.name().ok().as_deref() == Some(name) && supports(&d) {
                 eprintln!(
-                    "[voice] macOS: found '{name}' via host.devices() fallback ({} requested)",
+                    "[voice] macOS: found '{name}' via host.devices() fallback ({} validated)",
                     if is_input { "input" } else { "output" }
                 );
                 return Some(d);
             }
         }
     }
-    // Opposite scope as last resort: AirPods in HFP can appear only in the
-    // input list while still capable of output (or vice versa).
+    // Opposite-scope last resort: AirPods in HFP can appear only in the input
+    // list while still capable of output (or vice versa). Still direction-
+    // validate so we don't hand back a stub.
     let opposite = if is_input { host.output_devices().ok() } else { host.input_devices().ok() };
     if let Some(it) = opposite {
         for d in it {
-            if d.name().ok().as_deref() == Some(name) {
+            if d.name().ok().as_deref() == Some(name) && supports(&d) {
                 eprintln!(
-                    "[voice] macOS: found '{name}' via opposite-scope enumeration ({} requested)",
+                    "[voice] macOS: found '{name}' via opposite-scope enumeration ({} validated)",
                     if is_input { "input" } else { "output" }
                 );
                 return Some(d);

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -80,6 +80,13 @@ openmls_basic_credential = "0.5"
 tls_codec = "0.4"
 rusqlite = { version = "0.31", features = ["bundled-sqlcipher"] }
 
+[target.'cfg(unix)'.dependencies]
+# setrlimit(RLIMIT_NOFILE, ...) at startup so we don't hit the macOS default
+# soft FD cap (256) once realtime rooms + libsql + reqwest pools + CoreAudio
+# AudioUnits start consuming descriptors. Already a transitive dep; pinned
+# here so the import in lib.rs resolves.
+libc = "0.2"
+
 [target.'cfg(target_os = "linux")'.dependencies]
 webkit2gtk = { version = "2", features = ["v2_38"] }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -232,6 +232,33 @@ fn hide_window(window: tauri::Window) {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // macOS launches GUI apps with a soft `RLIMIT_NOFILE` of 256, which is
+    // not enough once realtime LiveKit rooms (one per group), libsql
+    // websockets, reqwest connection pools, the local media-cache HTTP
+    // server, and CoreAudio AudioUnits all coexist. Hitting the cap surfaces
+    // as `EMFILE` (`Too many open files`) inside CoreAudio (`UpdateStreamFormats:
+    // 0 output streams`), `libsystem_dnssd` (`socketpair failed 24`), and
+    // websocket reconnects — i.e. voice silently failing to publish, devices
+    // disappearing from enumeration, and random kicks from voice channels.
+    // Raise the soft limit to the hard max; the hard max on macOS is
+    // typically `unlimited` (OPEN_MAX, 10240 in practice).
+    #[cfg(unix)]
+    unsafe {
+        let mut rl = libc::rlimit { rlim_cur: 0, rlim_max: 0 };
+        if libc::getrlimit(libc::RLIMIT_NOFILE, &mut rl) == 0 {
+            let target = rl.rlim_max.min(65_536);
+            if rl.rlim_cur < target {
+                let prev = rl.rlim_cur;
+                rl.rlim_cur = target;
+                if libc::setrlimit(libc::RLIMIT_NOFILE, &rl) == 0 {
+                    eprintln!("[startup] raised RLIMIT_NOFILE soft limit {prev} -> {target}");
+                } else {
+                    eprintln!("[startup] setrlimit(RLIMIT_NOFILE, {target}) failed: {}", std::io::Error::last_os_error());
+                }
+            }
+        }
+    }
+
     // WebKitGTK 2.42+ attempts DMA-BUF rendering and aborts if GBM/EGL is
     // unavailable (e.g. certain GPU drivers, VMs, Wayland compositors without
     // DRM). Disable it unconditionally so the app doesn't crash on launch.


### PR DESCRIPTION
## Summary
- Bump `RLIMIT_NOFILE` soft limit to `min(rlim_max, 65536)` at app start. macOS launches GUI apps with a 256 FD soft cap which is too low once 9 realtime LiveKit rooms + libsql + reqwest + WebKit + CoreAudio AudioUnits all coexist. EMFILE then surfaces as silent mic publish, AirPods dropping from device enumeration, websocket reconnect failures, and random voice-channel kicks. Closes #244.
- `macos_lookup_any_scope`: direction-validate name-matched devices via `supported_*_configs()` before returning. Without this, the fallback could return a stub AudioObject with no usable streams in the requested scope, causing `start_mic_stream` to hang inside `default_input_config()` and silently freezing the Join flow.

## Test plan
- [x] macOS: launch, log shows `[startup] raised RLIMIT_NOFILE soft limit 256 -> 65536`.
- [x] macOS: 9 realtime rooms connect, then voice channel join completes; mic publishes; AirPods present in output dropdown.
- [x] `cargo check -p pollis` clean.