### PR TITLE
UI: font scaling, layout shuffle, offline call, switch fixes

### DIFF
--- a/frontend/src/components/Layout/BreadcrumbNav.tsx
+++ b/frontend/src/components/Layout/BreadcrumbNav.tsx
@@ -108,20 +108,20 @@ export const BreadcrumbNav: React.FC = () => {
         }
       }
     } else if (pathname === "/settings") {
-      out.push({ label: "Settings", to: "/settings" });
+      out.push({ label: "Account", to: "/settings" });
     } else if (pathname === "/preferences") {
-      out.push({ label: "Settings", to: "/settings" });
+      out.push({ label: "Account", to: "/settings" });
       out.push({ label: "Preferences", to: "/preferences" });
     } else if (pathname === "/user") {
-      out.push({ label: "Settings", to: "/settings" });
-      out.push({ label: "User", to: "/user" });
+      out.push({ label: "Account", to: "/settings" });
+      out.push({ label: "User Settings", to: "/user" });
     } else if (pathname.startsWith("/user/")) {
       out.push({ label: "Profile", to: pathname });
     } else if (pathname === "/security") {
-      out.push({ label: "Settings", to: "/settings" });
+      out.push({ label: "Account", to: "/settings" });
       out.push({ label: "Security", to: "/security" });
     } else if (pathname === "/voice-settings") {
-      out.push({ label: "Settings", to: "/settings" });
+      out.push({ label: "Account", to: "/settings" });
       out.push({ label: "Voice", to: "/voice-settings" });
     } else if (pathname === "/invites") {
       out.push({ label: "Invites", to: "/invites" });

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -92,7 +92,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ isOpen, onToggle }) => {
   const isOnSettingsHub = pathname === "/settings";
   const settingsItems = [
     { id: "preferences", label: "Preferences", icon: <Palette size={14} />, to: "/preferences" as const, isActive: pathname === "/preferences" },
-    { id: "user", label: "User", icon: <UserIcon size={14} />, to: "/user" as const, isActive: pathname === "/user" || pathname.startsWith("/user/") },
+    { id: "user", label: "User Settings", icon: <UserIcon size={14} />, to: "/user" as const, isActive: pathname === "/user" },
     { id: "voice-settings", label: "Voice", icon: <Volume2 size={14} />, to: "/voice-settings" as const, isActive: pathname === "/voice-settings" },
     { id: "security", label: "Security", icon: <ShieldCheck size={14} />, to: "/security" as const, isActive: pathname === "/security" || pathname.startsWith("/security/") },
   ];
@@ -200,7 +200,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ isOpen, onToggle }) => {
         </ul>
 
         <SectionHeader
-          label="settings"
+          label="account"
           icon={<SettingsIcon size={14} />}
           isActive={isOnAnySettings}
           onClick={() => router.navigate({ to: "/settings" })}

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -20,6 +20,20 @@ import { shortcutLabel } from "../../utils/platform";
 const SIDEBAR_WIDTH = 220;
 const COLLAPSED_GROUPS_KEY = "pollis.sidebar.collapsedGroups";
 
+// The sidebar chrome is sized in rem so it tracks the user's font-size
+// preference (`--font-size-base` on :root, which scales rem). Hardcoded px
+// would stay frozen while the rest of the app scales. Values are expressed
+// relative to the 15px default base; rem keeps them reactive to live
+// changes without needing a re-render.
+const BASE_FONT_PX = 15;
+const rem = (px: number): string => `${px / BASE_FONT_PX}rem`;
+// Shared lucide sizing: `size` seeds the SVG attribute, the rem width/height
+// override actually scales it with the font preference.
+const iconProps = {
+  size: 14,
+  style: { width: rem(14), height: rem(14), flexShrink: 0 },
+} as const;
+
 interface SidebarProps {
   isOpen: boolean;
   onToggle: () => void;
@@ -91,10 +105,10 @@ export const Sidebar: React.FC<SidebarProps> = ({ isOpen, onToggle }) => {
 
   const isOnSettingsHub = pathname === "/settings";
   const settingsItems = [
-    { id: "preferences", label: "Preferences", icon: <Palette size={14} />, to: "/preferences" as const, isActive: pathname === "/preferences" },
-    { id: "user", label: "User Settings", icon: <UserIcon size={14} />, to: "/user" as const, isActive: pathname === "/user" },
-    { id: "voice-settings", label: "Voice", icon: <Volume2 size={14} />, to: "/voice-settings" as const, isActive: pathname === "/voice-settings" },
-    { id: "security", label: "Security", icon: <ShieldCheck size={14} />, to: "/security" as const, isActive: pathname === "/security" || pathname.startsWith("/security/") },
+    { id: "preferences", label: "Preferences", icon: <Palette {...iconProps} />, to: "/preferences" as const, isActive: pathname === "/preferences" },
+    { id: "user", label: "User Settings", icon: <UserIcon {...iconProps} />, to: "/user" as const, isActive: pathname === "/user" },
+    { id: "voice-settings", label: "Voice", icon: <Volume2 {...iconProps} />, to: "/voice-settings" as const, isActive: pathname === "/voice-settings" },
+    { id: "security", label: "Security", icon: <ShieldCheck {...iconProps} />, to: "/security" as const, isActive: pathname === "/security" || pathname.startsWith("/security/") },
   ];
   const isOnAnySettings = isOnSettingsHub || settingsItems.some((s) => s.isActive);
 
@@ -102,7 +116,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ isOpen, onToggle }) => {
     <aside
       data-testid="sidebar"
       style={{
-        width: SIDEBAR_WIDTH,
+        width: rem(SIDEBAR_WIDTH),
         flexShrink: 0,
         borderRight: "1px solid var(--c-border)",
         background: "var(--c-surface)",
@@ -114,7 +128,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ isOpen, onToggle }) => {
       <div style={{ flex: 1, overflowY: "auto", overflowX: "hidden" }}>
         <SectionHeader
           label="groups"
-          icon={<Users size={14} />}
+          icon={<Users {...iconProps} />}
           isActive={isOnGroups}
           onClick={() => router.navigate({ to: "/groups" })}
           borderedBottom
@@ -163,7 +177,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ isOpen, onToggle }) => {
                               params: { groupId: group.id, channelId: ch.id },
                             })
                         }
