### PR TITLE
ci(linux): install libpipewire-0.3-dev so the screen-capture helper builds

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -243,6 +243,7 @@ jobs:
             libssl-dev \
             libasound2-dev \
             libpulse-dev \
+            libpipewire-0.3-dev \
             libdbus-1-dev \
             rpm \
             cmake \


### PR DESCRIPTION
The Linux release job builds `pollis-capture-linux` (new in #273), which pulls `libspa-sys`/`pipewire` and needs the `libpipewire-0.3` system dev package at build time. It was missing from the apt list, so the `Build and stage screen-capture helper` step failed on v1.0.154 with `Package libpipewire-0.3 was not found`. Adds `libpipewire-0.3-dev` (provides both `libpipewire-0.3.pc` and `libspa-0.2.pc`). Linux-only; mac/Windows jobs unaffected.