### PR TITLE
fix(mobile): build RN from source via expo-build-properties (tracked)

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -42,6 +42,14 @@
       "expo-image",
       "expo-font",
       [
+        "expo-build-properties",
+        {
+          "ios": {
+            "buildReactNativeFromSource": true
+          }
+        }
+      ],
+      [
         "expo-camera",
         {
           "cameraPermission": "Pollis needs your camera to scan the pairing QR code from your desktop."

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -13,6 +13,7 @@
     "@expo-google-fonts/sora": "^0.4.2",
     "@gorhom/bottom-sheet": "^5.2.10",
     "expo": "~55.0.17",
+    "expo-build-properties": "^55.0.14",
     "expo-camera": "^55.0.16",
     "expo-constants": "~55.0.15",
     "expo-dev-client": "^55.0.28",

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       expo:
         specifier: ~55.0.17
         version: 55.0.17(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.13)(react-dom@19.2.5(react@19.2.0))(react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      expo-build-properties:
+        specifier: ^55.0.14
+        version: 55.0.14(expo@55.0.17)
       expo-camera:
         specifier: ^55.0.16
         version: 55.0.16(@types/emscripten@1.41.5)(expo@55.0.17)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
@@ -748,6 +751,9 @@ packages:
 
   '@expo/schema-utils@55.0.3':
     resolution: {integrity: sha512-l9KHVjTo6MvoeyvwNr6AjckGJm8NIcqZ3QSAh51cWozXW9v2AUjyCyqYtFtyntLWRZ0x/ByYJishpQo4ZQq45Q==}
+
+  '@expo/schema-utils@55.0.4':
+    resolution: {integrity: sha512-65IdeeE8dAZR3n3J5Eq7LYiQ8BFGeEYCWPBCzycvafL7PkskbCyIclTQarRwf/HXFoRvezKCjaLwy/8v9Prk6g==}
 
   '@expo/sdk-runtime-versions@1.0.0':
     resolution: {integrity: sha512-Doz2bfiPndXYFPMRwPyGa1k5QaKDVpY806UJj570epIiMzWaYyCtobasyfC++qfIXVb5Ocy7r3tP9d62hAQ7IQ==}
@@ -1757,6 +1763,11 @@ packages:
       expo: '*'
       react: '*'
       react-native: '*'
+
+  expo-build-properties@55.0.14:
+    resolution: {integrity: sha512-5wopuLXlzFpDnCfsIjgAcj4yKnVTYg3XYGnYV5Hqi7u6jJipLG4fwtUqxVIFqBj7vEHXjd4zYCyXjp39AtAD7w==}
+    peerDependencies:
+      expo: '*'
 
   expo-camera@55.0.16:
     resolution: {integrity: sha512-9c6FGrLVwMLyQ08wqwkH7DXAC8Oj1VD0LXM4hFu62Nuq2f2zIAZwsXxG7J5ex+HHHAGyligGGi6VJWuiib9qNg==}
@@ -4229,6 +4240,8 @@ snapshots:
 
   '@expo/schema-utils@55.0.3': {}
 
+  '@expo/schema-utils@55.0.4': {}
+
   '@expo/sdk-runtime-versions@1.0.0': {}
 
   '@expo/spawn-async@1.7.2':
@@ -5388,6 +5401,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  expo-build-properties@55.0.14(expo@55.0.17):
+    dependencies:
+      '@expo/schema-utils': 55.0.4
+      expo: 55.0.17(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.13)(react-dom@19.2.5(react@19.2.0))(react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      resolve-from: 5.0.0
+      semver: 7.7.4
 
   expo-camera@55.0.16(@types/emscripten@1.41.5)(expo@55.0.17)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0):
     dependencies:


### PR DESCRIPTION
The `buildReactNativeFromSource: true` setting that makes the iOS app launch (avoids the dyld crash on the missing prebuilt `ReactNativeDependencies.framework`) was previously only in `ios/Podfile.properties.json` — which is under the **gitignored `ios/` dir** (Expo CNG regenerates native dirs from `app.json`). It wouldn't survive a clean checkout.

Moves it into the `expo-build-properties` config plugin in `app.json` (tracked), so `expo prebuild` emits it on every machine. Adds `expo-build-properties` dep.

## Test plan
- [ ] `expo prebuild --clean` regenerates `ios/Podfile.properties.json` with `ios.buildReactNativeFromSource` true
- [ ] iOS app builds from source + launches (no dyld crash) on a fresh checkout