### PR TITLE
feat(mobile): wire pollis-native bridge, real auth flow, screen data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,6 +320,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compat"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ba85bc55464dcbf728b56d97e119d673f4cf9062be330a9a26f3acf504a590"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "once_cell",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-executor"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9293,6 +9306,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77baf5d539fe2e1ad6805e942dbc5dbdeb2b83eb5f2b3a6535d422ca4b02a12f"
 dependencies = [
  "anyhow",
+ "async-compat",
  "bytes",
  "once_cell",
  "static_assertions",

--- a/mobile/.env.example
+++ b/mobile/.env.example
@@ -1,0 +1,25 @@
+# Mobile environment template. Copy to `mobile/.env` and fill in.
+# Expo bundles EXPO_PUBLIC_* vars into the JS bundle at build time and
+# `app/_layout.tsx` passes them to `initializeNativeBridge` at startup,
+# which forwards them to Rust's `init_pollis()`.
+#
+# Required:
+EXPO_PUBLIC_TURSO_URL=
+EXPO_PUBLIC_TURSO_TOKEN=
+
+# Optional (R2-backed media isn't wired in mobile yet — leave blank until
+# avatar/attachment upload lands):
+EXPO_PUBLIC_R2_ENDPOINT=
+EXPO_PUBLIC_R2_ACCESS_KEY_ID=
+EXPO_PUBLIC_R2_SECRET_KEY=
+EXPO_PUBLIC_R2_PUBLIC_URL=
+
+# Optional (LiveKit isn't used on mobile — voice/screenshare are desktop-
+# only, see mobile/CLAUDE.md):
+EXPO_PUBLIC_LIVEKIT_URL=
+EXPO_PUBLIC_LIVEKIT_API_KEY=
+EXPO_PUBLIC_LIVEKIT_API_SECRET=
+
+# Optional (Resend is server-side OTP delivery — mobile doesn't send,
+# only verifies):
+EXPO_PUBLIC_RESEND_API_KEY=

--- a/mobile/app/(auth)/email.tsx
+++ b/mobile/app/(auth)/email.tsx
@@ -5,10 +5,25 @@ import { Screen, Crumb, Field, Button, BottomAction } from "../../components/ui"
 import { PollisMark } from "../../components/PollisMark";
 import { Icon } from "../../components/icons";
 import { semantic, type as ty } from "../../theme/tokens";
+import { useRequestOtp } from "../../hooks/queries/useAuth";
 
 export default function AuthEmail() {
   const router = useRouter();
-  const [email, setEmail] = useState("dan@example.io");
+  const [email, setEmail] = useState("");
+  const requestOtp = useRequestOtp();
+
+  const onSubmit = () => {
+    const trimmed = email.trim();
+    if (!trimmed) {
+      return;
+    }
+    requestOtp.mutate(trimmed, {
+      onSuccess: () => {
+        router.push({ pathname: "/(auth)/otp", params: { email: trimmed } });
+      },
+    });
+  };
+
   return (
     <Screen>
       <Crumb segs={[{ label: "AUTH" }, { label: "Identify", leaf: true }]} />
@@ -39,6 +54,18 @@ export default function AuthEmail() {
             icon={<Icon.mail color={semantic.mute} />}
           />
         </View>
+        {requestOtp.isError ? (
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 12,
+              color: semantic.danger,
+            }}
+          >
+            {(requestOtp.error as Error).message ||
+              "Couldn't send code. Check your connection and try again."}
+          </Text>
+        ) : null}
         <View
           style={{ flexDirection: "row", alignItems: "center", gap: 8 }}
         >
@@ -60,10 +87,11 @@ export default function AuthEmail() {
         <Button
           variant="primary"
           full
-          onPress={() => router.push("/(auth)/otp")}
+          onPress={onSubmit}
+          disabled={requestOtp.isPending || !email.trim()}
           iconRight={<Icon.arrowRight color="#0a0907" />}
         >
-          CONTINUE
+          {requestOtp.isPending ? "SENDING…" : "CONTINUE"}
         </Button>
         <Button variant="subtle" full>
           I have a recovery key

--- a/mobile/app/(auth)/initializing.tsx
+++ b/mobile/app/(auth)/initializing.tsx
@@ -1,17 +1,19 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { View, Text, Pressable } from "react-native";
 import Svg, { Rect } from "react-native-svg";
 import { useRouter } from "expo-router";
 import { Screen, Crumb, Card } from "../../components/ui";
 import { PollisMark } from "../../components/PollisMark";
 import { palette, semantic, type as ty } from "../../theme/tokens";
+import { useInitializeIdentity } from "../../hooks/queries/useAuth";
+import { useAppStore } from "../../stores/appStore";
 
-const STEPS = [
-  { n: "KEYS LOADED", s: "OK", done: true },
-  { n: "DEVICE PAIRED", s: "OK", done: true },
-  { n: "SYNC GROUPS", s: "62%", done: false },
-  { n: "RESOLVE PEERS", s: "—", done: false, muted: true },
-];
+interface Step {
+  n: string;
+  s: string;
+  done: boolean;
+  muted?: boolean;
+}
 
 function Corner({ pos }: { pos: "tl" | "tr" | "bl" | "br" }) {
   const top = pos[0] === "t";
@@ -37,11 +39,47 @@ function Corner({ pos }: { pos: "tl" | "tr" | "bl" | "br" }) {
 
 export default function Initializing() {
   const router = useRouter();
+  const currentUser = useAppStore((s) => s.currentUser);
+  const initIdentity = useInitializeIdentity();
+  const [error, setError] = useState<string | null>(null);
+
+  const ranRef = useState({ ran: false })[0];
 
   useEffect(() => {
-    const t = setTimeout(() => router.replace("/(tabs)/groups"), 2600);
-    return () => clearTimeout(t);
-  }, [router]);
+    if (!currentUser || ranRef.ran) {
+      return;
+    }
+    ranRef.ran = true;
+    initIdentity.mutate(currentUser.id, {
+      onSuccess: () => router.replace("/(tabs)/groups"),
+      onError: (e) => setError((e as Error).message || "Setup failed."),
+    });
+    // initIdentity is a stable mutation ref; intentionally fire once when
+    // currentUser becomes available.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentUser?.id]);
+
+  const progress = initIdentity.isPending
+    ? "WORKING…"
+    : initIdentity.isSuccess
+      ? "DONE"
+      : "READY";
+  const steps: Step[] = [
+    { n: "KEYS LOADED", s: "OK", done: true },
+    { n: "DEVICE PAIRED", s: "OK", done: true },
+    {
+      n: "INITIALIZE IDENTITY",
+      s: initIdentity.isPending
+        ? "…"
+        : initIdentity.isSuccess
+          ? "OK"
+          : initIdentity.isError
+            ? "ERR"
+            : "—",
+      done: initIdentity.isSuccess,
+    },
+    { n: "RESOLVE PEERS", s: "—", done: false, muted: true },
+  ];
 
   return (
     <Screen>
@@ -49,7 +87,7 @@ export default function Initializing() {
       <Corner pos="tr" />
       <Corner pos="bl" />
       <Corner pos="br" />
-      <Crumb segs={[{ label: "INITIALIZING", leaf: true }]} end="62%" />
+      <Crumb segs={[{ label: "INITIALIZING", leaf: true }]} end={progress} />
 
       <View
         style={{
@@ -131,12 +169,16 @@ export default function Initializing() {
             <View
               style={{
                 height: 2,
-                width: "62%",
+                width: initIdentity.isSuccess
+                  ? "100%"
+                  : initIdentity.isPending
+                    ? "62%"
+                    : "30%",
                 backgroundColor: semantic.accent,
               }}
             />
           </View>
-          {STEPS.map((r2, i) => (
+          {steps.map((r2, i) => (
             <View
               key={i}
               style={{
@@ -148,9 +190,7 @@ export default function Initializing() {
             >
               <Text style={[ty.label, { fontSize: 10 }]}>
                 <Text
-                  style={{
-                    color: r2.done ? semantic.accent : semantic.mute,
-                  }}
+                  style={{ color: r2.done ? semantic.accent : semantic.mute }}
                 >
                   {r2.done ? "◆" : "◇"}
                 </Text>{" "}
@@ -159,13 +199,28 @@ export default function Initializing() {
               <Text
                 style={[
                   ty.label,
-                  { fontSize: 10, color: r2.done ? semantic.accent : semantic.ink2 },
+                  {
+                    fontSize: 10,
+                    color: r2.done ? semantic.accent : semantic.ink2,
+                  },
                 ]}
               >
                 {r2.s}
               </Text>
             </View>
           ))}
+          {error ? (
+            <Text
+              style={{
+                fontFamily: ty.body.fontFamily,
+                fontSize: 12,
+                color: semantic.danger,
+                marginTop: 14,
+              }}
+            >
+              {error}
+            </Text>
+          ) : null}
         </Card>
       </View>
 

--- a/mobile/app/(auth)/otp.tsx
+++ b/mobile/app/(auth)/otp.tsx
@@ -1,22 +1,37 @@
 import { useRef, useState } from "react";
 import { View, Text, TextInput, Pressable } from "react-native";
-import { useRouter } from "expo-router";
+import { useRouter, useLocalSearchParams } from "expo-router";
 import { Screen, Crumb, Button, BottomAction } from "../../components/ui";
 import { PollisMark } from "../../components/PollisMark";
 import { Icon } from "../../components/icons";
 import { semantic, type as ty, r } from "../../theme/tokens";
+import { useVerifyOtp } from "../../hooks/queries/useAuth";
 
 export default function AuthOTP() {
   const router = useRouter();
-  const [code, setCode] = useState("472");
+  const { email: emailParam } = useLocalSearchParams<{ email?: string }>();
+  const email = (emailParam ?? "").trim();
+  const [code, setCode] = useState("");
   const input = useRef<TextInput>(null);
   const cells = Array.from({ length: 6 });
+  const verifyOtp = useVerifyOtp();
+
+  const onSubmit = () => {
+    if (code.length !== 6 || !email) {
+      return;
+    }
+    verifyOtp.mutate(
+      { email, code },
+      {
+        onSuccess: () => router.push("/(auth)/pin"),
+      },
+    );
+  };
 
   return (
     <Screen>
       <Crumb
         segs={[{ label: "AUTH" }, { label: "Verify email", leaf: true }]}
-        end="04:38"
       />
       <View style={{ flex: 1, paddingHorizontal: 24, paddingTop: 30, gap: 22 }}>
         <PollisMark />
@@ -31,8 +46,10 @@ export default function AuthOTP() {
             }}
           >
             We sent a 6-digit code to{" "}
-            <Text style={{ color: semantic.ink2 }}>dan@example.io</Text>. Enter
-            it to continue.
+            <Text style={{ color: semantic.ink2 }}>
+              {email || "your email"}
+            </Text>
+            . Enter it to continue.
           </Text>
         </View>
 
@@ -93,36 +110,23 @@ export default function AuthOTP() {
           value={code}
           onChangeText={(v) => setCode(v.replace(/[^0-9]/g, "").slice(0, 6))}
           keyboardType="number-pad"
+          autoFocus
           style={{ position: "absolute", opacity: 0 }}
         />
 
-        <View
-          style={{
-            flexDirection: "row",
-            justifyContent: "space-between",
-            alignItems: "center",
-          }}
-        >
+        {verifyOtp.isError ? (
           <Text
             style={{
               fontFamily: ty.body.fontFamily,
-              fontSize: 11,
-              color: semantic.mute,
+              fontSize: 12,
+              color: semantic.danger,
+              textAlign: "center",
             }}
           >
-            Didn't receive it?
+            {(verifyOtp.error as Error).message ||
+              "Invalid code. Please try again."}
           </Text>
-          <Text
-            style={{
-              fontFamily: ty.body.fontFamily,
-              fontSize: 11,
-              letterSpacing: 0.6,
-              color: semantic.accent,
-            }}
-          >
-            RESEND IN 04:38
-          </Text>
-        </View>
+        ) : null}
 
         <Pressable
           onPress={() => router.back()}
@@ -147,10 +151,11 @@ export default function AuthOTP() {
         <Button
           variant="primary"
           full
-          onPress={() => router.push("/(auth)/pin")}
+          onPress={onSubmit}
+          disabled={code.length !== 6 || verifyOtp.isPending}
           iconRight={<Icon.arrowRight color="#0a0907" />}
         >
-          VERIFY
+          {verifyOtp.isPending ? "VERIFYING…" : "VERIFY"}
         </Button>
       </BottomAction>
     </Screen>

--- a/mobile/app/(auth)/pin.tsx
+++ b/mobile/app/(auth)/pin.tsx
@@ -1,36 +1,145 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { View, Text, Pressable } from "react-native";
 import { useRouter } from "expo-router";
 import { Screen, Crumb } from "../../components/ui";
 import { PollisMark } from "../../components/PollisMark";
 import { palette, semantic, type as ty, fonts, r } from "../../theme/tokens";
+import {
+  useSetPin,
+  useUnlock,
+  useUnlockState,
+} from "../../hooks/queries/useAuth";
+import { useAppStore } from "../../stores/appStore";
 
 const SUBS = ["", "ABC", "DEF", "GHI", "JKL", "MNO", "PQRS", "TUV", "WXYZ"];
 
+type Stage = "checking" | "create-first" | "create-confirm" | "unlock";
+
 export default function AuthPIN() {
   const router = useRouter();
+  const currentUser = useAppStore((s) => s.currentUser);
   const [pin, setPin] = useState("");
+  const [firstPin, setFirstPin] = useState("");
+  const [stage, setStage] = useState<Stage>("checking");
+  const [error, setError] = useState<string | null>(null);
+
+  const setPinMutation = useSetPin();
+  const unlockMutation = useUnlock();
+  const unlockState = useUnlockState();
+
+  useEffect(() => {
+    unlockState.mutate(undefined, {
+      onSuccess: (snapshot) => {
+        setStage(snapshot.pin_set ? "unlock" : "create-first");
+      },
+      onError: () => {
+        // Treat a snapshot-read error as first-time setup; set_pin will
+        // re-fail loudly if state is actually inconsistent.
+        setStage("create-first");
+      },
+    });
+    // unlockState is a stable mutation ref; intentionally fire only once
+    // on mount.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const stageLabel = (() => {
+    switch (stage) {
+      case "checking":
+        return "CHECKING…";
+      case "create-first":
+        return "STEP 1 OF 2 · ENTER PIN";
+      case "create-confirm":
+        return "STEP 2 OF 2 · CONFIRM PIN";
+      case "unlock":
+        return "ENTER PIN TO UNLOCK";
+    }
+  })();
+
+  const headline = stage === "unlock" ? "Unlock Pollis" : "New device PIN";
+  const subtitle =
+    stage === "unlock"
+      ? "Enter your device PIN to unlock encrypted local data."
+      : "Used to unlock Pollis on this device. This stays on your phone — we never see it.";
+
+  const onComplete = (entered: string) => {
+    setError(null);
+    if (stage === "unlock") {
+      if (!currentUser) {
+        setError("No active user. Sign in again.");
+        setStage("checking");
+        return;
+      }
+      unlockMutation.mutate(
+        { userId: currentUser.id, pin: entered },
+        {
+          onSuccess: () => router.replace("/(auth)/initializing"),
+          onError: (e) => {
+            setError((e as Error).message || "Invalid PIN.");
+            setPin("");
+          },
+        },
+      );
+      return;
+    }
+    if (stage === "create-first") {
+      setFirstPin(entered);
+      setPin("");
+      setStage("create-confirm");
+      return;
+    }
+    if (stage === "create-confirm") {
+      if (entered !== firstPin) {
+        setError("PINs didn't match. Start over.");
+        setFirstPin("");
+        setPin("");
+        setStage("create-first");
+        return;
+      }
+      setPinMutation.mutate(
+        { newPin: entered },
+        {
+          onSuccess: () => router.replace("/(auth)/initializing"),
+          onError: (e) => {
+            setError((e as Error).message || "Couldn't save PIN.");
+            setFirstPin("");
+            setPin("");
+            setStage("create-first");
+          },
+        },
+      );
+    }
+  };
 
   const push = (n: string) => {
-    if (pin.length >= 4) {
+    if (pin.length >= 4 || stage === "checking") {
       return;
     }
     const next = pin + n;
     setPin(next);
     if (next.length === 4) {
-      setTimeout(() => router.replace("/(auth)/initializing"), 150);
+      setTimeout(() => onComplete(next), 120);
     }
   };
 
   const keys = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "", "0", "bk"];
+  const busy =
+    stage === "checking" ||
+    setPinMutation.isPending ||
+    unlockMutation.isPending;
 
   return (
     <Screen>
-      <Crumb segs={[{ label: "AUTH" }, { label: "Set device PIN", leaf: true }]} />
+      <Crumb
+        segs={[
+          { label: "AUTH" },
+          { label: stage === "unlock" ? "Unlock device" : "Set device PIN", leaf: true },
+        ]}
+      />
       <View style={{ flex: 1, paddingHorizontal: 24, paddingTop: 24, gap: 18 }}>
         <PollisMark />
         <View style={{ gap: 8 }}>
-          <Text style={[ty.h1, { color: semantic.ink }]}>New device PIN</Text>
+          <Text style={[ty.h1, { color: semantic.ink }]}>{headline}</Text>
           <Text
             style={{
               fontFamily: ty.body.fontFamily,
@@ -39,8 +148,7 @@ export default function AuthPIN() {
               color: semantic.mute,
             }}
           >
-            Used to unlock Pollis on this device. This stays on your phone — we
-            never see it.
+            {subtitle}
           </Text>
         </View>
 
@@ -94,8 +202,21 @@ export default function AuthPIN() {
           <Text
             style={[ty.label, { textAlign: "center", marginTop: 14 }]}
           >
-            STEP 1 OF 2 · ENTER PIN
+            {stageLabel}
           </Text>
+          {error ? (
+            <Text
+              style={{
+                fontFamily: ty.body.fontFamily,
+                fontSize: 12,
+                color: semantic.danger,
+                textAlign: "center",
+                marginTop: 8,
+              }}
+            >
+              {error}
+            </Text>
+          ) : null}
         </View>
       </View>
 
@@ -106,7 +227,9 @@ export default function AuthPIN() {
           borderTopWidth: 1,
           borderTopColor: semantic.hairSoft,
           backgroundColor: semantic.hairSoft,
+          opacity: busy ? 0.5 : 1,
         }}
+        pointerEvents={busy ? "none" : "auto"}
       >
         {keys.map((k, i) => (
           <Pressable

--- a/mobile/app/(tabs)/direct.tsx
+++ b/mobile/app/(tabs)/direct.tsx
@@ -6,45 +6,77 @@ import {
   Body,
   ListRow,
   Avatar,
-  Badge,
-  Diamond,
   Button,
   BottomAction,
 } from "../../components/ui";
 import { Icon } from "../../components/icons";
 import { semantic, type as ty } from "../../theme/tokens";
-
-const DMS = [
-  { h: "brian", s: "recently onlineman", t: "21:34", unread: 2, v: true },
-  { h: "meilan.solly", s: "hello", t: "MAY 5", v: true },
-  { h: "c8", s: "verified key 0x4a…", t: "MAY 2", v: true },
-  { h: "j0n", s: "unverified · tap to verify", t: "APR", v: false },
-  { h: "rune.4", s: "see you tomorrow", t: "APR", v: true },
-];
+import { useDMChannels } from "../../hooks/queries";
+import { useAppStore } from "../../stores/appStore";
 
 export default function Direct() {
   const router = useRouter();
+  const { data: dms = [], isLoading, isError } = useDMChannels();
+  const setSelectedConversationId = useAppStore(
+    (s) => s.setSelectedConversationId,
+  );
+
   return (
     <Screen>
-      <Crumb segs={[{ label: "DIRECT", leaf: true }]} end="5" />
+      <Crumb segs={[{ label: "DIRECT", leaf: true }]} end={String(dms.length)} />
       <Body>
-        {DMS.map((d) => (
-          <ListRow
-            key={d.h}
-            minHeight={64}
-            onPress={() => router.push(`/chat/dm-${d.h}`)}
-            glyph={
-              <Avatar
-                label={d.h.slice(0, 2)}
-                style={{
-                  borderColor: d.v ? semantic.hairStrong : semantic.mute2,
-                }}
-              />
-            }
-            name={
-              <View
-                style={{ flexDirection: "row", alignItems: "center", gap: 6 }}
-              >
+        {isLoading ? (
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 13,
+              color: semantic.mute,
+              paddingHorizontal: 18,
+              paddingTop: 12,
+            }}
+          >
+            Loading conversations…
+          </Text>
+        ) : null}
+        {isError ? (
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 13,
+              color: semantic.danger,
+              paddingHorizontal: 18,
+              paddingTop: 12,
+            }}
+          >
+            Couldn't load conversations.
+          </Text>
+        ) : null}
+        {!isLoading && !isError && dms.length === 0 ? (
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 13,
+              color: semantic.mute,
+              paddingHorizontal: 18,
+              paddingTop: 12,
+            }}
+          >
+            No direct messages yet.
+          </Text>
+        ) : null}
+        {dms.map((d) => {
+          const handle = d.user2_identifier || "user";
+          const label = handle.slice(0, 2);
+          return (
+            <ListRow
+              key={d.id}
+              minHeight={64}
+              onPress={() => {
+                setSelectedConversationId(d.id);
+                router.push(`/chat/${d.id}`);
+              }}
+              glyph={<Avatar label={label} />}
+              name={
                 <Text
                   style={{
                     fontFamily: ty.rowN.fontFamily,
@@ -52,28 +84,12 @@ export default function Direct() {
                     color: semantic.ink,
                   }}
                 >
-                  @{d.h}
+                  @{handle}
                 </Text>
-                {d.v && <Diamond size={6} />}
-              </View>
-            }
-            sub={d.s}
-            end={
-              <View style={{ alignItems: "flex-end", gap: 4 }}>
-                <Text
-                  style={{
-                    fontFamily: ty.body.fontFamily,
-                    fontSize: 10,
-                    color: semantic.mute,
-                  }}
-                >
-                  {d.t}
-                </Text>
-                {d.unread ? <Badge>{d.unread}</Badge> : null}
-              </View>
-            }
-          />
-        ))}
+              }
+            />
+          );
+        })}
       </Body>
       <BottomAction>
         <Button full icon={<Icon.plus color={semantic.ink} />}>

--- a/mobile/app/(tabs)/groups.tsx
+++ b/mobile/app/(tabs)/groups.tsx
@@ -1,4 +1,4 @@
-import { View } from "react-native";
+import { View, Text } from "react-native";
 import { useRouter } from "expo-router";
 import {
   Screen,
@@ -6,59 +6,94 @@ import {
   Body,
   SectionTitle,
   ListRow,
-  Badge,
   Button,
   BottomAction,
 } from "../../components/ui";
 import { Icon } from "../../components/icons";
-import { semantic } from "../../theme/tokens";
-
-const GROUPS = [
-  {
-    name: "QUICK GROUP",
-    sel: "General",
-    items: [
-      { n: "General", sub: "dan: frick its been a minute", unread: 2 },
-      { n: "Random", sub: "meilan: meeting moved" },
-    ],
-  },
-  {
-    name: "TEST GROUP",
-    items: [
-      { n: "General", sub: "No new messages" },
-      { n: "Random" },
-    ],
-  },
-  {
-    name: "BLUESTONE",
-    items: [{ n: "General" }],
-  },
-];
+import { semantic, type as ty } from "../../theme/tokens";
+import { useUserGroupsWithChannels } from "../../hooks/queries";
+import { useAppStore } from "../../stores/appStore";
 
 export default function Groups() {
   const router = useRouter();
+  const { data: groups = [], isLoading, isError } = useUserGroupsWithChannels();
+  const setSelectedGroupId = useAppStore((s) => s.setSelectedGroupId);
+  const setSelectedChannelId = useAppStore((s) => s.setSelectedChannelId);
+
+  const totalChannels = groups.reduce((acc, g) => acc + g.channels.length, 0);
+
   return (
     <Screen>
-      <Crumb segs={[{ label: "GROUPS", leaf: true }]} end="3" />
+      <Crumb segs={[{ label: "GROUPS", leaf: true }]} end={String(totalChannels)} />
       <Body>
-        {GROUPS.map((g) => (
-          <View key={g.name}>
+        {isLoading ? (
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 13,
+              color: semantic.mute,
+              paddingHorizontal: 18,
+              paddingTop: 12,
+            }}
+          >
+            Loading groups…
+          </Text>
+        ) : null}
+        {isError ? (
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 13,
+              color: semantic.danger,
+              paddingHorizontal: 18,
+              paddingTop: 12,
+            }}
+          >
+            Couldn't load groups.
+          </Text>
+        ) : null}
+        {!isLoading && !isError && groups.length === 0 ? (
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 13,
+              color: semantic.mute,
+              paddingHorizontal: 18,
+              paddingTop: 12,
+            }}
+          >
+            No groups yet. Create one to get started.
+          </Text>
+        ) : null}
+        {groups.map((g) => (
+          <View key={g.id}>
             <SectionTitle right={<Icon.fwd color={semantic.mute} />}>
-              {g.name}
+              {g.name.toUpperCase()}
             </SectionTitle>
-            {g.items.map((c) => (
+            {g.channels.length === 0 ? (
+              <Text
+                style={{
+                  fontFamily: ty.body.fontFamily,
+                  fontSize: 12,
+                  color: semantic.mute,
+                  paddingHorizontal: 18,
+                  paddingVertical: 6,
+                }}
+              >
+                No channels.
+              </Text>
+            ) : null}
+            {g.channels.map((c) => (
               <ListRow
-                key={c.n}
-                selected={g.sel === c.n}
+                key={c.id}
                 glyph={<Icon.hash color={semantic.mute} />}
-                name={c.n}
-                sub={(c as { sub?: string }).sub}
-                onPress={() => router.push(`/chat/${g.name}-${c.n}`)}
-                end={
-                  (c as { unread?: number }).unread ? (
-                    <Badge>{(c as { unread?: number }).unread}</Badge>
-                  ) : undefined
-                }
+                name={c.name}
+                sub={c.description ?? undefined}
+                onPress={() => {
+                  setSelectedGroupId(g.id);
+                  setSelectedChannelId(c.id);
+                  router.push(`/chat/${c.id}`);
+                }}
               />
             ))}
           </View>

--- a/mobile/app/(tabs)/self.tsx
+++ b/mobile/app/(tabs)/self.tsx
@@ -11,29 +11,46 @@ import {
 } from "../../components/ui";
 import { Icon } from "../../components/icons";
 import { semantic, type as ty, r } from "../../theme/tokens";
+import { useUserProfile, useLogout } from "../../hooks/queries";
+import { useAppStore } from "../../stores/appStore";
 
 export default function Self() {
   const router = useRouter();
+  const currentUser = useAppStore((s) => s.currentUser);
+  const { data: profile } = useUserProfile();
+  const logout = useLogout();
+
+  const handle = profile?.username ?? currentUser?.username ?? "user";
+  const display = profile?.preferred_name || handle;
+  const avatarLabel = (handle || "us").slice(0, 2);
+
+  const onSignOut = () => {
+    logout.mutate(undefined, {
+      onSuccess: () => router.replace("/(auth)/email"),
+      onError: () => router.replace("/(auth)/email"),
+    });
+  };
+
   const cards = [
     {
       g: <Icon.gear color={semantic.accent} />,
       n: "Preferences",
       s: "Theme, density, behavior",
-      to: "/self/preferences",
+      to: "/self/preferences" as const,
     },
     {
       g: <Icon.user color={semantic.accent} />,
       n: "User settings",
       s: "Display name, handle, email",
-      to: "/self/user-settings",
+      to: "/self/user-settings" as const,
     },
     {
       g: <Icon.shield color={semantic.accent} />,
       n: "Security",
       s: "Keys, devices, sign out",
-      to: "/self/security",
+      to: "/self/security" as const,
     },
-  ] as const;
+  ];
 
   return (
     <Screen>
@@ -49,7 +66,7 @@ export default function Self() {
             paddingBottom: 18,
           }}
         >
-          <Avatar label="dn" size="lg" variant="amber" />
+          <Avatar label={avatarLabel} size="lg" variant="amber" />
           <View style={{ flex: 1 }}>
             <Text
               style={{
@@ -58,7 +75,7 @@ export default function Self() {
                 color: semantic.ink,
               }}
             >
-              dan
+              {display}
             </Text>
             <Text
               style={{
@@ -67,7 +84,7 @@ export default function Self() {
                 color: semantic.mute,
               }}
             >
-              @dan · key 0x4a2c
+              @{handle}
             </Text>
           </View>
           <View
@@ -115,9 +132,10 @@ export default function Self() {
             full
             variant="danger"
             icon={<Icon.exit color={semantic.danger} />}
-            onPress={() => router.replace("/(auth)/email")}
+            onPress={onSignOut}
+            disabled={logout.isPending}
           >
-            SIGN OUT
+            {logout.isPending ? "SIGNING OUT…" : "SIGN OUT"}
           </Button>
         </View>
       </Body>

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { Stack } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import * as SplashScreen from "expo-splash-screen";
@@ -15,6 +15,7 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { palette } from "../theme/tokens";
 import { ThemeProvider } from "../components/theme";
 import { queryClient } from "../lib/queryClient";
+import { initializeNativeBridge } from "../lib/native";
 
 SplashScreen.preventAutoHideAsync();
 
@@ -25,16 +26,47 @@ export default function RootLayout() {
     Sora_600SemiBold,
     Sora_700Bold,
   });
+  const [bridgeReady, setBridgeReady] = useState(false);
+  const [bridgeError, setBridgeError] = useState<Error | null>(null);
 
   useEffect(() => {
-    if (loaded) {
+    initializeNativeBridge({
+      tursoUrl: process.env.EXPO_PUBLIC_TURSO_URL ?? "",
+      tursoToken: process.env.EXPO_PUBLIC_TURSO_TOKEN ?? "",
+      r2Endpoint: process.env.EXPO_PUBLIC_R2_ENDPOINT,
+      r2AccessKeyId: process.env.EXPO_PUBLIC_R2_ACCESS_KEY_ID,
+      r2SecretAccessKey: process.env.EXPO_PUBLIC_R2_SECRET_KEY,
+      r2PublicUrl: process.env.EXPO_PUBLIC_R2_PUBLIC_URL,
+      livekitUrl: process.env.EXPO_PUBLIC_LIVEKIT_URL,
+      livekitApiKey: process.env.EXPO_PUBLIC_LIVEKIT_API_KEY,
+      livekitApiSecret: process.env.EXPO_PUBLIC_LIVEKIT_API_SECRET,
+      resendApiKey: process.env.EXPO_PUBLIC_RESEND_API_KEY,
+    })
+      .then(() => setBridgeReady(true))
+      .catch((e) => {
+        // Surfacing the error here at least makes it obvious during dev
+        // that the bridge didn't come up — the alternative is silent
+        // "every command throws" later, which is harder to diagnose.
+        console.error("[bridge] initializeNativeBridge failed:", e);
+        setBridgeError(e);
+        setBridgeReady(true);
+      });
+  }, []);
+
+  useEffect(() => {
+    if (loaded && bridgeReady) {
       SplashScreen.hideAsync();
     }
-  }, [loaded]);
+  }, [loaded, bridgeReady]);
 
-  if (!loaded) {
+  if (!loaded || !bridgeReady) {
     return null;
   }
+
+  // Bridge errors are non-fatal at the layout level — the auth screen will
+  // surface a clearer error when the user tries to sign in. We still log
+  // above so device logs show what went wrong.
+  void bridgeError;
 
   return (
     <GestureHandlerRootView style={{ flex: 1, backgroundColor: palette.bg }}>

--- a/mobile/app/chat/[id].tsx
+++ b/mobile/app/chat/[id].tsx
@@ -1,14 +1,37 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { View, Text, ScrollView, TextInput, Pressable } from "react-native";
-import {
-  Screen,
-  Crumb,
-  Avatar,
-  Ctx,
-  CtxAct,
-} from "../../components/ui";
+import { useLocalSearchParams } from "expo-router";
+import { Screen, Crumb, Avatar, Ctx, CtxAct } from "../../components/ui";
 import { Icon } from "../../components/icons";
 import { semantic, type as ty, r } from "../../theme/tokens";
+import { useMessages, type Message } from "../../hooks/queries";
+import { useAppStore } from "../../stores/appStore";
+
+function dayKey(ts: number | string): string {
+  const d = new Date(typeof ts === "number" ? ts : ts);
+  return d.toDateString();
+}
+
+function dayLabel(ts: number | string): string {
+  const d = new Date(typeof ts === "number" ? ts : ts);
+  const today = new Date();
+  if (d.toDateString() === today.toDateString()) {
+    return "TODAY";
+  }
+  const yest = new Date(today);
+  yest.setDate(today.getDate() - 1);
+  if (d.toDateString() === yest.toDateString()) {
+    return "YESTERDAY";
+  }
+  return d
+    .toLocaleDateString(undefined, { month: "short", day: "numeric" })
+    .toUpperCase();
+}
+
+function timeLabel(ts: number | string): string {
+  const d = new Date(typeof ts === "number" ? ts : ts);
+  return d.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" });
+}
 
 function Day({ label }: { label: string }) {
   return (
@@ -35,14 +58,12 @@ function Msg({
   name,
   time,
   text,
-  image,
 }: {
   av: string;
   amber?: boolean;
   name: string;
   time: string;
   text?: string;
-  image?: string;
 }) {
   return (
     <View
@@ -88,51 +109,104 @@ function Msg({
             {text}
           </Text>
         ) : null}
-        {image ? (
-          <View
-            style={{
-              width: 180,
-              height: 120,
-              marginTop: 4,
-              borderWidth: 1,
-              borderColor: semantic.hair,
-              borderRadius: r.sm,
-              backgroundColor: semantic.cardBg,
-              alignItems: "center",
-              justifyContent: "center",
-            }}
-          >
-            <Text style={[ty.label, { letterSpacing: 1.8 }]}>{image}</Text>
-          </View>
-        ) : null}
       </View>
     </View>
   );
 }
 
 export default function TextChat() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const conversationId = id ?? null;
   const [draft, setDraft] = useState("");
+  const currentUser = useAppStore((s) => s.currentUser);
+  const { data: messages = [], isLoading, isError } = useMessages(conversationId);
+
+  // Group by day boundary so we render `<Day>` headers between blocks.
+  const sections = useMemo(() => {
+    const out: { label: string; messages: Message[] }[] = [];
+    let lastKey = "";
+    for (const m of messages) {
+      const k = dayKey(m.created_at);
+      if (k !== lastKey) {
+        out.push({ label: dayLabel(m.created_at), messages: [] });
+        lastKey = k;
+      }
+      out[out.length - 1].messages.push(m);
+    }
+    return out;
+  }, [messages]);
+
   return (
     <Screen>
       <Crumb
-        segs={[
-          { label: "GROUPS" },
-          { label: "Quick Group" },
-          { label: "# General", leaf: true },
-        ]}
+        segs={[{ label: "CHAT", leaf: true }]}
       />
-      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingVertical: 4 }}>
-        <Day label="MAY 5" />
-        <Msg av="me" name="meilan.solly" time="21:34" text="hello" />
-        <Msg av="dn" amber name="dan" time="21:34" text="test" />
-        <Msg av="me" name="meilan.solly" time="21:36" image="NOODLES.JPG" />
-        <Day label="TODAY" />
-        <Msg av="br" name="brian" time="11:11" text="recently onlineman" />
-        <Msg av="dn" amber name="dan" time="00:00" text="frick its been a minute" />
+      <ScrollView
+        style={{ flex: 1 }}
+        contentContainerStyle={{ paddingVertical: 4 }}
+      >
+        {isLoading ? (
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 13,
+              color: semantic.mute,
+              paddingHorizontal: 18,
+              paddingTop: 12,
+            }}
+          >
+            Loading messages…
+          </Text>
+        ) : null}
+        {isError ? (
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 13,
+              color: semantic.danger,
+              paddingHorizontal: 18,
+              paddingTop: 12,
+            }}
+          >
+            Couldn't load messages.
+          </Text>
+        ) : null}
+        {!isLoading && !isError && sections.length === 0 ? (
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 13,
+              color: semantic.mute,
+              paddingHorizontal: 18,
+              paddingTop: 12,
+            }}
+          >
+            No messages yet. Be the first to say something.
+          </Text>
+        ) : null}
+        {sections.map((section, sIdx) => (
+          <View key={`${section.label}-${sIdx}`}>
+            <Day label={section.label} />
+            {section.messages.map((m) => {
+              const mine = currentUser?.id === m.sender_id;
+              const name = m.sender_username || (mine ? "you" : "user");
+              return (
+                <Msg
+                  key={m.id}
+                  av={name.slice(0, 2)}
+                  amber={mine}
+                  name={name}
+                  time={timeLabel(m.created_at)}
+                  text={m.content}
+                />
+              );
+            })}
+          </View>
+        ))}
       </ScrollView>
 
       <Ctx
-        cr="QUICK GROUP"
+        cr="CHAT"
         name={
           <View style={{ flexDirection: "row", alignItems: "center", gap: 6 }}>
             <Icon.hash color={semantic.ink} />
@@ -143,7 +217,7 @@ export default function TextChat() {
                 color: semantic.ink,
               }}
             >
-              General
+              {conversationId ?? "—"}
             </Text>
           </View>
         }

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -1,7 +1,79 @@
-import { Redirect } from "expo-router";
+import { useEffect, useState } from "react";
+import { View, ActivityIndicator } from "react-native";
+import { useRouter } from "expo-router";
+import { restoreSession } from "../hooks/queries/useAuth";
+import { invoke } from "../lib/native";
+import { palette, semantic } from "../theme/tokens";
 
-// Stub: always start at the auth flow. Real builds would branch on a
-// persisted session in secure-store.
+interface UnlockStateSnapshot {
+  pin_set: boolean;
+  is_unlocked: boolean;
+  last_active_user: string | null;
+}
+
+/**
+ * Boot router. Decides where the first frame lands:
+ *   - signed-out  → /(auth)/email
+ *   - signed-in, locked, PIN set → /(auth)/pin (unlock flow)
+ *   - signed-in, no PIN set (first run on this device) → /(auth)/pin (create)
+ *   - signed-in and already unlocked → /(tabs)/groups
+ *
+ * Runs once; downstream screens own the rest of the flow.
+ */
 export default function Index() {
-  return <Redirect href="/(auth)/email" />;
+  const router = useRouter();
+  const [routed, setRouted] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const profile = await restoreSession();
+        if (cancelled) {
+          return;
+        }
+        if (!profile) {
+          router.replace("/(auth)/email");
+          return;
+        }
+        // Have a session — find out where to land based on unlock state.
+        const snap = await invoke<UnlockStateSnapshot>("get_unlock_state");
+        if (cancelled) {
+          return;
+        }
+        if (snap.is_unlocked) {
+          router.replace("/(tabs)/groups");
+        } else {
+          router.replace("/(auth)/pin");
+        }
+      } catch (e) {
+        console.warn("[index] boot routing failed:", e);
+        if (!cancelled) {
+          router.replace("/(auth)/email");
+        }
+      } finally {
+        if (!cancelled) {
+          setRouted(true);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [router]);
+
+  return (
+    <View
+      style={{
+        flex: 1,
+        backgroundColor: palette.bg,
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      {!routed ? (
+        <ActivityIndicator color={semantic.accent} />
+      ) : null}
+    </View>
+  );
 }

--- a/mobile/components/ui.tsx
+++ b/mobile/components/ui.tsx
@@ -218,6 +218,7 @@ export function Button({
   onPress,
   icon,
   iconRight,
+  disabled,
 }: {
   children: string;
   variant?: "default" | "primary" | "subtle" | "danger";
@@ -225,14 +226,17 @@ export function Button({
   onPress?: () => void;
   icon?: React.ReactNode;
   iconRight?: React.ReactNode;
+  disabled?: boolean;
 }) {
   const primary = variant === "primary";
   const danger = variant === "danger";
   const subtle = variant === "subtle";
   return (
     <Pressable
-      onPress={onPress}
+      onPress={disabled ? undefined : onPress}
+      disabled={disabled}
       style={{
+        opacity: disabled ? 0.45 : 1,
         flexDirection: "row",
         alignItems: "center",
         justifyContent: "center",

--- a/mobile/hooks/queries/index.ts
+++ b/mobile/hooks/queries/index.ts
@@ -1,5 +1,9 @@
 // Re-export hub for query hooks. Mirrors `frontend/src/hooks/queries/index.ts`.
 // Add new hooks by importing them here so screens have one import path:
-//   import { useUserProfile } from "../../hooks/queries";
+//   import { useUserGroups } from "../../hooks/queries";
 
 export * from "./useUserProfile";
+export * from "./useUserGroups";
+export * from "./useDMChannels";
+export * from "./useMessages";
+export * from "./useAuth";

--- a/mobile/hooks/queries/useAuth.ts
+++ b/mobile/hooks/queries/useAuth.ts
@@ -1,0 +1,143 @@
+// Auth mutation hooks. Wraps the request_otp / verify_otp / set_pin /
+// unlock / initialize_identity flow that all four `(auth)/*` screens
+// share. Mirrors the auth shape in `frontend/src/hooks/queries/useAuth.ts`
+// where the desktop equivalents live — there's no public hook there, so
+// this file is a fresh start scoped to mobile's screen sequence.
+
+import { useMutation } from "@tanstack/react-query";
+import { invoke } from "../../lib/native";
+import { useAppStore } from "../../stores/appStore";
+import type { User } from "../../types";
+
+export interface RawUserProfile {
+  id: string;
+  email: string;
+  username: string;
+  new_secret_key?: string;
+  enrollment_required?: boolean;
+}
+
+export interface UnlockOutcome {
+  user_id: string;
+  // Whatever else `crate::commands::pin::UnlockOutcome` carries — opaque
+  // to the UI; we read user_id and trust the Rust side to have set
+  // AppState.unlock for downstream commands.
+}
+
+export interface UnlockStateSnapshot {
+  pin_set: boolean;
+  is_unlocked: boolean;
+  last_active_user: string | null;
+}
+
+function profileToUser(p: RawUserProfile): User {
+  const now = Date.now();
+  return {
+    id: p.id,
+    email: p.email,
+    username: p.username,
+    created_at: now,
+    updated_at: now,
+  };
+}
+
+export function useRequestOtp() {
+  return useMutation({
+    mutationFn: async (email: string) => {
+      await invoke("request_otp", { email });
+    },
+  });
+}
+
+export function useVerifyOtp() {
+  const setCurrentUser = useAppStore((s) => s.setCurrentUser);
+  const setUsername = useAppStore((s) => s.setUsername);
+
+  return useMutation({
+    mutationFn: async (vars: { email: string; code: string }) => {
+      const profile = await invoke<RawUserProfile>("verify_otp", {
+        email: vars.email,
+        code: vars.code,
+      });
+      return profile;
+    },
+    onSuccess: (profile) => {
+      const user = profileToUser(profile);
+      setCurrentUser(user);
+      setUsername(profile.username);
+    },
+  });
+}
+
+export function useUnlockState() {
+  return useMutation({
+    mutationFn: async () => {
+      return await invoke<UnlockStateSnapshot>("get_unlock_state");
+    },
+  });
+}
+
+export function useSetPin() {
+  return useMutation({
+    mutationFn: async (vars: { oldPin?: string; newPin: string }) => {
+      await invoke("set_pin", {
+        oldPin: vars.oldPin ?? null,
+        newPin: vars.newPin,
+      });
+    },
+  });
+}
+
+export function useUnlock() {
+  return useMutation({
+    mutationFn: async (vars: { userId: string; pin: string }) => {
+      return await invoke<UnlockOutcome>("unlock", {
+        userId: vars.userId,
+        pin: vars.pin,
+      });
+    },
+  });
+}
+
+export function useInitializeIdentity() {
+  return useMutation({
+    mutationFn: async (userId: string) => {
+      return await invoke<{ user_id: string; public_key: string; is_new: boolean }>(
+        "initialize_identity",
+        { userId },
+      );
+    },
+  });
+}
+
+export function useLogout() {
+  const setCurrentUser = useAppStore((s) => s.setCurrentUser);
+  const logoutStore = useAppStore((s) => s.logout);
+
+  return useMutation({
+    mutationFn: async (vars: { deleteData?: boolean } | void) => {
+      await invoke("logout", { deleteData: vars?.deleteData ?? false });
+    },
+    onSuccess: () => {
+      logoutStore();
+      setCurrentUser(null);
+    },
+  });
+}
+
+/**
+ * One-shot session-restore call. Used by `app/index.tsx` to decide where
+ * to send the user at app start: existing session → tabs, no session →
+ * auth flow. Returns the profile (and side-effects the store) when there
+ * is one; returns null when not signed in.
+ */
+export async function restoreSession(): Promise<RawUserProfile | null> {
+  const profile = await invoke<RawUserProfile | null>("get_session");
+  if (!profile) {
+    return null;
+  }
+  const { setCurrentUser, setUsername } = useAppStore.getState();
+  setCurrentUser(profileToUser(profile));
+  setUsername(profile.username);
+  return profile;
+}

--- a/mobile/hooks/queries/useDMChannels.ts
+++ b/mobile/hooks/queries/useDMChannels.ts
@@ -1,0 +1,83 @@
+// DM listing hooks. Mirrors the read paths of
+// `frontend/src/hooks/queries/useMessages.ts::useDMConversations` —
+// transforms the Rust `DmChannel` shape into the mobile UI's lighter
+// `DMConversation` view-model, picking the "other side" relative to the
+// currently signed-in user.
+
+import { useQuery } from "@tanstack/react-query";
+import { invoke } from "../../lib/native";
+import { useAppStore } from "../../stores/appStore";
+import type { DMConversation } from "../../types";
+
+interface RawDmMember {
+  user_id: string;
+  username?: string;
+  avatar_url?: string;
+}
+
+interface RawDmChannel {
+  id: string;
+  members: RawDmMember[];
+  created_at: string;
+}
+
+export const dmQueryKeys = {
+  all: ["dm"] as const,
+  channels: (userId: string | null) => ["dm", "channels", userId] as const,
+  requests: (userId: string | null) => ["dm", "requests", userId] as const,
+};
+
+function transform(
+  raw: RawDmChannel,
+  selfId: string,
+): DMConversation {
+  const other = raw.members.find((m) => m.user_id !== selfId);
+  const ts = new Date(raw.created_at).getTime();
+  return {
+    id: raw.id,
+    user1_id: selfId,
+    user2_identifier: other?.username || other?.user_id || "Unknown",
+    user2_id: other?.user_id,
+    user2_avatar_url: other?.avatar_url,
+    created_at: ts,
+    updated_at: ts,
+  };
+}
+
+export function useDMChannels() {
+  const currentUser = useAppStore((s) => s.currentUser);
+
+  return useQuery({
+    queryKey: dmQueryKeys.channels(currentUser?.id ?? null),
+    queryFn: async (): Promise<DMConversation[]> => {
+      if (!currentUser) {
+        return [];
+      }
+      const channels = await invoke<RawDmChannel[]>("list_dm_channels", {
+        userId: currentUser.id,
+      });
+      return (channels ?? []).map((c) => transform(c, currentUser.id));
+    },
+    enabled: !!currentUser,
+    staleTime: 1000 * 60,
+  });
+}
+
+export function useDMRequests() {
+  const currentUser = useAppStore((s) => s.currentUser);
+
+  return useQuery({
+    queryKey: dmQueryKeys.requests(currentUser?.id ?? null),
+    queryFn: async (): Promise<DMConversation[]> => {
+      if (!currentUser) {
+        return [];
+      }
+      const channels = await invoke<RawDmChannel[]>("list_dm_requests", {
+        userId: currentUser.id,
+      });
+      return (channels ?? []).map((c) => transform(c, currentUser.id));
+    },
+    enabled: !!currentUser,
+    staleTime: 1000 * 60,
+  });
+}

--- a/mobile/hooks/queries/useMessages.ts
+++ b/mobile/hooks/queries/useMessages.ts
@@ -1,0 +1,44 @@
+// Message read hook. Mirrors `frontend/src/hooks/queries/useMessages.ts`
+// for the chat screen's read path. Send / ingest / pagination come later
+// — this hook covers the "open a chat, see the recent messages" flow.
+
+import { useQuery } from "@tanstack/react-query";
+import { invoke } from "../../lib/native";
+
+export interface Message {
+  id: string;
+  conversation_id: string;
+  sender_id: string;
+  sender_username?: string;
+  content: string;
+  reply_to_id?: string | null;
+  created_at: number | string;
+  updated_at: number | string;
+}
+
+export const messageQueryKeys = {
+  all: ["messages"] as const,
+  conversation: (conversationId: string | null) =>
+    ["messages", "conversation", conversationId] as const,
+};
+
+export function useMessages(
+  conversationId: string | null,
+  opts?: { limit?: number },
+) {
+  return useQuery({
+    queryKey: messageQueryKeys.conversation(conversationId),
+    queryFn: async (): Promise<Message[]> => {
+      if (!conversationId) {
+        return [];
+      }
+      const messages = await invoke<Message[]>("list_messages", {
+        conversationId,
+        limit: opts?.limit ?? 50,
+      });
+      return messages ?? [];
+    },
+    enabled: !!conversationId,
+    staleTime: 1000 * 30,
+  });
+}

--- a/mobile/hooks/queries/useUserGroups.ts
+++ b/mobile/hooks/queries/useUserGroups.ts
@@ -1,0 +1,70 @@
+// Group/channel listing hooks. Mirrors `frontend/src/hooks/queries/useGroups.ts`
+// for the read paths the mobile UI needs. Mutations (create_group,
+// invite_to_group, etc.) come later when we add those flows.
+
+import { useQuery } from "@tanstack/react-query";
+import { invoke } from "../../lib/native";
+import { useAppStore } from "../../stores/appStore";
+import type { Channel, Group } from "../../types";
+
+export interface GroupWithChannels extends Group {
+  channels: Channel[];
+}
+
+export const groupQueryKeys = {
+  all: ["groups"] as const,
+  userGroups: (userId: string | null) => ["groups", "user", userId] as const,
+  userGroupsWithChannels: (userId: string | null) =>
+    ["groups", "with-channels", userId] as const,
+  channels: (groupId: string | null) => ["groups", groupId, "channels"] as const,
+};
+
+export function useUserGroups() {
+  const currentUser = useAppStore((state) => state.currentUser);
+
+  return useQuery({
+    queryKey: groupQueryKeys.userGroups(currentUser?.id ?? null),
+    queryFn: async (): Promise<Group[]> => {
+      if (!currentUser) {
+        throw new Error("No current user");
+      }
+      return await invoke<Group[]>("list_user_groups", {
+        userId: currentUser.id,
+      });
+    },
+    enabled: !!currentUser,
+    staleTime: 1000 * 60,
+  });
+}
+
+export function useUserGroupsWithChannels() {
+  const currentUser = useAppStore((state) => state.currentUser);
+
+  return useQuery({
+    queryKey: groupQueryKeys.userGroupsWithChannels(currentUser?.id ?? null),
+    queryFn: async (): Promise<GroupWithChannels[]> => {
+      if (!currentUser) {
+        throw new Error("No current user");
+      }
+      return await invoke<GroupWithChannels[]>("list_user_groups_with_channels", {
+        userId: currentUser.id,
+      });
+    },
+    enabled: !!currentUser,
+    staleTime: 1000 * 60,
+  });
+}
+
+export function useGroupChannels(groupId: string | null) {
+  return useQuery({
+    queryKey: groupQueryKeys.channels(groupId),
+    queryFn: async (): Promise<Channel[]> => {
+      if (!groupId) {
+        throw new Error("No group ID provided");
+      }
+      return await invoke<Channel[]>("list_group_channels", { groupId });
+    },
+    enabled: !!groupId,
+    staleTime: 1000 * 60,
+  });
+}

--- a/mobile/lib/native/bridge.ts
+++ b/mobile/lib/native/bridge.ts
@@ -2,33 +2,36 @@
 // to the Rust core (`pollis-core`) — everything else goes through `invoke()`
 // in ./invoke.ts.
 //
-// CURRENT STATE: placeholder. The `pollis-native` turbo-module
-// (`mobile/modules/pollis-native`) is wired into the build but does not yet
-// expose a generic `invoke(cmd, args)` entry point. To unblock UI work the
-// bridge currently throws a clear "not yet implemented" error for any cmd.
+// Two implementations live behind the same NativeBridge interface:
 //
-// HOW TO PLUG IN REAL BINDINGS: when `pollis-native`'s uniffi-generated
-// bindings expose a command dispatcher (e.g. `PollisNative.invoke(cmd, json)`),
-// swap `defaultBridge` for an implementation that:
-//   1. JSON-stringifies `args`,
-//   2. calls the native function across JSI,
-//   3. JSON-parses the result,
-//   4. throws if the native side returned an error.
+//   1. `pollisNativeBridge` (default in production) — calls into the
+//      `pollis-native` JSI turbo-module. JSON-marshals args, awaits the
+//      Rust `invoke()` promise, JSON-parses the result. Call sites that
+//      use `invoke<T>(cmd, args)` get fully-typed results back.
 //
-// Call sites using `invoke<T>(cmd, args)` do not change.
+//   2. `defaultBridge` (fallback) — used when neither the real native
+//      module nor an explicit override has been installed. Defers to the
+//      `registerMockCommand` registry, and throws a clear error for any
+//      unregistered command. Useful for jest / typecheck / unit work.
+//
+// Production code calls `initializeNativeBridge()` once at app startup
+// (see app/_layout.tsx) which calls Rust's `initPollis()` with config
+// and then swaps in `pollisNativeBridge`.
+
+import * as pollisNative from "pollis-native";
 
 export interface NativeBridge {
   invoke<T = unknown>(cmd: string, args?: Record<string, unknown>): Promise<T>;
 }
 
-// In-process registry of mock command handlers — useful for early UI work
-// and for the typecheck/build to pass without a real native module.
 type MockHandler = (args?: Record<string, unknown>) => unknown | Promise<unknown>;
 const mockHandlers = new Map<string, MockHandler>();
 
 /**
- * Register a mock implementation for a command. Useful while the real
- * `pollis-native` invoke dispatcher is being built. Returns a disposer.
+ * Register a mock implementation for a command. Mocks always take precedence
+ * over the underlying bridge — handy for screen-development without a real
+ * backend, or for jest tests that don't want to spin up Turso. Returns a
+ * disposer.
  */
 export function registerMockCommand(cmd: string, handler: MockHandler): () => void {
   mockHandlers.set(cmd, handler);
@@ -44,21 +47,90 @@ const defaultBridge: NativeBridge = {
       return (await mock(args)) as T;
     }
     throw new Error(
-      `[pollis-native] invoke("${cmd}") is not implemented yet. ` +
-        `Register a mock via registerMockCommand("${cmd}", …) or wire it ` +
-        `through the pollis-native turbo-module.`,
+      `[pollis-native] invoke("${cmd}") has no handler. ` +
+        `Call initializeNativeBridge() at app startup, or register a mock via ` +
+        `registerMockCommand("${cmd}", …) for development.`,
     );
+  },
+};
+
+/**
+ * Production bridge — routes invoke() through `pollis-native`'s JSI module
+ * into the Rust dispatcher in `pollis-core/src/bridge.rs`. Mocks still win
+ * if registered, so individual commands can be stubbed during UI work even
+ * after the bridge is installed.
+ */
+const pollisNativeBridge: NativeBridge = {
+  async invoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
+    const mock = mockHandlers.get(cmd);
+    if (mock) {
+      return (await mock(args)) as T;
+    }
+    const argsJson = args ? JSON.stringify(args) : "{}";
+    const resultJson = await pollisNative.invoke(cmd, argsJson);
+    if (resultJson === "" || resultJson === "null") {
+      return null as T;
+    }
+    return JSON.parse(resultJson) as T;
   },
 };
 
 let currentBridge: NativeBridge = defaultBridge;
 
 /**
- * Swap the underlying bridge implementation. Production code should call
- * this once at app startup with the real `pollis-native`-backed bridge.
+ * Swap the underlying bridge implementation. Most call sites should not
+ * touch this — `initializeNativeBridge()` is the normal entry point. Exposed
+ * for tests that want to inject a fully custom bridge.
  */
 export function setNativeBridge(bridge: NativeBridge): void {
   currentBridge = bridge;
+}
+
+export interface InitConfig {
+  tursoUrl: string;
+  tursoToken: string;
+  r2Endpoint?: string;
+  r2AccessKeyId?: string;
+  r2SecretAccessKey?: string;
+  r2Region?: string;
+  r2PublicUrl?: string;
+  livekitUrl?: string;
+  livekitApiKey?: string;
+  livekitApiSecret?: string;
+  resendApiKey?: string;
+}
+
+let initialized = false;
+
+/**
+ * Boot the Rust core and install the JSI-backed bridge. Idempotent — safe to
+ * call multiple times; subsequent calls are no-ops. Call once during app
+ * startup before any `invoke()` consumer mounts (the root layout in
+ * `app/_layout.tsx` is the right place).
+ *
+ * Throws if `init_pollis` on the Rust side fails (e.g. Turso URL is
+ * unreachable, config JSON is malformed).
+ */
+export async function initializeNativeBridge(config: InitConfig): Promise<void> {
+  if (initialized) {
+    return;
+  }
+  const configJson = JSON.stringify({
+    turso_url: config.tursoUrl,
+    turso_token: config.tursoToken,
+    r2_endpoint: config.r2Endpoint ?? "",
+    r2_access_key_id: config.r2AccessKeyId ?? "",
+    r2_secret_access_key: config.r2SecretAccessKey ?? "",
+    r2_region: config.r2Region ?? "auto",
+    r2_public_url: config.r2PublicUrl ?? "",
+    livekit_url: config.livekitUrl ?? "",
+    livekit_api_key: config.livekitApiKey ?? "",
+    livekit_api_secret: config.livekitApiSecret ?? "",
+    resend_api_key: config.resendApiKey ?? "",
+  });
+  await pollisNative.initPollis(configJson);
+  setNativeBridge(pollisNativeBridge);
+  initialized = true;
 }
 
 export const nativeBridge: NativeBridge = {

--- a/mobile/lib/native/index.ts
+++ b/mobile/lib/native/index.ts
@@ -3,5 +3,7 @@ export {
   nativeBridge,
   setNativeBridge,
   registerMockCommand,
+  initializeNativeBridge,
   type NativeBridge,
+  type InitConfig,
 } from "./bridge";

--- a/pollis-core/Cargo.toml
+++ b/pollis-core/Cargo.toml
@@ -20,7 +20,7 @@ cli = ["uniffi/cli"]
 test-harness = []
 
 [dependencies]
-uniffi = { version = "0.31", features = [] }
+uniffi = { version = "0.31", features = ["tokio"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["fs", "sync", "rt-multi-thread", "time", "macros", "io-util", "net", "process", "signal"] }

--- a/pollis-core/src/bridge.rs
+++ b/pollis-core/src/bridge.rs
@@ -1,0 +1,278 @@
+//! Generic uniffi-exposed command dispatcher.
+//!
+//! Lets a non-Tauri host (currently `pollis-native` for mobile, future
+//! CLI/TUI) drive the same command surface the desktop hits via Tauri's
+//! `invoke()`. JS calls `init_pollis(config_json)` once at startup, then
+//! `invoke("cmd_name", args_json)` for everything else — mirroring the
+//! `@tauri-apps/api/core` `invoke()` shape so call-sites port 1:1.
+//!
+//! Lifecycle:
+//!   - `init_pollis` constructs `AppState` once, parks it in a process-
+//!     global `OnceCell`. Idempotent; subsequent calls are no-ops.
+//!   - `invoke` looks up the state and dispatches on the command name,
+//!     deserializing args / serializing return values as JSON. Unknown
+//!     commands return a clear error string.
+//!
+//! Adding a command: add a `match` arm. Args are read off `args` via the
+//! `arg!` / `arg_opt!` helpers; the body calls into `crate::commands::*`
+//! the same way the Tauri shim does, and the return value goes through
+//! `ok(...)` so it round-trips as a JSON string on the JS side.
+
+use serde_json::Value;
+use std::sync::Arc;
+use tokio::sync::OnceCell;
+
+use crate::config::Config;
+use crate::state::AppState;
+
+static APP_STATE: OnceCell<Arc<AppState>> = OnceCell::const_new();
+
+#[derive(Debug, thiserror::Error, uniffi::Error)]
+#[uniffi(flat_error)]
+pub enum BridgeError {
+    #[error("{0}")]
+    Bridge(String),
+}
+
+impl From<crate::error::Error> for BridgeError {
+    fn from(e: crate::error::Error) -> Self {
+        BridgeError::Bridge(e.to_string())
+    }
+}
+impl From<serde_json::Error> for BridgeError {
+    fn from(e: serde_json::Error) -> Self {
+        BridgeError::Bridge(format!("json: {e}"))
+    }
+}
+impl From<anyhow::Error> for BridgeError {
+    fn from(e: anyhow::Error) -> Self {
+        BridgeError::Bridge(e.to_string())
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct InitConfig {
+    turso_url: String,
+    turso_token: String,
+    #[serde(default)]
+    r2_endpoint: String,
+    #[serde(default)]
+    r2_access_key_id: String,
+    #[serde(default)]
+    r2_secret_access_key: String,
+    #[serde(default)]
+    r2_region: Option<String>,
+    #[serde(default)]
+    r2_public_url: String,
+    #[serde(default)]
+    livekit_url: String,
+    #[serde(default)]
+    livekit_api_key: String,
+    #[serde(default)]
+    livekit_api_secret: String,
+    #[serde(default)]
+    resend_api_key: String,
+}
+
+/// Initialize the process-global `AppState`. Safe to call multiple times —
+/// only the first call does any work. `config_json` is a JSON object whose
+/// fields mirror [`Config`]; the only required fields are `turso_url` and
+/// `turso_token` (the rest default to empty so a mobile build that doesn't
+/// use R2 / LiveKit yet can omit them).
+#[uniffi::export(async_runtime = "tokio")]
+pub async fn init_pollis(config_json: String) -> Result<(), BridgeError> {
+    APP_STATE
+        .get_or_try_init(|| async {
+            let parsed: InitConfig = serde_json::from_str(&config_json)?;
+            let config = Config {
+                turso_url: parsed.turso_url,
+                turso_token: parsed.turso_token,
+                r2_endpoint: parsed.r2_endpoint,
+                r2_access_key_id: parsed.r2_access_key_id,
+                r2_secret_access_key: parsed.r2_secret_access_key,
+                r2_region: parsed.r2_region.unwrap_or_else(|| "auto".into()),
+                r2_public_url: parsed.r2_public_url,
+                livekit_url: parsed.livekit_url,
+                livekit_api_key: parsed.livekit_api_key,
+                livekit_api_secret: parsed.livekit_api_secret,
+                resend_api_key: parsed.resend_api_key,
+            };
+            let state = AppState::new(config).await?;
+            Ok::<Arc<AppState>, BridgeError>(Arc::new(state))
+        })
+        .await?;
+    Ok(())
+}
+
+fn state() -> Result<Arc<AppState>, BridgeError> {
+    APP_STATE.get().cloned().ok_or_else(|| {
+        BridgeError::Bridge(
+            "pollis-core not initialized — call init_pollis() first".into(),
+        )
+    })
+}
+
+fn arg<T: serde::de::DeserializeOwned>(v: &Value, key: &str) -> Result<T, BridgeError> {
+    let field = v
+        .get(key)
+        .ok_or_else(|| BridgeError::Bridge(format!("missing arg: {key}")))?;
+    serde_json::from_value(field.clone())
+        .map_err(|e| BridgeError::Bridge(format!("arg {key}: {e}")))
+}
+
+fn arg_opt<T: serde::de::DeserializeOwned>(
+    v: &Value,
+    key: &str,
+) -> Result<Option<T>, BridgeError> {
+    let Some(field) = v.get(key) else {
+        return Ok(None);
+    };
+    if field.is_null() {
+        return Ok(None);
+    }
+    Ok(Some(
+        serde_json::from_value(field.clone())
+            .map_err(|e| BridgeError::Bridge(format!("arg {key}: {e}")))?,
+    ))
+}
+
+fn ok<T: serde::Serialize>(v: T) -> Result<String, BridgeError> {
+    serde_json::to_string(&v).map_err(BridgeError::from)
+}
+
+/// Dispatch a command by name. `args_json` must be a JSON object; pass
+/// `"{}"` (or `""`) for nullary commands. Returns the command's result
+/// re-serialized as a JSON string (the JS side `JSON.parse`s it inside
+/// `mobile/lib/native/bridge.ts`).
+///
+/// The initial command set is deliberately small — enough to wire auth
+/// + the static screens. Add commands here as the mobile UI needs them.
+#[uniffi::export(async_runtime = "tokio")]
+pub async fn invoke(cmd: String, args_json: String) -> Result<String, BridgeError> {
+    let args: Value = if args_json.trim().is_empty() {
+        Value::Object(Default::default())
+    } else {
+        serde_json::from_str(&args_json)?
+    };
+
+    use crate::commands::{auth, dm, groups, messages, pin, user};
+
+    match cmd.as_str() {
+        "version" => ok(env!("CARGO_PKG_VERSION")),
+
+        // ----- auth -----
+        "get_identity" => ok(auth::get_identity().await?),
+        "get_session" => ok(auth::get_session(&state()?).await?),
+        "request_otp" => {
+            let email: String = arg(&args, "email")?;
+            auth::request_otp(&state()?, email).await?;
+            ok(())
+        }
+        "verify_otp" => {
+            let email: String = arg(&args, "email")?;
+            let code: String = arg(&args, "code")?;
+            ok(auth::verify_otp(&state()?, email, code).await?)
+        }
+        "initialize_identity" => {
+            let user_id: String = arg(&args, "userId")?;
+            ok(auth::initialize_identity(&state()?, user_id).await?)
+        }
+        "logout" => {
+            let delete: bool = arg_opt(&args, "deleteData")?.unwrap_or(false);
+            auth::logout(&state()?, delete).await?;
+            ok(())
+        }
+        "list_known_accounts" => ok(auth::list_known_accounts()?),
+
+        // ----- pin -----
+        "set_pin" => {
+            let old_pin: Option<String> = arg_opt(&args, "oldPin")?;
+            let new_pin: String = arg(&args, "newPin")?;
+            pin::set_pin(&state()?, old_pin, new_pin).await?;
+            ok(())
+        }
+        "unlock" => {
+            let user_id: String = arg(&args, "userId")?;
+            let p: String = arg(&args, "pin")?;
+            ok(pin::unlock(&state()?, user_id, p).await?)
+        }
+        "lock" => {
+            pin::lock(&state()?).await?;
+            ok(())
+        }
+        "get_unlock_state" => ok(pin::get_unlock_state(&state()?).await?),
+
+        // ----- user -----
+        "get_user_profile" => {
+            let user_id: String = arg(&args, "userId")?;
+            ok(user::get_user_profile(user_id, &state()?).await?)
+        }
+        "update_user_profile" => {
+            let user_id: String = arg(&args, "userId")?;
+            let username: Option<String> = arg_opt(&args, "username")?;
+            let preferred_name: Option<String> = arg_opt(&args, "preferredName")?;
+            let phone: Option<String> = arg_opt(&args, "phone")?;
+            let avatar_url: Option<String> = arg_opt(&args, "avatarUrl")?;
+            user::update_user_profile(
+                user_id,
+                username,
+                preferred_name,
+                phone,
+                avatar_url,
+                &state()?,
+            )
+            .await?;
+            ok(())
+        }
+        "search_user_by_username" => {
+            let username: String = arg(&args, "username")?;
+            ok(user::search_user_by_username(username, &state()?).await?)
+        }
+
+        // ----- groups -----
+        "list_user_groups" => {
+            let user_id: String = arg(&args, "userId")?;
+            ok(groups::list_user_groups(user_id, &state()?).await?)
+        }
+        "list_user_groups_with_channels" => {
+            let user_id: String = arg(&args, "userId")?;
+            ok(groups::list_user_groups_with_channels(user_id, &state()?).await?)
+        }
+        "list_group_channels" => {
+            let group_id: String = arg(&args, "groupId")?;
+            ok(groups::list_group_channels(group_id, &state()?).await?)
+        }
+
+        // ----- messages -----
+        "list_messages" => {
+            let conversation_id: String = arg(&args, "conversationId")?;
+            let limit: Option<i64> = arg_opt(&args, "limit")?;
+            let before_id: Option<String> = arg_opt(&args, "beforeId")?;
+            ok(messages::list_messages(
+                conversation_id,
+                limit,
+                before_id,
+                &state()?,
+            )
+            .await?)
+        }
+        "list_channel_previews" => {
+            let user_id: String = arg(&args, "userId")?;
+            ok(messages::list_channel_previews(user_id, &state()?).await?)
+        }
+
+        // ----- dm -----
+        "list_dm_channels" => {
+            let user_id: String = arg(&args, "userId")?;
+            ok(dm::list_dm_channels(user_id, &state()?).await?)
+        }
+        "list_dm_requests" => {
+            let user_id: String = arg(&args, "userId")?;
+            ok(dm::list_dm_requests(user_id, &state()?).await?)
+        }
+
+        _ => Err(BridgeError::Bridge(format!(
+            "unknown command: {cmd} (add it to pollis-core/src/bridge.rs)"
+        ))),
+    }
+}

--- a/pollis-core/src/lib.rs
+++ b/pollis-core/src/lib.rs
@@ -1,6 +1,7 @@
 uniffi::setup_scaffolding!();
 
 pub mod accounts;
+pub mod bridge;
 pub mod commands;
 pub mod config;
 pub mod db;


### PR DESCRIPTION
## Summary
- Adds `pollis-core::bridge::{init_pollis, invoke}` — a uniffi-exposed JSI dispatcher so non-Tauri hosts (mobile, future CLI/TUI) can drive the same `pollis-core::commands::*` surface the desktop hits via Tauri. Initial command set covers auth, PIN, user, groups, messages, DMs — enough to wire the static mobile screens.
- Swaps `mobile/lib/native/bridge.ts` from the "not implemented" placeholder to a real JSI-backed bridge. `initializeNativeBridge()` boots Rust with config from `EXPO_PUBLIC_*` env vars at app startup.
- Wires the four `(auth)/*` screens — email → OTP → PIN → initializing — through real `request_otp` / `verify_otp` / `set_pin` / `unlock` / `initialize_identity`. `app/index.tsx` does session restore + branches based on `get_unlock_state`.
- Ports `(tabs)/groups`, `(tabs)/direct`, `(tabs)/self`, and `chat/[id]` from hardcoded mocks to React Query hooks (`useUserGroupsWithChannels`, `useDMChannels`, `useUserProfile`, `useMessages`).

## Test plan
- [ ] On macOS dev box, ubrn iOS regen already produced fresh bindings here (`pollis-native/cpp/`, `src/generated/`). On Linux dev box, re-run Android regen: `cd mobile/modules/pollis-native && uniffi-bindgen-react-native build android --config ubrn.config.yaml --and-generate`.
- [ ] Copy `mobile/.env.example` → `mobile/.env`, fill in `EXPO_PUBLIC_TURSO_URL` and `EXPO_PUBLIC_TURSO_TOKEN` (match your dev Turso).
- [ ] `cd mobile && pnpm expo run:ios` — sign in with a real email, accept the OTP from your inbox, set PIN, reach `/(tabs)/groups`.
- [ ] Verify groups + DMs render real Turso data (or "No groups yet" empty states for a fresh account).
- [ ] Sign out from `(tabs)/self` returns to `(auth)/email` and `restoreSession()` re-routes correctly on relaunch.
- [ ] Repeat on Android after the Android regen above.

## Notes
- Bindings (`mobile/modules/pollis-native/cpp/`, `src/generated/`, `*.xcframework`, etc.) are gitignored — they regen on every `pnpm expo run:*`.
- Send / pagination / message sync intentionally not in this PR; chat screen renders the read path only. `useMessages` exposes the surface that those follow-ons will hang off.
- `update_user_profile`, `search_user_by_username`, etc. are already dispatched in `pollis-core/src/bridge.rs`, but no mobile screen calls them yet — they're ready for the next sweep (self/user-settings, search).