### PR TITLE
feat: Signal-style safety numbers for contact verification

### DIFF
--- a/frontend/src/hooks/queries/useUserProfile.ts
+++ b/frontend/src/hooks/queries/useUserProfile.ts
@@ -44,6 +44,45 @@ export function useOtherUserProfile(userId: string | null | undefined) {
   });
 }
 
+export interface SafetyNumberInfo {
+  safety_number: string;
+  status: "unverified" | "verified" | "changed";
+  peer_identity_version: number;
+}
+
+export const safetyQueryKeys = {
+  number: (peerUserId: string | null) => ["safety", "number", peerUserId] as const,
+};
+
+export function useSafetyNumber(peerUserId: string | null | undefined) {
+  const currentUser = useAppStore((state) => state.currentUser);
+  return useQuery({
+    queryKey: safetyQueryKeys.number(peerUserId ?? null),
+    queryFn: async (): Promise<SafetyNumberInfo> => {
+      return await invoke<SafetyNumberInfo>("get_safety_number", {
+        myUserId: currentUser!.id,
+        peerUserId,
+      });
+    },
+    enabled: !!peerUserId && !!currentUser && currentUser.id !== peerUserId,
+    staleTime: 1000 * 30,
+  });
+}
+
+export function useSetContactVerified(peerUserId: string | null | undefined) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (verified: boolean) => {
+      await invoke("set_contact_verified", { peerUserId, verified });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: safetyQueryKeys.number(peerUserId ?? null),
+      });
+    },
+  });
+}
+
 export function useUserProfile() {
   const currentUser = useAppStore((state) => state.currentUser);
 

--- a/frontend/src/pages/UserProfile.tsx
+++ b/frontend/src/pages/UserProfile.tsx
@@ -4,7 +4,12 @@ import { ArrowLeft, MessageCircle, Ban } from "lucide-react";
 import { PageShell } from "../components/Layout/PageShell";
 import { PresenceAvatar } from "../components/ui/PresenceAvatar";
 import { TerminalMenu, type TerminalMenuItem } from "../components/ui/TerminalMenu";
-import { useOtherUserProfile } from "../hooks/queries/useUserProfile";
+import {
+  useOtherUserProfile,
+  useSafetyNumber,
+  useSetContactVerified,
+} from "../hooks/queries/useUserProfile";
+import { Button } from "../components/ui/Button";
 import { useBlockUser } from "../hooks/queries";
 import { useCreateOrGetDMConversation } from "../hooks/queries/useMessages";
 import { useAppStore } from "../stores/appStore";
@@ -15,6 +20,8 @@ export const UserProfilePage: React.FC = () => {
   const currentUser = useAppStore((s) => s.currentUser);
 
   const { data: profile, isLoading } = useOtherUserProfile(userId);
+  const { data: safety } = useSafetyNumber(userId);
+  const setVerified = useSetContactVerified(userId);
   const blockMutation = useBlockUser();
   const dmMutation = useCreateOrGetDMConversation();
 
@@ -131,6 +138,78 @@ export const UserProfilePage: React.FC = () => {
                   variant="profile"
                 />
               </div>
+
+              {!isSelf && safety && (
+                <div
+                  data-testid="safety-number"
+                  className="flex flex-col gap-3 pt-4"
+                  style={{ borderTop: "1px solid var(--c-border)" }}
+                >
+                  <div className="flex items-center justify-between">
+                    <span
+                      className="font-mono text-xs uppercase tracking-wide"
+                      style={{ color: "var(--c-text-muted)" }}
+                    >
+                      Safety number
+                    </span>
+                    <span
+                      data-testid="safety-status"
+                      className="font-mono text-xs"
+                      style={{
+                        color:
+                          safety.status === "verified"
+                            ? "var(--c-accent)"
+                            : safety.status === "changed"
+                              ? "var(--c-danger)"
+                              : "var(--c-text-muted)",
+                      }}
+                    >
+                      {safety.status === "verified"
+                        ? "Verified"
+                        : safety.status === "changed"
+                          ? "Changed — re-verify"
+                          : "Not verified"}
+                    </span>
+                  </div>
+                  <code
+                    className="font-mono text-sm leading-relaxed break-all"
+                    style={{ color: "var(--c-text)" }}
+                  >
+                    {safety.safety_number}
+                  </code>
+                  {safety.status === "changed" && (
+                    <span
+                      className="font-mono text-xs"
+                      style={{ color: "var(--c-danger)" }}
+                    >
+                      This contact's identity key changed since you last verified
+                      it. Compare the number again out-of-band before trusting it.
+                    </span>
+                  )}
+                  <p
+                    className="font-mono text-xs"
+                    style={{ color: "var(--c-text-muted)" }}
+                  >
+                    Compare these digits with {headlineName} over a trusted
+                    channel (in person, a call you recognise). If they match,
+                    mark this contact verified.
+                  </p>
+                  <div>
+                    <Button
+                      variant={safety.status === "verified" ? "secondary" : "primary"}
+                      disabled={setVerified.isPending}
+                      onClick={() =>
+                        setVerified.mutate(safety.status !== "verified")
+                      }
+                      data-testid="safety-verify-toggle"
+                    >
+                      {safety.status === "verified"
+                        ? "Remove verification"
+                        : "Mark verified"}
+                    </Button>
+                  </div>
+                </div>
+              )}
 
               <div style={{ borderTop: "1px solid var(--c-border)" }}>
                 <TerminalMenu items={items} onEsc={() => navigate({ to: "/dms" })} />

--- a/pollis-core/src/commands/dm.rs
+++ b/pollis-core/src/commands/dm.rs
@@ -139,6 +139,16 @@ pub async fn create_dm_channel(
         Err(e) => eprintln!("[mls] create_dm_channel: mls group init failed (non-fatal): {e}"),
     }
 
+    // TOFU-pin each peer's account_id_pub locally so a later Turso-side
+    // key swap is detectable. Advisory — never blocks DM creation.
+    for member in members.iter().filter(|m| m.user_id != creator_id) {
+        if let Err(e) =
+            crate::commands::safety::check_and_pin_account_key(state, &member.user_id).await
+        {
+            eprintln!("[safety] create_dm_channel: pin {} failed: {e}", member.user_id);
+        }
+    }
+
     // Notify non-creator members via their personal inbox rooms so they see
     // the new DM channel immediately without needing to refresh.
     let inbox_payload = serde_json::json!({

--- a/pollis-core/src/commands/mod.rs
+++ b/pollis-core/src/commands/mod.rs
@@ -17,6 +17,7 @@ pub mod livekit;
 pub mod livekit;
 pub mod mls;
 pub mod r2;
+pub mod safety;
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
 pub mod sfx;
 #[cfg(not(any(target_os = "ios", target_os = "android")))]

--- a/pollis-core/src/commands/safety.rs
+++ b/pollis-core/src/commands/safety.rs
@@ -1,0 +1,259 @@
+//! Signal-style safety numbers / contact verification.
+//!
+//! The cryptographic root of trust for a user is `users.account_id_pub`
+//! (32-byte Ed25519). Every device cert chains to it, so verifying this
+//! one value out-of-band transitively covers all of a user's devices.
+//!
+//! Turso (and anyone who can write to it) is untrusted, so we cannot rely
+//! on the server to honestly report a peer's `account_id_pub`. This module
+//! pins the first-seen key locally (TOFU) and lets two humans compare a
+//! 60-digit safety number derived from both parties' keys.
+
+use std::sync::Arc;
+
+use serde::Serialize;
+use sha2::{Digest, Sha512};
+
+use crate::error::{Error, Result};
+use crate::state::AppState;
+
+/// Iteration count for the fingerprint hash. Matches Signal's
+/// NumericFingerprintGenerator default — deliberately slow so a brute
+/// force against a truncated fingerprint is infeasible.
+const FP_ITERATIONS: usize = 5200;
+
+/// Bump if the fingerprint derivation ever changes so old and new
+/// clients never display a matching number under different schemes.
+const FP_VERSION: u16 = 0;
+
+#[derive(Debug, Serialize)]
+pub struct SafetyNumberInfo {
+    /// 60 decimal digits, grouped into 5-digit blocks for display.
+    pub safety_number: String,
+    /// "unverified" | "verified" | "changed"
+    pub status: String,
+    /// Peer's current identity version (bumps on account reset).
+    pub peer_identity_version: i64,
+}
+
+/// SHA-512^N over (version || pubkey || stable_id), then 6 blocks of
+/// 5 bytes each rendered as 5 decimal digits → a 30-digit per-user
+/// fingerprint. Signal's scheme, our own domain/version.
+fn fingerprint(pubkey: &[u8], stable_id: &[u8]) -> String {
+    let mut hasher = Sha512::new();
+    hasher.update(FP_VERSION.to_be_bytes());
+    hasher.update(pubkey);
+    hasher.update(stable_id);
+    let mut hash = hasher.finalize().to_vec();
+    for _ in 1..FP_ITERATIONS {
+        let mut h = Sha512::new();
+        h.update(&hash);
+        h.update(pubkey);
+        hash = h.finalize().to_vec();
+    }
+
+    let mut out = String::with_capacity(30);
+    for block in 0..6 {
+        let off = block * 5;
+        let mut v: u64 = 0;
+        for j in 0..5 {
+            v = (v << 8) | hash[off + j] as u64;
+        }
+        out.push_str(&format!("{:05}", v % 100_000));
+    }
+    out
+}
+
+/// Combine both parties' 30-digit fingerprints into one 60-digit number.
+/// Sorted so both sides compute the identical string regardless of who
+/// opens whose profile, then grouped into 5-digit blocks.
+fn combined(my_fp: &str, peer_fp: &str) -> String {
+    let (a, b) = if my_fp <= peer_fp {
+        (my_fp, peer_fp)
+    } else {
+        (peer_fp, my_fp)
+    };
+    let joined = format!("{a}{b}");
+    joined
+        .as_bytes()
+        .chunks(5)
+        .map(|c| std::str::from_utf8(c).unwrap_or(""))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Fetch a user's `account_id_pub` + `identity_version` from Turso.
+async fn fetch_account_key(
+    conn: &libsql::Connection,
+    user_id: &str,
+) -> Result<(Vec<u8>, i64)> {
+    let mut rows = conn
+        .query(
+            "SELECT account_id_pub, identity_version FROM users WHERE id = ?1",
+            libsql::params![user_id],
+        )
+        .await?;
+    let row = rows
+        .next()
+        .await?
+        .ok_or_else(|| Error::Other(anyhow::anyhow!("user {user_id} not found")))?;
+    let pubkey: Option<Vec<u8>> = row.get::<Option<Vec<u8>>>(0).ok().flatten();
+    let pubkey = pubkey
+        .ok_or_else(|| Error::Other(anyhow::anyhow!("user {user_id} has no account_id_pub")))?;
+    let version: i64 = row.get(1).unwrap_or(0);
+    Ok((pubkey, version))
+}
+
+/// Compute the safety number for the pair (`my_user_id`, `peer_user_id`)
+/// and report its verification status against the local pin.
+pub async fn get_safety_number(
+    my_user_id: String,
+    peer_user_id: String,
+    state: &Arc<AppState>,
+) -> Result<SafetyNumberInfo> {
+    let conn = state.remote_db.conn().await?;
+    let (my_pub, _) = fetch_account_key(&conn, &my_user_id).await?;
+    let (peer_pub, peer_version) = fetch_account_key(&conn, &peer_user_id).await?;
+
+    let my_fp = fingerprint(&my_pub, my_user_id.as_bytes());
+    let peer_fp = fingerprint(&peer_pub, peer_user_id.as_bytes());
+    let safety_number = combined(&my_fp, &peer_fp);
+
+    let guard = state.local_db.lock().await;
+    let db = guard
+        .as_ref()
+        .ok_or_else(|| Error::Other(anyhow::anyhow!("Not signed in")))?;
+    let pin: Option<(Vec<u8>, i64)> = db
+        .conn()
+        .query_row(
+            "SELECT account_id_pub, verified FROM contact_verification WHERE peer_user_id = ?1",
+            rusqlite::params![peer_user_id],
+            |r| Ok((r.get::<_, Vec<u8>>(0)?, r.get::<_, i64>(1)?)),
+        )
+        .ok();
+
+    let status = match pin {
+        None => "unverified",
+        Some((pinned_pub, _)) if pinned_pub != peer_pub => "changed",
+        Some((_, verified)) if verified != 0 => "verified",
+        Some(_) => "unverified",
+    }
+    .to_string();
+
+    Ok(SafetyNumberInfo {
+        safety_number,
+        status,
+        peer_identity_version: peer_version,
+    })
+}
+
+/// Explicitly mark a contact verified (or unverified). Pins the peer's
+/// current `account_id_pub`/`identity_version` so a later swap flips the
+/// status back to "changed".
+pub async fn set_contact_verified(
+    peer_user_id: String,
+    verified: bool,
+    state: &Arc<AppState>,
+) -> Result<()> {
+    let conn = state.remote_db.conn().await?;
+    let (peer_pub, peer_version) = fetch_account_key(&conn, &peer_user_id).await?;
+
+    let guard = state.local_db.lock().await;
+    let db = guard
+        .as_ref()
+        .ok_or_else(|| Error::Other(anyhow::anyhow!("Not signed in")))?;
+    db.conn().execute(
+        "INSERT INTO contact_verification \
+           (peer_user_id, account_id_pub, identity_version, verified) \
+         VALUES (?1, ?2, ?3, ?4) \
+         ON CONFLICT(peer_user_id) DO UPDATE SET \
+           account_id_pub = excluded.account_id_pub, \
+           identity_version = excluded.identity_version, \
+           verified = excluded.verified, \
+           updated_at = datetime('now')",
+        rusqlite::params![peer_user_id, peer_pub, peer_version, verified as i64],
+    )?;
+    Ok(())
+}
+
+/// TOFU pin + change detection for the DM/reconcile path. First sight of a
+/// peer's key is pinned silently. A later mismatch updates the pin and
+/// clears `verified` (advisory — the caller does not block delivery, the
+/// next profile open shows "changed").
+pub async fn check_and_pin_account_key(
+    state: &Arc<AppState>,
+    peer_user_id: &str,
+) -> Result<()> {
+    let conn = state.remote_db.conn().await?;
+    let (peer_pub, peer_version) = match fetch_account_key(&conn, peer_user_id).await {
+        Ok(v) => v,
+        // Peer not provisioned yet — nothing to pin, not an error.
+        Err(_) => return Ok(()),
+    };
+
+    let guard = state.local_db.lock().await;
+    let db = guard
+        .as_ref()
+        .ok_or_else(|| Error::Other(anyhow::anyhow!("Not signed in")))?;
+    let pinned: Option<Vec<u8>> = db
+        .conn()
+        .query_row(
+            "SELECT account_id_pub FROM contact_verification WHERE peer_user_id = ?1",
+            rusqlite::params![peer_user_id],
+            |r| r.get::<_, Vec<u8>>(0),
+        )
+        .ok();
+
+    match pinned {
+        Some(p) if p == peer_pub => {}
+        Some(_) => {
+            eprintln!(
+                "[safety] account_id_pub for {peer_user_id} changed — clearing verified status"
+            );
+            db.conn().execute(
+                "UPDATE contact_verification SET \
+                   account_id_pub = ?2, identity_version = ?3, \
+                   verified = 0, updated_at = datetime('now') \
+                 WHERE peer_user_id = ?1",
+                rusqlite::params![peer_user_id, peer_pub, peer_version],
+            )?;
+        }
+        None => {
+            db.conn().execute(
+                "INSERT OR IGNORE INTO contact_verification \
+                   (peer_user_id, account_id_pub, identity_version, verified) \
+                 VALUES (?1, ?2, ?3, 0)",
+                rusqlite::params![peer_user_id, peer_pub, peer_version],
+            )?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fingerprint_is_deterministic_and_30_digits() {
+        let k = [7u8; 32];
+        let a = fingerprint(&k, b"user-a");
+        let b = fingerprint(&k, b"user-a");
+        assert_eq!(a, b);
+        assert_eq!(a.len(), 30);
+        assert!(a.chars().all(|c| c.is_ascii_digit()));
+    }
+
+    #[test]
+    fn different_keys_differ() {
+        assert_ne!(fingerprint(&[1u8; 32], b"x"), fingerprint(&[2u8; 32], b"x"));
+    }
+
+    #[test]
+    fn combined_is_order_independent() {
+        let x = fingerprint(&[1u8; 32], b"alice");
+        let y = fingerprint(&[2u8; 32], b"bob");
+        assert_eq!(combined(&x, &y), combined(&y, &x));
+        assert_eq!(combined(&x, &y).replace(' ', "").len(), 60);
+    }
+}

--- a/pollis-core/src/db/local_schema.sql
+++ b/pollis-core/src/db/local_schema.sql
@@ -71,3 +71,17 @@ CREATE TABLE IF NOT EXISTS user_cache (
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
+-- Safety-number / contact verification pins (Signal-style).
+-- TOFU: the first account_id_pub seen for a peer is stored here. A later
+-- mismatch is surfaced as a "changed" status and clears `verified`. Lives
+-- in the local (secrets) DB so a malicious Turso write to
+-- users.account_id_pub is detectable client-side.
+CREATE TABLE IF NOT EXISTS contact_verification (
+    peer_user_id     TEXT PRIMARY KEY,
+    account_id_pub   BLOB NOT NULL,
+    identity_version INTEGER NOT NULL,
+    verified         INTEGER NOT NULL DEFAULT 0,
+    first_seen_at    TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at       TEXT NOT NULL DEFAULT (datetime('now'))
+);
+

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -11,6 +11,7 @@ pub mod messages;
 pub mod mls;
 pub mod pin;
 pub mod r2;
+pub mod safety;
 pub mod sfx;
 pub mod terminal;
 pub mod update;

--- a/src-tauri/src/commands/safety.rs
+++ b/src-tauri/src/commands/safety.rs
@@ -1,0 +1,19 @@
+// Generated shim file. Each #[tauri::command] forwards to pollis_core::commands::safety::*. Edit pollis-core, not here.
+
+#![allow(unused_imports)]
+use std::sync::Arc;
+use tauri::State;
+
+use crate::error::Result;
+use crate::state::AppState;
+pub use pollis_core::commands::safety::*;
+
+#[tauri::command]
+pub async fn get_safety_number(my_user_id: String, peer_user_id: String, state: State<'_, Arc<AppState>>) -> Result<SafetyNumberInfo> {
+    pollis_core::commands::safety::get_safety_number(my_user_id, peer_user_id, &state).await
+}
+
+#[tauri::command]
+pub async fn set_contact_verified(peer_user_id: String, verified: bool, state: State<'_, Arc<AppState>>) -> Result<()> {
+    pollis_core::commands::safety::set_contact_verified(peer_user_id, verified, &state).await
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -392,6 +392,8 @@ pub fn run() {
             commands::device_enrollment::reset_identity_and_recover,
             commands::device_enrollment::finalize_device_enrollment,
             commands::device_enrollment::list_security_events,
+            commands::safety::get_safety_number,
+            commands::safety::set_contact_verified,
             commands::user::get_user_profile,
             commands::user::update_user_profile,
             commands::user::search_user_by_username,

--- a/src-tauri/src/test_harness.rs
+++ b/src-tauri/src/test_harness.rs
@@ -54,6 +54,8 @@ pub fn build_client_app(state: Arc<AppState>) -> Result<(App<MockRuntime>, Webvi
             crate::commands::device_enrollment::reset_identity_and_recover,
             crate::commands::device_enrollment::finalize_device_enrollment,
             crate::commands::device_enrollment::list_security_events,
+            crate::commands::safety::get_safety_number,
+            crate::commands::safety::set_contact_verified,
             crate::commands::user::get_user_profile,
             crate::commands::user::update_user_profile,
             crate::commands::user::search_user_by_username,

--- a/src-tauri/tests/flows.rs
+++ b/src-tauri/tests/flows.rs
@@ -3198,3 +3198,94 @@ async fn unlock_resigns_stale_sibling_device_cert() {
 
     drop(alice);
 }
+
+// ─── Safety numbers / contact verification ───────────────────────────────────
+
+/// Full lifecycle of the Signal-style safety number:
+///   1. Creating a DM TOFU-pins the peer → status "unverified", 60 digits.
+///   2. Both sides compute the *same* number regardless of who asks.
+///   3. `set_contact_verified` flips status → "verified".
+///   4. A Turso-side `account_id_pub` swap (the exact attack this defends
+///      against) is detected → status "changed".
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn safety_number_lifecycle_and_key_change_detection() {
+    wipe().await;
+
+    let mut alice = TestClient::new().await;
+    let mut bob = TestClient::new().await;
+    alice.sign_up("alice@test.local").await;
+    bob.sign_up("bob@test.local").await;
+    let alice_id = alice.user_id().to_string();
+    let bob_id = bob.user_id().to_string();
+
+    // Creating the DM runs check_and_pin_account_key for bob on alice's side.
+    alice.create_dm(&[&bob_id]).await;
+
+    let a_view = alice
+        .invoke_json(
+            "get_safety_number",
+            json!({ "myUserId": alice_id, "peerUserId": bob_id }),
+        )
+        .await;
+    assert_eq!(a_view["status"], "unverified");
+    let a_num = a_view["safety_number"].as_str().unwrap().to_string();
+    assert_eq!(
+        a_num.chars().filter(|c| c.is_ascii_digit()).count(),
+        60,
+        "safety number must be 60 digits"
+    );
+
+    // Order independence: bob asking about alice yields the identical number.
+    let b_view = bob
+        .invoke_json(
+            "get_safety_number",
+            json!({ "myUserId": bob_id, "peerUserId": alice_id }),
+        )
+        .await;
+    assert_eq!(
+        b_view["safety_number"].as_str().unwrap(),
+        a_num,
+        "both parties must derive the same safety number"
+    );
+
+    // Explicit verification.
+    alice
+        .invoke_json(
+            "set_contact_verified",
+            json!({ "peerUserId": bob_id, "verified": true }),
+        )
+        .await;
+    let verified = alice
+        .invoke_json(
+            "get_safety_number",
+            json!({ "myUserId": alice_id, "peerUserId": bob_id }),
+        )
+        .await;
+    assert_eq!(verified["status"], "verified");
+
+    // Simulate the attack: someone with Turso write access swaps bob's
+    // account_id_pub. alice's locally-pinned key no longer matches.
+    let conn = world().await.remote.conn().await.expect("remote conn");
+    conn.execute(
+        "UPDATE users SET account_id_pub = ?1, identity_version = identity_version + 1 \
+         WHERE id = ?2",
+        libsql::params![vec![9u8; 32], bob_id.clone()],
+    )
+    .await
+    .expect("swap bob account_id_pub");
+
+    let changed = alice
+        .invoke_json(
+            "get_safety_number",
+            json!({ "myUserId": alice_id, "peerUserId": bob_id }),
+        )
+        .await;
+    assert_eq!(
+        changed["status"], "changed",
+        "a Turso-side key swap must be detected as 'changed'"
+    );
+
+    drop(alice);
+    drop(bob);
+}


### PR DESCRIPTION
- Per-pair safety number derived from both users' `account_id_pub` (Signal-style SHA-512 iterated fingerprint).
- TOFU pin in local DB; detects Turso-side `account_id_pub` swaps as "changed".
- `get_safety_number` / `set_contact_verified` commands; verification UI on the user profile page.
- Unit tests + integration test `safety_number_lifecycle_and_key_change_detection` (passing).