### PR TITLE
Add Key Bindings page

### DIFF
--- a/.codesight/wiki/ui.md
+++ b/.codesight/wiki/ui.md
@@ -55,6 +55,7 @@
 - **InvitesPage** — `frontend/src/pages/InvitesPage.tsx`
 - **JoinRequests** — props: groupId, groupName — `frontend/src/pages/JoinRequests.tsx`
 - **JoinRequestsPage** — `frontend/src/pages/JoinRequestsPage.tsx`
+- **KeyboardShortcutsPage** — "Key Bindings" global keyboard-shortcut reference (route `/shortcuts`, linked from the Account hub) — `frontend/src/pages/KeyboardShortcutsPage.tsx`
 - **KickMemberPage** — `frontend/src/pages/KickMemberPage.tsx`
 - **LeaveGroupPage** — `frontend/src/pages/LeaveGroup.tsx`
 - **Members** — props: groupId, isAdmin — `frontend/src/pages/Members.tsx`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,6 +222,7 @@ Concrete implications:
 - **Never reinvent UI components** — always use existing components from `frontend/src/components/ui/`. Toggles/switches use `Switch`, buttons use `Button`, text inputs use `TextInput`, etc. Do not build custom styled `<button>` or `<input>` elements when a ui/ component already exists.
 - **NO MODALS** — this is absolute. No fixed-position overlays, no backdrops, no dialog elements, no modal patterns of any kind. The only exception is the Cmd+K search menu. If a flow needs confirmation or input, replace the chat input bar (edit/delete bar pattern in `MainContent`) or navigate to a new page/view. A full page with two buttons is preferable to a modal.
 - **Confirmation and editing flows replace the chat input bar** — render a bar in place of the chat input at the bottom of `MainContent`, following the edit/delete bar pattern already established there.
+- **New static pages must be registered in three places** — when adding a page with a fixed route (e.g. `/shortcuts`, `/preferences`): (1) the route in `frontend/src/router.tsx`, (2) the `PAGE_RESULTS` array in `frontend/src/components/SearchPanel.tsx` so it's reachable via Cmd+K, and (3) the relevant nav list in `frontend/src/components/Layout/Sidebar.tsx`. This does **not** apply to dynamic/parameterized pages (e.g. `/groups/$groupId`, `/dms/$conversationId`, `/user/$userId`) — those are reached contextually, not from search/sidebar.
 
 ## Design Choices
 

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
   Palette,
   User as UserIcon,
   ShieldCheck,
+  Keyboard,
 } from "lucide-react";
 import { useUserGroupsWithChannels } from "../../hooks/queries/useGroups";
 import { useDMConversations } from "../../hooks/queries/useMessages";
@@ -109,6 +110,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ isOpen, onToggle }) => {
     { id: "user", label: "User Settings", icon: <UserIcon {...iconProps} />, to: "/user" as const, isActive: pathname === "/user" },
     { id: "voice-settings", label: "Voice", icon: <Volume2 {...iconProps} />, to: "/voice-settings" as const, isActive: pathname === "/voice-settings" },
     { id: "security", label: "Security", icon: <ShieldCheck {...iconProps} />, to: "/security" as const, isActive: pathname === "/security" || pathname.startsWith("/security/") },
+    { id: "shortcuts", label: "Key Bindings", icon: <Keyboard {...iconProps} />, to: "/shortcuts" as const, isActive: pathname === "/shortcuts" },
   ];
   const isOnAnySettings = isOnSettingsHub || settingsItems.some((s) => s.isActive);
 

