### PR TITLE
feat(screenshare): default H.264 across platforms (HW where available)

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -294,6 +294,13 @@ jobs:
           echo "Stamping version ${VERSION} into tauri.conf.json"
           jq --arg v "$VERSION" '.version = $v' src-tauri/tauri.conf.json > tmp.json && mv tmp.json src-tauri/tauri.conf.json
 
+      # libva-dev: header-only build dep for webrtc-sys's VAAPI H.264
+      # encoder wrapper. `libva.so.2` / `libva-drm.so.2` are dlopened at
+      # runtime via lazy-load shims — the binary doesn't link them — so
+      # missing libva at the user's machine just makes the VAAPI factory
+      # report unsupported and falls back to OpenH264 software. With
+      # libva headers present at build time we get the VAAPI factory
+      # compiled in; Intel/AMD iGPU users then get HW H.264. See #293.
       - name: Install system dependencies
         run: |
           sudo apt-get update
@@ -307,6 +314,7 @@ jobs:
             libasound2-dev \
             libpulse-dev \
             libpipewire-0.3-dev \
+            libva-dev \
             libdbus-1-dev \
             rpm \
             cmake \

--- a/pollis-core/src/commands/screenshare.rs
+++ b/pollis-core/src/commands/screenshare.rs
@@ -93,17 +93,26 @@ const MAX_SHARE_FPS: u32 = 60;
 
 /// Picks the codec used to publish the local screen-share track.
 ///
-/// macOS defaults to H.264. The LiveKit Rust SDK we ship
-/// (`webrtc-sys 0.3.27`) unconditionally links `VideoToolbox` and
-/// registers `RTCDefaultVideoEncoderFactory` ahead of the software
-/// encoders, so picking `H264` here routes the encode through Apple's
-/// hardware engine with zero additional wiring. Linux and Windows stay
-/// on VP8 software until their respective HW paths (VAAPI/NVENC,
-/// MediaFoundation) land in follow-up changes — see issue #293.
+/// Defaults to H.264 on every platform. The encoder factory in
+/// `webrtc-sys 0.3.27` routes the request to the best available backend
+/// for the current build/host:
+/// - macOS: `RTCDefaultVideoEncoderFactory` → VideoToolbox (HW). Always
+///   present — `framework=VideoToolbox` is linked unconditionally.
+/// - Linux: NVENC if `cuda.h` was present at build time AND `libcuda` /
+///   `libnvcuvid` dlopen at runtime; else VAAPI if `libva-dev` was
+///   present at build time AND `libva.so.2` / `libva-drm.so.2` dlopen
+///   at runtime; else OpenH264 software (`WEBRTC_USE_H264` is baked
+///   into the prebuilt libwebrtc).
+/// - Windows: OpenH264 software (no MediaFoundation factory exists in
+///   this SDK yet — see issue #293).
 ///
