### PR TITLE
feat(mobile): react-query apparatus + starter hook

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -11,8 +11,10 @@ import {
   Sora_600SemiBold,
   Sora_700Bold,
 } from "@expo-google-fonts/sora";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { palette } from "../theme/tokens";
 import { ThemeProvider } from "../components/theme";
+import { queryClient } from "../lib/queryClient";
 
 SplashScreen.preventAutoHideAsync();
 
@@ -37,25 +39,27 @@ export default function RootLayout() {
   return (
     <GestureHandlerRootView style={{ flex: 1, backgroundColor: palette.bg }}>
       <SafeAreaProvider>
-        <ThemeProvider>
-          <StatusBar style="light" />
-          <Stack
-          screenOptions={{
-            headerShown: false,
-            contentStyle: { backgroundColor: palette.bg },
-            animation: "fade",
-          }}
-        >
-          <Stack.Screen name="index" />
-          <Stack.Screen name="(auth)" />
-          <Stack.Screen name="(tabs)" />
-          <Stack.Screen name="group/[id]" />
-          <Stack.Screen name="chat/[id]" />
-          <Stack.Screen name="self/preferences" />
-          <Stack.Screen name="self/user-settings" />
-          <Stack.Screen name="self/security" />
-          </Stack>
-        </ThemeProvider>
+        <QueryClientProvider client={queryClient}>
+          <ThemeProvider>
+            <StatusBar style="light" />
+            <Stack
+              screenOptions={{
+                headerShown: false,
+                contentStyle: { backgroundColor: palette.bg },
+                animation: "fade",
+              }}
+            >
+              <Stack.Screen name="index" />
+              <Stack.Screen name="(auth)" />
+              <Stack.Screen name="(tabs)" />
+              <Stack.Screen name="group/[id]" />
+              <Stack.Screen name="chat/[id]" />
+              <Stack.Screen name="self/preferences" />
+              <Stack.Screen name="self/user-settings" />
+              <Stack.Screen name="self/security" />
+            </Stack>
+          </ThemeProvider>
+        </QueryClientProvider>
       </SafeAreaProvider>
     </GestureHandlerRootView>
   );

--- a/mobile/hooks/queries/index.ts
+++ b/mobile/hooks/queries/index.ts
@@ -1,0 +1,5 @@
+// Re-export hub for query hooks. Mirrors `frontend/src/hooks/queries/index.ts`.
+// Add new hooks by importing them here so screens have one import path:
+//   import { useUserProfile } from "../../hooks/queries";
+
+export * from "./useUserProfile";

--- a/mobile/hooks/queries/useUserProfile.ts
+++ b/mobile/hooks/queries/useUserProfile.ts
@@ -1,0 +1,94 @@
+// Starter hook to seed the mobile data-fetching pattern. Mirrors the
+// shape of `frontend/src/hooks/queries/useUserProfile.ts` so that:
+//   - Future hooks copy this layout (query key fn, queryFn that calls
+//     `invoke()`, store-derived enable flag, staleTime in ms).
+//   - When `pollis-native` exposes a real `invoke()` dispatcher, this
+//     hook starts returning real data without any call-site change.
+//
+// Until the bridge is wired (see lib/native/bridge.ts), this hook will
+// throw "[pollis-native] invoke('get_user_profile') is not implemented"
+// — by design, so the lack of a backend is loud rather than silent.
+// Register a mock with `registerMockCommand("get_user_profile", …)` in
+// dev to unblock UI work.
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { invoke } from "../../lib/native";
+import { useAppStore } from "../../stores/appStore";
+
+export interface ServiceUserData {
+  username: string;
+  preferred_name?: string;
+  email: string;
+  phone: string;
+  avatar_url?: string;
+}
+
+export const userQueryKeys = {
+  profile: (userId: string | null) => ["user", "profile", userId] as const,
+};
+
+export function useUserProfile() {
+  const currentUser = useAppStore((state) => state.currentUser);
+
+  return useQuery({
+    queryKey: userQueryKeys.profile(currentUser?.id ?? null),
+    queryFn: async (): Promise<ServiceUserData> => {
+      if (!currentUser) {
+        throw new Error("No current user");
+      }
+      const profile = await invoke<{
+        id: string;
+        username?: string;
+        preferred_name?: string;
+        phone?: string;
+        avatar_url?: string;
+      } | null>("get_user_profile", { userId: currentUser.id });
+
+      return {
+        username: profile?.username || currentUser.username || "",
+        preferred_name: profile?.preferred_name,
+        email: currentUser.email || "",
+        phone: profile?.phone || "",
+        avatar_url: profile?.avatar_url,
+      };
+    },
+    enabled: !!currentUser,
+    staleTime: 1000 * 30,
+    gcTime: 1000 * 60 * 5,
+  });
+}
+
+export function useUpdateProfile() {
+  const queryClient = useQueryClient();
+  const currentUser = useAppStore((state) => state.currentUser);
+  const setUsername = useAppStore((state) => state.setUsername);
+
+  return useMutation({
+    mutationFn: async ({
+      username,
+      preferredName,
+      phone,
+    }: {
+      username: string;
+      preferredName?: string;
+      phone?: string;
+    }) => {
+      if (!currentUser) {
+        throw new Error("No current user");
+      }
+      await invoke("update_user_profile", {
+        userId: currentUser.id,
+        username,
+        preferredName: preferredName ?? null,
+        phone: phone ?? null,
+      });
+      return { username };
+    },
+    onSuccess: (data) => {
+      setUsername(data.username);
+      queryClient.invalidateQueries({
+        queryKey: userQueryKeys.profile(currentUser?.id ?? null),
+      });
+    },
+  });
+}

--- a/mobile/lib/queryClient.ts
+++ b/mobile/lib/queryClient.ts
@@ -1,0 +1,22 @@
+// Mobile React Query client. Mirrors the desktop client's defaults in
+// frontend/src/main.tsx so hooks ported across produce equivalent caching
+// behavior on both platforms. Tweak per-query options at the hook level
+// (staleTime, refetchOnReconnect, etc.) the same way desktop hooks do.
+
+import { QueryClient } from "@tanstack/react-query";
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 1000 * 60,
+      gcTime: 1000 * 60 * 5,
+      // RN has no "window focus" event in the browser sense, but
+      // react-query polyfills it via AppState (foreground/background).
+      // Match desktop and rely on realtime push + explicit invalidations
+      // instead of focus-driven refetch storms.
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: true,
+      retry: 1,
+    },
+  },
+});

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -13,6 +13,7 @@
     "@expo-google-fonts/geist": "^0.4.1",
     "@expo-google-fonts/sora": "^0.4.2",
     "@gorhom/bottom-sheet": "^5.2.10",
