### PR TITLE
ci(release): install libxcb dev headers for Linux capture helper

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -243,6 +243,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             libpipewire-0.3-dev \
+            libxcb1-dev \
+            libxcb-shm0-dev \
+            libxcb-randr0-dev \
             clang \
             pkg-config
 


### PR DESCRIPTION
The Linux capture helper links `libxcb` (X11 backend via the `xcb` crate, plus the SHM and RandR extensions). The runner only installed `libpipewire-0.3-dev`, so the helper failed to link with `unable to find library -lxcb`. Adds `libxcb1-dev`, `libxcb-shm0-dev`, `libxcb-randr0-dev` to the helper build job.