### PR TITLE
fix(terminal): binary IPC + coalescing + flow control for PTY throughput

### DIFF
--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -75,9 +75,26 @@ export const TerminalView: React.FC<TerminalViewProps> = ({ visible }) => {
         /* container momentarily zero-sized (hidden) — ignore */
       }
     };
-    const channel = new Channel<number[]>();
-    channel.onmessage = (bytes) => {
-      term.write(new Uint8Array(bytes));
+    // Binary IPC: bytes arrive as an ArrayBuffer (InvokeResponseBody::Raw)
+    // with no JSON number-array bloat / parse. Hand the raw Uint8Array to
+    // xterm — its write() has an internal UTF-8 decoder that correctly
+    // holds partial multi-byte sequences split across chunks, so we must
+    // NOT TextDecode per-chunk. The write callback fires once the chunk is
+    // actually parsed/rendered: that's the true end-to-end backpressure
+    // signal we credit back to the aggregator via terminal_ack.
+    const channel = new Channel<ArrayBuffer>();
+    channel.onmessage = (buf) => {
+      const bytes = new Uint8Array(buf);
+      term.write(bytes, () => {
+        const id = terminalIdRef.current;
+        if (id === null) {
+          return;
+        }
+        invoke("terminal_ack", {
+          terminalId: id,
+          bytes: bytes.byteLength,
+        }).catch(() => {});
+      });
     };
 
     let disposed = false;

--- a/pollis-core/src/commands/screenshare.rs
+++ b/pollis-core/src/commands/screenshare.rs
@@ -380,12 +380,10 @@ impl ScreenShareState {
     }
 }
 
-/// Trait wrapper for the raw-bytes Channel sink so pollis-core stays
-/// free of a tauri runtime dependency. The src-tauri shim adapts a
-/// `tauri::ipc::Channel<InvokeResponseBody>` into this.
-pub trait RawSink: Send + Sync {
-    fn send(&self, bytes: Vec<u8>) -> Result<()>;
-}
+/// Re-export of the binary-bytes sink (now defined in `crate::sink` as a
+/// neutral home so the terminal path can share it). Kept here so existing
+/// `commands::screenshare::RawSink` imports keep working.
+pub use crate::sink::RawSink;
 
 // ── Tauri-facing commands ─────────────────────────────────────────────────
 

--- a/pollis-core/src/commands/terminal.rs
+++ b/pollis-core/src/commands/terminal.rs
@@ -1,37 +1,111 @@
 //! In-app terminal pane backend.
 //!
 //! Spawns the user's `$SHELL` behind a PTY via `portable-pty`. Each session
-//! gets a dedicated OS thread pumping the master fd into an [`EventSink`] of
-//! raw bytes (≤64 KB chunks). The frontend (xterm.js) writes those bytes to
-//! the screen and forwards keystrokes back through [`terminal_write`].
+//! gets a dedicated OS reader thread plus an aggregator thread that coalesce
+//! the master fd into a [`RawSink`] of raw bytes (binary IPC, no serde — see
+//! issue #282). The frontend (xterm.js) writes those bytes to the screen and
+//! forwards keystrokes back through [`terminal_write`].
 //!
 //! Sessions are spawned on first activation and kept alive for the app's
 //! lifetime; toggling the view away and back reattaches to the same PTY.
 //! Dropping a [`PtySession`] kills its child, so process exit / `logout`
 //! cleanup leaves no zombies.
+//!
+//! Backpressure: bytes handed to xterm are credited via [`terminal_ack`]
+//! (fired from xterm's write callback when a chunk is actually rendered).
+//! The aggregator parks while `in_flight` exceeds [`HIGH_WATERMARK`] so a
+//! runaway producer (`cat bigfile`, chatty build) can't balloon xterm's
+//! unbounded internal write buffer on weak/software-rendered devices.
 
 use std::io::{Read, Write};
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
+use std::mem::take;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::mpsc::{self, TryRecvError};
+use std::sync::{Arc, Condvar, Mutex};
 
 use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
 
 use crate::error::{Error, Result};
-use crate::sink::EventSink;
+use crate::sink::RawSink;
 use crate::state::AppState;
 
 fn map_pty<E: std::fmt::Display>(e: E) -> Error {
     Error::Other(anyhow::anyhow!("PTY error: {e}"))
 }
 