+    "@tanstack/react-query": "^5.100.11",
     "expo": "~55.0.17",
     "expo-build-properties": "^55.0.14",
     "expo-camera": "^55.0.16",

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@gorhom/bottom-sheet':
         specifier: ^5.2.10
         version: 5.2.10(@types/react@19.2.14)(react-native-gesture-handler@2.31.1(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native-reanimated@4.3.0(react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+      '@tanstack/react-query':
+        specifier: ^5.100.11
+        version: 5.100.11(react@19.2.0)
       expo:
         specifier: ~55.0.17
         version: 55.0.17(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.13)(react-dom@19.2.5(react@19.2.0))(react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
@@ -1234,6 +1237,14 @@ packages:
 
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
+
+  '@tanstack/query-core@5.100.11':
+    resolution: {integrity: sha512-lmE0994apShXPj8CUxgx4ch5yUJhE9k/+tVwihBvPOyerACWdBocfFg24t8+0RhtlTd7tEgchDkhlCxNssvDxw==}
+
+  '@tanstack/react-query@5.100.11':
+    resolution: {integrity: sha512-J0f9s5x3LE1450nNNfYx+e/n0DMa0uOBdFJUy5r0RvmsXd4nB/n0rbHtHI1vYXhikNFan+wf51p6Tmp4c8ucrg==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -4861,6 +4872,13 @@ snapshots:
   '@sinonjs/fake-timers@10.3.0':
     dependencies:
       '@sinonjs/commons': 3.0.1
+
+  '@tanstack/query-core@5.100.11': {}
+
+  '@tanstack/react-query@5.100.11(react@19.2.0)':
+    dependencies:
+      '@tanstack/query-core': 5.100.11
+      react: 19.2.0
 
   '@types/babel__core@7.20.5':
     dependencies:


### PR DESCRIPTION
Follow-on to 2ca17f0. Wires \`@tanstack/react-query\` into the mobile app on top of the existing \`invoke()\` + zustand seam, and seeds the hooks/queries pattern with \`useUserProfile\` so future hooks ported from desktop have a template.

- \`lib/queryClient.ts\` — \`QueryClient\` with desktop-matching defaults
- \`app/_layout.tsx\` — \`<QueryClientProvider>\` mounted outside \`<ThemeProvider>\`
- \`hooks/queries/useUserProfile.ts\` — mirrors \`frontend/src/hooks/queries/useUserProfile.ts\`, calls \`invoke("get_user_profile")\` via the existing bridge
- \`hooks/queries/index.ts\` — barrel re-export

Bridge still throws on unimplemented commands (correct — fail loudly until \`pollis-native\` exposes a real dispatcher).