### PR TITLE
fix(capture/linux): use write_msg for portal-cancel path

### DIFF
--- a/pollis-capture-linux/src/linux.rs
+++ b/pollis-capture-linux/src/linux.rs
@@ -184,9 +184,14 @@ async fn run_portal(sock: &mut UnixStream) -> Result<()> {
             // silently instead of showing a red "permission denied"
             // toast — cancelling is a normal flow, not a failure.
             eprintln!("[capture] portal cancelled by user");
-            send_error(&mut sock, "cancel: user dismissed picker")
-                .await
-                .ok();
+            write_msg(
+                sock,
+                &CaptureMsg::Error {
+                    message: "cancel: user dismissed picker".into(),
+                },
+            )
+            .await
+            .ok();
             return Ok(());
         }
         Err(PortalError::Other(e)) => {


### PR DESCRIPTION
Leftover reference to a removed `send_error` helper broke the Linux build of the capture helper, which failed the v1.0.161 release workflow. Replaces it with the same `write_msg` + `CaptureMsg::Error` pattern used elsewhere in the file.