### PR TITLE
ci(release): rotate Turso tokens to scoped, split admin from app

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -302,7 +302,7 @@ jobs:
       - name: Apply pending DB migrations to production
         env:
           TURSO_URL: ${{ secrets.TURSO_URL }}
-          TURSO_TOKEN: ${{ secrets.TURSO_TOKEN }}
+          TURSO_TOKEN: ${{ secrets.TURSO_ADMIN_TOKEN }}
         run: ./scripts/db-apply.sh
 
   release:


### PR DESCRIPTION
Closes https://github.com/actuallydan/pollis/issues/211

## Summary

Retired the embedded super-admin `TURSO_TOKEN` and stood up a proper per-environment Turso group / DB structure. The code change in this PR is a one-line workflow swap; the rest of the work was Turso + Doppler infra rotation done out-of-band against the platforms (described below so this PR is a record of what shipped).

## Why

The shipped `TURSO_TOKEN` was full-access (data + schema). Anyone who decompiled a release binary held a token that could `DROP TABLE` against prod. The same token was also used by CI to apply migrations, so we couldn't scope it down without also breaking the migration runner. Additionally, dev / prod / test DBs were spread across the shared `default` group with the rest of my unrelated projects, so we couldn't rotate or invalidate tokens for the Pollis DBs without nuking tokens for those projects too.

## What changed in this PR

`.github/workflows/desktop-release.yml`: the `apply-migrations` step now reads `secrets.TURSO_ADMIN_TOKEN` instead of `secrets.TURSO_TOKEN`. Build steps still read `secrets.TURSO_TOKEN` — that's the value baked into the shipped binary and is now the scoped client token (data-only).

## Out-of-band changes done before this PR

### Turso group + DB layout

| Group (new) | DB | URL | Notes |
|---|---|---|---|
| `pollis-test` | `test` | `libsql://test-actuallydan…` | Was `pollis/pollis-test`; dumped + restored into new group as `test` |
| `pollis-dev` | `dev` | `libsql://dev-actuallydan…` | Was `default/pollis-new`; dumped + restored, schema + data verified identical |
| `pollis-prod` | `prod` | `libsql://prod-actuallydan…` | Was `default/pollis`; dumped + restored, 6 users / 3 groups / 39 envelopes preserved |

Each Pollis DB now lives in its own group, so future rotations of one don't disturb the others, and the prod group can grow regional replicas without affecting dev or test.

### Token scoping

The `TURSO_TOKEN` (used by the desktop client at runtime, baked into shipped binaries) is now minted with `-p all:data_read,data_insert,data_update,data_delete`. It cannot run `CREATE / ALTER / DROP TABLE` — those are rejected at the Turso layer, not by client-side enforcement.

Production additionally has a separate `TURSO_ADMIN_TOKEN` minted with default (full) scope, only used by the CI `apply-migrations` step. This token never leaves CI and is not embedded in any client binary.

### Doppler

- `dev_personal.TURSO_URL`, `dev_personal.TURSO_TOKEN` → point at new `dev` DB with scoped token
- `dev_test.TURSO_URL`, `dev_test.TURSO_TOKEN` → point at new `test` DB with scoped token
- `prd_prod.TURSO_URL`, `prd_prod.TURSO_TOKEN` → point at new `prod` DB with scoped token
- `prd_prod.TURSO_ADMIN_TOKEN` (new) → full-scope token for migrations; synced to GH Actions

### Old DBs still alive

`default/pollis-new` and `default/pollis` have **not** been destroyed yet. They remain as the rollback path while we verify the new DBs work end-to-end. Their old super-admin tokens are still valid against them but become useless the moment those DBs are destroyed. Local SQL dumps are also in `/tmp/pollis-backups/` as a second safety net.

## Threat model after this PR

A leaked `TURSO_TOKEN` from a shipped binary can now:
- Read / insert / update / delete rows on data tables (recoverable via Turso PITR)
- Cannot DROP / ALTER / CREATE tables — Turso rejects those.

`TURSO_ADMIN_TOKEN` lives only in CI secrets and never in client builds.

## Test plan

- [ ] Refresh `.env.development` from Doppler; `pnpm dev` against the new `dev` DB: login, send message, create group, revoke device
- [ ] Verify GH Actions sees `TURSO_ADMIN_TOKEN` (already confirmed via `gh secret list` — synced at the same timestamp as `TURSO_TOKEN`)
- [ ] Cut a no-op release / dry-run to confirm `apply-migrations` reaches the new prod DB with the admin token (no pending migrations expected; should exit 0 with "No pending migrations")
- [ ] Once verified end-to-end: `turso db destroy pollis-new -y` and `turso db destroy pollis -y` to retire the old super-admin token's access to any pollis data