-                        leading={isVoice ? <Volume2 size={14} /> : <Hash size={14} />}
+                        leading={isVoice ? <Volume2 {...iconProps} /> : <Hash {...iconProps} />}
                         label={ch.name}
                         badge={unread > 0 ? unread : null}
                       />
@@ -176,7 +190,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ isOpen, onToggle }) => {
 
         <SectionHeader
           label="dms"
-          icon={<MessageCircle size={14} />}
+          icon={<MessageCircle {...iconProps} />}
           isActive={isOnDms}
           onClick={() => router.navigate({ to: "/dms" })}
           badge={totalDmUnread > 0 ? totalDmUnread : null}
@@ -201,7 +215,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ isOpen, onToggle }) => {
 
         <SectionHeader
           label="account"
-          icon={<SettingsIcon size={14} />}
+          icon={<SettingsIcon {...iconProps} />}
           isActive={isOnAnySettings}
           onClick={() => router.navigate({ to: "/settings" })}
           bordered
@@ -228,13 +242,13 @@ export const Sidebar: React.FC<SidebarProps> = ({ isOpen, onToggle }) => {
           flexShrink: 0,
           display: "flex",
           alignItems: "center",
-          gap: 8,
-          padding: "8px 10px",
+          gap: rem(8),
+          padding: `${rem(8)} ${rem(10)}`,
           borderTop: "1px solid var(--c-border)",
           background: "none",
           color: "var(--c-text-muted)",
           fontFamily: "inherit",
-          fontSize: 13,
+          fontSize: rem(13),
           textAlign: "left",
           cursor: "pointer",
         }}
