### PR TITLE
perf(terminal): binary IPC for keystroke input

### DIFF
--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -125,15 +125,22 @@ export const TerminalView: React.FC<TerminalViewProps> = ({ visible }) => {
         });
     });
 
+    // Binary IPC input, symmetric with the output Channel above: hand the
+    // raw UTF-8 bytes straight to invoke() as the request body (Tauri 2
+    // accepts a Uint8Array as InvokeArgs and ships it as InvokeBody::Raw,
+    // bypassing JSON entirely). The terminal id rides in a header so the
+    // body stays a pure byte stream. The pre-binary path was
+    // `data: Array.from(encoder.encode(data))` which expanded every
+    // keystroke into a JSON number array — a per-key serialize/parse
+    // roundtrip noticeable as input lag on WebKitGTK/X11.
     const encoder = new TextEncoder();
     const onDataDisposable = term.onData((data) => {
       const id = terminalIdRef.current;
       if (id === null) {
         return;
       }
-      invoke("terminal_write", {
-        terminalId: id,
-        data: Array.from(encoder.encode(data)),
+      invoke("terminal_write", encoder.encode(data), {
+        headers: { "x-terminal-id": id },
       }).catch(() => {});
     });
 

--- a/pollis-core/src/commands/terminal.rs
+++ b/pollis-core/src/commands/terminal.rs
@@ -268,16 +268,19 @@ pub async fn terminal_ack(
     Ok(())
 }
 
-/// Forward user keystrokes (UTF-8 bytes) to the shell. Unknown ids are a
-/// no-op — the PTY may have exited between a keypress and this call.
+/// Forward user keystrokes (UTF-8 bytes) to the shell. Borrows the id +
+/// payload so the Tauri shim can hand straight through the IPC raw body
+/// (no clone, no JSON number-array per keystroke — see issue #282 for the
+/// matching output path). Unknown ids are a no-op — the PTY may have
+/// exited between a keypress and this call.
 pub async fn terminal_write(
-    terminal_id: String,
-    data: Vec<u8>,
+    terminal_id: &str,
+    data: &[u8],
     state: &Arc<AppState>,
 ) -> Result<()> {
     let mut map = state.terminals.lock().await;
-    if let Some(session) = map.get_mut(&terminal_id) {
-        session.writer.write_all(&data).map_err(map_pty)?;
+    if let Some(session) = map.get_mut(terminal_id) {
+        session.writer.write_all(data).map_err(map_pty)?;
         let _ = session.writer.flush();
     }
     Ok(())

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -1,10 +1,13 @@
-// Generated shim file. Each #[tauri::command] forwards to pollis_core::commands::terminal::*. Edit pollis-core, not here.
+// Shim layer. Each #[tauri::command] forwards to pollis_core::commands::terminal::*.
+// `terminal_write` is hand-rolled to consume the IPC raw-byte body symmetric
+// with the output Channel; the rest are straight pass-throughs — edit
+// pollis-core, not here.
 
 #![allow(unused_imports)]
 use std::sync::Arc;
 use tauri::State;
 
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::state::AppState;
 pub use pollis_core::commands::terminal::*;
 
@@ -18,8 +21,36 @@ pub async fn terminal_ack(terminal_id: String, bytes: usize, state: State<'_, Ar
     pollis_core::commands::terminal::terminal_ack(terminal_id, bytes, &state).await
 }
 
+/// Forward a keystroke chunk to the PTY using a binary IPC body — symmetric
+/// with the output Channel that already pushes raw bytes via
+/// `InvokeResponseBody::Raw` (issue #282). The frontend hands us the
+/// `Uint8Array` from `TextEncoder.encode(data)` as the request body, and
+/// the terminal id rides in the `x-terminal-id` header. This avoids the
+/// `Array.from(uint8) -> JSON number-array -> serde Vec<u8>` roundtrip
+/// previously paid on *every* keypress — the latency that made the
+/// terminal feel laggy on WebKitGTK/X11.
 #[tauri::command]
-pub async fn terminal_write(terminal_id: String, data: Vec<u8>, state: State<'_, Arc<AppState>>) -> Result<()> {
+pub async fn terminal_write(
+    request: tauri::ipc::Request<'_>,
+    state: State<'_, Arc<AppState>>,
+) -> Result<()> {
+    let terminal_id = request
+        .headers()
+        .get("x-terminal-id")
+        .and_then(|v| v.to_str().ok())
+        .ok_or_else(|| {
+            Error::Other(anyhow::anyhow!(
+                "terminal_write: missing or invalid x-terminal-id header"
+            ))
+        })?;
+    let data: &[u8] = match request.body() {
+        tauri::ipc::InvokeBody::Raw(bytes) => bytes,
+        tauri::ipc::InvokeBody::Json(_) => {
+            return Err(Error::Other(anyhow::anyhow!(
+                "terminal_write: expected raw body, got json — frontend must invoke with a Uint8Array"
+            )));
+        }
+    };
     pollis_core::commands::terminal::terminal_write(terminal_id, data, &state).await
 }
 


### PR DESCRIPTION
## Summary
- Keystroke input now ships as `InvokeBody::Raw` (Uint8Array body + `x-terminal-id` header), symmetric with the existing binary output `Channel<ArrayBuffer>` from #282.
- Eliminates the per-keystroke `Array.from(uint8)` → JSON number-array → serde `Vec<u8>` roundtrip that was visible as input lag on WebKitGTK (especially X11).

## Test plan
- [x] macOS: typed in terminal, no regression
- [ ] Linux Wayland: confirm "slight delay" reduced
- [ ] Linux X11 Mint: confirm "horribly sluggish" → responsive