### PR TITLE
fix(macos): drop EDR-triggering entitlements (keeps screen share)

### DIFF
--- a/src-tauri/Entitlements.plist
+++ b/src-tauri/Entitlements.plist
@@ -8,9 +8,5 @@
 	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
-	<key>com.apple.security.cs.allow-dyld-environment-variables</key>
-	<true/>
-	<key>com.apple.developer.persistent-content-capture</key>
-	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Closes #279.

Removes two macOS entitlements that completed a CrowdStrike behavioral-prevention signature SIGKILLing v1.0.157 on launch:

- `com.apple.developer.persistent-content-capture` — restricted persistent-capture entitlement added by #273; **not** required for interactive ScreenCaptureKit (gated by TCC + `NSScreenCaptureUsageDescription`). Screen share keeps working.
- `com.apple.security.cs.allow-dyld-environment-variables` — zero runtime DYLD_ usage; pure hardened-runtime attack surface.

Kept: `allow-jit`/`allow-unsigned-executable-memory` (removal needs a notarized test build to verify), `audio-input` (inert today, required if Mac App Store later).

Org-side follow-up (out of scope): signer-based Falcon allowlist for `Developer ID Application: Daniel Kral (9JF7WWYMU2)`.