+/// Largest coalesced message handed to one sink send. The reader fills the
+/// mpsc faster than the aggregator drains under bulk output, so try_recv
+/// naturally batches many 64 KiB reads up to this bound.
+const MAX_BATCH: usize = 256 * 1024;
+
+/// Aggregator parks once this many un-acked bytes are outstanding.
+const HIGH_WATERMARK: usize = 1024 * 1024;
+
+/// ...and resumes once outstanding drops back below this.
+const LOW_WATERMARK: usize = 256 * 1024;
+
+/// Shared credit counter + parking primitive for one session's flow
+/// control. `terminal_ack` decrements and notifies; the aggregator parks
+/// on the condvar while over the high watermark. `closed` lets
+/// `terminal_close` / drop wake a parked aggregator so its thread exits
+/// instead of leaking until EOF.
+struct FlowControl {
+    in_flight: AtomicUsize,
+    closed: AtomicU64,
+    lock: Mutex<()>,
+    cv: Condvar,
+}
+
+impl FlowControl {
+    fn new() -> Self {
+        Self {
+            in_flight: AtomicUsize::new(0),
+            closed: AtomicU64::new(0),
+            lock: Mutex::new(()),
+            cv: Condvar::new(),
+        }
+    }
+
+    /// Park the aggregator until outstanding bytes fall below the low
+    /// watermark (or the session is closed), then reserve `n` bytes.
+    fn gate(&self, n: usize) {
+        if self.in_flight.load(Ordering::Acquire) > HIGH_WATERMARK {
+            let mut guard = self.lock.lock().unwrap();
+            while self.in_flight.load(Ordering::Acquire) > LOW_WATERMARK
+                && self.closed.load(Ordering::Acquire) == 0
+            {
+                guard = self.cv.wait(guard).unwrap();
+            }
+        }
+        self.in_flight.fetch_add(n, Ordering::AcqRel);
+    }
+
+    /// Credit `n` acked bytes back and wake a parked aggregator.
+    fn ack(&self, n: usize) {
+        self.in_flight.fetch_sub(n, Ordering::AcqRel);
+        let _g = self.lock.lock().unwrap();
+        self.cv.notify_all();
+    }
+
+    /// Mark closed and wake any parked aggregator so its thread exits.
+    fn close(&self) {
+        self.closed.store(1, Ordering::Release);
+        let _g = self.lock.lock().unwrap();
+        self.cv.notify_all();
+    }
+}
+
 pub struct PtySession {
     master: Box<dyn MasterPty + Send>,
     writer: Box<dyn Write + Send>,
     child: Box<dyn portable_pty::Child + Send + Sync>,
+    flow: Arc<FlowControl>,
 }
 
 impl Drop for PtySession {
     fn drop(&mut self) {
+        // Wake a parked aggregator so its thread isn't stuck until EOF.
+        self.flow.close();
         let _ = self.child.kill();
         let _ = self.child.wait();
     }
@@ -62,7 +136,7 @@ fn default_shell() -> String {
 pub async fn terminal_open(
     rows: u16,
     cols: u16,
-    on_output: Arc<dyn EventSink<Vec<u8>>>,
+    on_output: Arc<dyn RawSink>,
     state: &Arc<AppState>,
 ) -> Result<String> {
     let pty_system = native_pty_system();
@@ -98,18 +172,21 @@ pub async fn terminal_open(
 
     let id = NEXT_ID.fetch_add(1, Ordering::Relaxed).to_string();
 
-    // PTY reads are blocking, so this lives on a dedicated OS thread
-    // rather than a tokio task. 64 KB chunks bound per-message size; if
-    // the sink detaches (view closed / app shutting down) we stop.
+    let flow = Arc::new(FlowControl::new());
+
+    // PTY reads are blocking, so the reader lives on a dedicated OS thread.
+    // It does no sinking — just forwards 64 KiB chunks over an mpsc to the
+    // aggregator. Dropping `tx` on EOF/err signals Disconnected downstream.
+    let (tx, rx) = mpsc::channel::<Vec<u8>>();
     std::thread::Builder::new()
-        .name(format!("pty-{id}"))
+        .name(format!("pty-rd-{id}"))
         .spawn(move || {
             let mut buf = [0u8; 64 * 1024];
             loop {
                 match reader.read(&mut buf) {
                     Ok(0) => break,
                     Ok(n) => {
-                        if on_output.send(buf[..n].to_vec()).is_err() {
+                        if tx.send(buf[..n].to_vec()).is_err() {
                             break;
                         }
                     }
@@ -119,13 +196,69 @@ pub async fn terminal_open(
         })
         .map_err(map_pty)?;
 
+    // Aggregator: coalesces queued reads into one ≤MAX_BATCH message with
+    // no timer (try_recv drains only what's already queued, so interactive
+    // keystrokes add zero latency), gates on flow control, then sinks.
+    let flow_agg = Arc::clone(&flow);
+    std::thread::Builder::new()
+        .name(format!("pty-agg-{id}"))
+        .spawn(move || {
+            loop {
+                // Blocks; returns immediately for interactive output.
+                let first = match rx.recv() {
+                    Ok(c) => c,
+                    Err(_) => break,
+                };
+                let mut buf = first;
+                let mut disconnected = false;
+                while buf.len() < MAX_BATCH {
+                    match rx.try_recv() {
+                        Ok(c) => buf.extend(c),
+                        // Nothing queued -> send now (low latency).
+                        Err(TryRecvError::Empty) => break,
+                        // EOF: flush tail below, then exit after send.
+                        Err(TryRecvError::Disconnected) => {
+                            disconnected = true;
+                            break;
+                        }
+                    }
+                }
+                let n = buf.len();
+                flow_agg.gate(n);
+                if on_output.send(take(&mut buf)).is_err() {
+                    break;
+                }
+                if disconnected {
+                    break;
+                }
+            }
+        })
+        .map_err(map_pty)?;
+
     let session = PtySession {
         master: pair.master,
         writer,
         child,
+        flow,
     };
     state.terminals.lock().await.insert(id.clone(), session);
     Ok(id)
+}
+
+/// Credit acked bytes back toward the per-session flow-control window so
+/// the aggregator can resume producing. Fired from xterm.js's `write`
+/// callback (true end-to-end render signal). Unknown ids are a no-op —
+/// the PTY may have closed between render and this call.
+pub async fn terminal_ack(
+    terminal_id: String,
+    bytes: usize,
+    state: &Arc<AppState>,
+) -> Result<()> {
+    let map = state.terminals.lock().await;
+    if let Some(session) = map.get(&terminal_id) {
+        session.flow.ack(bytes);
+    }
+    Ok(())
 }
 
 /// Forward user keystrokes (UTF-8 bytes) to the shell. Unknown ids are a

--- a/pollis-core/src/sink.rs
+++ b/pollis-core/src/sink.rs
@@ -16,6 +16,15 @@ pub trait EventSink<T>: Send + Sync {
     fn send(&self, event: T) -> Result<(), String>;
 }
 
+/// Push raw bytes toward the frontend with no serde encoding. The desktop
+/// crate adapts a `tauri::ipc::Channel<InvokeResponseBody>` into this so
+/// payloads ride the binary IPC path (`InvokeResponseBody::Raw`) instead of
+/// being JSON-encoded as a number array (~4-6x bloat + a JS-side parse).
+/// Used by screenshare frame delivery and the terminal PTY output stream.
+pub trait RawSink: Send + Sync {
+    fn send(&self, bytes: Vec<u8>) -> crate::error::Result<()>;
+}
+
 /// No-op sink. Useful for the integration-test harness, or any code path
 /// that drives command logic without a connected frontend.
 pub struct NoopSink;

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -9,8 +9,13 @@ use crate::state::AppState;
 pub use pollis_core::commands::terminal::*;
 
 #[tauri::command]
-pub async fn terminal_open(rows: u16, cols: u16, on_output: tauri::ipc::Channel<Vec<u8>>, state: State<'_, Arc<AppState>>) -> Result<String> {
-    pollis_core::commands::terminal::terminal_open(rows, cols, std::sync::Arc::new(crate::sink::ChannelSink(on_output)), &state).await
+pub async fn terminal_open(rows: u16, cols: u16, on_output: tauri::ipc::Channel<tauri::ipc::InvokeResponseBody>, state: State<'_, Arc<AppState>>) -> Result<String> {
+    pollis_core::commands::terminal::terminal_open(rows, cols, std::sync::Arc::new(crate::sink::RawChannelSink(on_output)), &state).await
+}
+
+#[tauri::command]
+pub async fn terminal_ack(terminal_id: String, bytes: usize, state: State<'_, Arc<AppState>>) -> Result<()> {
+    pollis_core::commands::terminal::terminal_ack(terminal_id, bytes, &state).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -516,6 +516,7 @@ commands::livekit::get_livekit_token,
             commands::terminal::terminal_write,
             commands::terminal::terminal_resize,
             commands::terminal::terminal_close,
+            commands::terminal::terminal_ack,
         ])
         // On macOS, hide the window on close instead of quitting.
         // On window focus, re-evaluate the media-cache cap so files

--- a/src-tauri/src/sink.rs
+++ b/src-tauri/src/sink.rs
@@ -4,8 +4,7 @@
 use serde::Serialize;
 use tauri::ipc::{Channel, InvokeResponseBody};
 
-use pollis_core::commands::screenshare::RawSink;
-use pollis_core::sink::EventSink;
+use pollis_core::sink::{EventSink, RawSink};
 
 pub struct ChannelSink<E>(pub Channel<E>)
 where


### PR DESCRIPTION
Fixes the sluggish embedded terminal on weak/software-rendered devices.

Root cause: PTY output went through the serde `ChannelSink<Vec<u8>>`, so Tauri JSON-encoded bytes as an int array (~4-6x bloat + JS parse per read).

- Binary `InvokeResponseBody::Raw` transport (`RawSink` relocated to `pollis_core::sink`)
- Reader+aggregator mpsc split: no-timer 256 KiB coalescing, tail-flush on EOF
- Credit-based flow control (1 MiB/256 KiB watermarks) via new `terminal_ack` + xterm write callback
- Frontend on `Channel<ArrayBuffer>`, no `TextDecoder`

Verified: `cargo check -p pollis-core`, `cargo check -p pollis`, `tsc --noEmit` all clean.

Closes #282