-/// `POLLIS_SCREENSHARE_CODEC` overrides the default at runtime so we can
-/// A/B without rebuilding. Accepts `vp8|h264|vp9|av1|h265`; anything
-/// else (including unset) → platform default above.
+/// SW H.264 (OpenH264) is roughly on par with SW VP8 in CPU cost on
+/// Linux and noticeably cheaper on Windows, so the SW fallback isn't a
+/// regression versus the previous VP8 default.
+///
+/// `POLLIS_SCREENSHARE_CODEC` overrides the default at runtime for A/B
+/// without rebuilding. Accepts `vp8|h264|vp9|av1|h265`; anything else
+/// (including unset) → H.264.
 fn pick_screenshare_codec() -> VideoCodec {
     if let Ok(v) = std::env::var("POLLIS_SCREENSHARE_CODEC") {
         match v.to_ascii_lowercase().as_str() {
@@ -115,14 +124,7 @@ fn pick_screenshare_codec() -> VideoCodec {
             _ => {}
         }
     }
-    #[cfg(target_os = "macos")]
-    {
-        VideoCodec::H264
-    }
-    #[cfg(not(target_os = "macos"))]
-    {
-        VideoCodec::VP8
-    }
+    VideoCodec::H264
 }
 
 /// Minimum spacing between published frames to enforce `MAX_SHARE_FPS`.

--- a/pollis-core/src/commands/screenshare.rs
+++ b/pollis-core/src/commands/screenshare.rs
@@ -91,6 +91,40 @@ const MAX_SHARE_WIDTH: u32 = 1920;
 const MAX_SHARE_HEIGHT: u32 = 1080;
 const MAX_SHARE_FPS: u32 = 60;
 
+/// Picks the codec used to publish the local screen-share track.
+///
+/// macOS defaults to H.264. The LiveKit Rust SDK we ship
+/// (`webrtc-sys 0.3.27`) unconditionally links `VideoToolbox` and
+/// registers `RTCDefaultVideoEncoderFactory` ahead of the software
+/// encoders, so picking `H264` here routes the encode through Apple's
+/// hardware engine with zero additional wiring. Linux and Windows stay
+/// on VP8 software until their respective HW paths (VAAPI/NVENC,
+/// MediaFoundation) land in follow-up changes — see issue #293.
+///
+/// `POLLIS_SCREENSHARE_CODEC` overrides the default at runtime so we can
+/// A/B without rebuilding. Accepts `vp8|h264|vp9|av1|h265`; anything
+/// else (including unset) → platform default above.
+fn pick_screenshare_codec() -> VideoCodec {
+    if let Ok(v) = std::env::var("POLLIS_SCREENSHARE_CODEC") {
+        match v.to_ascii_lowercase().as_str() {
+            "vp8" => return VideoCodec::VP8,
+            "h264" => return VideoCodec::H264,
+            "vp9" => return VideoCodec::VP9,
+            "av1" => return VideoCodec::AV1,
+            "h265" => return VideoCodec::H265,
+            _ => {}
+        }
+    }
+    #[cfg(target_os = "macos")]
+    {
+        VideoCodec::H264
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        VideoCodec::VP8
+    }
+}
+
 /// Minimum spacing between published frames to enforce `MAX_SHARE_FPS`.
 /// Used by the Linux reader (the macOS/Windows native pipelines are
 /// already display-rate-locked and SCK/WGC honour their own interval
@@ -740,7 +774,7 @@ pub async fn start_screen_share(
             LocalTrack::Video(track.clone()),
             TrackPublishOptions {
                 source: TrackSource::Screenshare,
-                video_codec: VideoCodec::VP8,
+                video_codec: pick_screenshare_codec(),
                 ..Default::default()
             },
         )
@@ -927,7 +961,7 @@ pub async fn start_screen_share(
             LocalTrack::Video(track.clone()),
             TrackPublishOptions {
                 source: TrackSource::Screenshare,
-                video_codec: VideoCodec::VP8,
+                video_codec: pick_screenshare_codec(),
                 ..Default::default()
             },
         )


### PR DESCRIPTION
First slice of #293. Switches the screenshare publish codec from VP8 to H.264 on every platform, with a `POLLIS_SCREENSHARE_CODEC` env override for A/B.

What this gets us per platform:
- **macOS** — H.264 routes through Apple's `RTCDefaultVideoEncoderFactory` (already registered ahead of SW encoders in `webrtc-sys 0.3.27`) → VideoToolbox HW encode, zero new wiring.
- **Linux** — VAAPI factory compiled in via the new `libva-dev` CI dep; Intel/AMD iGPU users get HW H.264, others fall through to OpenH264 SW (lazy-load shim, no link-time dep). NVENC still requires CUDA headers and is left for a follow-up.
- **Windows** — OpenH264 SW (no MediaFoundation factory in this SDK yet). ~10% cheaper CPU than VP8 SW per the Hopp.app benchmark.

Resolution cap (`MAX_SHARE_WIDTH/HEIGHT = 1920×1080`) deliberately left in place — lifting it on HW paths is a separate change after we measure VT-H264 at 1080p first.

## Test plan
- [ ] Build on macOS, screenshare into a call, confirm via `top`/Activity Monitor that the Pollis process CPU drops vs the prior VP8 SW baseline.
- [ ] Build on Linux with `libva-dev` installed (CI now handles this), screenshare on an Intel/AMD machine, watch for `[VAAPI] is supported` in the libwebrtc log.
- [ ] `POLLIS_SCREENSHARE_CODEC=vp8 pnpm dev` reverts to today's behaviour as a safety knob.