### PR TITLE
feat(shortcuts): user-configurable key bindings

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -99,6 +99,11 @@ function MainApp() {
         accent_color: getPreference<string | undefined>(json, "accent_color", undefined),
         background_color: getPreference<string | undefined>(json, "background_color", undefined),
         font_size: getPreference<string | undefined>(json, "font_size", undefined),
+        shortcut_overrides: getPreference<{ [commandId: string]: string } | undefined>(
+          json,
+          "shortcut_overrides",
+          undefined,
+        ),
       };
       applyPreferences(prefs);
       // Font size is device-local; the legacy remote field (if any) seeds it once.

--- a/frontend/src/hooks/queries/usePreferences.ts
+++ b/frontend/src/hooks/queries/usePreferences.ts
@@ -9,6 +9,10 @@ import {
   loadDeviceFontSize,
   saveDeviceFontSize,
 } from "../../utils/colorUtils";
+import {
+  setShortcutOverrides,
+  type ShortcutCommandId,
+} from "../../keyboard";
 
 /**
  * Mirrors `voice_apm::NsLevel` in src-tauri.
@@ -51,6 +55,13 @@ export interface PreferencesData {
    * in `src-tauri/src/commands/voice.rs`.
    */
   user_volumes?: { [userId: string]: number };
+  /**
+   * Per-command keyboard shortcut overrides, keyed by `ShortcutCommandId`.
+   * Values are canonical combo strings (e.g. `"mod+shift+k"`) understood by
+   * `keyboard/keyCombo.ts`. Missing entries fall back to the built-in
+   * `defaultCombo` in `keyboard/commands.ts`.
+   */
+  shortcut_overrides?: { [commandId: string]: string };
 }
 
 /**
@@ -248,6 +259,11 @@ export function usePreferences() {
           "user_volumes",
           undefined,
         ),
+        shortcut_overrides: getPreference<{ [commandId: string]: string } | undefined>(
+          json,
+          "shortcut_overrides",
+          undefined,
+        ),
       };
     },
     enabled: !!currentUser,
@@ -282,6 +298,12 @@ export function applyPreferences(prefs: PreferencesData): void {
   if (prefs.background_color) {
     applyBackgroundColor(prefs.background_color);
   }
+  // Shortcut overrides flow through the same bindings module that
+  // `useGlobalShortcut` resolves against on every keydown — no callsite
+  // changes needed. An undefined map clears any previous override.
+  setShortcutOverrides(
+    (prefs.shortcut_overrides ?? {}) as Partial<Record<ShortcutCommandId, string>>,
+  );
 }
 
 /**
@@ -323,10 +345,14 @@ export function useApplyPreferences(): void {
   const { query } = usePreferences();
   const currentUser = useAppStore((state) => state.currentUser);
   const data = query.data;
+  // Stringify the override map so the effect re-runs when any override
+  // changes (a React Query refetch returns a new object reference, and we
+  // don't want to re-fire on unrelated pref edits either).
+  const overridesKey = JSON.stringify(data?.shortcut_overrides ?? {});
   useEffect(() => {
     if (data) {
       applyPreferences(data);
       applyDeviceFontSize(currentUser?.id, data);
     }
-  }, [data?.accent_color, data?.background_color, data?.font_size, currentUser?.id]);
+  }, [data?.accent_color, data?.background_color, data?.font_size, overridesKey, currentUser?.id]);
 }

--- a/frontend/src/keyboard/keyCombo.ts
+++ b/frontend/src/keyboard/keyCombo.ts
@@ -142,5 +142,8 @@ export function formatCombo(combo: string): string {
     (p.key.length === 1 ? p.key.toUpperCase() : p.key.replace(/^\w/, (c) => c.toUpperCase()));
   parts.push(keyLabel);
 
-  return isMac ? parts.join("") : parts.join("+");
+  // macOS condenses modifier glyphs against the key; a thin space (U+2009)
+  // gives the kbd badge a little breathing room without bloating to a full
+  // space. Other platforms use the conventional "+" separator.
+  return isMac ? parts.join(" ") : parts.join("+");
 }

--- a/frontend/src/pages/KeyboardShortcutsPage.tsx
+++ b/frontend/src/pages/KeyboardShortcutsPage.tsx
@@ -2,7 +2,13 @@ import React from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { PageShell } from "../components/Layout/PageShell";
 import { NavigableList } from "../components/ui/NavigableList";
-import { shortcutLabel } from "../utils/platform";
+import { isMac } from "../utils/platform";
+
+// macOS condenses ⌘ tight against the next glyph; a thin space (U+2009)
+// gives the kbd badge a little air without affecting Ctrl+ layout.
+function shortcutDisplay(key: string): string {
+  return isMac ? `⌘ ${key}` : `Ctrl+${key}`;
+}
 
 interface Shortcut {
   id: string;
@@ -58,7 +64,7 @@ export const KeyboardShortcutsPage: React.FC = () => {
                 lineHeight: 1.2,
               }}
             >
-              {s.key ? shortcutLabel(s.key) : s.label}
+              {s.key ? shortcutDisplay(s.key) : s.label}
             </kbd>
           )}
         />

--- a/frontend/src/pages/KeyboardShortcutsPage.tsx
+++ b/frontend/src/pages/KeyboardShortcutsPage.tsx
@@ -1,37 +1,129 @@
-import React from "react";
-import { useNavigate } from "@tanstack/react-router";
+import React, { useState, useEffect, useCallback } from "react";
 import { PageShell } from "../components/Layout/PageShell";
 import { NavigableList } from "../components/ui/NavigableList";
-import { isMac } from "../utils/platform";
+import {
+  SHORTCUT_COMMANDS,
+  ALL_SHORTCUT_COMMAND_IDS,
+  formatCombo,
+  type ShortcutCommandId,
+  type ShortcutCategory,
+} from "../keyboard";
+import { usePreferences } from "../hooks/queries/usePreferences";
 
-// macOS condenses ⌘ tight against the next glyph; a thin space (U+2009)
-// gives the kbd badge a little air without affecting Ctrl+ layout.
-function shortcutDisplay(key: string): string {
-  return isMac ? `⌘ ${key}` : `Ctrl+${key}`;
+interface Row {
+  id: ShortcutCommandId;
+  title: string;
+  category: ShortcutCategory;
+  combo: string;
+  isOverridden: boolean;
 }
 
-interface Shortcut {
-  id: string;
-  description: string;
-  // The base key combined with the platform modifier (⌘ on macOS,
-  // Ctrl elsewhere) via shortcutLabel. When omitted, `label` is shown
-  // verbatim (e.g. plain Escape, which has no modifier).
-  key?: string;
-  label?: string;
+// Build the canonical combo string from a captured keydown. Mirrors the
+// format consumed by parseCombo (`mod`, `alt`, `shift`, then the key).
+// metaKey OR ctrlKey collapses to `mod` to match the platform-primary
+// convention used by the defaults.
+function comboFromEvent(e: KeyboardEvent): string | null {
+  const k = e.key;
+  if (k === "Meta" || k === "Control" || k === "Alt" || k === "Shift") {
+    return null;
+  }
+  const parts: string[] = [];
+  if (e.metaKey || e.ctrlKey) {
+    parts.push("mod");
+  }
+  if (e.altKey) {
+    parts.push("alt");
+  }
+  if (e.shiftKey) {
+    parts.push("shift");
+  }
+  parts.push(k.toLowerCase());
+  return parts.join("+");
 }
-
-const SHORTCUTS: Shortcut[] = [
-  { id: "search", description: "Open search", key: "K" },
-  { id: "sidebar", description: "Toggle sidebar", key: "B" },
-  { id: "terminal", description: "Toggle chat ⇆ terminal", key: "`" },
-  { id: "refresh", description: "Refresh & sync", key: "R" },
-  { id: "lock", description: "Lock app", key: "L" },
-  { id: "hide", description: "Hide window", key: "W" },
-  { id: "back", description: "Go back", label: "Esc" },
-];
 
 export const KeyboardShortcutsPage: React.FC = () => {
-  const navigate = useNavigate();
+  const { query, save } = usePreferences();
+  const overrides = query.data?.shortcut_overrides ?? {};
+  const [capturingId, setCapturingId] = useState<ShortcutCommandId | null>(null);
+
+  const rows: Row[] = ALL_SHORTCUT_COMMAND_IDS.map((id) => {
+    const meta = SHORTCUT_COMMANDS[id];
+    const override = overrides[id];
+    return {
+      id,
+      title: meta.title,
+      category: meta.category,
+      combo: override ?? meta.defaultCombo,
+      isOverridden: override !== undefined && override !== meta.defaultCombo,
+    };
+  });
+
+  // Until the preferences query resolves we can't safely merge — writing
+  // `{ shortcut_overrides: ... }` alone would clobber accent_color, etc.
+  // Editing is disabled in the UI below until `data` is present.
+  const dataLoaded = !!query.data;
+  const persistOverrides = useCallback(
+    (next: { [commandId: string]: string }) => {
+      if (!query.data) {
+        return;
+      }
+      save({ ...query.data, shortcut_overrides: next });
+    },
+    [save, query.data],
+  );
+
+  const resetToDefault = useCallback(
+    (id: ShortcutCommandId) => {
+      const next = { ...overrides };
+      delete next[id];
+      persistOverrides(next);
+    },
+    [overrides, persistOverrides],
+  );
+
+  // Capture-phase listener so the global shortcut dispatcher (bubble phase)
+  // never sees the event while we're rebinding.
+  useEffect(() => {
+    if (!capturingId) {
+      return;
+    }
+    const onKeyDown = (e: KeyboardEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      e.stopImmediatePropagation();
+
+      // Esc with no modifiers cancels capture. Esc + any modifier is a
+      // valid binding (e.g. Shift+Esc); to bind plain Esc, use Reset on
+      // a command whose default is escape (e.g. nav.back).
+      if (
+        e.key === "Escape" &&
+        !e.metaKey &&
+        !e.ctrlKey &&
+        !e.altKey &&
+        !e.shiftKey
+      ) {
+        setCapturingId(null);
+        return;
+      }
+      const combo = comboFromEvent(e);
+      if (!combo) {
+        return;
+      }
+      const meta = SHORTCUT_COMMANDS[capturingId];
+      const next = { ...overrides };
+      if (combo === meta.defaultCombo) {
+        delete next[capturingId];
+      } else {
+        next[capturingId] = combo;
+      }
+      persistOverrides(next);
+      setCapturingId(null);
+    };
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown, true);
+    };
+  }, [capturingId, overrides, persistOverrides]);
 
   return (
     <PageShell title="Key Bindings" scrollable>
@@ -39,34 +131,75 @@ export const KeyboardShortcutsPage: React.FC = () => {
         data-testid="keyboard-shortcuts-page"
         className="flex-1 flex flex-col overflow-hidden"
       >
-        <NavigableList<Shortcut>
+        <NavigableList<Row>
           testId="keyboard-shortcuts-list"
-          items={SHORTCUTS}
-          getKey={(s) => s.id}
-          rowTestId={(s) => `shortcut-${s.id}`}
-          onEnterRow={() => navigate({ to: "/settings" })}
+          items={rows}
+          getKey={(r) => r.id}
+          rowTestId={(r) => `shortcut-${r.id}`}
+          onEnterRow={(r) => {
+            if (dataLoaded) {
+              setCapturingId(r.id);
+            }
+          }}
           emptyLabel="No shortcuts."
-          renderRow={(s) => (
-            <span className="flex-1 truncate" style={{ color: "var(--c-text)" }}>
-              {s.description}
+          renderRow={(r) => (
+            <span
+              className="flex-1 truncate"
+              style={{ color: "var(--c-text)" }}
+            >
+              {r.title}
             </span>
           )}
-          trailing={(s) => (
-            <kbd
-              aria-hidden="true"
-              className="font-mono text-xs"
-              style={{
-                color: "inherit",
-                background: "var(--c-bg)",
-                padding: "1px 5px",
-                borderRadius: 3,
-                border: "1px solid var(--c-border)",
-                lineHeight: 1.2,
-              }}
-            >
-              {s.key ? shortcutDisplay(s.key) : s.label}
-            </kbd>
-          )}
+          controls={(r) => {
+            const isCapturing = capturingId === r.id;
+            const controls: React.ReactNode[] = [
+              <button
+                key="edit"
+                type="button"
+                disabled={!dataLoaded}
+                onClick={() => setCapturingId(r.id)}
+                aria-label={`Rebind ${r.title}`}
+                data-testid={`shortcut-${r.id}-edit`}
+                className="font-mono text-xs"
+                style={{
+                  color: "inherit",
+                  background: "var(--c-bg)",
+                  padding: "1px 6px",
+                  borderRadius: 3,
+                  border: `1px solid ${
+                    isCapturing ? "var(--c-accent)" : "var(--c-border)"
+                  }`,
+                  lineHeight: 1.2,
+                  cursor: dataLoaded ? "pointer" : "default",
+                  opacity: dataLoaded ? 1 : 0.6,
+                }}
+              >
+                {isCapturing ? "Press keys…" : formatCombo(r.combo)}
+              </button>,
+            ];
+            if (r.isOverridden) {
+              controls.push(
+                <button
+                  key="reset"
+                  type="button"
+                  onClick={() => resetToDefault(r.id)}
+                  aria-label={`Reset ${r.title} to default`}
+                  data-testid={`shortcut-${r.id}-reset`}
+                  className="text-xs font-mono"
+                  style={{
+                    color: "var(--c-text-dim)",
+                    background: "transparent",
+                    padding: "1px 4px",
+                    border: "none",
+                    cursor: "pointer",
+                  }}
+                >
+                  reset
+                </button>,
+              );
+            }
+            return controls;
+          }}
         />
       </div>
     </PageShell>

--- a/frontend/src/pages/KeyboardShortcutsPage.tsx
+++ b/frontend/src/pages/KeyboardShortcutsPage.tsx
@@ -1,19 +1,18 @@
 import React, { useState, useEffect, useCallback } from "react";
 import { PageShell } from "../components/Layout/PageShell";
 import { NavigableList } from "../components/ui/NavigableList";
+import { Button } from "../components/ui/Button";
 import {
   SHORTCUT_COMMANDS,
   ALL_SHORTCUT_COMMAND_IDS,
   formatCombo,
   type ShortcutCommandId,
-  type ShortcutCategory,
 } from "../keyboard";
 import { usePreferences } from "../hooks/queries/usePreferences";
 
 interface Row {
   id: ShortcutCommandId;
   title: string;
-  category: ShortcutCategory;
   combo: string;
   isOverridden: boolean;
 }
@@ -52,7 +51,6 @@ export const KeyboardShortcutsPage: React.FC = () => {
     return {
       id,
       title: meta.title,
-      category: meta.category,
       combo: override ?? meta.defaultCombo,
       isOverridden: override !== undefined && override !== meta.defaultCombo,
     };
@@ -179,23 +177,16 @@ export const KeyboardShortcutsPage: React.FC = () => {
             ];
             if (r.isOverridden) {
               controls.push(
-                <button
+                <Button
                   key="reset"
-                  type="button"
+                  variant="ghost"
+                  size="xs"
                   onClick={() => resetToDefault(r.id)}
                   aria-label={`Reset ${r.title} to default`}
                   data-testid={`shortcut-${r.id}-reset`}
-                  className="text-xs font-mono"
-                  style={{
-                    color: "var(--c-text-dim)",
-                    background: "transparent",
-                    padding: "1px 4px",
-                    border: "none",
-                    cursor: "pointer",
-                  }}
                 >
                   reset
-                </button>,
+                </Button>,
               );
             }
             return controls;


### PR DESCRIPTION
Makes the Key Bindings page actually configurable: users can override shortcuts, overrides persist through preferences, and the page uses the standard `Button` for reset. Also adds a thin space between ⌘ and the key label on macOS.

## Commits
- `d1a97de` thin space between ⌘ and key label on macOS
- `88efda7` persist user shortcut overrides through preferences
- `b683529` make key bindings user-configurable
- `d6d2761` use Button component for reset, drop unused category field