@@ -252,10 +266,10 @@ export const Sidebar: React.FC<SidebarProps> = ({ isOpen, onToggle }) => {
           style={{
             color: "inherit",
             background: "var(--c-bg)",
-            padding: "1px 5px",
+            padding: `${rem(1)} ${rem(5)}`,
             borderRadius: 3,
             border: "1px solid var(--c-border)",
-            fontSize: 11,
+            fontSize: rem(11),
             lineHeight: 1.2,
           }}
         >
@@ -286,15 +300,15 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({ label, icon, isActive, on
       width: "100%",
       display: "flex",
       alignItems: "center",
-      gap: 6,
-      padding: "8px 10px 9px",
-      marginTop: bordered ? 4 : 0,
+      gap: rem(6),
+      padding: `${rem(8)} ${rem(10)} ${rem(9)}`,
+      marginTop: bordered ? rem(4) : 0,
       background: "var(--c-surface)",
       border: "none",
       borderTop: bordered ? "1px solid var(--c-border)" : "none",
       borderBottom: bordered || borderedBottom ? "1px solid var(--c-border)" : "none",
       color: isActive ? "var(--c-accent)" : "var(--c-text-muted)",
-      fontSize: 12,
+      fontSize: rem(12),
       letterSpacing: "0.08em",
       textTransform: "uppercase",
       cursor: "pointer",
@@ -369,7 +383,7 @@ const Row: React.FC<RowProps> = ({ indent, isActive, onClick, leading, chevron, 
             border: "none",
             padding: 0,
             margin: 0,
-            paddingLeft: 10 + indent * 16,
+            paddingLeft: rem(10 + indent * 16),
             paddingRight: 0,
             display: "inline-flex",
             alignItems: "center",
@@ -377,7 +391,7 @@ const Row: React.FC<RowProps> = ({ indent, isActive, onClick, leading, chevron, 
             cursor: "pointer",
           }}
         >
-          {chevron.isCollapsed ? <ChevronRight size={14} /> : <ChevronDown size={14} />}
+          {chevron.isCollapsed ? <ChevronRight {...iconProps} /> : <ChevronDown {...iconProps} />}
         </button>
       )}
       <button
@@ -388,19 +402,19 @@ const Row: React.FC<RowProps> = ({ indent, isActive, onClick, leading, chevron, 
           minWidth: 0,
           display: "flex",
           alignItems: "center",
-          gap: 6,
-          paddingTop: 2,
-          paddingBottom: 2,
-          paddingLeft: chevron ? 6 : 10 + indent * 16,
-          paddingRight: 10,
+          gap: rem(6),
+          paddingTop: rem(2),
+          paddingBottom: rem(2),
+          paddingLeft: chevron ? rem(6) : rem(10 + indent * 16),
+          paddingRight: rem(10),
           background: "none",
           border: "none",
           color: "inherit",
-          fontSize: 15,
+          fontSize: rem(15),
           fontFamily: "inherit",
           cursor: "pointer",
           textAlign: "left",
-          lineHeight: "24px",
+          lineHeight: rem(24),
         }}
       >
         {leading}
@@ -423,9 +437,9 @@ const Row: React.FC<RowProps> = ({ indent, isActive, onClick, leading, chevron, 
 const UnreadBadge: React.FC<{ count: number; muted?: boolean }> = ({ count, muted }) => (
   <span
     style={{
-      fontSize: 11,
+      fontSize: rem(11),
       lineHeight: 1,
-      padding: "2px 6px",
+      padding: `${rem(2)} ${rem(6)}`,
       borderRadius: "0.25rem",
       background: muted ? "var(--c-text-muted)" : "var(--c-accent)",
       color: "var(--c-bg)",

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -426,7 +426,7 @@ const UnreadBadge: React.FC<{ count: number; muted?: boolean }> = ({ count, mute
       fontSize: 11,
       lineHeight: 1,
       padding: "2px 6px",
-      borderRadius: 8,
+      borderRadius: "0.25rem",
       background: muted ? "var(--c-text-muted)" : "var(--c-accent)",
       color: "var(--c-bg)",
       flexShrink: 0,

--- a/frontend/src/components/ui/Avatar.tsx
+++ b/frontend/src/components/ui/Avatar.tsx
@@ -16,8 +16,8 @@ interface AvatarProps {
 }
 
 const PRESENCE_COLORS: Record<PresenceStatus, string> = {
-  online: "#22c55e",
-  offline: "#6b7280",
+  online: "var(--c-accent)",
+  offline: "var(--c-bg)",
 };
 
 export const Avatar: React.FC<AvatarProps> = ({
@@ -36,7 +36,7 @@ export const Avatar: React.FC<AvatarProps> = ({
   const containerStyle: React.CSSProperties = {
     width: dim,
     height: dim,
-    borderRadius: isProfile ? "0.5rem" : "50%",
+    borderRadius: isProfile ? "0.65rem" : "50%",
     overflow: "hidden",
     display: "inline-flex",
     alignItems: "center",
@@ -65,7 +65,10 @@ export const Avatar: React.FC<AvatarProps> = ({
     height: dotSize,
     borderRadius: "50%",
     background: presence ? PRESENCE_COLORS[presence] : "transparent",
-    border: "2px solid var(--c-surface, var(--c-bg))",
+    border:
+      presence === "offline"
+        ? "2px solid var(--c-accent-muted)"
+        : "2px solid var(--c-surface, var(--c-bg))",
     boxSizing: "content-box",
   };
 

--- a/frontend/src/components/ui/Switch.tsx
+++ b/frontend/src/components/ui/Switch.tsx
@@ -43,10 +43,16 @@ export const Switch: React.FC<SwitchProps> = ({
           }}
         >
           <span
-            className="inline-block h-3 w-3 transform rounded-full transition-transform duration-200"
+            className="inline-block h-4 w-4 transform rounded-full transition-transform duration-200"
             style={{
               background: "var(--c-bg)",
-              transform: checked ? "translateX(20px)" : "translateX(4px)",
+              // Track is w-9 (2.25rem), thumb is w-4 (1rem). Express travel
+              // in rem (not px) so it scales with the same root font size the
+              // track does — keeps the dot centered with an even 0.125rem
+              // inset at any font-size preference.
+              transform: checked
+                ? "translateX(1.125rem)"
+                : "translateX(0.125rem)",
             }}
           />
         </button>

--- a/frontend/src/components/ui/TerminalMenu.tsx
+++ b/frontend/src/components/ui/TerminalMenu.tsx
@@ -215,7 +215,7 @@ export const TerminalMenu: React.FC<TerminalMenuProps> = ({
 
               <div className="flex-1 min-w-0">
                 <div
-                  className="font-sans text-sm flex items-center gap-3"
+                  className="font-mono text-sm flex items-center gap-3"
                   style={{
                     color: isSelected
                       ? "var(--c-accent)"
@@ -232,7 +232,7 @@ export const TerminalMenu: React.FC<TerminalMenuProps> = ({
                   <span>{item.label}</span>
                   {item.badge != null && item.badge > 0 && (
                     <span
-                      className="font-sans text-xs"
+                      className="font-mono text-xs"
                       style={{ color: "var(--c-accent)" }}
                     >
                       [{item.badge}]
@@ -241,7 +241,7 @@ export const TerminalMenu: React.FC<TerminalMenuProps> = ({
                 </div>
                 {item.description && (
                   <div
-                    className="text-xs font-sans mt-0.5 truncate"
+                    className="text-xs font-mono mt-0.5 truncate"
                     style={{ color: "var(--c-text-muted)" }}
                   >
                     {item.description}

--- a/frontend/src/pages/DM.tsx
+++ b/frontend/src/pages/DM.tsx
@@ -4,6 +4,7 @@ import { Phone } from "lucide-react";
 import { MainContent } from "../components/Layout/MainContent";
 import { useDMConversations } from "../hooks/queries/useMessages";
 import { useAppStore } from "../stores/appStore";
+import { usePresenceStatus } from "../stores/presenceStore";
 import { invoke } from "@tauri-apps/api/core";
 import { voiceSession } from "../voice";
 
@@ -61,7 +62,12 @@ export const DMPage: React.FC = () => {
   const canShowProfile = isOneOnOne;
   // Calling is only offered once the other party has accepted the DM, so an
   // unwanted DM request can never be escalated to a phone call.
-  const canCall = isOneOnOne && otherAcceptedAt !== null;
+  const otherPresence = usePresenceStatus(otherUserId);
+  const isOtherOnline = otherPresence === "online";
+  // Calls to an offline user fail at the LiveKit handshake (nobody to
+  // create/answer the room), so only offer the call button when the peer
+  // is online.
+  const canCall = isOneOnOne && otherAcceptedAt !== null && isOtherOnline;
 
   const startCall = async () => {
     if (!currentUser || !otherUserId) {

--- a/frontend/src/pages/SecurityPage.tsx
+++ b/frontend/src/pages/SecurityPage.tsx
@@ -1,10 +1,11 @@
-import React, { useEffect, useState } from "react";
-import { useNavigate } from "@tanstack/react-router";
+import React, { useEffect, useState, useCallback } from "react";
+import { useNavigate, useRouter } from "@tanstack/react-router";
 import { PageShell } from "../components/Layout/PageShell";
 import { Button } from "../components/ui/Button";
 import { TextInput } from "../components/ui/TextInput";
 import { NavigableList } from "../components/ui/NavigableList";
 import { useAppStore } from "../stores/appStore";
+import type { RouterContext } from "../types/router";
 import * as api from "../services/api";
 
 /// Human-readable summary for each `security_event.kind` the backend
@@ -70,9 +71,15 @@ const sectionHeaderStyle: React.CSSProperties = {
 
 export const SecurityPage: React.FC = () => {
   const navigate = useNavigate();
+  const router = useRouter();
+  const { onDeleteAccount } = router.options.context as RouterContext;
   const { currentUser } = useAppStore();
   const [events, setEvents] = useState<api.SecurityEvent[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  const [deleteConfirmText, setDeleteConfirmText] = useState("");
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const [devices, setDevices] = useState<api.DeviceInfo[] | null>(null);
   const [devicesError, setDevicesError] = useState<string | null>(null);
@@ -141,6 +148,31 @@ export const SecurityPage: React.FC = () => {
 
   const deviceDisplayName = (device: api.DeviceInfo): string =>
     device.device_name ?? shortId(device.device_id);
+
+  const handleDeleteAccount = useCallback(async () => {
+    if (!currentUser) {
+      return;
+    }
+    if (deleteConfirmText !== "DELETE") {
+      return;
+    }
+    setIsDeleting(true);
+    setDeleteError(null);
+    try {
+      await api.deleteAccount(currentUser.id);
+      // Clear local state immediately so the user is logged out even if the
+      // callback chain from the router context is broken.
+      useAppStore.getState().logout();
+      if (onDeleteAccount) {
+        onDeleteAccount();
+      } else {
+        console.error("[SecurityPage] onDeleteAccount callback is undefined — falling back to logout only");
+      }
+    } catch (err) {
+      setDeleteError(err instanceof Error ? err.message : "Failed to delete account");
+      setIsDeleting(false);
+    }
+  }, [currentUser, deleteConfirmText, onDeleteAccount]);
 
   return (
     <PageShell title="Security" scrollable>
@@ -318,6 +350,44 @@ export const SecurityPage: React.FC = () => {
                 );
               }}
             />
+          </section>
+
+          {/* Danger zone — account deletion lives at the very bottom of the
+              security page so it's the last thing a user can reach. */}
+          <section className="flex flex-col gap-4 mb-12" data-testid="settings-danger-zone">
+            <h2
+              className="text-xs font-mono font-medium uppercase tracking-widest pb-1 border-b"
+              style={{ color: "hsl(0 60% 55%)", borderColor: "hsl(0 60% 30% / 40%)" }}
+            >
+              Danger Zone
+            </h2>
+
+            <p className="text-xs" style={{ color: "var(--c-text-muted)", lineHeight: 1.5 }}>
+              Permanently delete your account and all associated data. This cannot be undone.
+            </p>
+
+            <TextInput
+              label="Type DELETE to confirm"
+              id="settings-delete-confirm"
+              data-testid="settings-delete-confirm-input"
+              value={deleteConfirmText}
+              onChange={setDeleteConfirmText}
+              placeholder="DELETE"
+              disabled={isDeleting}
+              error={deleteError || undefined}
+            />
+
+            <Button
+              data-testid="settings-delete-account-button"
+              onClick={handleDeleteAccount}
+              disabled={deleteConfirmText !== "DELETE" || isDeleting}
+              isLoading={isDeleting}
+              loadingText="Deleting account…"
+              variant="danger"
+              className="w-full"
+            >
+              Delete my account
+            </Button>
           </section>
         </div>
       </div>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -10,13 +10,8 @@ import { Button } from "../components/ui/Button";
 import { getVersion } from "@tauri-apps/api/app";
 import { check as checkForUpdate } from "@tauri-apps/plugin-updater";
 import { invoke } from "@tauri-apps/api/core";
-import * as api from "../services/api";
 
-interface SettingsProps {
-  onDeleteAccount?: () => void;
-}
-
-export const Settings: React.FC<SettingsProps> = ({ onDeleteAccount }) => {
+export const Settings: React.FC = () => {
   const { currentUser } = useAppStore();
   const setUpdateRequired = useAppStore((s) => s.setUpdateRequired);
 
@@ -25,9 +20,6 @@ export const Settings: React.FC<SettingsProps> = ({ onDeleteAccount }) => {
   const updateProfileMutation = useUpdateProfile();
   const updateAvatarMutation = useUpdateAvatar();
 
-  const [deleteConfirmText, setDeleteConfirmText] = useState("");
-  const [isDeleting, setIsDeleting] = useState(false);
-  const [deleteError, setDeleteError] = useState<string | null>(null);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [preview, setPreview] = useState<string | null>(null);
   const [currentAvatarUrl, setCurrentAvatarUrl] = useState<string | null>(null);
@@ -213,31 +205,6 @@ export const Settings: React.FC<SettingsProps> = ({ onDeleteAccount }) => {
       setEmailChangePending(false);
     }
   };
-
-  const handleDeleteAccount = useCallback(async () => {
-    if (!currentUser) {
-      return;
-    }
-    if (deleteConfirmText !== "DELETE") {
-      return;
-    }
-    setIsDeleting(true);
-    setDeleteError(null);
-    try {
-      await api.deleteAccount(currentUser.id);
-      // Clear local state immediately so the user is logged out even if the
-      // callback chain from the router context is broken.
-      useAppStore.getState().logout();
-      if (onDeleteAccount) {
-        onDeleteAccount();
-      } else {
-        console.error("[Settings] onDeleteAccount callback is undefined — falling back to logout only");
-      }
-    } catch (error) {
-      setDeleteError(error instanceof Error ? error.message : "Failed to delete account");
-      setIsDeleting(false);
-    }
-  }, [currentUser, deleteConfirmText, onDeleteAccount]);
 
   const handleCheckForUpdates = useCallback(async () => {
     setUpdateStatus("checking");
@@ -613,43 +580,6 @@ export const Settings: React.FC<SettingsProps> = ({ onDeleteAccount }) => {
                 </Button>
               )}
             </div>
-          </section>
-
-          {/* Danger zone */}
-          <section className="flex flex-col gap-4 mb-12" data-testid="settings-danger-zone">
-            <h2
-              className="text-xs font-mono font-medium uppercase tracking-widest pb-1 border-b"
-              style={{ color: 'hsl(0 60% 55%)', borderColor: 'hsl(0 60% 30% / 40%)' }}
-            >
-              Danger Zone
-            </h2>
-
-            <p className="text-xs font-mono" style={{ color: 'var(--c-text-muted)' }}>
-              Permanently delete your account and all associated data. This cannot be undone.
-            </p>
-
-            <TextInput
-              label="Type DELETE to confirm"
-              id="settings-delete-confirm"
-              data-testid="settings-delete-confirm-input"
-              value={deleteConfirmText}
-              onChange={setDeleteConfirmText}
-              placeholder="DELETE"
-              disabled={isDeleting}
-              error={deleteError || undefined}
-            />
-
-            <Button
-              data-testid="settings-delete-account-button"
-              onClick={handleDeleteAccount}
-              disabled={deleteConfirmText !== "DELETE" || isDeleting}
-              isLoading={isDeleting}
-              loadingText="Deleting account…"
-              variant="danger"
-              className="w-full"
-            >
-              Delete my account
-            </Button>
           </section>
 
         </div>

--- a/frontend/src/pages/SettingsHub.tsx
+++ b/frontend/src/pages/SettingsHub.tsx
@@ -1,10 +1,19 @@
 import React from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { Palette, User, ShieldCheck, Volume2 } from "lucide-react";
+import { PageShell } from "../components/Layout/PageShell";
+import { PresenceAvatar } from "../components/ui/PresenceAvatar";
 import { TerminalMenu, type TerminalMenuItem } from "../components/ui/TerminalMenu";
+import { useUserProfile } from "../hooks/queries";
+import { useAppStore } from "../stores/appStore";
 
 export const SettingsHubPage: React.FC = () => {
   const navigate = useNavigate();
+  const currentUser = useAppStore((s) => s.currentUser);
+  const { data: profile } = useUserProfile();
+
+  const headlineName =
+    profile?.preferred_name || (profile?.username ? `@${profile.username}` : "Account");
 
   const items: TerminalMenuItem[] = [
     {
@@ -17,7 +26,7 @@ export const SettingsHubPage: React.FC = () => {
     },
     {
       id: "user",
-      label: "User",
+      label: "User Settings",
       icon: <User size={14} />,
       description: "Profile, username, avatar",
       action: () => navigate({ to: "/user" }),
@@ -42,9 +51,45 @@ export const SettingsHubPage: React.FC = () => {
   ];
 
   return (
-    <TerminalMenu
-      items={items}
-      onEsc={() => navigate({ to: "/" })}
-    />
+    <PageShell title="Account" scrollable>
+      <div data-testid="settings-hub-page" className="flex justify-center px-6 py-10">
+        <div className="w-full max-w-md flex flex-col gap-6">
+          {/* Own-profile header — mirrors the layout of viewing another
+              user's profile (name on the left, avatar on the right). */}
+          <div className="flex items-center justify-between gap-4">
+            <div className="flex flex-col min-w-0">
+              <div
+                data-testid="settings-hub-headline"
+                className="font-mono text-2xl truncate"
+                style={{ color: "var(--c-accent)" }}
+              >
+                {headlineName}
+              </div>
+              {profile?.preferred_name && profile?.username && (
+                <div
+                  data-testid="settings-hub-username"
+                  className="font-mono text-xs truncate"
+                  style={{ color: "var(--c-text-muted)" }}
+                >
+                  @{profile.username}
+                </div>
+              )}
+            </div>
+            <PresenceAvatar
+              userId={currentUser?.id}
+              avatarKey={profile?.avatar_url}
+              size={72}
+              alt={`${headlineName} avatar`}
+              testId="settings-hub-avatar"
+              variant="profile"
+            />
+          </div>
+
+          <div style={{ borderTop: "1px solid var(--c-border)" }}>
+            <TerminalMenu items={items} onEsc={() => navigate({ to: "/" })} />
+          </div>
+        </div>
+      </div>
+    </PageShell>
   );
 };

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,16 +1,11 @@
 import React from "react";
-import { useRouter } from "@tanstack/react-router";
 import { PageShell } from "../components/Layout/PageShell";
 import { Settings } from "./Settings";
-import type { RouterContext } from "../types/router";
 
 export const SettingsPage: React.FC = () => {
-  const router = useRouter();
-  const { onDeleteAccount } = router.options.context as RouterContext;
-
   return (
-    <PageShell title="User" scrollable>
-      <Settings onDeleteAccount={onDeleteAccount} />
+    <PageShell title="User Settings" scrollable>
+      <Settings />
     </PageShell>
   );
 };


### PR DESCRIPTION
Small UI fixes:

- Geist Mono on TerminalMenu items; profile avatar radius + presence dot theming
- Hide DM call button when the other user is offline
- Settings → Account: own-profile header, "User Settings" rename, Danger Zone moved to bottom of Security
- Sidebar scales with the font-size preference; Switch thumb recentered