--- a/frontend/src/components/SearchPanel.tsx
+++ b/frontend/src/components/SearchPanel.tsx
@@ -187,6 +187,7 @@ const PAGE_RESULTS: SearchResultItem[] = [
   { type: "page", id: "page-preferences", name: "Preferences", breadcrumb: "/preferences", path: "/preferences", keywords: "theme color font notifications appearance" },
   { type: "page", id: "page-voice-settings", name: "Voice Settings", breadcrumb: "/settings/voice", path: "/voice-settings", keywords: "microphone speaker audio mic noise suppression echo cancellation agc auto join" },
   { type: "page", id: "page-security", name: "Security", breadcrumb: "/security", path: "/security", keywords: "audit log devices identity key rotation" },
+  { type: "page", id: "page-shortcuts", name: "Key Bindings", breadcrumb: "/shortcuts", path: "/shortcuts", keywords: "key bindings keyboard shortcuts hotkeys keybindings cmd ctrl" },
   { type: "page", id: "page-invites", name: "Invites", breadcrumb: "/invites", path: "/invites", keywords: "pending invitations groups" },
   { type: "page", id: "page-join-requests", name: "Join Requests", breadcrumb: "/join-requests", path: "/join-requests", keywords: "pending group membership" },
   { type: "page", id: "page-dm-requests", name: "DM Requests", breadcrumb: "/dms/requests", path: "/dms/requests", keywords: "direct message pending" },

--- a/frontend/src/pages/KeyboardShortcutsPage.tsx
+++ b/frontend/src/pages/KeyboardShortcutsPage.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { PageShell } from "../components/Layout/PageShell";
+import { NavigableList } from "../components/ui/NavigableList";
+import { shortcutLabel } from "../utils/platform";
+
+interface Shortcut {
+  id: string;
+  description: string;
+  // The base key combined with the platform modifier (⌘ on macOS,
+  // Ctrl elsewhere) via shortcutLabel. When omitted, `label` is shown
+  // verbatim (e.g. plain Escape, which has no modifier).
+  key?: string;
+  label?: string;
+}
+
+const SHORTCUTS: Shortcut[] = [
+  { id: "search", description: "Open search", key: "K" },
+  { id: "sidebar", description: "Toggle sidebar", key: "B" },
+  { id: "terminal", description: "Toggle chat ⇆ terminal", key: "`" },
+  { id: "refresh", description: "Refresh & sync", key: "R" },
+  { id: "lock", description: "Lock app", key: "L" },
+  { id: "hide", description: "Hide window", key: "W" },
+  { id: "back", description: "Go back", label: "Esc" },
+];
+
+export const KeyboardShortcutsPage: React.FC = () => {
+  const navigate = useNavigate();
+
+  return (
+    <PageShell title="Key Bindings" scrollable>
+      <div
+        data-testid="keyboard-shortcuts-page"
+        className="flex-1 flex flex-col overflow-hidden"
+      >
+        <NavigableList<Shortcut>
+          testId="keyboard-shortcuts-list"
+          items={SHORTCUTS}
+          getKey={(s) => s.id}
+          rowTestId={(s) => `shortcut-${s.id}`}
+          onEnterRow={() => navigate({ to: "/settings" })}
+          emptyLabel="No shortcuts."
+          renderRow={(s) => (
+            <span className="flex-1 truncate" style={{ color: "var(--c-text)" }}>
+              {s.description}
+            </span>
+          )}
+          trailing={(s) => (
+            <kbd
+              aria-hidden="true"
+              className="font-mono text-xs"
+              style={{
+                color: "inherit",
+                background: "var(--c-bg)",
+                padding: "1px 5px",
+                borderRadius: 3,
+                border: "1px solid var(--c-border)",
+                lineHeight: 1.2,
+              }}
+            >
+              {s.key ? shortcutLabel(s.key) : s.label}
+            </kbd>
+          )}
+        />
+      </div>
+    </PageShell>
+  );
+};

--- a/frontend/src/pages/SettingsHub.tsx
+++ b/frontend/src/pages/SettingsHub.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useNavigate } from "@tanstack/react-router";
-import { Palette, User, ShieldCheck, Volume2 } from "lucide-react";
+import { Palette, User, ShieldCheck, Volume2, Keyboard } from "lucide-react";
 import { PageShell } from "../components/Layout/PageShell";
 import { PresenceAvatar } from "../components/ui/PresenceAvatar";
 import { TerminalMenu, type TerminalMenuItem } from "../components/ui/TerminalMenu";
@@ -47,6 +47,14 @@ export const SettingsHubPage: React.FC = () => {
       description: "Device enrollments, identity resets",
       action: () => navigate({ to: "/security" }),
       testId: "menu-item-security",
+    },
+    {
+      id: "shortcuts",
+      label: "Key Bindings",
+      icon: <Keyboard size={14} />,
+      description: "Global keyboard shortcuts reference",
+      action: () => navigate({ to: "/shortcuts" }),
+      testId: "menu-item-shortcuts",
     },
   ];
 

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -38,6 +38,7 @@ import { BlockedPage } from "./pages/BlockedPage";
 import { CallPage } from "./pages/Call";
 import { RenameChannelPage } from "./pages/RenameChannelPage";
 import { RenameGroupPage } from "./pages/RenameGroupPage";
+import { KeyboardShortcutsPage } from "./pages/KeyboardShortcutsPage";
 
 // Re-export RouterContext so callers can import from either location.
 export type { RouterContext };
@@ -240,6 +241,12 @@ const searchRoute = createRoute({
   component: SearchPage,
 });
 
+const keyboardShortcutsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/shortcuts",
+  component: KeyboardShortcutsPage,
+});
+
 const callRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/call/$callId",
@@ -289,6 +296,7 @@ const routeTree = rootRoute.addChildren([
   invitesRoute,
   allJoinRequestsRoute,
   searchRoute,
+  keyboardShortcutsRoute,
   callRoute,
   terminalRoute,
 ]);


### PR DESCRIPTION
## Summary
- New "Key Bindings" page (route `/shortcuts`) listing global keyboard shortcuts in a full-width `NavigableList`, keybinds shown in `<kbd>` boxes matching the Cmd+K/Cmd+B hint style.
- Registered in the router, Cmd+K search index (`PAGE_RESULTS`), the sidebar nav, and the Account hub menu.
- Added a CLAUDE.md rule: new static pages must be registered in router + Cmd+K + sidebar (dynamic/parameterized routes exempt).

## Test plan
- [ ] Open Account hub → "Key Bindings" navigates to the page
- [ ] Cmd+K search for "key bindings" / "shortcuts" finds it
- [ ] Sidebar shows the "Key Bindings" entry, highlights when active
- [ ] List spans full width, no top gap, keybinds rendered in boxes