### PR TITLE
ui(font): swap Atkinson Hyperlegible Mono for Geist Mono

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,8 +12,8 @@
   },
   "dependencies": {
     "@fontsource/atkinson-hyperlegible": "^5.2.8",
-    "@fontsource/atkinson-hyperlegible-mono": "^5.2.10",
     "@fontsource/atkinson-hyperlegible-next": "^5.2.7",
+    "@fontsource/geist-mono": "^5.2.7",
     "@internationalized/date": "^3.10.0",
     "@react-aria/button": "^3.14.2",
     "@react-aria/overlays": "^3.30.0",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,5 +1,5 @@
 @import "@fontsource/atkinson-hyperlegible-next";
-@import "@fontsource/atkinson-hyperlegible-mono/500.css";
+@import "@fontsource/geist-mono/500.css";
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -52,7 +52,7 @@
     /* ── Focus ring (used by all input components) ──────────────── */
     --c-focus-ring: hsl(var(--accent-h) var(--accent-s) var(--accent-l) / 22%);
 
-    --font-mono: 'Atkinson Hyperlegible Mono', ui-monospace, monospace;
+    --font-mono: 'Geist Mono', ui-monospace, monospace;
     --font-sans: 'Atkinson Hyperlegible Next', system-ui, sans-serif;
   }
 

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -25,7 +25,7 @@ export default {
         bg: 'var(--c-bg)',
       },
       fontFamily: {
-        mono: ['"Atkinson Hyperlegible Mono"', 'ui-monospace', 'monospace'],
+        mono: ['"Geist Mono"', 'ui-monospace', 'monospace'],
         sans: ['"Atkinson Hyperlegible Next"', 'system-ui', 'sans-serif'],
       },
       borderRadius: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,10 +27,10 @@ importers:
       '@fontsource/atkinson-hyperlegible':
         specifier: ^5.2.8
         version: 5.2.8
-      '@fontsource/atkinson-hyperlegible-mono':
-        specifier: ^5.2.10
-        version: 5.2.10
       '@fontsource/atkinson-hyperlegible-next':
+        specifier: ^5.2.7
+        version: 5.2.7
+      '@fontsource/geist-mono':
         specifier: ^5.2.7
         version: 5.2.7
       '@internationalized/date':
@@ -464,14 +464,14 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@fontsource/atkinson-hyperlegible-mono@5.2.10':
-    resolution: {integrity: sha512-BHT+CUi8GmNXuHkqRm+fZgN2K06GpxHBPO2T4xG2OI5yXcvv7L4gBCCtt84xUyawbccHvnkhp6AWBv4DzH+x+Q==}
-
   '@fontsource/atkinson-hyperlegible-next@5.2.7':
     resolution: {integrity: sha512-FDRsNkqauNRBRiTD3YF6FV8yOVFjkcBqUjwrv6KnooEIRjsTuePUnahPsLHApWNtp1riztVCOPnr9RMHUZU3TQ==}
 
   '@fontsource/atkinson-hyperlegible@5.2.8':
     resolution: {integrity: sha512-HciLcJ5DIK/OVOdo71EbEN4NnvDFlp6/SpAxtcbWf2aAdcsOuPqITxj5KNEXb48qSPSdnnZdGGnSJChPKi3/bA==}
+
+  '@fontsource/geist-mono@5.2.7':
+    resolution: {integrity: sha512-xVPVFISJg/K0VVd+aQN0Y7X/sw9hUcJPyDWFJ5GpyU3bHELhoRsJkPSRSHXW32mOi0xZCUQDOaPj1sqIFJ1FGg==}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -1884,11 +1884,11 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
-  '@fontsource/atkinson-hyperlegible-mono@5.2.10': {}
-
   '@fontsource/atkinson-hyperlegible-next@5.2.7': {}
 
   '@fontsource/atkinson-hyperlegible@5.2.8': {}
+
+  '@fontsource/geist-mono@5.2.7': {}
 
   '@img/colour@1.1.0': {}
 


### PR DESCRIPTION
Replace bundled Atkinson Hyperlegible Mono with Geist Mono. Still bundled via @fontsource — no runtime fetch.