### PR TITLE
feat(mobile): write-path parity with desktop (no more mocks)

### DIFF
--- a/mobile/app/(auth)/email.tsx
+++ b/mobile/app/(auth)/email.tsx
@@ -93,9 +93,10 @@ export default function AuthEmail() {
         >
           {requestOtp.isPending ? "SENDING…" : "CONTINUE"}
         </Button>
-        <Button variant="subtle" full>
-          I have a recovery key
-        </Button>
+        {/* Recovery is reachable through the standard sign-in flow: enter
+            your email, verify the OTP, and Pollis routes you to the
+            recovery-key entry on a fresh device. No dedicated button
+            needed. */}
       </BottomAction>
     </Screen>
   );

--- a/mobile/app/(auth)/emergency-kit.tsx
+++ b/mobile/app/(auth)/emergency-kit.tsx
@@ -1,0 +1,156 @@
+import { useState } from "react";
+import { View, Text, Pressable, ScrollView } from "react-native";
+import { useRouter } from "expo-router";
+import {
+  Screen,
+  Crumb,
+  Body,
+  Card,
+  Button,
+  BottomAction,
+} from "../../components/ui";
+import { PollisMark } from "../../components/PollisMark";
+import { Icon } from "../../components/icons";
+import { semantic, type as ty, fonts, r } from "../../theme/tokens";
+import { useAppStore } from "../../stores/appStore";
+
+/**
+ * Emergency Kit — shown once, right after a brand-new account's PIN is set.
+ * The recovery key emitted by `verify_otp` lives in the zustand store
+ * (`pendingSecretKey`) for one screen-jump only. The user must explicitly
+ * acknowledge they've saved it before we drop it from memory.
+ *
+ * After ACK we route to /(auth)/initializing — exactly the same path a
+ * returning user takes — so the rest of the launch sequence stays the
+ * same regardless of whether this was a new account or not.
+ */
+export default function EmergencyKit() {
+  const router = useRouter();
+  const pendingSecretKey = useAppStore((s) => s.pendingSecretKey);
+  const setPendingSecretKey = useAppStore((s) => s.setPendingSecretKey);
+  const [acknowledged, setAcknowledged] = useState(false);
+
+  // Defensive: if someone deep-links here without a stashed key, just
+  // continue to initializing — nothing to display.
+  if (!pendingSecretKey) {
+    router.replace("/(auth)/initializing");
+    return null;
+  }
+
+  const onContinue = () => {
+    setPendingSecretKey(null);
+    router.replace("/(auth)/initializing");
+  };
+
+  return (
+    <Screen>
+      <Crumb
+        segs={[{ label: "AUTH" }, { label: "Emergency kit", leaf: true }]}
+      />
+      <Body>
+        <ScrollView contentContainerStyle={{ paddingHorizontal: 24, paddingTop: 18, gap: 18, paddingBottom: 24 }}>
+          <PollisMark />
+          <View style={{ gap: 8 }}>
+            <Text style={[ty.h1, { color: semantic.ink }]}>Save your recovery key</Text>
+            <Text
+              style={{
+                fontFamily: ty.body.fontFamily,
+                fontSize: 13,
+                lineHeight: 19,
+                color: semantic.mute,
+              }}
+            >
+              This key is the only way to add Pollis to a new device or
+              recover after losing this one. We don't store it anywhere
+              you can read it later — write it down or save it to a
+              password manager now.
+            </Text>
+          </View>
+
+          <Card style={{ borderColor: semantic.accent }}>
+            <Text
+              selectable
+              style={{
+                fontFamily: fonts.mono400,
+                fontSize: 14,
+                lineHeight: 22,
+                color: semantic.accent,
+                letterSpacing: 0.4,
+              }}
+            >
+              {pendingSecretKey}
+            </Text>
+          </Card>
+
+          <View
+            style={{
+              flexDirection: "row",
+              alignItems: "center",
+              gap: 8,
+            }}
+          >
+            <Icon.shield color={semantic.mute} />
+            <Text
+              style={{
+                fontFamily: ty.body.fontFamily,
+                fontSize: 11,
+                color: semantic.mute,
+                flex: 1,
+                lineHeight: 16,
+              }}
+            >
+              Anyone with this key can sign in as you on a new device.
+              Treat it like a master password.
+            </Text>
+          </View>
+
+          <Pressable
+            onPress={() => setAcknowledged((v) => !v)}
+            style={{
+              flexDirection: "row",
+              alignItems: "center",
+              gap: 10,
+              paddingVertical: 8,
+            }}
+          >
+            <View
+              style={{
+                width: 18,
+                height: 18,
+                borderWidth: 1,
+                borderColor: acknowledged ? semantic.accent : semantic.hairStrong,
+                backgroundColor: acknowledged ? semantic.accent : "transparent",
+                borderRadius: r.sm,
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            >
+              {acknowledged ? <Icon.check color="#0a0907" /> : null}
+            </View>
+            <Text
+              style={{
+                flex: 1,
+                fontFamily: ty.body.fontFamily,
+                fontSize: 13,
+                color: semantic.ink,
+              }}
+            >
+              I've saved my recovery key in a safe place.
+            </Text>
+          </Pressable>
+        </ScrollView>
+      </Body>
+      <BottomAction>
+        <Button
+          full
+          variant="primary"
+          onPress={onContinue}
+          disabled={!acknowledged}
+          iconRight={<Icon.arrowRight color="#0a0907" />}
+        >
+          CONTINUE
+        </Button>
+      </BottomAction>
+    </Screen>
+  );
+}

--- a/mobile/app/(auth)/enrollment.tsx
+++ b/mobile/app/(auth)/enrollment.tsx
@@ -1,0 +1,226 @@
+import { useEffect, useState } from "react";
+import { View, Text } from "react-native";
+import { useRouter } from "expo-router";
+import {
+  Screen,
+  Crumb,
+  Body,
+  Field,
+  Button,
+  BottomAction,
+} from "../../components/ui";
+import { PollisMark } from "../../components/PollisMark";
+import { Icon } from "../../components/icons";
+import { semantic, type as ty, fonts } from "../../theme/tokens";
+import {
+  useStartEnrollment,
+  useEnrollmentStatus,
+  useFinalizeEnrollment,
+  useRecoverWithSecretKey,
+  type EnrollmentHandle,
+} from "../../hooks/queries";
+
+type Mode = "chooser" | "polling" | "recovery";
+
+export default function Enrollment() {
+  const router = useRouter();
+  const [mode, setMode] = useState<Mode>("chooser");
+  const [handle, setHandle] = useState<EnrollmentHandle | null>(null);
+  const [secretKey, setSecretKey] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const start = useStartEnrollment();
+  const finalize = useFinalizeEnrollment();
+  const recover = useRecoverWithSecretKey();
+  const status = useEnrollmentStatus(
+    mode === "polling" ? handle?.request_id ?? null : null,
+  );
+
+  // When the existing device approves, finalize on this side then route
+  // to PIN-create so the user can set a local PIN for this device.
+  useEffect(() => {
+    if (status.data?.status === "approved") {
+      finalize.mutate(undefined, {
+        onSuccess: () => router.replace("/(auth)/pin"),
+        onError: (e) => setError((e as Error).message || "Couldn't finalize."),
+      });
+    }
+    if (status.data?.status === "rejected") {
+      setError("The other device rejected this request.");
+    }
+    if (status.data?.status === "expired") {
+      setError("Request expired. Start again.");
+    }
+    // finalize is a stable mutation ref.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [status.data?.status]);
+
+  const onStart = () => {
+    setError(null);
+    start.mutate(undefined, {
+      onSuccess: (h) => {
+        setHandle(h);
+        setMode("polling");
+      },
+      onError: (e) => setError((e as Error).message || "Couldn't start enrollment."),
+    });
+  };
+
+  const onRecover = () => {
+    setError(null);
+    if (!secretKey.trim()) {
+      return;
+    }
+    recover.mutate(secretKey.trim(), {
+      onSuccess: () => router.replace("/(auth)/pin"),
+      onError: (e) => setError((e as Error).message || "Couldn't recover with that key."),
+    });
+  };
+
+  return (
+    <Screen>
+      <Crumb segs={[{ label: "AUTH" }, { label: "Pair device", leaf: true }]} />
+      <Body>
+        <View style={{ paddingHorizontal: 24, paddingTop: 24, gap: 18 }}>
+          <PollisMark />
+          <View style={{ gap: 8 }}>
+            <Text style={[ty.h1, { color: semantic.ink }]}>
+              {mode === "polling"
+                ? "Approve on your other device"
+                : mode === "recovery"
+                  ? "Enter recovery key"
+                  : "Pair this device"}
+            </Text>
+            <Text
+              style={{
+                fontFamily: ty.body.fontFamily,
+                fontSize: 13,
+                lineHeight: 19,
+                color: semantic.mute,
+              }}
+            >
+              {mode === "polling"
+                ? "On a device that's already signed in, open Self → Security and approve the request with the code below."
+                : mode === "recovery"
+                  ? "Paste the recovery key you saved when you first signed up. It looks like a long string of letters and numbers."
+                  : "This device doesn't have your keys yet. Choose how to get them onto it."}
+            </Text>
+          </View>
+
+          {mode === "chooser" ? (
+            <View style={{ gap: 10, paddingTop: 6 }}>
+              <Button
+                full
+                variant="primary"
+                onPress={onStart}
+                disabled={start.isPending}
+                icon={<Icon.device color="#0a0907" />}
+              >
+                {start.isPending ? "STARTING…" : "APPROVE FROM ANOTHER DEVICE"}
+              </Button>
+              <Button
+                full
+                onPress={() => setMode("recovery")}
+                icon={<Icon.key color={semantic.ink} />}
+              >
+                USE RECOVERY KEY
+              </Button>
+            </View>
+          ) : null}
+
+          {mode === "polling" && handle ? (
+            <View style={{ gap: 14, paddingTop: 6 }}>
+              <View
+                style={{
+                  borderWidth: 1,
+                  borderColor: semantic.accent,
+                  backgroundColor: semantic.accentSoft,
+                  paddingVertical: 18,
+                  paddingHorizontal: 14,
+                  alignItems: "center",
+                }}
+              >
+                <Text style={[ty.label, { marginBottom: 6 }]}>
+                  VERIFICATION CODE
+                </Text>
+                <Text
+                  style={{
+                    fontFamily: fonts.mono400,
+                    fontSize: 28,
+                    letterSpacing: 4,
+                    color: semantic.ink,
+                  }}
+                >
+                  {handle.verification_code}
+                </Text>
+              </View>
+              <Text
+                style={{
+                  fontFamily: ty.body.fontFamily,
+                  fontSize: 12,
+                  color: semantic.mute,
+                  textAlign: "center",
+                }}
+              >
+                Waiting for approval…
+              </Text>
+            </View>
+          ) : null}
+
+          {mode === "recovery" ? (
+            <View style={{ gap: 10, paddingTop: 6 }}>
+              <Text style={ty.label}>RECOVERY KEY</Text>
+              <Field
+                amber
+                value={secretKey}
+                onChangeText={setSecretKey}
+                icon={<Icon.key color={semantic.mute} />}
+              />
+            </View>
+          ) : null}
+
+          {error ? (
+            <Text
+              style={{
+                fontFamily: ty.body.fontFamily,
+                fontSize: 12,
+                color: semantic.danger,
+              }}
+            >
+              {error}
+            </Text>
+          ) : null}
+        </View>
+      </Body>
+      {mode === "recovery" ? (
+        <BottomAction>
+          <Button
+            full
+            variant="primary"
+            onPress={onRecover}
+            disabled={!secretKey.trim() || recover.isPending}
+            iconRight={<Icon.arrowRight color="#0a0907" />}
+          >
+            {recover.isPending ? "RECOVERING…" : "RECOVER"}
+          </Button>
+          <Button variant="subtle" full onPress={() => setMode("chooser")}>
+            Back
+          </Button>
+        </BottomAction>
+      ) : mode === "polling" ? (
+        <BottomAction>
+          <Button
+            variant="subtle"
+            full
+            onPress={() => {
+              setHandle(null);
+              setMode("chooser");
+            }}
+          >
+            Cancel
+          </Button>
+        </BottomAction>
+      ) : null}
+    </Screen>
+  );
+}

--- a/mobile/app/(auth)/otp.tsx
+++ b/mobile/app/(auth)/otp.tsx
@@ -23,7 +23,16 @@ export default function AuthOTP() {
     verifyOtp.mutate(
       { email, code },
       {
-        onSuccess: () => router.push("/(auth)/pin"),
+        onSuccess: (profile) => {
+          // Existing user signing in on a new device — needs to enroll
+          // first (sibling-device approval or recovery key) before any
+          // local key material exists for the PIN screen to wrap.
+          if (profile.enrollment_required) {
+            router.push("/(auth)/enrollment");
+            return;
+          }
+          router.push("/(auth)/pin");
+        },
       },
     );
   };

--- a/mobile/app/(auth)/pin.tsx
+++ b/mobile/app/(auth)/pin.tsx
@@ -99,7 +99,18 @@ export default function AuthPIN() {
       setPinMutation.mutate(
         { newPin: entered },
         {
-          onSuccess: () => router.replace("/(auth)/initializing"),
+          onSuccess: () => {
+            // First-device signup has a one-time recovery key stashed in
+            // the store by `verify_otp`. Show it before initializing so
+            // the user can save it before we drop it from memory.
+            const pendingSecretKey =
+              useAppStore.getState().pendingSecretKey;
+            if (pendingSecretKey) {
+              router.replace("/(auth)/emergency-kit");
+            } else {
+              router.replace("/(auth)/initializing");
+            }
+          },
           onError: (e) => {
             setError((e as Error).message || "Couldn't save PIN.");
             setFirstPin("");

--- a/mobile/app/(tabs)/direct.tsx
+++ b/mobile/app/(tabs)/direct.tsx
@@ -4,19 +4,27 @@ import {
   Screen,
   Crumb,
   Body,
+  SectionTitle,
   ListRow,
   Avatar,
+  Chip,
   Button,
   BottomAction,
 } from "../../components/ui";
 import { Icon } from "../../components/icons";
 import { semantic, type as ty } from "../../theme/tokens";
-import { useDMChannels } from "../../hooks/queries";
+import {
+  useDMChannels,
+  useDMRequests,
+  useAcceptDMRequest,
+} from "../../hooks/queries";
 import { useAppStore } from "../../stores/appStore";
 
 export default function Direct() {
   const router = useRouter();
   const { data: dms = [], isLoading, isError } = useDMChannels();
+  const { data: requests = [] } = useDMRequests();
+  const acceptRequest = useAcceptDMRequest();
   const setSelectedConversationId = useAppStore(
     (s) => s.setSelectedConversationId,
   );
@@ -25,6 +33,41 @@ export default function Direct() {
     <Screen>
       <Crumb segs={[{ label: "DIRECT", leaf: true }]} end={String(dms.length)} />
       <Body>
+        {requests.length > 0 ? (
+          <View>
+            <SectionTitle>PENDING REQUESTS</SectionTitle>
+            {requests.map((d) => {
+              const handle = d.user2_identifier || "user";
+              return (
+                <ListRow
+                  key={d.id}
+                  minHeight={64}
+                  glyph={<Avatar label={handle.slice(0, 2)} />}
+                  name={
+                    <Text
+                      style={{
+                        fontFamily: ty.rowN.fontFamily,
+                        fontSize: 15,
+                        color: semantic.ink,
+                      }}
+                    >
+                      @{handle}
+                    </Text>
+                  }
+                  sub="wants to message you"
+                  end={
+                    <Chip
+                      variant="on"
+                      onPress={() => acceptRequest.mutate(d.id)}
+                    >
+                      {acceptRequest.isPending ? "…" : "Accept"}
+                    </Chip>
+                  }
+                />
+              );
+            })}
+          </View>
+        ) : null}
         {isLoading ? (
           <Text
             style={{

--- a/mobile/app/(tabs)/direct.tsx
+++ b/mobile/app/(tabs)/direct.tsx
@@ -73,7 +73,10 @@ export default function Direct() {
               minHeight={64}
               onPress={() => {
                 setSelectedConversationId(d.id);
-                router.push(`/chat/${d.id}`);
+                router.push({
+                  pathname: "/chat/[id]",
+                  params: { id: d.id, kind: "dm" },
+                });
               }}
               glyph={<Avatar label={label} />}
               name={

--- a/mobile/app/(tabs)/direct.tsx
+++ b/mobile/app/(tabs)/direct.tsx
@@ -95,7 +95,11 @@ export default function Direct() {
         })}
       </Body>
       <BottomAction>
-        <Button full icon={<Icon.plus color={semantic.ink} />}>
+        <Button
+          full
+          icon={<Icon.plus color={semantic.ink} />}
+          onPress={() => router.push("/dm/new")}
+        >
           NEW DIRECT MESSAGE
         </Button>
       </BottomAction>

--- a/mobile/app/(tabs)/groups.tsx
+++ b/mobile/app/(tabs)/groups.tsx
@@ -6,17 +6,26 @@ import {
   Body,
   SectionTitle,
   ListRow,
+  Chip,
   Button,
   BottomAction,
 } from "../../components/ui";
 import { Icon } from "../../components/icons";
 import { semantic, type as ty } from "../../theme/tokens";
-import { useUserGroupsWithChannels } from "../../hooks/queries";
+import {
+  useUserGroupsWithChannels,
+  usePendingGroupInvites,
+  useAcceptGroupInvite,
+  useDeclineGroupInvite,
+} from "../../hooks/queries";
 import { useAppStore } from "../../stores/appStore";
 
 export default function Groups() {
   const router = useRouter();
   const { data: groups = [], isLoading, isError } = useUserGroupsWithChannels();
+  const { data: invites = [] } = usePendingGroupInvites();
+  const acceptInvite = useAcceptGroupInvite();
+  const declineInvite = useDeclineGroupInvite();
   const setSelectedGroupId = useAppStore((s) => s.setSelectedGroupId);
   const setSelectedChannelId = useAppStore((s) => s.setSelectedChannelId);
 
@@ -26,6 +35,34 @@ export default function Groups() {
     <Screen>
       <Crumb segs={[{ label: "GROUPS", leaf: true }]} end={String(totalChannels)} />
       <Body>
+        {invites.length > 0 ? (
+          <View>
+            <SectionTitle>PENDING INVITES</SectionTitle>
+            {invites.map((inv) => (
+              <ListRow
+                key={inv.id}
+                glyph={<Icon.inbox color={semantic.accent} />}
+                name={inv.group_name}
+                sub={`from @${inv.inviter_username ?? "someone"}`}
+                end={
+                  <View style={{ flexDirection: "row", gap: 6 }}>
+                    <Chip
+                      onPress={() => declineInvite.mutate(inv.id)}
+                    >
+                      Decline
+                    </Chip>
+                    <Chip
+                      variant="on"
+                      onPress={() => acceptInvite.mutate(inv.id)}
+                    >
+                      {acceptInvite.isPending ? "…" : "Accept"}
+                    </Chip>
+                  </View>
+                }
+              />
+            ))}
+          </View>
+        ) : null}
         {isLoading ? (
           <Text
             style={{

--- a/mobile/app/(tabs)/groups.tsx
+++ b/mobile/app/(tabs)/groups.tsx
@@ -92,7 +92,10 @@ export default function Groups() {
                 onPress={() => {
                   setSelectedGroupId(g.id);
                   setSelectedChannelId(c.id);
-                  router.push(`/chat/${c.id}`);
+                  router.push({
+                    pathname: "/chat/[id]",
+                    params: { id: c.id, kind: "channel" },
+                  });
                 }}
               />
             ))}

--- a/mobile/app/(tabs)/groups.tsx
+++ b/mobile/app/(tabs)/groups.tsx
@@ -106,7 +106,7 @@ export default function Groups() {
         <Button
           full
           icon={<Icon.plus color={semantic.ink} />}
-          onPress={() => router.push("/group/quick-group")}
+          onPress={() => router.push("/group/new")}
         >
           NEW GROUP
         </Button>

--- a/mobile/app/(tabs)/groups.tsx
+++ b/mobile/app/(tabs)/groups.tsx
@@ -147,6 +147,14 @@ export default function Groups() {
         >
           NEW GROUP
         </Button>
+        <Button
+          variant="subtle"
+          full
+          icon={<Icon.search color={semantic.ink} />}
+          onPress={() => router.push("/group/discover")}
+        >
+          Join by slug
+        </Button>
       </BottomAction>
     </Screen>
   );

--- a/mobile/app/(tabs)/search.tsx
+++ b/mobile/app/(tabs)/search.tsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { View, Text } from "react-native";
+import { useRouter } from "expo-router";
 import {
   Screen,
   Crumb,
@@ -11,99 +12,185 @@ import {
 } from "../../components/ui";
 import { Icon } from "../../components/icons";
 import { semantic, type as ty } from "../../theme/tokens";
-
-function Hi({ children }: { children: string }) {
-  return (
-    <Text
-      style={{
-        backgroundColor: semantic.accentSoft,
-        color: semantic.ink,
-      }}
-    >
-      {children}
-    </Text>
-  );
-}
+import {
+  useSearchMessages,
+  useUserGroupsWithChannels,
+  useUserSearch,
+} from "../../hooks/queries";
 
 export default function Search() {
-  const [q, setQ] = useState("quick");
+  const router = useRouter();
+  const [q, setQ] = useState("");
+  const trimmed = q.trim();
+  const messages = useSearchMessages(trimmed);
+  const user = useUserSearch(trimmed);
+  const { data: groups = [] } = useUserGroupsWithChannels();
+
+  // Client-side filter of cached groups/channels. The Rust DB doesn't
+  // expose a single "search everything" command — desktop also stitches
+  // these on the frontend.
+  const filtered = useMemo(() => {
+    if (trimmed.length < 2) {
+      return { groups: [], channels: [] as { id: string; name: string; groupName: string }[] };
+    }
+    const lower = trimmed.toLowerCase();
+    const matchingGroups = groups.filter((g) =>
+      g.name.toLowerCase().includes(lower),
+    );
+    const matchingChannels: { id: string; name: string; groupName: string }[] = [];
+    for (const g of groups) {
+      for (const c of g.channels) {
+        if (c.name.toLowerCase().includes(lower)) {
+          matchingChannels.push({ id: c.id, name: c.name, groupName: g.name });
+        }
+      }
+    }
+    return { groups: matchingGroups, channels: matchingChannels };
+  }, [groups, trimmed]);
+
+  const totalResults =
+    (user.data ? 1 : 0) +
+    filtered.groups.length +
+    filtered.channels.length +
+    (messages.data?.length ?? 0);
+
+  const showEmpty =
+    trimmed.length >= 2 &&
+    !messages.isLoading &&
+    !user.isLoading &&
+    totalResults === 0;
+
   return (
     <Screen>
-      <Crumb segs={[{ label: "SEARCH", leaf: true }]} end="12 RESULTS" />
+      <Crumb
+        segs={[{ label: "SEARCH", leaf: true }]}
+        end={trimmed.length >= 2 ? `${totalResults} RESULTS` : "TYPE…"}
+      />
       <Body>
-        <SectionTitle>GROUPS</SectionTitle>
-        <ListRow
-          minHeight={46}
-          glyph={<Icon.diamond size={14} color={semantic.mute} />}
-          name={
-            <Text style={{ fontFamily: ty.rowN.fontFamily, fontSize: 14, color: semantic.ink }}>
-              <Hi>Quick</Hi> Group
-            </Text>
-          }
-        />
+        {trimmed.length < 2 ? (
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 13,
+              color: semantic.mute,
+              paddingHorizontal: 18,
+              paddingTop: 14,
+            }}
+          >
+            Type at least two characters to search groups, channels, people,
+            and messages.
+          </Text>
+        ) : null}
+        {showEmpty ? (
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 13,
+              color: semantic.mute,
+              paddingHorizontal: 18,
+              paddingTop: 14,
+            }}
+          >
+            Nothing matched.
+          </Text>
+        ) : null}
 
-        <SectionTitle>CHANNELS</SectionTitle>
-        <ListRow
-          selected
-          minHeight={48}
-          glyph={<Icon.hash color={semantic.accent} />}
-          name="General"
-          sub={
-            <Text style={{ fontFamily: ty.body.fontFamily, fontSize: 12, color: semantic.mute }}>
-              <Hi>Quick</Hi> Group
-            </Text>
-          }
-          end={<Text style={ty.label}>↵</Text>}
-        />
-        <ListRow
-          minHeight={48}
-          glyph={<Icon.hash color={semantic.mute} />}
-          name="quick-notes"
-          sub="Test Group"
-        />
+        {filtered.groups.length > 0 ? (
+          <View>
+            <SectionTitle>GROUPS</SectionTitle>
+            {filtered.groups.map((g) => (
+              <ListRow
+                key={g.id}
+                minHeight={46}
+                glyph={<Icon.diamond size={14} color={semantic.mute} />}
+                name={g.name}
+                nameStyle={{ fontSize: 14, fontFamily: ty.rowN.fontFamily }}
+                onPress={() =>
+                  router.push({
+                    pathname: "/group/[id]",
+                    params: { id: g.id },
+                  })
+                }
+              />
+            ))}
+          </View>
+        ) : null}
 
-        <SectionTitle>DIRECT</SectionTitle>
-        <ListRow
-          minHeight={48}
-          glyph={<Avatar label="qb" size="sm" />}
-          name={
-            <Text style={{ fontFamily: ty.rowN.fontFamily, fontSize: 14, color: semantic.ink }}>
-              @<Hi>quick</Hi>brian
-            </Text>
-          }
-          sub="last: APR 22"
-        />
+        {filtered.channels.length > 0 ? (
+          <View>
+            <SectionTitle>CHANNELS</SectionTitle>
+            {filtered.channels.map((c) => (
+              <ListRow
+                key={c.id}
+                minHeight={48}
+                glyph={<Icon.hash color={semantic.mute} />}
+                name={c.name}
+                sub={c.groupName}
+                onPress={() =>
+                  router.push({
+                    pathname: "/chat/[id]",
+                    params: { id: c.id, kind: "channel" },
+                  })
+                }
+              />
+            ))}
+          </View>
+        ) : null}
 
-        <SectionTitle>MESSAGES</SectionTitle>
-        <ListRow
-          minHeight={58}
-          glyph={<Avatar label="me" size="sm" />}
-          name={
-            <Text style={{ fontFamily: ty.rowN.fontFamily, fontSize: 13, color: semantic.ink }}>
-              meilan{" "}
-              <Text style={{ color: semantic.mute, fontFamily: ty.body.fontFamily }}>
-                · Test / General
-              </Text>
-            </Text>
-          }
-          sub={
-            <Text style={{ fontFamily: ty.body.fontFamily, fontSize: 12, color: semantic.mute }}>
-              that was a <Hi>quick</Hi> response
-            </Text>
-          }
-          end={<Text style={ty.label}>MAY 3</Text>}
-        />
+        {user.data ? (
+          <View>
+            <SectionTitle>DIRECT</SectionTitle>
+            <ListRow
+              minHeight={48}
+              glyph={
+                <Avatar
+                  label={(user.data.username || "us").slice(0, 2)}
+                  size="sm"
+                />
+              }
+              name={`@${user.data.username}`}
+              sub={user.data.preferred_name || user.data.email || undefined}
+              onPress={() =>
+                router.push({
+                  pathname: "/user/[id]",
+                  params: { id: user.data!.id },
+                })
+              }
+            />
+          </View>
+        ) : null}
 
-        <SectionTitle>SETTINGS</SectionTitle>
-        <ListRow
-          minHeight={44}
-          glyph={<Icon.bell color={semantic.mute} />}
-          name={
-            <Text style={{ fontFamily: ty.rowN.fontFamily, fontSize: 14, color: semantic.ink }}>
-              <Hi>Quick</Hi> reply notifications
-            </Text>
-          }
-        />
+        {(messages.data?.length ?? 0) > 0 ? (
+          <View>
+            <SectionTitle>MESSAGES</SectionTitle>
+            {messages.data!.map((m) => (
+              <ListRow
+                key={m.message_id}
+                minHeight={58}
+                glyph={<Avatar label={m.sender_id.slice(0, 2)} size="sm" />}
+                name={m.sender_id}
+                nameStyle={{ fontSize: 13, fontFamily: ty.rowN.fontFamily }}
+                sub={m.snippet || m.content}
+                end={
+                  <Text style={ty.label}>
+                    {new Date(m.sent_at)
+                      .toLocaleDateString(undefined, {
+                        month: "short",
+                        day: "numeric",
+                      })
+                      .toUpperCase()}
+                  </Text>
+                }
+                onPress={() =>
+                  router.push({
+                    pathname: "/chat/[id]",
+                    params: { id: m.conversation_id, kind: "channel" },
+                  })
+                }
+              />
+            ))}
+          </View>
+        ) : null}
       </Body>
 
       <View
@@ -120,7 +207,6 @@ export default function Search() {
           onChangeText={setQ}
           placeholder="Search everything…"
           icon={<Icon.search color={semantic.mute} />}
-          trailing={<Text style={ty.label}>ESC</Text>}
         />
       </View>
     </Screen>

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -85,6 +85,8 @@ export default function RootLayout() {
               <Stack.Screen name="(auth)" />
               <Stack.Screen name="(tabs)" />
               <Stack.Screen name="group/[id]" />
+              <Stack.Screen name="group/new" />
+              <Stack.Screen name="dm/new" />
               <Stack.Screen name="chat/[id]" />
               <Stack.Screen name="self/preferences" />
               <Stack.Screen name="self/user-settings" />

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -89,12 +89,17 @@ export default function RootLayout() {
               <Stack.Screen name="group/invite" />
               <Stack.Screen name="group/members" />
               <Stack.Screen name="group/settings" />
+              <Stack.Screen name="group/requests" />
+              <Stack.Screen name="group/discover" />
               <Stack.Screen name="dm/new" />
+              <Stack.Screen name="dm/info" />
               <Stack.Screen name="chat/[id]" />
               <Stack.Screen name="user/[id]" />
               <Stack.Screen name="self/preferences" />
               <Stack.Screen name="self/user-settings" />
               <Stack.Screen name="self/security" />
+              <Stack.Screen name="self/blocked" />
+              <Stack.Screen name="self/change-email" />
             </Stack>
           </ThemeProvider>
         </QueryClientProvider>

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -87,6 +87,8 @@ export default function RootLayout() {
               <Stack.Screen name="group/[id]" />
               <Stack.Screen name="group/new" />
               <Stack.Screen name="group/invite" />
+              <Stack.Screen name="group/members" />
+              <Stack.Screen name="group/settings" />
               <Stack.Screen name="dm/new" />
               <Stack.Screen name="chat/[id]" />
               <Stack.Screen name="user/[id]" />

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -86,6 +86,7 @@ export default function RootLayout() {
               <Stack.Screen name="(tabs)" />
               <Stack.Screen name="group/[id]" />
               <Stack.Screen name="group/new" />
+              <Stack.Screen name="group/invite" />
               <Stack.Screen name="dm/new" />
               <Stack.Screen name="chat/[id]" />
               <Stack.Screen name="self/preferences" />

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -89,6 +89,7 @@ export default function RootLayout() {
               <Stack.Screen name="group/invite" />
               <Stack.Screen name="dm/new" />
               <Stack.Screen name="chat/[id]" />
+              <Stack.Screen name="user/[id]" />
               <Stack.Screen name="self/preferences" />
               <Stack.Screen name="self/user-settings" />
               <Stack.Screen name="self/security" />

--- a/mobile/app/chat/[id].tsx
+++ b/mobile/app/chat/[id].tsx
@@ -1,19 +1,24 @@
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { View, Text, ScrollView, TextInput, Pressable } from "react-native";
-import { useLocalSearchParams } from "expo-router";
+import { useFocusEffect, useLocalSearchParams } from "expo-router";
 import { Screen, Crumb, Avatar, Ctx, CtxAct } from "../../components/ui";
 import { Icon } from "../../components/icons";
 import { semantic, type as ty, r } from "../../theme/tokens";
-import { useMessages, type Message } from "../../hooks/queries";
+import {
+  useMessages,
+  useSendMessage,
+  useIngestConversation,
+  type ConversationKind,
+  type Message,
+} from "../../hooks/queries";
 import { useAppStore } from "../../stores/appStore";
 
-function dayKey(ts: number | string): string {
-  const d = new Date(typeof ts === "number" ? ts : ts);
-  return d.toDateString();
+function dayKey(ts: number): string {
+  return new Date(ts).toDateString();
 }
 
-function dayLabel(ts: number | string): string {
-  const d = new Date(typeof ts === "number" ? ts : ts);
+function dayLabel(ts: number): string {
+  const d = new Date(ts);
   const today = new Date();
   if (d.toDateString() === today.toDateString()) {
     return "TODAY";
@@ -28,9 +33,11 @@ function dayLabel(ts: number | string): string {
     .toUpperCase();
 }
 
-function timeLabel(ts: number | string): string {
-  const d = new Date(typeof ts === "number" ? ts : ts);
-  return d.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" });
+function timeLabel(ts: number): string {
+  return new Date(ts).toLocaleTimeString(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
 }
 
 function Day({ label }: { label: string }) {
@@ -58,12 +65,14 @@ function Msg({
   name,
   time,
   text,
+  pending,
 }: {
   av: string;
   amber?: boolean;
   name: string;
   time: string;
   text?: string;
+  pending?: boolean;
 }) {
   return (
     <View
@@ -72,6 +81,7 @@ function Msg({
         gap: 12,
         paddingHorizontal: 18,
         paddingVertical: 8,
+        opacity: pending ? 0.55 : 1,
       }}
     >
       <Avatar label={av} variant={amber ? "amber" : "default"} />
@@ -93,7 +103,7 @@ function Msg({
               color: semantic.mute,
             }}
           >
-            {time}
+            {pending ? "sending…" : time}
           </Text>
         </View>
         {text ? (
@@ -115,13 +125,52 @@ function Msg({
 }
 
 export default function TextChat() {
-  const { id } = useLocalSearchParams<{ id: string }>();
-  const conversationId = id ?? null;
-  const [draft, setDraft] = useState("");
-  const currentUser = useAppStore((s) => s.currentUser);
-  const { data: messages = [], isLoading, isError } = useMessages(conversationId);
+  const params = useLocalSearchParams<{ id?: string; kind?: string }>();
+  const conversationId = params.id ?? null;
+  const kind: ConversationKind | null =
+    params.kind === "channel" || params.kind === "dm" ? params.kind : null;
 
-  // Group by day boundary so we render `<Day>` headers between blocks.
+  const [draft, setDraft] = useState("");
+  const scrollRef = useRef<ScrollView>(null);
+  const currentUser = useAppStore((s) => s.currentUser);
+
+  const { data, isLoading, isError } = useMessages(conversationId, kind);
+  const messages = data?.messages ?? [];
+  const sendMessage = useSendMessage(conversationId, kind);
+  const ingest = useIngestConversation();
+
+  // Trigger ingest on screen focus — covers the "returning to a chat after
+  // the app was backgrounded" case where the periodic refetch hasn't fired
+  // yet. The query invalidation inside `useIngestConversation` refreshes
+  // the visible list once new envelopes have been decrypted.
+  useFocusEffect(
+    useCallback(() => {
+      if (conversationId && kind) {
+        void ingest(conversationId, kind);
+      }
+    }, [conversationId, kind, ingest]),
+  );
+
+  // Auto-scroll to bottom whenever the message list grows (new arrival or
+  // optimistic send).
+  useEffect(() => {
+    if (messages.length === 0) {
+      return;
+    }
+    requestAnimationFrame(() => {
+      scrollRef.current?.scrollToEnd({ animated: true });
+    });
+  }, [messages.length]);
+
+  const onSend = () => {
+    const text = draft.trim();
+    if (!text || sendMessage.isPending) {
+      return;
+    }
+    setDraft("");
+    sendMessage.mutate({ content: text });
+  };
+
   const sections = useMemo(() => {
     const out: { label: string; messages: Message[] }[] = [];
     let lastKey = "";
@@ -136,16 +185,17 @@ export default function TextChat() {
     return out;
   }, [messages]);
 
+  const ctxLabel = kind === "dm" ? "DIRECT" : "CHANNEL";
+
   return (
     <Screen>
-      <Crumb
-        segs={[{ label: "CHAT", leaf: true }]}
-      />
+      <Crumb segs={[{ label: ctxLabel, leaf: true }]} />
       <ScrollView
+        ref={scrollRef}
         style={{ flex: 1 }}
         contentContainerStyle={{ paddingVertical: 4 }}
       >
-        {isLoading ? (
+        {isLoading && messages.length === 0 ? (
           <Text
             style={{
               fontFamily: ty.body.fontFamily,
@@ -198,15 +248,30 @@ export default function TextChat() {
                   name={name}
                   time={timeLabel(m.created_at)}
                   text={m.content}
+                  pending={m.pending}
                 />
               );
             })}
           </View>
         ))}
+        {sendMessage.isError ? (
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 12,
+              color: semantic.danger,
+              paddingHorizontal: 18,
+              paddingTop: 8,
+              paddingBottom: 4,
+            }}
+          >
+            {(sendMessage.error as Error).message || "Couldn't send message."}
+          </Text>
+        ) : null}
       </ScrollView>
 
       <Ctx
-        cr="CHAT"
+        cr={ctxLabel}
         name={
           <View style={{ flexDirection: "row", alignItems: "center", gap: 6 }}>
             <Icon.hash color={semantic.ink} />
@@ -257,6 +322,9 @@ export default function TextChat() {
           onChangeText={setDraft}
           placeholder="Type a message…"
           placeholderTextColor={semantic.mute}
+          onSubmitEditing={onSend}
+          returnKeyType="send"
+          editable={!!kind && !!conversationId}
           style={{
             flex: 1,
             borderWidth: 1,
@@ -271,7 +339,8 @@ export default function TextChat() {
           }}
         />
         <Pressable
-          onPress={() => setDraft("")}
+          onPress={onSend}
+          disabled={!draft.trim() || sendMessage.isPending}
           style={{
             width: 38,
             height: 38,
@@ -279,6 +348,7 @@ export default function TextChat() {
             justifyContent: "center",
             backgroundColor: semantic.accent,
             borderRadius: r.sm,
+            opacity: !draft.trim() || sendMessage.isPending ? 0.4 : 1,
           }}
         >
           <Icon.send color="#0a0907" />

--- a/mobile/app/chat/[id].tsx
+++ b/mobile/app/chat/[id].tsx
@@ -335,7 +335,20 @@ export default function TextChat() {
         actions={
           <>
             <CtxAct icon={<Icon.people color={semantic.ink2} />} />
-            <CtxAct icon={<Icon.kebab color={semantic.ink2} />} />
+            <CtxAct
+              icon={<Icon.kebab color={semantic.ink2} />}
+              onPress={() => {
+                if (!conversationId) {
+                  return;
+                }
+                if (kind === "dm") {
+                  router.push({
+                    pathname: "/dm/info",
+                    params: { id: conversationId },
+                  });
+                }
+              }}
+            />
           </>
         }
       />

--- a/mobile/app/chat/[id].tsx
+++ b/mobile/app/chat/[id].tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { View, Text, ScrollView, TextInput, Pressable } from "react-native";
-import { useFocusEffect, useLocalSearchParams } from "expo-router";
+import { useFocusEffect, useLocalSearchParams, useRouter } from "expo-router";
 import { Screen, Crumb, Avatar, Ctx, CtxAct } from "../../components/ui";
 import { Icon } from "../../components/icons";
 import { semantic, type as ty, r } from "../../theme/tokens";
@@ -66,6 +66,7 @@ function Msg({
   time,
   text,
   pending,
+  onPressAvatar,
 }: {
   av: string;
   amber?: boolean;
@@ -73,6 +74,7 @@ function Msg({
   time: string;
   text?: string;
   pending?: boolean;
+  onPressAvatar?: () => void;
 }) {
   return (
     <View
@@ -84,7 +86,9 @@ function Msg({
         opacity: pending ? 0.55 : 1,
       }}
     >
-      <Avatar label={av} variant={amber ? "amber" : "default"} />
+      <Pressable onPress={onPressAvatar} disabled={!onPressAvatar}>
+        <Avatar label={av} variant={amber ? "amber" : "default"} />
+      </Pressable>
       <View style={{ flex: 1 }}>
         <View style={{ flexDirection: "row", alignItems: "baseline", gap: 8 }}>
           <Text
@@ -125,6 +129,7 @@ function Msg({
 }
 
 export default function TextChat() {
+  const router = useRouter();
   const params = useLocalSearchParams<{ id?: string; kind?: string }>();
   const conversationId = params.id ?? null;
   const kind: ConversationKind | null =
@@ -249,6 +254,15 @@ export default function TextChat() {
                   time={timeLabel(m.created_at)}
                   text={m.content}
                   pending={m.pending}
+                  onPressAvatar={
+                    mine
+                      ? undefined
+                      : () =>
+                          router.push({
+                            pathname: "/user/[id]",
+                            params: { id: m.sender_id },
+                          })
+                  }
                 />
               );
             })}

--- a/mobile/app/chat/[id].tsx
+++ b/mobile/app/chat/[id].tsx
@@ -3,15 +3,20 @@ import { View, Text, ScrollView, TextInput, Pressable } from "react-native";
 import { useFocusEffect, useLocalSearchParams, useRouter } from "expo-router";
 import { Screen, Crumb, Avatar, Ctx, CtxAct } from "../../components/ui";
 import { Icon } from "../../components/icons";
-import { semantic, type as ty, r } from "../../theme/tokens";
+import { semantic, type as ty, fonts, r } from "../../theme/tokens";
 import {
   useMessages,
   useSendMessage,
   useIngestConversation,
+  useToggleReaction,
+  useEditMessage,
+  useDeleteMessage,
   type ConversationKind,
   type Message,
 } from "../../hooks/queries";
 import { useAppStore } from "../../stores/appStore";
+
+const QUICK_EMOJI = ["👍", "❤️", "😂", "🎉", "🔥", "🙏"];
 
 function dayKey(ts: number): string {
   return new Date(ts).toDateString();
@@ -66,7 +71,9 @@ function Msg({
   time,
   text,
   pending,
+  edited,
   onPressAvatar,
+  onLongPress,
 }: {
   av: string;
   amber?: boolean;
@@ -74,10 +81,14 @@ function Msg({
   time: string;
   text?: string;
   pending?: boolean;
+  edited?: boolean;
   onPressAvatar?: () => void;
+  onLongPress?: () => void;
 }) {
   return (
-    <View
+    <Pressable
+      onLongPress={onLongPress}
+      delayLongPress={350}
       style={{
         flexDirection: "row",
         gap: 12,
@@ -121,10 +132,21 @@ function Msg({
             }}
           >
             {text}
+            {edited ? (
+              <Text
+                style={{
+                  fontFamily: ty.body.fontFamily,
+                  fontSize: 11,
+                  color: semantic.mute,
+                }}
+              >
+                {"  (edited)"}
+              </Text>
+            ) : null}
           </Text>
         ) : null}
       </View>
-    </View>
+    </Pressable>
   );
 }
 
@@ -136,6 +158,9 @@ export default function TextChat() {
     params.kind === "channel" || params.kind === "dm" ? params.kind : null;
 
   const [draft, setDraft] = useState("");
+  const [actionTarget, setActionTarget] = useState<Message | null>(null);
+  const [editTarget, setEditTarget] = useState<Message | null>(null);
+  const [editDraft, setEditDraft] = useState("");
   const scrollRef = useRef<ScrollView>(null);
   const currentUser = useAppStore((s) => s.currentUser);
 
@@ -143,6 +168,9 @@ export default function TextChat() {
   const messages = data?.messages ?? [];
   const sendMessage = useSendMessage(conversationId, kind);
   const ingest = useIngestConversation();
+  const toggleReaction = useToggleReaction(conversationId, kind);
+  const editMessage = useEditMessage(conversationId, kind);
+  const deleteMessage = useDeleteMessage(conversationId, kind);
 
   // Trigger ingest on screen focus — covers the "returning to a chat after
   // the app was backgrounded" case where the periodic refetch hasn't fired
@@ -254,6 +282,7 @@ export default function TextChat() {
                   time={timeLabel(m.created_at)}
                   text={m.content}
                   pending={m.pending}
+                  edited={!!m.edited_at}
                   onPressAvatar={
                     mine
                       ? undefined
@@ -262,6 +291,9 @@ export default function TextChat() {
                             pathname: "/user/[id]",
                             params: { id: m.sender_id },
                           })
+                  }
+                  onLongPress={
+                    m.pending ? undefined : () => setActionTarget(m)
                   }
                 />
               );
@@ -307,67 +339,307 @@ export default function TextChat() {
           </>
         }
       />
-      <View
-        style={{
-          flexDirection: "row",
-          alignItems: "center",
-          gap: 10,
-          paddingVertical: 10,
-          paddingHorizontal: 12,
-          borderTopWidth: 1,
-          borderTopColor: semantic.hairSoft,
-        }}
-      >
-        <Pressable
+      {editTarget ? (
+        <View
           style={{
-            width: 38,
-            height: 38,
+            flexDirection: "row",
             alignItems: "center",
-            justifyContent: "center",
-            borderWidth: 1,
-            borderColor: semantic.hairStrong,
-            borderRadius: r.sm,
-          }}
-        >
-          <Icon.plus color={semantic.ink} />
-        </Pressable>
-        <TextInput
-          value={draft}
-          onChangeText={setDraft}
-          placeholder="Type a message…"
-          placeholderTextColor={semantic.mute}
-          onSubmitEditing={onSend}
-          returnKeyType="send"
-          editable={!!kind && !!conversationId}
-          style={{
-            flex: 1,
-            borderWidth: 1,
-            borderColor: semantic.hairStrong,
-            borderRadius: r.sm,
+            gap: 10,
             paddingVertical: 10,
             paddingHorizontal: 12,
-            fontFamily: ty.body.fontFamily,
-            fontSize: 14,
-            color: semantic.ink,
-            backgroundColor: semantic.fieldBg,
-          }}
-        />
-        <Pressable
-          onPress={onSend}
-          disabled={!draft.trim() || sendMessage.isPending}
-          style={{
-            width: 38,
-            height: 38,
-            alignItems: "center",
-            justifyContent: "center",
-            backgroundColor: semantic.accent,
-            borderRadius: r.sm,
-            opacity: !draft.trim() || sendMessage.isPending ? 0.4 : 1,
+            borderTopWidth: 1,
+            borderTopColor: semantic.accent,
+            backgroundColor: semantic.accentSoft,
           }}
         >
-          <Icon.send color="#0a0907" />
+          <Pressable
+            onPress={() => {
+              setEditTarget(null);
+              setEditDraft("");
+            }}
+            style={{
+              width: 38,
+              height: 38,
+              alignItems: "center",
+              justifyContent: "center",
+              borderWidth: 1,
+              borderColor: semantic.hairStrong,
+              borderRadius: r.sm,
+            }}
+          >
+            <Icon.exit color={semantic.ink} />
+          </Pressable>
+          <TextInput
+            value={editDraft}
+            onChangeText={setEditDraft}
+            autoFocus
+            placeholder="Edit message…"
+            placeholderTextColor={semantic.mute}
+            onSubmitEditing={() => {
+              const text = editDraft.trim();
+              if (!text || !editTarget) {
+                return;
+              }
+              editMessage.mutate(
+                { messageId: editTarget.id, newContent: text },
+                {
+                  onSuccess: () => {
+                    setEditTarget(null);
+                    setEditDraft("");
+                  },
+                },
+              );
+            }}
+            returnKeyType="send"
+            style={{
+              flex: 1,
+              borderWidth: 1,
+              borderColor: semantic.accent,
+              borderRadius: r.sm,
+              paddingVertical: 10,
+              paddingHorizontal: 12,
+              fontFamily: ty.body.fontFamily,
+              fontSize: 14,
+              color: semantic.ink,
+              backgroundColor: semantic.fieldBg,
+            }}
+          />
+          <Pressable
+            onPress={() => {
+              const text = editDraft.trim();
+              if (!text || !editTarget) {
+                return;
+              }
+              editMessage.mutate(
+                { messageId: editTarget.id, newContent: text },
+                {
+                  onSuccess: () => {
+                    setEditTarget(null);
+                    setEditDraft("");
+                  },
+                },
+              );
+            }}
+            disabled={!editDraft.trim() || editMessage.isPending}
+            style={{
+              width: 38,
+              height: 38,
+              alignItems: "center",
+              justifyContent: "center",
+              backgroundColor: semantic.accent,
+              borderRadius: r.sm,
+              opacity:
+                !editDraft.trim() || editMessage.isPending ? 0.4 : 1,
+            }}
+          >
+            <Icon.check color="#0a0907" />
+          </Pressable>
+        </View>
+      ) : (
+        <View
+          style={{
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 10,
+            paddingVertical: 10,
+            paddingHorizontal: 12,
+            borderTopWidth: 1,
+            borderTopColor: semantic.hairSoft,
+          }}
+        >
+          <Pressable
+            style={{
+              width: 38,
+              height: 38,
+              alignItems: "center",
+              justifyContent: "center",
+              borderWidth: 1,
+              borderColor: semantic.hairStrong,
+              borderRadius: r.sm,
+            }}
+          >
+            <Icon.plus color={semantic.ink} />
+          </Pressable>
+          <TextInput
+            value={draft}
+            onChangeText={setDraft}
+            placeholder="Type a message…"
+            placeholderTextColor={semantic.mute}
+            onSubmitEditing={onSend}
+            returnKeyType="send"
+            editable={!!kind && !!conversationId}
+            style={{
+              flex: 1,
+              borderWidth: 1,
+              borderColor: semantic.hairStrong,
+              borderRadius: r.sm,
+              paddingVertical: 10,
+              paddingHorizontal: 12,
+              fontFamily: ty.body.fontFamily,
+              fontSize: 14,
+              color: semantic.ink,
+              backgroundColor: semantic.fieldBg,
+            }}
+          />
+          <Pressable
+            onPress={onSend}
+            disabled={!draft.trim() || sendMessage.isPending}
+            style={{
+              width: 38,
+              height: 38,
+              alignItems: "center",
+              justifyContent: "center",
+              backgroundColor: semantic.accent,
+              borderRadius: r.sm,
+              opacity: !draft.trim() || sendMessage.isPending ? 0.4 : 1,
+            }}
+          >
+            <Icon.send color="#0a0907" />
+          </Pressable>
+        </View>
+      )}
+
+      {actionTarget ? (
+        <Pressable
+          onPress={() => setActionTarget(null)}
+          style={{
+            position: "absolute",
+            top: 0,
+            bottom: 0,
+            left: 0,
+            right: 0,
+            backgroundColor: "rgba(0,0,0,0.55)",
+            justifyContent: "flex-end",
+          }}
+        >
+          <Pressable
+            onPress={(e) => e.stopPropagation()}
+            style={{
+              backgroundColor: semantic.cardBg,
+              borderTopWidth: 1,
+              borderTopColor: semantic.hair,
+              paddingHorizontal: 18,
+              paddingTop: 14,
+              paddingBottom: 30,
+              gap: 10,
+            }}
+          >
+            <View
+              style={{
+                flexDirection: "row",
+                justifyContent: "space-between",
+                gap: 8,
+                paddingVertical: 6,
+              }}
+            >
+              {QUICK_EMOJI.map((emoji) => (
+                <Pressable
+                  key={emoji}
+                  onPress={() => {
+                    if (!actionTarget) {
+                      return;
+                    }
+                    toggleReaction.mutate({
+                      messageId: actionTarget.id,
+                      emoji,
+                      mode: "add",
+                    });
+                    setActionTarget(null);
+                  }}
+                  style={{
+                    width: 44,
+                    height: 44,
+                    alignItems: "center",
+                    justifyContent: "center",
+                    borderWidth: 1,
+                    borderColor: semantic.hair,
+                    borderRadius: r.sm,
+                  }}
+                >
+                  <Text style={{ fontSize: 22 }}>{emoji}</Text>
+                </Pressable>
+              ))}
+            </View>
+
+            {actionTarget.sender_id === currentUser?.id ? (
+              <>
+                <Pressable
+                  onPress={() => {
+                    setEditTarget(actionTarget);
+                    setEditDraft(actionTarget.content);
+                    setActionTarget(null);
+                  }}
+                  style={{
+                    paddingVertical: 14,
+                    paddingHorizontal: 12,
+                    borderWidth: 1,
+                    borderColor: semantic.hairStrong,
+                    borderRadius: r.sm,
+                    flexDirection: "row",
+                    alignItems: "center",
+                    gap: 10,
+                  }}
+                >
+                  <Icon.edit color={semantic.ink} />
+                  <Text
+                    style={{
+                      fontFamily: ty.body.fontFamily,
+                      fontSize: 14,
+                      color: semantic.ink,
+                    }}
+                  >
+                    Edit message
+                  </Text>
+                </Pressable>
+                <Pressable
+                  onPress={() => {
+                    if (!actionTarget) {
+                      return;
+                    }
+                    deleteMessage.mutate(actionTarget.id);
+                    setActionTarget(null);
+                  }}
+                  style={{
+                    paddingVertical: 14,
+                    paddingHorizontal: 12,
+                    borderWidth: 1,
+                    borderColor: "rgba(196,106,46,0.4)",
+                    borderRadius: r.sm,
+                    flexDirection: "row",
+                    alignItems: "center",
+                    gap: 10,
+                  }}
+                >
+                  <Icon.exit color={semantic.danger} />
+                  <Text
+                    style={{
+                      fontFamily: ty.body.fontFamily,
+                      fontSize: 14,
+                      color: semantic.danger,
+                    }}
+                  >
+                    Delete message
+                  </Text>
+                </Pressable>
+              </>
+            ) : null}
+
+            <Pressable
+              onPress={() => setActionTarget(null)}
+              style={{
+                paddingVertical: 14,
+                alignItems: "center",
+              }}
+            >
+              <Text
+                style={[ty.label, { color: semantic.mute }]}
+              >
+                CANCEL
+              </Text>
+            </Pressable>
+          </Pressable>
         </Pressable>
-      </View>
+      ) : null}
     </Screen>
   );
 }

--- a/mobile/app/dm/info.tsx
+++ b/mobile/app/dm/info.tsx
@@ -1,0 +1,157 @@
+import { useState } from "react";
+import { View, Text } from "react-native";
+import { useRouter, useLocalSearchParams } from "expo-router";
+import {
+  Screen,
+  Crumb,
+  Body,
+  SectionTitle,
+  ListRow,
+  Avatar,
+  Button,
+  BottomAction,
+  Ctx,
+} from "../../components/ui";
+import { Icon } from "../../components/icons";
+import { semantic, type as ty } from "../../theme/tokens";
+import { useQuery } from "@tanstack/react-query";
+import { invoke } from "../../lib/native";
+import { useLeaveDM } from "../../hooks/queries";
+import { useAppStore } from "../../stores/appStore";
+
+interface DmMember {
+  user_id: string;
+  username?: string;
+  avatar_url?: string;
+}
+
+interface DmChannel {
+  id: string;
+  created_by: string;
+  created_at: string;
+  members: DmMember[];
+}
+
+export default function DMInfo() {
+  const router = useRouter();
+  const { id } = useLocalSearchParams<{ id?: string }>();
+  const channelId = id ?? null;
+  const currentUser = useAppStore((s) => s.currentUser);
+  const [confirmLeave, setConfirmLeave] = useState(false);
+
+  const channel = useQuery({
+    queryKey: ["dm", "channel", channelId],
+    queryFn: async (): Promise<DmChannel | null> => {
+      if (!channelId) {
+        return null;
+      }
+      return await invoke<DmChannel>("get_dm_channel", {
+        dmChannelId: channelId,
+      });
+    },
+    enabled: !!channelId,
+    staleTime: 1000 * 60,
+  });
+
+  const leave = useLeaveDM();
+
+  const onLeave = () => {
+    if (!confirmLeave) {
+      setConfirmLeave(true);
+      return;
+    }
+    if (!channelId) {
+      return;
+    }
+    leave.mutate(channelId, {
+      onSuccess: () => router.replace("/(tabs)/direct"),
+    });
+  };
+
+  const members = channel.data?.members ?? [];
+
+  return (
+    <Screen>
+      <Crumb segs={[{ label: "DIRECT" }, { label: "Info", leaf: true }]} />
+      <Body>
+        <SectionTitle>PARTICIPANTS</SectionTitle>
+        {channel.isLoading ? (
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 13,
+              color: semantic.mute,
+              paddingHorizontal: 18,
+              paddingVertical: 8,
+            }}
+          >
+            Loading…
+          </Text>
+        ) : null}
+        {members.map((m) => {
+          const isMe = m.user_id === currentUser?.id;
+          const handle = m.username ?? m.user_id.slice(0, 8);
+          return (
+            <ListRow
+              key={m.user_id}
+              minHeight={54}
+              glyph={<Avatar label={handle.slice(0, 2)} />}
+              name={`@${handle}${isMe ? " · you" : ""}`}
+              nameStyle={{ fontSize: 14 }}
+              onPress={
+                isMe
+                  ? undefined
+                  : () =>
+                      router.push({
+                        pathname: "/user/[id]",
+                        params: { id: m.user_id },
+                      })
+              }
+              end={!isMe ? <Icon.fwd color={semantic.mute} /> : undefined}
+            />
+          );
+        })}
+
+        <SectionTitle>DANGER</SectionTitle>
+        <View style={{ paddingHorizontal: 18 }}>
+          <Button
+            full
+            variant="danger"
+            icon={<Icon.exit color={semantic.danger} />}
+            onPress={onLeave}
+            disabled={leave.isPending || !channelId}
+          >
+            {leave.isPending
+              ? "LEAVING…"
+              : confirmLeave
+                ? "TAP AGAIN TO CONFIRM"
+                : "LEAVE CONVERSATION"}
+          </Button>
+          {leave.isError ? (
+            <Text
+              style={{
+                fontFamily: ty.body.fontFamily,
+                fontSize: 12,
+                color: semantic.danger,
+                paddingTop: 6,
+              }}
+            >
+              {(leave.error as Error).message || "Couldn't leave."}
+            </Text>
+          ) : null}
+        </View>
+      </Body>
+      <Ctx cr="DIRECT" name="Info" />
+      <BottomAction>
+        <Button
+          full
+          variant="subtle"
+          onPress={() => router.back()}
+          icon={<Icon.back color={semantic.ink} />}
+        >
+          Back to conversation
+        </Button>
+      </BottomAction>
+    </Screen>
+  );
+}

--- a/mobile/app/dm/new.tsx
+++ b/mobile/app/dm/new.tsx
@@ -1,0 +1,174 @@
+import { useState } from "react";
+import { View, Text, Pressable } from "react-native";
+import { useRouter } from "expo-router";
+import {
+  Screen,
+  Crumb,
+  Body,
+  Field,
+  ListRow,
+  Avatar,
+  Ctx,
+  CtxAct,
+} from "../../components/ui";
+import { Icon } from "../../components/icons";
+import { semantic, type as ty } from "../../theme/tokens";
+import { useUserSearch, useCreateDM } from "../../hooks/queries";
+
+export default function NewDM() {
+  const router = useRouter();
+  const [query, setQuery] = useState("");
+  const search = useUserSearch(query);
+  const createDM = useCreateDM();
+
+  const onStartDM = (userId: string) => {
+    createDM.mutate(
+      { memberIds: [userId] },
+      {
+        onSuccess: (channel) => {
+          router.replace({
+            pathname: "/chat/[id]",
+            params: { id: channel.id, kind: "dm" },
+          });
+        },
+      },
+    );
+  };
+
+  const found = search.data;
+  const showEmpty =
+    !search.isLoading && !search.isError && query.trim().length >= 2 && !found;
+
+  return (
+    <Screen>
+      <Crumb
+        segs={[{ label: "DIRECT" }, { label: "New", leaf: true }]}
+      />
+      <Body>
+        <View style={{ paddingHorizontal: 18, paddingTop: 12, gap: 8 }}>
+          <Text style={ty.label}>USERNAME OR EMAIL</Text>
+          <Field
+            amber
+            value={query}
+            onChangeText={setQuery}
+            icon={<Icon.search color={semantic.mute} />}
+          />
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 11,
+              color: semantic.mute,
+            }}
+          >
+            Type at least two characters. Exact match only — Pollis doesn't
+            broadcast partial matches.
+          </Text>
+        </View>
+
+        <View style={{ paddingTop: 8 }}>
+          {search.isLoading && query.trim().length >= 2 ? (
+            <Text
+              style={{
+                fontFamily: ty.body.fontFamily,
+                fontSize: 13,
+                color: semantic.mute,
+                paddingHorizontal: 18,
+                paddingVertical: 12,
+              }}
+            >
+              Searching…
+            </Text>
+          ) : null}
+          {search.isError ? (
+            <Text
+              style={{
+                fontFamily: ty.body.fontFamily,
+                fontSize: 13,
+                color: semantic.danger,
+                paddingHorizontal: 18,
+                paddingVertical: 12,
+              }}
+            >
+              Search failed.
+            </Text>
+          ) : null}
+          {showEmpty ? (
+            <Text
+              style={{
+                fontFamily: ty.body.fontFamily,
+                fontSize: 13,
+                color: semantic.mute,
+                paddingHorizontal: 18,
+                paddingVertical: 12,
+              }}
+            >
+              No user found.
+            </Text>
+          ) : null}
+          {found ? (
+            <ListRow
+              minHeight={64}
+              glyph={
+                <Avatar
+                  label={(found.username || found.email || "us").slice(0, 2)}
+                />
+              }
+              name={
+                <Text
+                  style={{
+                    fontFamily: ty.rowN.fontFamily,
+                    fontSize: 15,
+                    color: semantic.ink,
+                  }}
+                >
+                  @{found.username}
+                </Text>
+              }
+              sub={
+                found.preferred_name || found.email || undefined
+              }
+              onPress={() => onStartDM(found.id)}
+              end={<Icon.fwd color={semantic.mute} />}
+            />
+          ) : null}
+          {createDM.isError ? (
+            <Text
+              style={{
+                fontFamily: ty.body.fontFamily,
+                fontSize: 12,
+                color: semantic.danger,
+                paddingHorizontal: 18,
+                paddingTop: 8,
+              }}
+            >
+              {(createDM.error as Error).message ||
+                "Couldn't open a DM with this user."}
+            </Text>
+          ) : null}
+        </View>
+      </Body>
+      <Ctx
+        cr="DIRECT"
+        name={
+          <Pressable onPress={() => router.back()}>
+            <Text
+              style={{
+                fontFamily: ty.rowN.fontFamily,
+                fontSize: 13,
+                color: semantic.ink,
+              }}
+            >
+              ← Back to inbox
+            </Text>
+          </Pressable>
+        }
+        actions={
+          <CtxAct
+            icon={<Icon.exit color={semantic.ink2} />}
+            onPress={() => router.back()}
+          />
+        }
+      />
+    </Screen>
+  );
+}

--- a/mobile/app/group/[id].tsx
+++ b/mobile/app/group/[id].tsx
@@ -1,5 +1,5 @@
 import { View, Text } from "react-native";
-import { useRouter } from "expo-router";
+import { useRouter, useLocalSearchParams } from "expo-router";
 import {
   Screen,
   Crumb,
@@ -7,29 +7,58 @@ import {
   SectionTitle,
   ListRow,
   Avatar,
-  Badge,
   Chip,
   Ctx,
   CtxAct,
 } from "../../components/ui";
 import { Icon } from "../../components/icons";
 import { semantic, type as ty } from "../../theme/tokens";
+import {
+  useGroupChannels,
+  useUserGroupsWithChannels,
+  useGroupMembers,
+  useLeaveGroup,
+} from "../../hooks/queries";
+import { useAppStore } from "../../stores/appStore";
 
 export default function GroupDetail() {
   const router = useRouter();
-  // Built per-render so glyph colors track the live accent.
-  const ADMIN = [
-    { g: <Icon.people color={semantic.mute} />, n: "Members", s: "3 · 1 admin" },
-    { g: <Icon.at color={semantic.mute} />, n: "Invite a member" },
-    { g: <Icon.plus color={semantic.mute} />, n: "New channel" },
-    { g: <Icon.inbox color={semantic.mute} />, n: "Join requests", badge: "2" },
-    { g: <Icon.edit color={semantic.mute} />, n: "Rename group" },
-  ];
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const groupId = id ?? null;
+
+  // Reuse the cached groups list to find the group's metadata without
+  // hitting Turso again. Falls back to "Group" when the cache hasn't
+  // hydrated yet (deep-link / fresh launch).
+  const { data: groups = [] } = useUserGroupsWithChannels();
+  const group = groups.find((g) => g.id === groupId);
+
+  const { data: channels = [], isLoading: channelsLoading } =
+    useGroupChannels(groupId);
+  const { data: members = [] } = useGroupMembers(groupId);
+  const leaveGroup = useLeaveGroup();
+
+  const setSelectedGroupId = useAppStore((s) => s.setSelectedGroupId);
+  const setSelectedChannelId = useAppStore((s) => s.setSelectedChannelId);
+
+  const groupName = group?.name ?? "Group";
+  const adminCount = members.filter(
+    (m) => m.role === "admin" || m.role === "owner",
+  ).length;
+
+  const onLeave = () => {
+    if (!groupId) {
+      return;
+    }
+    leaveGroup.mutate(groupId, {
+      onSuccess: () => router.replace("/(tabs)/groups"),
+    });
+  };
+
   return (
     <Screen>
       <Crumb
-        segs={[{ label: "GROUPS" }, { label: "Quick Group", leaf: true }]}
-        end="3 MEMBERS"
+        segs={[{ label: "GROUPS" }, { label: groupName, leaf: true }]}
+        end={`${members.length || 0} MEMBERS`}
       />
       <Body>
         <View
@@ -43,9 +72,15 @@ export default function GroupDetail() {
           }}
         >
           <View style={{ flexDirection: "row" }}>
-            <Avatar label="dn" size="sm" variant="amber" style={{ marginRight: -8 }} />
-            <Avatar label="br" size="sm" style={{ marginRight: -8 }} />
-            <Avatar label="me" size="sm" />
+            {members.slice(0, 3).map((m, i) => (
+              <Avatar
+                key={m.user_id}
+                label={(m.username || m.user_id || "us").slice(0, 2)}
+                size="sm"
+                variant={i === 0 ? "amber" : "default"}
+                style={{ marginRight: i < 2 ? -8 : 0 }}
+              />
+            ))}
           </View>
           <Text
             style={{
@@ -55,62 +90,100 @@ export default function GroupDetail() {
               color: semantic.mute,
             }}
           >
-            dan, brian, meilan.solly
+            {members
+              .slice(0, 3)
+              .map((m) => m.username || m.user_id.slice(0, 6))
+              .join(", ")}
+            {members.length > 3 ? ` +${members.length - 3}` : ""}
           </Text>
-          <Chip>View all</Chip>
         </View>
 
         <SectionTitle>TEXT CHANNELS</SectionTitle>
-        <ListRow
-          selected
-          minHeight={54}
-          glyph={<Icon.hash color={semantic.accent} />}
-          name="General"
-          sub="dan: frick its been a minute"
-          onPress={() => router.push("/chat/quick-general")}
-          end={<Badge>2</Badge>}
-        />
-        <ListRow
-          minHeight={54}
-          glyph={<Icon.hash color={semantic.mute} />}
-          name="Random"
-          sub="No new messages"
-          onPress={() => router.push("/chat/quick-random")}
-        />
-
-        <SectionTitle>ADMIN</SectionTitle>
-        {ADMIN.map((rw, i) => (
+        {channelsLoading && channels.length === 0 ? (
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 13,
+              color: semantic.mute,
+              paddingHorizontal: 18,
+              paddingVertical: 8,
+            }}
+          >
+            Loading channels…
+          </Text>
+        ) : null}
+        {channels.map((c) => (
           <ListRow
-            key={i}
-            minHeight={48}
-            glyph={rw.g}
-            name={rw.n}
-            nameStyle={{ fontSize: 14, fontFamily: ty.body.fontFamily }}
-            end={
-              <>
-                {rw.badge ? <Badge>{rw.badge}</Badge> : null}
-                <Icon.fwd color={semantic.mute} />
-              </>
-            }
+            key={c.id}
+            minHeight={54}
+            glyph={<Icon.hash color={semantic.mute} />}
+            name={c.name}
+            sub={c.description ?? undefined}
+            onPress={() => {
+              setSelectedGroupId(groupId);
+              setSelectedChannelId(c.id);
+              router.push({
+                pathname: "/chat/[id]",
+                params: { id: c.id, kind: "channel" },
+              });
+            }}
           />
         ))}
+
+        <SectionTitle>ADMIN</SectionTitle>
+        <ListRow
+          minHeight={48}
+          glyph={<Icon.people color={semantic.mute} />}
+          name="Members"
+          nameStyle={{ fontSize: 14, fontFamily: ty.body.fontFamily }}
+          sub={`${members.length}${adminCount ? ` · ${adminCount} admin` : ""}`}
+          end={<Icon.fwd color={semantic.mute} />}
+        />
+        <ListRow
+          minHeight={48}
+          glyph={<Icon.at color={semantic.mute} />}
+          name="Invite a member"
+          nameStyle={{ fontSize: 14, fontFamily: ty.body.fontFamily }}
+          onPress={() =>
+            groupId &&
+            router.push({
+              pathname: "/group/invite",
+              params: { groupId },
+            })
+          }
+          end={<Icon.fwd color={semantic.mute} />}
+        />
 
         <SectionTitle>DANGER</SectionTitle>
         <ListRow
           minHeight={48}
           glyph={<Icon.exit color={semantic.danger} />}
-          name="Leave group"
+          name={leaveGroup.isPending ? "Leaving…" : "Leave group"}
           nameStyle={{
             fontSize: 14,
             fontFamily: ty.body.fontFamily,
             color: semantic.danger,
           }}
+          onPress={onLeave}
         />
+        {leaveGroup.isError ? (
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 12,
+              color: semantic.danger,
+              paddingHorizontal: 18,
+              paddingTop: 6,
+            }}
+          >
+            {(leaveGroup.error as Error).message || "Couldn't leave the group."}
+          </Text>
+        ) : null}
       </Body>
 
       <Ctx
         cr="GROUPS"
-        name="Quick Group"
+        name={groupName}
         actions={<CtxAct icon={<Icon.kebab color={semantic.ink2} />} />}
       />
     </Screen>

--- a/mobile/app/group/[id].tsx
+++ b/mobile/app/group/[id].tsx
@@ -137,6 +137,13 @@ export default function GroupDetail() {
           name="Members"
           nameStyle={{ fontSize: 14, fontFamily: ty.body.fontFamily }}
           sub={`${members.length}${adminCount ? ` · ${adminCount} admin` : ""}`}
+          onPress={() =>
+            groupId &&
+            router.push({
+              pathname: "/group/members",
+              params: { groupId },
+            })
+          }
           end={<Icon.fwd color={semantic.mute} />}
         />
         <ListRow
@@ -148,6 +155,21 @@ export default function GroupDetail() {
             groupId &&
             router.push({
               pathname: "/group/invite",
+              params: { groupId },
+            })
+          }
+          end={<Icon.fwd color={semantic.mute} />}
+        />
+        <ListRow
+          minHeight={48}
+          glyph={<Icon.gear color={semantic.mute} />}
+          name="Settings"
+          nameStyle={{ fontSize: 14, fontFamily: ty.body.fontFamily }}
+          sub="Rename, channels, danger zone"
+          onPress={() =>
+            groupId &&
+            router.push({
+              pathname: "/group/settings",
               params: { groupId },
             })
           }

--- a/mobile/app/group/[id].tsx
+++ b/mobile/app/group/[id].tsx
@@ -18,6 +18,7 @@ import {
   useUserGroupsWithChannels,
   useGroupMembers,
   useLeaveGroup,
+  useGroupJoinRequests,
 } from "../../hooks/queries";
 import { useAppStore } from "../../stores/appStore";
 
@@ -35,6 +36,7 @@ export default function GroupDetail() {
   const { data: channels = [], isLoading: channelsLoading } =
     useGroupChannels(groupId);
   const { data: members = [] } = useGroupMembers(groupId);
+  const { data: joinRequests = [] } = useGroupJoinRequests(groupId);
   const leaveGroup = useLeaveGroup();
 
   const setSelectedGroupId = useAppStore((s) => s.setSelectedGroupId);
@@ -175,6 +177,23 @@ export default function GroupDetail() {
           }
           end={<Icon.fwd color={semantic.mute} />}
         />
+        {joinRequests.length > 0 ? (
+          <ListRow
+            minHeight={48}
+            glyph={<Icon.inbox color={semantic.mute} />}
+            name="Join requests"
+            nameStyle={{ fontSize: 14, fontFamily: ty.body.fontFamily }}
+            sub={`${joinRequests.length} pending`}
+            onPress={() =>
+              groupId &&
+              router.push({
+                pathname: "/group/requests",
+                params: { groupId },
+              })
+            }
+            end={<Icon.fwd color={semantic.mute} />}
+          />
+        ) : null}
 
         <SectionTitle>DANGER</SectionTitle>
         <ListRow

--- a/mobile/app/group/discover.tsx
+++ b/mobile/app/group/discover.tsx
@@ -1,0 +1,150 @@
+import { useState } from "react";
+import { View, Text } from "react-native";
+import { useRouter } from "expo-router";
+import {
+  Screen,
+  Crumb,
+  Body,
+  Field,
+  Button,
+  BottomAction,
+  Card,
+  Ctx,
+} from "../../components/ui";
+import { Icon } from "../../components/icons";
+import { semantic, type as ty } from "../../theme/tokens";
+import { useGroupBySlug, useRequestGroupAccess, useMyJoinRequest } from "../../hooks/queries";
+
+export default function Discover() {
+  const router = useRouter();
+  const [slug, setSlug] = useState("");
+  const search = useGroupBySlug(slug.trim().replace(/^#/, ""));
+  const requestAccess = useRequestGroupAccess();
+  const myRequest = useMyJoinRequest(search.data?.id ?? null);
+
+  const onRequest = () => {
+    if (!search.data) {
+      return;
+    }
+    requestAccess.mutate(search.data.id);
+  };
+
+  const status = myRequest.data?.status;
+
+  return (
+    <Screen>
+      <Crumb segs={[{ label: "GROUPS" }, { label: "Discover", leaf: true }]} />
+      <Body>
+        <View style={{ paddingHorizontal: 18, paddingTop: 12, gap: 8 }}>
+          <Text style={ty.label}>GROUP SLUG</Text>
+          <Field
+            amber
+            value={slug}
+            onChangeText={setSlug}
+            placeholder="#general-room"
+            icon={<Icon.diamond size={14} color={semantic.mute} />}
+          />
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 11,
+              color: semantic.mute,
+              lineHeight: 16,
+            }}
+          >
+            Slugs are short, unique identifiers chosen by group owners.
+            Ask for one to join — there's no public directory.
+          </Text>
+        </View>
+
+        <View style={{ paddingHorizontal: 18, paddingTop: 18 }}>
+          {search.isLoading && slug.trim().length >= 2 ? (
+            <Text
+              style={{
+                fontFamily: ty.body.fontFamily,
+                fontSize: 13,
+                color: semantic.mute,
+              }}
+            >
+              Looking up…
+            </Text>
+          ) : null}
+          {search.isError ? (
+            <Text
+              style={{
+                fontFamily: ty.body.fontFamily,
+                fontSize: 13,
+                color: semantic.danger,
+              }}
+            >
+              {(search.error as Error).message || "No group with that slug."}
+            </Text>
+          ) : null}
+          {search.data ? (
+            <Card>
+              <Text
+                style={{
+                  fontFamily: ty.h1.fontFamily,
+                  fontSize: 18,
+                  color: semantic.ink,
+                }}
+              >
+                {search.data.name}
+              </Text>
+              {search.data.description ? (
+                <Text
+                  style={{
+                    fontFamily: ty.body.fontFamily,
+                    fontSize: 13,
+                    color: semantic.mute,
+                    marginTop: 4,
+                  }}
+                >
+                  {search.data.description}
+                </Text>
+              ) : null}
+              <View style={{ paddingTop: 12 }}>
+                {status === "pending" ? (
+                  <Text
+                    style={[ty.label, { color: semantic.accent }]}
+                  >
+                    REQUEST PENDING
+                  </Text>
+                ) : status === "approved" ? (
+                  <Text style={[ty.label, { color: semantic.accent }]}>
+                    APPROVED — OPEN GROUPS TAB
+                  </Text>
+                ) : status === "rejected" ? (
+                  <Text style={[ty.label, { color: semantic.danger }]}>
+                    REQUEST DECLINED
+                  </Text>
+                ) : (
+                  <Button
+                    full
+                    variant="primary"
+                    onPress={onRequest}
+                    disabled={requestAccess.isPending}
+                    iconRight={<Icon.arrowRight color="#0a0907" />}
+                  >
+                    {requestAccess.isPending ? "REQUESTING…" : "REQUEST TO JOIN"}
+                  </Button>
+                )}
+              </View>
+            </Card>
+          ) : null}
+        </View>
+      </Body>
+      <Ctx cr="GROUPS" name="Discover" />
+      <BottomAction>
+        <Button
+          full
+          variant="subtle"
+          onPress={() => router.back()}
+          icon={<Icon.back color={semantic.ink} />}
+        >
+          Back
+        </Button>
+      </BottomAction>
+    </Screen>
+  );
+}

--- a/mobile/app/group/invite.tsx
+++ b/mobile/app/group/invite.tsx
@@ -1,0 +1,114 @@
+import { useState } from "react";
+import { View, Text } from "react-native";
+import { useRouter, useLocalSearchParams } from "expo-router";
+import {
+  Screen,
+  Crumb,
+  Body,
+  Field,
+  Button,
+  BottomAction,
+  Ctx,
+} from "../../components/ui";
+import { Icon } from "../../components/icons";
+import { semantic, type as ty } from "../../theme/tokens";
+import {
+  useSendGroupInvite,
+  useUserGroupsWithChannels,
+} from "../../hooks/queries";
+
+export default function InviteToGroup() {
+  const router = useRouter();
+  const { groupId } = useLocalSearchParams<{ groupId?: string }>();
+  const [identifier, setIdentifier] = useState("");
+  const sendInvite = useSendGroupInvite(groupId ?? null);
+  const { data: groups = [] } = useUserGroupsWithChannels();
+  const group = groups.find((g) => g.id === groupId);
+
+  const onSend = () => {
+    const trimmed = identifier.trim();
+    if (!trimmed) {
+      return;
+    }
+    sendInvite.mutate(trimmed, {
+      onSuccess: () => {
+        setIdentifier("");
+        router.back();
+      },
+    });
+  };
+
+  return (
+    <Screen>
+      <Crumb
+        segs={[
+          { label: "GROUPS" },
+          { label: group?.name ?? "Group" },
+          { label: "Invite", leaf: true },
+        ]}
+      />
+      <Body>
+        <View style={{ paddingHorizontal: 18, paddingTop: 12, gap: 8 }}>
+          <Text style={ty.label}>USERNAME OR EMAIL</Text>
+          <Field
+            amber
+            value={identifier}
+            onChangeText={setIdentifier}
+            icon={<Icon.at color={semantic.mute} />}
+          />
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 11,
+              color: semantic.mute,
+              lineHeight: 16,
+            }}
+          >
+            They'll see this invite in their Pending section the next time
+            they open Pollis. Only admins of {group?.name ?? "this group"}{" "}
+            can invite — if you're not one, the server will reject this.
+          </Text>
+          {sendInvite.isError ? (
+            <Text
+              style={{
+                fontFamily: ty.body.fontFamily,
+                fontSize: 12,
+                color: semantic.danger,
+                paddingTop: 8,
+              }}
+            >
+              {(sendInvite.error as Error).message || "Couldn't send invite."}
+            </Text>
+          ) : null}
+          {sendInvite.isSuccess ? (
+            <Text
+              style={{
+                fontFamily: ty.body.fontFamily,
+                fontSize: 12,
+                color: semantic.accent,
+                paddingTop: 8,
+              }}
+            >
+              Invite sent.
+            </Text>
+          ) : null}
+        </View>
+      </Body>
+      <Ctx cr={group?.name ?? "GROUP"} name="Invite a member" />
+      <BottomAction>
+        <Button
+          full
+          variant="primary"
+          onPress={onSend}
+          disabled={!identifier.trim() || sendInvite.isPending}
+          iconRight={<Icon.arrowRight color="#0a0907" />}
+        >
+          {sendInvite.isPending ? "SENDING…" : "SEND INVITE"}
+        </Button>
+        <Button variant="subtle" full onPress={() => router.back()}>
+          Cancel
+        </Button>
+      </BottomAction>
+    </Screen>
+  );
+}

--- a/mobile/app/group/members.tsx
+++ b/mobile/app/group/members.tsx
@@ -1,0 +1,168 @@
+import { useMemo, useState } from "react";
+import { View, Text } from "react-native";
+import { useRouter, useLocalSearchParams } from "expo-router";
+import {
+  Screen,
+  Crumb,
+  Body,
+  SectionTitle,
+  ListRow,
+  Avatar,
+  Chip,
+  Ctx,
+} from "../../components/ui";
+import { Icon } from "../../components/icons";
+import { semantic, type as ty } from "../../theme/tokens";
+import {
+  useGroupMembers,
+  useRemoveMember,
+  useSetMemberRole,
+  useUserGroupsWithChannels,
+} from "../../hooks/queries";
+import { useAppStore } from "../../stores/appStore";
+
+export default function Members() {
+  const router = useRouter();
+  const { groupId } = useLocalSearchParams<{ groupId?: string }>();
+  const id = groupId ?? null;
+  const currentUser = useAppStore((s) => s.currentUser);
+
+  const { data: members = [], isLoading } = useGroupMembers(id);
+  const { data: groups = [] } = useUserGroupsWithChannels();
+  const group = groups.find((g) => g.id === id);
+  const removeMember = useRemoveMember(id);
+  const setRole = useSetMemberRole(id);
+
+  const myRole = useMemo(
+    () => members.find((m) => m.user_id === currentUser?.id)?.role,
+    [members, currentUser?.id],
+  );
+  const iAmAdmin = myRole === "admin" || myRole === "owner";
+
+  const [confirmRemove, setConfirmRemove] = useState<string | null>(null);
+
+  const onRemove = (memberId: string) => {
+    if (confirmRemove !== memberId) {
+      setConfirmRemove(memberId);
+      return;
+    }
+    removeMember.mutate(memberId, {
+      onSettled: () => setConfirmRemove(null),
+    });
+  };
+
+  const onToggleRole = (memberId: string, role: string) => {
+    setRole.mutate({
+      userId: memberId,
+      role: role === "admin" ? "member" : "admin",
+    });
+  };
+
+  return (
+    <Screen>
+      <Crumb
+        segs={[
+          { label: "GROUPS" },
+          { label: group?.name ?? "Group" },
+          { label: "Members", leaf: true },
+        ]}
+        end={String(members.length || 0)}
+      />
+      <Body>
+        <SectionTitle>MEMBERS</SectionTitle>
+        {isLoading ? (
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 13,
+              color: semantic.mute,
+              paddingHorizontal: 18,
+              paddingVertical: 12,
+            }}
+          >
+            Loading…
+          </Text>
+        ) : null}
+        {members.map((m) => {
+          const isMe = m.user_id === currentUser?.id;
+          const isOwner = m.role === "owner";
+          const isAdmin = m.role === "admin";
+          const armed = confirmRemove === m.user_id;
+          return (
+            <ListRow
+              key={m.user_id}
+              minHeight={54}
+              glyph={
+                <Avatar label={(m.username || m.user_id).slice(0, 2)} />
+              }
+              name={
+                <Text
+                  style={{
+                    fontFamily: ty.rowN.fontFamily,
+                    fontSize: 14,
+                    color: semantic.ink,
+                  }}
+                >
+                  @{m.username ?? m.user_id.slice(0, 8)}
+                  {isMe ? " · you" : ""}
+                </Text>
+              }
+              sub={
+                isOwner
+                  ? "Owner"
+                  : isAdmin
+                    ? "Admin"
+                    : `joined ${new Date(m.joined_at).toLocaleDateString()}`
+              }
+              onPress={
+                isMe
+                  ? undefined
+                  : () =>
+                      router.push({
+                        pathname: "/user/[id]",
+                        params: { id: m.user_id },
+                      })
+              }
+              end={
+                iAmAdmin && !isMe && !isOwner ? (
+                  <View style={{ flexDirection: "row", gap: 6 }}>
+                    <Chip
+                      variant={isAdmin ? "on" : "default"}
+                      onPress={() => onToggleRole(m.user_id, m.role)}
+                    >
+                      {setRole.isPending ? "…" : isAdmin ? "Admin" : "Make admin"}
+                    </Chip>
+                    <Chip
+                      variant={armed ? "on" : "default"}
+                      onPress={() => onRemove(m.user_id)}
+                    >
+                      {removeMember.isPending && armed
+                        ? "…"
+                        : armed
+                          ? "Confirm"
+                          : "Remove"}
+                    </Chip>
+                  </View>
+                ) : null
+              }
+            />
+          );
+        })}
+        {removeMember.isError ? (
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 12,
+              color: semantic.danger,
+              paddingHorizontal: 18,
+              paddingTop: 6,
+            }}
+          >
+            {(removeMember.error as Error).message || "Couldn't remove member."}
+          </Text>
+        ) : null}
+      </Body>
+      <Ctx cr={group?.name ?? "GROUP"} name="Members" />
+    </Screen>
+  );
+}

--- a/mobile/app/group/new.tsx
+++ b/mobile/app/group/new.tsx
@@ -1,0 +1,115 @@
+import { useState } from "react";
+import { View, Text } from "react-native";
+import { useRouter } from "expo-router";
+import {
+  Screen,
+  Crumb,
+  Body,
+  Field,
+  Button,
+  BottomAction,
+} from "../../components/ui";
+import { Icon } from "../../components/icons";
+import { semantic, type as ty } from "../../theme/tokens";
+import { useCreateGroup } from "../../hooks/queries";
+import { useAppStore } from "../../stores/appStore";
+
+export default function NewGroup() {
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const createGroup = useCreateGroup();
+  const setSelectedGroupId = useAppStore((s) => s.setSelectedGroupId);
+
+  const onSubmit = () => {
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      return;
+    }
+    createGroup.mutate(
+      {
+        name: trimmedName,
+        description: description.trim() || undefined,
+        createDefaultTextChannel: true,
+      },
+      {
+        onSuccess: (group) => {
+          setSelectedGroupId(group.id);
+          // The default text channel created server-side is fetched
+          // lazily by the groups list; land the user on the group page
+          // so they see the new channel render in once the query
+          // refetches.
+          router.replace({
+            pathname: "/group/[id]",
+            params: { id: group.id },
+          });
+        },
+      },
+    );
+  };
+
+  return (
+    <Screen>
+      <Crumb segs={[{ label: "GROUPS" }, { label: "New", leaf: true }]} />
+      <Body>
+        <View style={{ paddingHorizontal: 18, paddingTop: 12, gap: 16 }}>
+          <View style={{ gap: 8 }}>
+            <Text style={ty.label}>GROUP NAME</Text>
+            <Field
+              amber
+              value={name}
+              onChangeText={setName}
+              placeholder="Quick Group"
+              icon={<Icon.people color={semantic.mute} />}
+            />
+          </View>
+          <View style={{ gap: 8 }}>
+            <Text style={ty.label}>DESCRIPTION (OPTIONAL)</Text>
+            <Field
+              value={description}
+              onChangeText={setDescription}
+              placeholder="What's this group for?"
+            />
+          </View>
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 11,
+              color: semantic.mute,
+              lineHeight: 16,
+            }}
+          >
+            A #General text channel is created automatically. You can add more
+            later. Group metadata is visible to invited members only.
+          </Text>
+          {createGroup.isError ? (
+            <Text
+              style={{
+                fontFamily: ty.body.fontFamily,
+                fontSize: 12,
+                color: semantic.danger,
+              }}
+            >
+              {(createGroup.error as Error).message ||
+                "Couldn't create the group."}
+            </Text>
+          ) : null}
+        </View>
+      </Body>
+      <BottomAction>
+        <Button
+          full
+          variant="primary"
+          onPress={onSubmit}
+          disabled={!name.trim() || createGroup.isPending}
+          iconRight={<Icon.arrowRight color="#0a0907" />}
+        >
+          {createGroup.isPending ? "CREATING…" : "CREATE GROUP"}
+        </Button>
+        <Button variant="subtle" full onPress={() => router.back()}>
+          Cancel
+        </Button>
+      </BottomAction>
+    </Screen>
+  );
+}

--- a/mobile/app/group/requests.tsx
+++ b/mobile/app/group/requests.tsx
@@ -1,0 +1,107 @@
+import { View, Text } from "react-native";
+import { useLocalSearchParams } from "expo-router";
+import {
+  Screen,
+  Crumb,
+  Body,
+  SectionTitle,
+  ListRow,
+  Avatar,
+  Chip,
+  Ctx,
+} from "../../components/ui";
+import { semantic, type as ty } from "../../theme/tokens";
+import {
+  useGroupJoinRequests,
+  useApproveJoinRequest,
+  useRejectJoinRequest,
+  useUserGroupsWithChannels,
+} from "../../hooks/queries";
+
+export default function JoinRequests() {
+  const { groupId } = useLocalSearchParams<{ groupId?: string }>();
+  const id = groupId ?? null;
+  const { data: groups = [] } = useUserGroupsWithChannels();
+  const group = groups.find((g) => g.id === id);
+  const { data: requests = [], isLoading } = useGroupJoinRequests(id);
+  const approve = useApproveJoinRequest(id);
+  const reject = useRejectJoinRequest(id);
+
+  return (
+    <Screen>
+      <Crumb
+        segs={[
+          { label: "GROUPS" },
+          { label: group?.name ?? "Group" },
+          { label: "Requests", leaf: true },
+        ]}
+        end={String(requests.length)}
+      />
+      <Body>
+        <SectionTitle>PENDING REQUESTS</SectionTitle>
+        {isLoading ? (
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 13,
+              color: semantic.mute,
+              paddingHorizontal: 18,
+              paddingVertical: 12,
+            }}
+          >
+            Loading…
+          </Text>
+        ) : null}
+        {!isLoading && requests.length === 0 ? (
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 13,
+              color: semantic.mute,
+              paddingHorizontal: 18,
+              paddingVertical: 12,
+            }}
+          >
+            No pending requests.
+          </Text>
+        ) : null}
+        {requests.map((r) => {
+          const handle = r.requester_username ?? r.requester_id.slice(0, 8);
+          return (
+            <ListRow
+              key={r.id}
+              minHeight={54}
+              glyph={<Avatar label={handle.slice(0, 2)} />}
+              name={`@${handle}`}
+              nameStyle={{ fontSize: 14 }}
+              sub={`requested ${new Date(r.created_at).toLocaleDateString()}`}
+              end={
+                <View style={{ flexDirection: "row", gap: 6 }}>
+                  <Chip onPress={() => reject.mutate(r.id)}>Decline</Chip>
+                  <Chip variant="on" onPress={() => approve.mutate(r.id)}>
+                    {approve.isPending ? "…" : "Approve"}
+                  </Chip>
+                </View>
+              }
+            />
+          );
+        })}
+        {(approve.isError || reject.isError) ? (
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 12,
+              color: semantic.danger,
+              paddingHorizontal: 18,
+              paddingTop: 6,
+            }}
+          >
+            {((approve.error ?? reject.error) as Error).message ||
+              "Couldn't process the request."}
+          </Text>
+        ) : null}
+      </Body>
+      <Ctx cr={group?.name ?? "GROUP"} name="Join requests" />
+    </Screen>
+  );
+}

--- a/mobile/app/group/settings.tsx
+++ b/mobile/app/group/settings.tsx
@@ -1,0 +1,241 @@
+import { useEffect, useState } from "react";
+import { View, Text } from "react-native";
+import { useRouter, useLocalSearchParams } from "expo-router";
+import {
+  Screen,
+  Crumb,
+  Body,
+  SectionTitle,
+  ListRow,
+  Field,
+  Button,
+  BottomAction,
+  Chip,
+  Ctx,
+} from "../../components/ui";
+import { Icon } from "../../components/icons";
+import { semantic, type as ty } from "../../theme/tokens";
+import {
+  useGroupChannels,
+  useUserGroupsWithChannels,
+  useUpdateGroup,
+  useDeleteGroup,
+  useDeleteChannel,
+  useGroupMembers,
+} from "../../hooks/queries";
+import { useAppStore } from "../../stores/appStore";
+
+export default function GroupSettings() {
+  const router = useRouter();
+  const { groupId } = useLocalSearchParams<{ groupId?: string }>();
+  const id = groupId ?? null;
+  const currentUser = useAppStore((s) => s.currentUser);
+
+  const { data: groups = [] } = useUserGroupsWithChannels();
+  const group = groups.find((g) => g.id === id);
+  const { data: channels = [] } = useGroupChannels(id);
+  const { data: members = [] } = useGroupMembers(id);
+  const updateGroup = useUpdateGroup(id);
+  const deleteGroup = useDeleteGroup();
+  const deleteChannel = useDeleteChannel(id);
+
+  const myRole = members.find((m) => m.user_id === currentUser?.id)?.role;
+  const iAmAdmin = myRole === "admin" || myRole === "owner";
+  const iAmOwner = myRole === "owner";
+
+  const [name, setName] = useState(group?.name ?? "");
+  const [description, setDescription] = useState(group?.description ?? "");
+  const [seeded, setSeeded] = useState(false);
+  const [confirmDeleteGroup, setConfirmDeleteGroup] = useState(false);
+  const [confirmDeleteChannel, setConfirmDeleteChannel] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (group && !seeded) {
+      setName(group.name);
+      setDescription(group.description ?? "");
+      setSeeded(true);
+    }
+  }, [group, seeded]);
+
+  const dirty =
+    group != null &&
+    (name !== group.name || description !== (group.description ?? ""));
+
+  const onSave = () => {
+    if (!name.trim()) {
+      return;
+    }
+    updateGroup.mutate({
+      name: name.trim(),
+      description: description.trim() || undefined,
+    });
+  };
+
+  const onDeleteGroup = () => {
+    if (!confirmDeleteGroup) {
+      setConfirmDeleteGroup(true);
+      return;
+    }
+    if (!id) {
+      return;
+    }
+    deleteGroup.mutate(id, {
+      onSuccess: () => router.replace("/(tabs)/groups"),
+    });
+  };
+
+  const onDeleteChannel = (channelId: string) => {
+    if (confirmDeleteChannel !== channelId) {
+      setConfirmDeleteChannel(channelId);
+      return;
+    }
+    deleteChannel.mutate(channelId, {
+      onSettled: () => setConfirmDeleteChannel(null),
+    });
+  };
+
+  return (
+    <Screen>
+      <Crumb
+        segs={[
+          { label: "GROUPS" },
+          { label: group?.name ?? "Group" },
+          { label: "Settings", leaf: true },
+        ]}
+      />
+      <Body>
+        {!iAmAdmin ? (
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 13,
+              color: semantic.mute,
+              paddingHorizontal: 18,
+              paddingTop: 14,
+            }}
+          >
+            You don't have admin permissions for this group.
+          </Text>
+        ) : null}
+
+        <SectionTitle>IDENTITY</SectionTitle>
+        <View style={{ paddingHorizontal: 18, paddingTop: 6, gap: 6 }}>
+          <Text style={ty.label}>NAME</Text>
+          <Field value={name} onChangeText={setName} editable={iAmAdmin} />
+        </View>
+        <View style={{ paddingHorizontal: 18, paddingTop: 14, gap: 6 }}>
+          <Text style={ty.label}>DESCRIPTION</Text>
+          <Field
+            value={description}
+            onChangeText={setDescription}
+            editable={iAmAdmin}
+          />
+        </View>
+
+        <SectionTitle>CHANNELS</SectionTitle>
+        {channels.map((c) => {
+          const armed = confirmDeleteChannel === c.id;
+          return (
+            <ListRow
+              key={c.id}
+              minHeight={48}
+              glyph={<Icon.hash color={semantic.mute} />}
+              name={c.name}
+              nameStyle={{ fontSize: 14, fontFamily: ty.body.fontFamily }}
+              sub={c.description ?? undefined}
+              end={
+                iAmAdmin && channels.length > 1 ? (
+                  <Chip
+                    variant={armed ? "on" : "default"}
+                    onPress={() => onDeleteChannel(c.id)}
+                  >
+                    {deleteChannel.isPending && armed
+                      ? "…"
+                      : armed
+                        ? "Confirm"
+                        : "Delete"}
+                  </Chip>
+                ) : null
+              }
+            />
+          );
+        })}
+        {channels.length === 0 ? (
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 13,
+              color: semantic.mute,
+              paddingHorizontal: 18,
+              paddingTop: 6,
+            }}
+          >
+            No channels.
+          </Text>
+        ) : null}
+
+        {iAmOwner ? (
+          <View>
+            <SectionTitle>DANGER</SectionTitle>
+            <View style={{ paddingHorizontal: 18 }}>
+              <Button
+                full
+                variant="danger"
+                icon={<Icon.exit color={semantic.danger} />}
+                onPress={onDeleteGroup}
+                disabled={deleteGroup.isPending}
+              >
+                {deleteGroup.isPending
+                  ? "DELETING…"
+                  : confirmDeleteGroup
+                    ? "TAP AGAIN TO CONFIRM"
+                    : "DELETE GROUP"}
+              </Button>
+              {deleteGroup.isError ? (
+                <Text
+                  style={{
+                    fontFamily: ty.body.fontFamily,
+                    fontSize: 12,
+                    color: semantic.danger,
+                    paddingTop: 6,
+                  }}
+                >
+                  {(deleteGroup.error as Error).message ||
+                    "Couldn't delete group."}
+                </Text>
+              ) : null}
+            </View>
+          </View>
+        ) : null}
+
+        {updateGroup.isError ? (
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 12,
+              color: semantic.danger,
+              paddingHorizontal: 18,
+              paddingTop: 6,
+            }}
+          >
+            {(updateGroup.error as Error).message || "Couldn't save changes."}
+          </Text>
+        ) : null}
+      </Body>
+      <Ctx cr={group?.name ?? "GROUP"} name="Settings" />
+      {iAmAdmin ? (
+        <BottomAction>
+          <Button
+            full
+            variant="primary"
+            onPress={onSave}
+            disabled={!dirty || !name.trim() || updateGroup.isPending}
+            iconRight={<Icon.check color="#0a0907" />}
+          >
+            {updateGroup.isPending ? "SAVING…" : "SAVE CHANGES"}
+          </Button>
+        </BottomAction>
+      ) : null}
+    </Screen>
+  );
+}

--- a/mobile/app/self/blocked.tsx
+++ b/mobile/app/self/blocked.tsx
@@ -1,0 +1,88 @@
+import { View, Text } from "react-native";
+import {
+  Screen,
+  Crumb,
+  Body,
+  SectionTitle,
+  ListRow,
+  Avatar,
+  Chip,
+  Ctx,
+} from "../../components/ui";
+import { semantic, type as ty } from "../../theme/tokens";
+import { useBlockedUsers, useUnblockUser } from "../../hooks/queries";
+
+export default function Blocked() {
+  const { data: blocked = [], isLoading } = useBlockedUsers();
+  const unblock = useUnblockUser();
+
+  return (
+    <Screen>
+      <Crumb
+        segs={[{ label: "SELF" }, { label: "Blocked", leaf: true }]}
+        end={String(blocked.length)}
+      />
+      <Body>
+        <SectionTitle>BLOCKED USERS</SectionTitle>
+        {isLoading ? (
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 13,
+              color: semantic.mute,
+              paddingHorizontal: 18,
+              paddingVertical: 12,
+            }}
+          >
+            Loading…
+          </Text>
+        ) : null}
+        {!isLoading && blocked.length === 0 ? (
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 13,
+              color: semantic.mute,
+              paddingHorizontal: 18,
+              paddingVertical: 12,
+            }}
+          >
+            You haven't blocked anyone.
+          </Text>
+        ) : null}
+        {blocked.map((b) => {
+          const handle = b.blocked_username ?? b.blocked_id.slice(0, 8);
+          return (
+            <ListRow
+              key={b.blocked_id}
+              minHeight={54}
+              glyph={<Avatar label={handle.slice(0, 2)} />}
+              name={`@${handle}`}
+              nameStyle={{ fontSize: 14 }}
+              sub={`blocked ${new Date(b.created_at).toLocaleDateString()}`}
+              end={
+                <Chip onPress={() => unblock.mutate(b.blocked_id)}>
+                  {unblock.isPending ? "…" : "Unblock"}
+                </Chip>
+              }
+            />
+          );
+        })}
+        {unblock.isError ? (
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 12,
+              color: semantic.danger,
+              paddingHorizontal: 18,
+              paddingTop: 6,
+            }}
+          >
+            {(unblock.error as Error).message || "Couldn't unblock."}
+          </Text>
+        ) : null}
+      </Body>
+      <Ctx cr="SELF" name="Blocked" />
+    </Screen>
+  );
+}

--- a/mobile/app/self/change-email.tsx
+++ b/mobile/app/self/change-email.tsx
@@ -1,0 +1,178 @@
+import { useState } from "react";
+import { View, Text } from "react-native";
+import { useRouter } from "expo-router";
+import {
+  Screen,
+  Crumb,
+  Body,
+  Field,
+  Button,
+  BottomAction,
+  Ctx,
+} from "../../components/ui";
+import { Icon } from "../../components/icons";
+import { semantic, type as ty } from "../../theme/tokens";
+import { useMutation } from "@tanstack/react-query";
+import { invoke } from "../../lib/native";
+import { useAppStore } from "../../stores/appStore";
+
+type Stage = "enter-email" | "enter-code";
+
+export default function ChangeEmail() {
+  const router = useRouter();
+  const currentUser = useAppStore((s) => s.currentUser);
+  const setCurrentUser = useAppStore((s) => s.setCurrentUser);
+  const [stage, setStage] = useState<Stage>("enter-email");
+  const [newEmail, setNewEmail] = useState("");
+  const [code, setCode] = useState("");
+
+  const requestOtp = useMutation({
+    mutationFn: async (email: string) => {
+      if (!currentUser) {
+        throw new Error("No current user");
+      }
+      await invoke("request_email_change_otp", {
+        userId: currentUser.id,
+        newEmail: email,
+      });
+    },
+    onSuccess: () => setStage("enter-code"),
+  });
+
+  const verify = useMutation({
+    mutationFn: async () => {
+      if (!currentUser) {
+        throw new Error("No current user");
+      }
+      await invoke("verify_email_change", {
+        userId: currentUser.id,
+        newEmail: newEmail.trim(),
+        code: code.trim(),
+      });
+    },
+    onSuccess: () => {
+      if (currentUser) {
+        setCurrentUser({ ...currentUser, email: newEmail.trim() });
+      }
+      router.back();
+    },
+  });
+
+  const onSubmit = () => {
+    if (stage === "enter-email") {
+      const trimmed = newEmail.trim();
+      if (!trimmed) {
+        return;
+      }
+      requestOtp.mutate(trimmed);
+    } else {
+      if (code.trim().length === 0) {
+        return;
+      }
+      verify.mutate();
+    }
+  };
+
+  const pending = requestOtp.isPending || verify.isPending;
+  const error = requestOtp.error ?? verify.error;
+
+  return (
+    <Screen>
+      <Crumb
+        segs={[
+          { label: "SELF" },
+          { label: "User settings" },
+          { label: "Email", leaf: true },
+        ]}
+      />
+      <Body>
+        <View style={{ paddingHorizontal: 18, paddingTop: 14, gap: 14 }}>
+          <Text style={[ty.h1, { color: semantic.ink }]}>Change email</Text>
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 13,
+              lineHeight: 19,
+              color: semantic.mute,
+            }}
+          >
+            {stage === "enter-email"
+              ? "Enter the new email. We'll send a 6-digit code to confirm you own it."
+              : `Enter the code we sent to ${newEmail}.`}
+          </Text>
+
+          {stage === "enter-email" ? (
+            <View style={{ gap: 6 }}>
+              <Text style={ty.label}>NEW EMAIL</Text>
+              <Field
+                amber
+                value={newEmail}
+                onChangeText={setNewEmail}
+                icon={<Icon.mail color={semantic.mute} />}
+                keyboardType="email-address"
+              />
+            </View>
+          ) : (
+            <View style={{ gap: 6 }}>
+              <Text style={ty.label}>VERIFICATION CODE</Text>
+              <Field
+                amber
+                value={code}
+                onChangeText={(v) =>
+                  setCode(v.replace(/[^0-9]/g, "").slice(0, 6))
+                }
+                keyboardType="number-pad"
+                icon={<Icon.key color={semantic.mute} />}
+              />
+            </View>
+          )}
+
+          {error ? (
+            <Text
+              style={{
+                fontFamily: ty.body.fontFamily,
+                fontSize: 12,
+                color: semantic.danger,
+              }}
+            >
+              {(error as Error).message || "Something went wrong."}
+            </Text>
+          ) : null}
+        </View>
+      </Body>
+      <Ctx cr="SELF" name="Change email" />
+      <BottomAction>
+        <Button
+          full
+          variant="primary"
+          onPress={onSubmit}
+          disabled={
+            pending ||
+            (stage === "enter-email"
+              ? !newEmail.trim()
+              : code.trim().length !== 6)
+          }
+          iconRight={<Icon.arrowRight color="#0a0907" />}
+        >
+          {pending
+            ? "WORKING…"
+            : stage === "enter-email"
+              ? "SEND CODE"
+              : "CONFIRM"}
+        </Button>
+        {stage === "enter-code" ? (
+          <Button
+            variant="subtle"
+            full
+            onPress={() => {
+              setCode("");
+              setStage("enter-email");
+            }}
+          >
+            Use a different email
+          </Button>
+        ) : null}
+      </BottomAction>
+    </Screen>
+  );
+}

--- a/mobile/app/self/preferences.tsx
+++ b/mobile/app/self/preferences.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { View, Text, Pressable } from "react-native";
 import {
   Screen,
@@ -13,6 +12,7 @@ import {
 import { Icon } from "../../components/icons";
 import { useTheme } from "../../components/theme";
 import { semantic, type as ty, r, DEFAULT_ACCENT_HEX } from "../../theme/tokens";
+import { usePreferences } from "../../hooks/queries";
 
 const SWATCHES = [
   { n: "Amber", c: DEFAULT_ACCENT_HEX },
@@ -23,19 +23,34 @@ const SWATCHES = [
   { n: "Rust", c: "#d68f5a" },
 ];
 
-const BEHAVIOR = [
-  { n: "Show inline timestamps", on: true },
-  { n: "Show member avatars", on: true },
-  { n: "Mark verified peers with ◆", on: true },
-  { n: "Read receipts", on: false },
-  { n: "Reduce motion", on: false },
-];
+const BEHAVIOR_KEYS = [
+  { key: "show_inline_timestamps", n: "Show inline timestamps", defaultOn: true },
+  { key: "show_member_avatars", n: "Show member avatars", defaultOn: true },
+  { key: "mark_verified_peers", n: "Mark verified peers with ◆", defaultOn: true },
+  { key: "read_receipts", n: "Read receipts", defaultOn: false },
+  { key: "reduce_motion", n: "Reduce motion", defaultOn: false },
+] as const;
+
+const THEMES = ["Coal", "Paper", "System"] as const;
+const DENSITIES = ["Compact", "Comfortable"] as const;
 
 export default function Preferences() {
   const { accentHex, setAccent } = useTheme();
-  const [theme, setTheme] = useState("Coal");
-  const [density, setDensity] = useState("Compact");
-  const [toggles, setToggles] = useState(BEHAVIOR.map((b) => b.on));
+  const { data: prefs, update } = usePreferences();
+
+  const theme = prefs?.mobile_theme ?? "Coal";
+  const density = prefs?.mobile_density ?? "Compact";
+  const behavior = prefs?.mobile_behavior ?? {};
+
+  const isBehaviorOn = (key: string, fallback: boolean): boolean => {
+    const v = behavior[key];
+    return typeof v === "boolean" ? v : fallback;
+  };
+
+  const toggleBehavior = (key: string, fallback: boolean) => {
+    const next = { ...behavior, [key]: !isBehaviorOn(key, fallback) };
+    update({ mobile_behavior: next });
+  };
 
   return (
     <Screen>
@@ -43,9 +58,7 @@ export default function Preferences() {
       <Body>
         <View style={{ paddingHorizontal: 18, paddingTop: 12 }}>
           <Text style={[ty.label, { marginBottom: 10 }]}>ACCENT</Text>
-          <View
-            style={{ flexDirection: "row", flexWrap: "wrap", gap: 8 }}
-          >
+          <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 8 }}>
             {SWATCHES.map((s) => {
               const sel = accentHex.toLowerCase() === s.c.toLowerCase();
               return (
@@ -98,11 +111,11 @@ export default function Preferences() {
         <View style={{ paddingHorizontal: 18, paddingTop: 18 }}>
           <Text style={[ty.label, { marginBottom: 10 }]}>THEME</Text>
           <View style={{ flexDirection: "row", gap: 8 }}>
-            {["Coal", "Paper", "System"].map((opt) => (
+            {THEMES.map((opt) => (
               <Chip
                 key={opt}
                 variant={theme === opt ? "on" : "default"}
-                onPress={() => setTheme(opt)}
+                onPress={() => update({ mobile_theme: opt })}
               >
                 {opt}
               </Chip>
@@ -113,11 +126,11 @@ export default function Preferences() {
         <View style={{ paddingHorizontal: 18, paddingTop: 18 }}>
           <Text style={[ty.label, { marginBottom: 10 }]}>DENSITY</Text>
           <View style={{ flexDirection: "row", gap: 8 }}>
-            {["Compact", "Comfortable"].map((opt) => (
+            {DENSITIES.map((opt) => (
               <Chip
                 key={opt}
                 variant={density === opt ? "on" : "default"}
-                onPress={() => setDensity(opt)}
+                onPress={() => update({ mobile_density: opt })}
               >
                 {opt}
               </Chip>
@@ -126,20 +139,16 @@ export default function Preferences() {
         </View>
 
         <SectionTitle>BEHAVIOR</SectionTitle>
-        {BEHAVIOR.map((b, i) => (
+        {BEHAVIOR_KEYS.map((b) => (
           <ListRow
-            key={b.n}
+            key={b.key}
             minHeight={46}
             name={b.n}
             nameStyle={{ fontSize: 14, fontFamily: ty.body.fontFamily }}
             end={
               <Toggle
-                on={toggles[i]}
-                onPress={() =>
-                  setToggles((t) =>
-                    t.map((v, idx) => (idx === i ? !v : v))
-                  )
-                }
+                on={isBehaviorOn(b.key, b.defaultOn)}
+                onPress={() => toggleBehavior(b.key, b.defaultOn)}
               />
             }
           />

--- a/mobile/app/self/security.tsx
+++ b/mobile/app/self/security.tsx
@@ -12,11 +12,14 @@ import {
   Ctx,
 } from "../../components/ui";
 import { Icon } from "../../components/icons";
-import { semantic, type as ty } from "../../theme/tokens";
+import { semantic, type as ty, fonts } from "../../theme/tokens";
 import {
   useUserDevices,
   useRevokeDevice,
   useLogout,
+  usePendingEnrollmentRequests,
+  useApproveEnrollment,
+  useRejectEnrollment,
 } from "../../hooks/queries";
 
 function formatRelative(iso: string): string {
@@ -49,6 +52,9 @@ export default function Security() {
   const { data: devices = [], isLoading, isError } = useUserDevices();
   const revoke = useRevokeDevice();
   const logout = useLogout();
+  const { data: pendingEnrollments = [] } = usePendingEnrollmentRequests();
+  const approveEnrollment = useApproveEnrollment();
+  const rejectEnrollment = useRejectEnrollment();
   const [confirmRevoke, setConfirmRevoke] = useState<string | null>(null);
 
   const onRevoke = (deviceId: string) => {
@@ -73,6 +79,86 @@ export default function Security() {
     <Screen>
       <Crumb segs={[{ label: "SELF" }, { label: "Security", leaf: true }]} />
       <Body>
+        {pendingEnrollments.length > 0 ? (
+          <View>
+            <SectionTitle>PAIR NEW DEVICE</SectionTitle>
+            {pendingEnrollments.map((req) => (
+              <View
+                key={req.request_id}
+                style={{
+                  paddingHorizontal: 18,
+                  paddingVertical: 12,
+                  gap: 8,
+                  borderBottomWidth: 1,
+                  borderBottomColor: semantic.hairSoft,
+                }}
+              >
+                <Text
+                  style={{
+                    fontFamily: ty.body.fontFamily,
+                    fontSize: 13,
+                    color: semantic.ink,
+                  }}
+                >
+                  A new device wants to pair with your account.
+                </Text>
+                <Text
+                  style={{
+                    fontFamily: fonts.mono400,
+                    fontSize: 18,
+                    letterSpacing: 3,
+                    color: semantic.accent,
+                  }}
+                >
+                  {req.verification_code}
+                </Text>
+                <Text
+                  style={{
+                    fontFamily: ty.body.fontFamily,
+                    fontSize: 11,
+                    color: semantic.mute,
+                  }}
+                >
+                  Confirm this code matches what's shown on the other device,
+                  then approve.
+                </Text>
+                <View style={{ flexDirection: "row", gap: 8, paddingTop: 6 }}>
+                  <Chip
+                    onPress={() => rejectEnrollment.mutate(req.request_id)}
+                  >
+                    Reject
+                  </Chip>
+                  <Chip
+                    variant="on"
+                    onPress={() =>
+                      approveEnrollment.mutate({
+                        requestId: req.request_id,
+                        verificationCode: req.verification_code,
+                      })
+                    }
+                  >
+                    {approveEnrollment.isPending ? "Approving…" : "Approve"}
+                  </Chip>
+                </View>
+              </View>
+            ))}
+            {(approveEnrollment.isError || rejectEnrollment.isError) ? (
+              <Text
+                style={{
+                  fontFamily: ty.body.fontFamily,
+                  fontSize: 12,
+                  color: semantic.danger,
+                  paddingHorizontal: 18,
+                  paddingTop: 6,
+                }}
+              >
+                {((approveEnrollment.error ?? rejectEnrollment.error) as Error)
+                  .message || "Couldn't process the enrollment request."}
+              </Text>
+            ) : null}
+          </View>
+        ) : null}
+
         <SectionTitle>DEVICES</SectionTitle>
         {isLoading ? (
           <Text

--- a/mobile/app/self/security.tsx
+++ b/mobile/app/self/security.tsx
@@ -233,6 +233,16 @@ export default function Security() {
           </Text>
         ) : null}
 
+        <SectionTitle>SAFETY</SectionTitle>
+        <ListRow
+          minHeight={48}
+          glyph={<Icon.exit color={semantic.mute} />}
+          name="Blocked users"
+          nameStyle={{ fontSize: 14, fontFamily: ty.body.fontFamily }}
+          onPress={() => router.push("/self/blocked")}
+          end={<Icon.fwd color={semantic.mute} />}
+        />
+
         <SectionTitle>RECOVERY</SectionTitle>
         <View style={{ paddingHorizontal: 18, paddingTop: 6 }}>
           <Text

--- a/mobile/app/self/security.tsx
+++ b/mobile/app/self/security.tsx
@@ -7,126 +7,171 @@ import {
   Body,
   SectionTitle,
   ListRow,
-  Card,
   Chip,
-  Toggle,
   Button,
   Ctx,
 } from "../../components/ui";
 import { Icon } from "../../components/icons";
-import { semantic, type as ty, fonts } from "../../theme/tokens";
+import { semantic, type as ty } from "../../theme/tokens";
+import {
+  useUserDevices,
+  useRevokeDevice,
+  useLogout,
+} from "../../hooks/queries";
 
-const DEVICES = [
-  { n: "iPhone · this device", s: "paired May 2 · last seen now", cur: true },
-  { n: "MacBook Pro", s: "paired Apr 18 · last seen 14:02" },
-  { n: "iPad", s: "paired Mar 4 · idle for 22 days" },
-];
+function formatRelative(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) {
+    return iso;
+  }
+  const diffMs = Date.now() - d.getTime();
+  const sec = Math.floor(diffMs / 1000);
+  if (sec < 60) {
+    return "just now";
+  }
+  const min = Math.floor(sec / 60);
+  if (min < 60) {
+    return `${min}m ago`;
+  }
+  const hr = Math.floor(min / 60);
+  if (hr < 48) {
+    return `${hr}h ago`;
+  }
+  const day = Math.floor(hr / 24);
+  if (day < 30) {
+    return `${day}d ago`;
+  }
+  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
 
 export default function Security() {
   const router = useRouter();
-  const [hideNotif, setHideNotif] = useState(true);
+  const { data: devices = [], isLoading, isError } = useUserDevices();
+  const revoke = useRevokeDevice();
+  const logout = useLogout();
+  const [confirmRevoke, setConfirmRevoke] = useState<string | null>(null);
+
+  const onRevoke = (deviceId: string) => {
+    if (confirmRevoke !== deviceId) {
+      setConfirmRevoke(deviceId);
+      return;
+    }
+    revoke.mutate(deviceId, {
+      onSuccess: () => setConfirmRevoke(null),
+      onError: () => setConfirmRevoke(null),
+    });
+  };
+
+  const onSignOut = () => {
+    logout.mutate(undefined, {
+      onSuccess: () => router.replace("/(auth)/email"),
+      onError: () => router.replace("/(auth)/email"),
+    });
+  };
 
   return (
     <Screen>
       <Crumb segs={[{ label: "SELF" }, { label: "Security", leaf: true }]} />
       <Body>
-        <View style={{ paddingHorizontal: 18, paddingTop: 12 }}>
-          <Card>
-            <Text style={[ty.label, { marginBottom: 8 }]}>YOUR PUBLIC KEY</Text>
-            <Text
-              style={{
-                fontFamily: fonts.mono400,
-                fontSize: 13,
-                color: semantic.accent,
-                marginBottom: 10,
-              }}
-            >
-              ed25519 · 0x4a2c 8f17 d3b9 ec40
-            </Text>
-            <View style={{ flexDirection: "row", gap: 8 }}>
-              <Chip>Copy</Chip>
-              <Chip>Show QR</Chip>
-              <Chip variant="on" style={{ marginLeft: "auto" }}>
-                ◆ Verified
-              </Chip>
-            </View>
-          </Card>
-        </View>
-
         <SectionTitle>DEVICES</SectionTitle>
-        {DEVICES.map((d, i) => (
-          <ListRow
-            key={i}
-            minHeight={54}
-            glyph={<Icon.device color={semantic.mute} />}
-            name={d.n}
-            nameStyle={{ fontSize: 14 }}
-            sub={d.s}
-            end={
-              d.cur ? (
-                <Chip variant="on">CURRENT</Chip>
-              ) : (
-                <Chip>Revoke</Chip>
-              )
-            }
-          />
-        ))}
+        {isLoading ? (
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 13,
+              color: semantic.mute,
+              paddingHorizontal: 18,
+              paddingVertical: 12,
+            }}
+          >
+            Loading devices…
+          </Text>
+        ) : null}
+        {isError ? (
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 13,
+              color: semantic.danger,
+              paddingHorizontal: 18,
+              paddingVertical: 12,
+            }}
+          >
+            Couldn't load devices.
+          </Text>
+        ) : null}
+        {devices.map((d) => {
+          const name =
+            (d.device_name && d.device_name.trim()) ||
+            d.device_id.slice(0, 8);
+          const sub = `paired ${formatRelative(d.created_at)} · last seen ${formatRelative(d.last_seen)}`;
+          const armed = confirmRevoke === d.device_id;
+          return (
+            <ListRow
+              key={d.device_id}
+              minHeight={54}
+              glyph={<Icon.device color={semantic.mute} />}
+              name={`${name}${d.is_current ? " · this device" : ""}`}
+              nameStyle={{ fontSize: 14 }}
+              sub={sub}
+              end={
+                d.is_current ? (
+                  <Chip variant="on">CURRENT</Chip>
+                ) : (
+                  <Chip
+                    variant={armed ? "on" : "default"}
+                    onPress={() => onRevoke(d.device_id)}
+                  >
+                    {revoke.isPending && armed
+                      ? "Revoking…"
+                      : armed
+                        ? "Confirm"
+                        : "Revoke"}
+                  </Chip>
+                )
+              }
+            />
+          );
+        })}
+        {revoke.isError ? (
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 12,
+              color: semantic.danger,
+              paddingHorizontal: 18,
+              paddingTop: 6,
+            }}
+          >
+            {(revoke.error as Error).message || "Couldn't revoke device."}
+          </Text>
+        ) : null}
 
         <SectionTitle>RECOVERY</SectionTitle>
-        <ListRow
-          minHeight={50}
-          glyph={<Icon.key color={semantic.mute} />}
-          name="Recovery phrase"
-          nameStyle={{ fontSize: 14, fontFamily: ty.body.fontFamily }}
-          sub="12 words · last viewed 14d ago"
-          end={<Icon.fwd color={semantic.mute} />}
-        />
-        <ListRow
-          minHeight={50}
-          glyph={<Icon.lock color={semantic.mute} />}
-          name="Device PIN"
-          nameStyle={{ fontSize: 14, fontFamily: ty.body.fontFamily }}
-          sub="4 digits · biometrics on"
-          end={<Icon.fwd color={semantic.mute} />}
-        />
+        <View style={{ paddingHorizontal: 18, paddingTop: 6 }}>
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 12,
+              color: semantic.mute,
+              lineHeight: 17,
+            }}
+          >
+            Recovery key and device PIN management aren't wired on mobile
+            yet. To set up a new device, sign in with your email — Pollis
+            walks you through enrollment.
+          </Text>
+        </View>
 
-        <SectionTitle>SESSION</SectionTitle>
-        <ListRow
-          minHeight={46}
-          name="Auto-lock after"
-          nameStyle={{ fontSize: 14, fontFamily: ty.body.fontFamily }}
-          end={
-            <>
-              <Text
-                style={{
-                  fontFamily: ty.body.fontFamily,
-                  fontSize: 12,
-                  color: semantic.ink2,
-                }}
-              >
-                5 min
-              </Text>
-              <Icon.fwd color={semantic.mute} />
-            </>
-          }
-        />
-        <ListRow
-          minHeight={46}
-          name="Hide notification content when locked"
-          nameStyle={{ fontSize: 14, fontFamily: ty.body.fontFamily }}
-          end={
-            <Toggle on={hideNotif} onPress={() => setHideNotif((v) => !v)} />
-          }
-        />
-
-        <View style={{ paddingHorizontal: 18, paddingTop: 14 }}>
+        <View style={{ paddingHorizontal: 18, paddingTop: 18 }}>
           <Button
             full
             variant="danger"
             icon={<Icon.exit color={semantic.danger} />}
-            onPress={() => router.replace("/(auth)/email")}
+            onPress={onSignOut}
+            disabled={logout.isPending}
           >
-            SIGN OUT EVERYWHERE
+            {logout.isPending ? "SIGNING OUT…" : "SIGN OUT"}
           </Button>
         </View>
       </Body>

--- a/mobile/app/self/user-settings.tsx
+++ b/mobile/app/self/user-settings.tsx
@@ -1,27 +1,64 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { View, Text } from "react-native";
+import { useRouter } from "expo-router";
 import {
   Screen,
   Crumb,
   Body,
   SectionTitle,
-  ListRow,
   Avatar,
-  Chip,
   Field,
-  Diamond,
   Ctx,
+  Button,
+  BottomAction,
 } from "../../components/ui";
 import { Icon } from "../../components/icons";
 import { semantic, type as ty } from "../../theme/tokens";
+import { useUserProfile, useUpdateProfile } from "../../hooks/queries";
+import { useAppStore } from "../../stores/appStore";
 
 export default function UserSettings() {
-  const [name, setName] = useState("dan");
-  const [handle, setHandle] = useState("dan");
+  const router = useRouter();
+  const currentUser = useAppStore((s) => s.currentUser);
+  const { data: profile, isLoading } = useUserProfile();
+  const updateProfile = useUpdateProfile();
+
+  const [displayName, setDisplayName] = useState("");
+  const [handle, setHandle] = useState("");
+
+  // Seed local form state once the profile loads, then leave it alone so
+  // the user's in-progress edits aren't clobbered by a background refetch.
+  const [seeded, setSeeded] = useState(false);
+  useEffect(() => {
+    if (!seeded && profile) {
+      setDisplayName(profile.preferred_name ?? "");
+      setHandle(profile.username ?? "");
+      setSeeded(true);
+    }
+  }, [profile, seeded]);
+
+  const dirty =
+    profile != null &&
+    (displayName !== (profile.preferred_name ?? "") ||
+      handle !== (profile.username ?? ""));
+
+  const onSave = () => {
+    if (!handle.trim()) {
+      return;
+    }
+    updateProfile.mutate({
+      username: handle.trim(),
+      preferredName: displayName.trim() || undefined,
+    });
+  };
+
+  const avatarLabel = (handle || currentUser?.username || "us").slice(0, 2);
 
   return (
     <Screen>
-      <Crumb segs={[{ label: "SELF" }, { label: "User settings", leaf: true }]} />
+      <Crumb
+        segs={[{ label: "SELF" }, { label: "User settings", leaf: true }]}
+      />
       <Body>
         <View
           style={{
@@ -33,7 +70,7 @@ export default function UserSettings() {
             paddingBottom: 8,
           }}
         >
-          <Avatar label="dn" size="lg" variant="amber" />
+          <Avatar label={avatarLabel} size="lg" variant="amber" />
           <View style={{ flex: 1 }}>
             <Text
               style={{
@@ -42,7 +79,7 @@ export default function UserSettings() {
                 color: semantic.ink,
               }}
             >
-              dan
+              {displayName || handle || "—"}
             </Text>
             <Text
               style={{
@@ -51,16 +88,17 @@ export default function UserSettings() {
                 color: semantic.mute,
               }}
             >
-              2 character initials · tap to change
+              {isLoading
+                ? "Loading…"
+                : "Derived from your handle's first two characters."}
             </Text>
           </View>
-          <Chip variant="on">EDIT</Chip>
         </View>
 
         <SectionTitle>IDENTITY</SectionTitle>
         <View style={{ paddingHorizontal: 18, paddingTop: 6, gap: 6 }}>
           <Text style={ty.label}>DISPLAY NAME</Text>
-          <Field value={name} onChangeText={setName} />
+          <Field value={displayName} onChangeText={setDisplayName} />
         </View>
         <View style={{ paddingHorizontal: 18, paddingTop: 14, gap: 6 }}>
           <Text style={ty.label}>HANDLE</Text>
@@ -77,18 +115,6 @@ export default function UserSettings() {
                 @
               </Text>
             }
-            trailing={
-              <Text
-                style={{
-                  fontFamily: ty.body.fontFamily,
-                  fontSize: 10,
-                  letterSpacing: 1,
-                  color: semantic.accent,
-                }}
-              >
-                AVAILABLE
-              </Text>
-            }
           />
           <Text
             style={{
@@ -103,67 +129,64 @@ export default function UserSettings() {
         <View style={{ paddingHorizontal: 18, paddingTop: 14, gap: 6 }}>
           <Text style={ty.label}>EMAIL</Text>
           <Field
-            value="dan@example.io"
+            value={profile?.email ?? currentUser?.email ?? ""}
             editable={false}
             icon={<Icon.mail color={semantic.mute} />}
-            trailing={
-              <Text
-                style={{
-                  fontFamily: ty.body.fontFamily,
-                  fontSize: 10,
-                  letterSpacing: 1,
-                  color: semantic.accent,
-                }}
-              >
-                VERIFIED
-              </Text>
-            }
           />
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 11,
+              color: semantic.mute,
+            }}
+          >
+            Email is the address you signed in with. Changing it isn't wired
+            on mobile yet.
+          </Text>
         </View>
 
-        <SectionTitle>PRESENCE</SectionTitle>
-        <ListRow
-          minHeight={46}
-          glyph={<Diamond size={6} />}
-          name="Status"
-          nameStyle={{ fontSize: 14, fontFamily: ty.body.fontFamily }}
-          end={
-            <>
-              <Text
-                style={{
-                  fontFamily: ty.body.fontFamily,
-                  fontSize: 12,
-                  color: semantic.accent,
-                }}
-              >
-                Online
-              </Text>
-              <Icon.fwd color={semantic.mute} />
-            </>
-          }
-        />
-        <ListRow
-          minHeight={46}
-          glyph={<Diamond size={6} fill={false} />}
-          name="Set away after"
-          nameStyle={{ fontSize: 14, fontFamily: ty.body.fontFamily }}
-          end={
-            <>
-              <Text
-                style={{
-                  fontFamily: ty.body.fontFamily,
-                  fontSize: 12,
-                  color: semantic.ink2,
-                }}
-              >
-                10 min
-              </Text>
-              <Icon.fwd color={semantic.mute} />
-            </>
-          }
-        />
+        {updateProfile.isError ? (
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 12,
+              color: semantic.danger,
+              paddingHorizontal: 18,
+              paddingTop: 10,
+            }}
+          >
+            {(updateProfile.error as Error).message || "Couldn't save changes."}
+          </Text>
+        ) : null}
+        {updateProfile.isSuccess && !dirty ? (
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 12,
+              color: semantic.accent,
+              paddingHorizontal: 18,
+              paddingTop: 10,
+            }}
+          >
+            Saved.
+          </Text>
+        ) : null}
       </Body>
       <Ctx cr="SELF" name="User settings" />
+      <BottomAction>
+        <Button
+          full
+          variant="primary"
+          onPress={onSave}
+          disabled={!dirty || !handle.trim() || updateProfile.isPending}
+          iconRight={<Icon.check color="#0a0907" />}
+        >
+          {updateProfile.isPending ? "SAVING…" : "SAVE CHANGES"}
+        </Button>
+        <Button variant="subtle" full onPress={() => router.back()}>
+          Cancel
+        </Button>
+      </BottomAction>
     </Screen>
   );
 }

--- a/mobile/app/self/user-settings.tsx
+++ b/mobile/app/self/user-settings.tsx
@@ -133,16 +133,14 @@ export default function UserSettings() {
             editable={false}
             icon={<Icon.mail color={semantic.mute} />}
           />
-          <Text
-            style={{
-              fontFamily: ty.body.fontFamily,
-              fontSize: 11,
-              color: semantic.mute,
-            }}
+          <Button
+            variant="subtle"
+            full
+            onPress={() => router.push("/self/change-email")}
+            icon={<Icon.edit color={semantic.ink} />}
           >
-            Email is the address you signed in with. Changing it isn't wired
-            on mobile yet.
-          </Text>
+            Change email address
+          </Button>
         </View>
 
         {updateProfile.isError ? (

--- a/mobile/app/user/[id].tsx
+++ b/mobile/app/user/[id].tsx
@@ -1,0 +1,304 @@
+import { View, Text, Pressable } from "react-native";
+import { useRouter, useLocalSearchParams } from "expo-router";
+import {
+  Screen,
+  Crumb,
+  Body,
+  SectionTitle,
+  Avatar,
+  Card,
+  Chip,
+  Button,
+  Ctx,
+  BottomAction,
+} from "../../components/ui";
+import { Icon } from "../../components/icons";
+import { semantic, type as ty, fonts } from "../../theme/tokens";
+import { useQuery } from "@tanstack/react-query";
+import { invoke } from "../../lib/native";
+import {
+  useSafetyNumber,
+  useSetContactVerified,
+  useCreateDM,
+  useBlockedUsers,
+  useBlockUser,
+  useUnblockUser,
+} from "../../hooks/queries";
+import { useAppStore } from "../../stores/appStore";
+
+interface RawProfile {
+  id: string;
+  username?: string;
+  preferred_name?: string;
+  avatar_url?: string;
+}
+
+export default function UserProfile() {
+  const router = useRouter();
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const peerId = id ?? null;
+  const currentUser = useAppStore((s) => s.currentUser);
+  const isSelf = currentUser?.id === peerId;
+
+  const profile = useQuery({
+    queryKey: ["user", "profile", peerId],
+    queryFn: async (): Promise<RawProfile | null> => {
+      if (!peerId) {
+        return null;
+      }
+      return await invoke<RawProfile | null>("get_user_profile", {
+        userId: peerId,
+      });
+    },
+    enabled: !!peerId,
+    staleTime: 1000 * 60,
+  });
+
+  const safety = useSafetyNumber(isSelf ? null : peerId);
+  const setVerified = useSetContactVerified();
+  const createDM = useCreateDM();
+
+  const blockedUsers = useBlockedUsers();
+  const isBlocked =
+    !!peerId && (blockedUsers.data ?? []).some((b) => b.blocked_id === peerId);
+  const block = useBlockUser();
+  const unblock = useUnblockUser();
+
+  const handle = profile.data?.username ?? peerId ?? "user";
+  const display = profile.data?.preferred_name || handle;
+  const avatarLabel = handle.slice(0, 2);
+
+  const onMessage = () => {
+    if (!peerId) {
+      return;
+    }
+    createDM.mutate(
+      { memberIds: [peerId] },
+      {
+        onSuccess: (channel) => {
+          router.replace({
+            pathname: "/chat/[id]",
+            params: { id: channel.id, kind: "dm" },
+          });
+        },
+      },
+    );
+  };
+
+  const onToggleVerified = () => {
+    if (!peerId || !safety.data) {
+      return;
+    }
+    setVerified.mutate({
+      peerUserId: peerId,
+      verified: safety.data.verification !== "verified",
+    });
+  };
+
+  const onToggleBlock = () => {
+    if (!peerId) {
+      return;
+    }
+    if (isBlocked) {
+      unblock.mutate(peerId);
+    } else {
+      block.mutate(peerId);
+    }
+  };
+
+  return (
+    <Screen>
+      <Crumb segs={[{ label: "USER" }, { label: display, leaf: true }]} />
+      <Body>
+        <View
+          style={{
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 14,
+            paddingHorizontal: 18,
+            paddingTop: 14,
+            paddingBottom: 16,
+          }}
+        >
+          <Avatar label={avatarLabel} size="lg" />
+          <View style={{ flex: 1 }}>
+            <Text
+              style={{
+                fontFamily: ty.h1.fontFamily,
+                fontSize: 20,
+                color: semantic.ink,
+              }}
+            >
+              {display}
+            </Text>
+            <Text
+              style={{
+                fontFamily: ty.body.fontFamily,
+                fontSize: 13,
+                color: semantic.mute,
+              }}
+            >
+              @{handle}
+            </Text>
+          </View>
+        </View>
+
+        {isSelf ? (
+          <View style={{ paddingHorizontal: 18, paddingTop: 4 }}>
+            <Text
+              style={{
+                fontFamily: ty.body.fontFamily,
+                fontSize: 12,
+                color: semantic.mute,
+              }}
+            >
+              This is you. Edit your handle and display name in{" "}
+              <Text
+                onPress={() => router.push("/self/user-settings")}
+                style={{ color: semantic.accent }}
+              >
+                Self → User settings
+              </Text>
+              .
+            </Text>
+          </View>
+        ) : (
+          <View>
+            <SectionTitle>SAFETY NUMBER</SectionTitle>
+            <View style={{ paddingHorizontal: 18 }}>
+              {safety.isLoading ? (
+                <Text
+                  style={{
+                    fontFamily: ty.body.fontFamily,
+                    fontSize: 13,
+                    color: semantic.mute,
+                  }}
+                >
+                  Computing…
+                </Text>
+              ) : safety.isError ? (
+                <Text
+                  style={{
+                    fontFamily: ty.body.fontFamily,
+                    fontSize: 13,
+                    color: semantic.danger,
+                  }}
+                >
+                  {(safety.error as Error).message ||
+                    "Couldn't fetch safety number."}
+                </Text>
+              ) : safety.data ? (
+                <Card
+                  style={{
+                    borderColor:
+                      safety.data.verification === "verified"
+                        ? semantic.accent
+                        : safety.data.verification === "changed"
+                          ? semantic.danger
+                          : semantic.hair,
+                  }}
+                >
+                  <Text
+                    selectable
+                    style={{
+                      fontFamily: fonts.mono400,
+                      fontSize: 13,
+                      lineHeight: 22,
+                      color: semantic.ink,
+                      letterSpacing: 0.4,
+                    }}
+                  >
+                    {safety.data.combined}
+                  </Text>
+                  <View
+                    style={{
+                      flexDirection: "row",
+                      alignItems: "center",
+                      gap: 8,
+                      marginTop: 12,
+                    }}
+                  >
+                    <Pressable onPress={onToggleVerified}>
+                      <Chip
+                        variant={
+                          safety.data.verification === "verified" ? "on" : "default"
+                        }
+                      >
+                        {setVerified.isPending
+                          ? "…"
+                          : safety.data.verification === "verified"
+                            ? "◆ Verified"
+                            : "Mark verified"}
+                      </Chip>
+                    </Pressable>
+                    {safety.data.verification === "changed" ? (
+                      <Text
+                        style={{
+                          fontFamily: ty.body.fontFamily,
+                          fontSize: 11,
+                          color: semantic.danger,
+                          flex: 1,
+                        }}
+                      >
+                        Key changed since you last verified — re-verify in
+                        person.
+                      </Text>
+                    ) : null}
+                  </View>
+                </Card>
+              ) : null}
+              <Text
+                style={{
+                  fontFamily: ty.body.fontFamily,
+                  fontSize: 11,
+                  color: semantic.mute,
+                  paddingTop: 10,
+                  lineHeight: 16,
+                }}
+              >
+                Compare these digits in person or over an out-of-band
+                channel. Matching numbers prove you're talking to the same
+                key the server published for this user.
+              </Text>
+            </View>
+
+            <SectionTitle>SAFETY ACTIONS</SectionTitle>
+            <View style={{ paddingHorizontal: 18 }}>
+              <Button
+                full
+                variant={isBlocked ? "default" : "danger"}
+                icon={
+                  <Icon.exit
+                    color={isBlocked ? semantic.ink : semantic.danger}
+                  />
+                }
+                onPress={onToggleBlock}
+                disabled={block.isPending || unblock.isPending}
+              >
+                {block.isPending || unblock.isPending
+                  ? "WORKING…"
+                  : isBlocked
+                    ? "UNBLOCK USER"
+                    : "BLOCK USER"}
+              </Button>
+            </View>
+          </View>
+        )}
+      </Body>
+      <Ctx cr="USER" name={display} />
+      {!isSelf ? (
+        <BottomAction>
+          <Button
+            full
+            variant="primary"
+            onPress={onMessage}
+            disabled={createDM.isPending}
+            iconRight={<Icon.send color="#0a0907" />}
+          >
+            {createDM.isPending ? "OPENING…" : "MESSAGE"}
+          </Button>
+        </BottomAction>
+      ) : null}
+    </Screen>
+  );
+}

--- a/mobile/components/theme.tsx
+++ b/mobile/components/theme.tsx
@@ -1,9 +1,16 @@
-import { createContext, useContext, useState, useCallback } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
 import {
   setAccentRgb,
   hexToRgbTriplet,
   DEFAULT_ACCENT_HEX,
 } from "../theme/tokens";
+import { usePreferences } from "../hooks/queries/usePreferences";
 
 type ThemeCtx = {
   accentHex: string;
@@ -17,11 +24,31 @@ const Ctx = createContext<ThemeCtx>({
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const [accentHex, setAccentHex] = useState(DEFAULT_ACCENT_HEX);
+  const { data: prefs, update } = usePreferences();
 
-  const setAccent = useCallback((hex: string) => {
-    setAccentRgb(hexToRgbTriplet(hex));
-    setAccentHex(hex);
-  }, []);
+  // Seed accent from server-side preferences when they first arrive (after
+  // sign-in). Subsequent local changes go through `setAccent` below and
+  // persist via `update({ accent_hex })`, so this effect only fires on the
+  // initial load.
+  useEffect(() => {
+    const remote = prefs?.accent_hex;
+    if (typeof remote === "string" && remote !== accentHex) {
+      setAccentRgb(hexToRgbTriplet(remote));
+      setAccentHex(remote);
+    }
+    // Only react to server data changes, not local accentHex updates —
+    // otherwise we'd loop on every local pick.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [prefs?.accent_hex]);
+
+  const setAccent = useCallback(
+    (hex: string) => {
+      setAccentRgb(hexToRgbTriplet(hex));
+      setAccentHex(hex);
+      update({ accent_hex: hex });
+    },
+    [update],
+  );
 
   return (
     <Ctx.Provider value={{ accentHex, setAccent }}>{children}</Ctx.Provider>

--- a/mobile/hooks/queries/index.ts
+++ b/mobile/hooks/queries/index.ts
@@ -9,3 +9,4 @@ export * from "./useMessages";
 export * from "./useAuth";
 export * from "./useUserSearch";
 export * from "./usePreferences";
+export * from "./useDevices";

--- a/mobile/hooks/queries/index.ts
+++ b/mobile/hooks/queries/index.ts
@@ -8,3 +8,4 @@ export * from "./useDMChannels";
 export * from "./useMessages";
 export * from "./useAuth";
 export * from "./useUserSearch";
+export * from "./usePreferences";

--- a/mobile/hooks/queries/index.ts
+++ b/mobile/hooks/queries/index.ts
@@ -7,3 +7,4 @@ export * from "./useUserGroups";
 export * from "./useDMChannels";
 export * from "./useMessages";
 export * from "./useAuth";
+export * from "./useUserSearch";

--- a/mobile/hooks/queries/index.ts
+++ b/mobile/hooks/queries/index.ts
@@ -11,3 +11,4 @@ export * from "./useUserSearch";
 export * from "./usePreferences";
 export * from "./useDevices";
 export * from "./useGroupInvites";
+export * from "./useEnrollment";

--- a/mobile/hooks/queries/index.ts
+++ b/mobile/hooks/queries/index.ts
@@ -12,3 +12,6 @@ export * from "./usePreferences";
 export * from "./useDevices";
 export * from "./useGroupInvites";
 export * from "./useEnrollment";
+export * from "./useSearch";
+export * from "./useSafety";
+export * from "./useBlocks";

--- a/mobile/hooks/queries/index.ts
+++ b/mobile/hooks/queries/index.ts
@@ -10,3 +10,4 @@ export * from "./useAuth";
 export * from "./useUserSearch";
 export * from "./usePreferences";
 export * from "./useDevices";
+export * from "./useGroupInvites";

--- a/mobile/hooks/queries/useAuth.ts
+++ b/mobile/hooks/queries/useAuth.ts
@@ -52,6 +52,7 @@ export function useRequestOtp() {
 export function useVerifyOtp() {
   const setCurrentUser = useAppStore((s) => s.setCurrentUser);
   const setUsername = useAppStore((s) => s.setUsername);
+  const setPendingSecretKey = useAppStore((s) => s.setPendingSecretKey);
 
   return useMutation({
     mutationFn: async (vars: { email: string; code: string }) => {
@@ -65,6 +66,11 @@ export function useVerifyOtp() {
       const user = profileToUser(profile);
       setCurrentUser(user);
       setUsername(profile.username);
+      // Stash the recovery key (returned only on first-device signup) so
+      // the PIN screen can hand it off to the Emergency Kit display.
+      if (profile.new_secret_key) {
+        setPendingSecretKey(profile.new_secret_key);
+      }
     },
   });
 }

--- a/mobile/hooks/queries/useBlocks.ts
+++ b/mobile/hooks/queries/useBlocks.ts
@@ -1,0 +1,83 @@
+// Block / unblock hooks. The Rust side hides blocked-by-me DM channels
+// in `list_dm_channels`, so toggling block state from the peer profile
+// screen automatically prunes the inbox on the next refetch.
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { invoke } from "../../lib/native";
+import { useAppStore } from "../../stores/appStore";
+import { dmQueryKeys } from "./useDMChannels";
+
+export interface BlockedUser {
+  blocked_id: string;
+  blocked_username?: string;
+  created_at: string;
+}
+
+export const blockQueryKeys = {
+  list: (userId: string | null) => ["blocks", userId] as const,
+};
+
+export function useBlockedUsers() {
+  const currentUser = useAppStore((s) => s.currentUser);
+  return useQuery({
+    queryKey: blockQueryKeys.list(currentUser?.id ?? null),
+    queryFn: async (): Promise<BlockedUser[]> => {
+      if (!currentUser) {
+        return [];
+      }
+      return await invoke<BlockedUser[]>("list_blocked_users", {
+        userId: currentUser.id,
+      });
+    },
+    enabled: !!currentUser,
+    staleTime: 1000 * 60,
+  });
+}
+
+export function useBlockUser() {
+  const queryClient = useQueryClient();
+  const currentUser = useAppStore((s) => s.currentUser);
+  return useMutation({
+    mutationFn: async (blockedId: string) => {
+      if (!currentUser) {
+        throw new Error("No current user");
+      }
+      await invoke("block_user", {
+        blockerId: currentUser.id,
+        blockedId,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: blockQueryKeys.list(currentUser?.id ?? null),
+      });
+      queryClient.invalidateQueries({
+        queryKey: dmQueryKeys.channels(currentUser?.id ?? null),
+      });
+    },
+  });
+}
+
+export function useUnblockUser() {
+  const queryClient = useQueryClient();
+  const currentUser = useAppStore((s) => s.currentUser);
+  return useMutation({
+    mutationFn: async (blockedId: string) => {
+      if (!currentUser) {
+        throw new Error("No current user");
+      }
+      await invoke("unblock_user", {
+        blockerId: currentUser.id,
+        blockedId,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: blockQueryKeys.list(currentUser?.id ?? null),
+      });
+      queryClient.invalidateQueries({
+        queryKey: dmQueryKeys.channels(currentUser?.id ?? null),
+      });
+    },
+  });
+}

--- a/mobile/hooks/queries/useDMChannels.ts
+++ b/mobile/hooks/queries/useDMChannels.ts
@@ -75,6 +75,14 @@ export function useAcceptDMRequest() {
         dmChannelId,
         userId: currentUser.id,
       });
+      // The other side queued an MLS welcome for us when they opened
+      // the DM. Pull it now so the conversation appears as fully-keyed
+      // immediately instead of after the next ingest.
+      try {
+        await invoke("poll_mls_welcomes", { userId: currentUser.id });
+      } catch (e) {
+        console.warn("[mls] poll_mls_welcomes after dm accept failed:", e);
+      }
     },
     onSuccess: () => {
       queryClient.invalidateQueries({

--- a/mobile/hooks/queries/useDMChannels.ts
+++ b/mobile/hooks/queries/useDMChannels.ts
@@ -95,6 +95,27 @@ export function useAcceptDMRequest() {
   });
 }
 
+export function useLeaveDM() {
+  const queryClient = useQueryClient();
+  const currentUser = useAppStore((s) => s.currentUser);
+  return useMutation({
+    mutationFn: async (dmChannelId: string) => {
+      if (!currentUser) {
+        throw new Error("No current user");
+      }
+      await invoke("leave_dm_channel", {
+        dmChannelId,
+        userId: currentUser.id,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: dmQueryKeys.channels(currentUser?.id ?? null),
+      });
+    },
+  });
+}
+
 export function useCreateDM() {
   const queryClient = useQueryClient();
   const currentUser = useAppStore((s) => s.currentUser);

--- a/mobile/hooks/queries/useDMChannels.ts
+++ b/mobile/hooks/queries/useDMChannels.ts
@@ -4,7 +4,7 @@
 // `DMConversation` view-model, picking the "other side" relative to the
 // currently signed-in user.
 
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { invoke } from "../../lib/native";
 import { useAppStore } from "../../stores/appStore";
 import type { DMConversation } from "../../types";
@@ -60,6 +60,29 @@ export function useDMChannels() {
     },
     enabled: !!currentUser,
     staleTime: 1000 * 60,
+  });
+}
+
+export function useCreateDM() {
+  const queryClient = useQueryClient();
+  const currentUser = useAppStore((s) => s.currentUser);
+
+  return useMutation({
+    mutationFn: async (vars: { memberIds: string[] }) => {
+      if (!currentUser) {
+        throw new Error("No current user");
+      }
+      const raw = await invoke<RawDmChannel>("create_dm_channel", {
+        creatorId: currentUser.id,
+        memberIds: vars.memberIds,
+      });
+      return transform(raw, currentUser.id);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: dmQueryKeys.channels(currentUser?.id ?? null),
+      });
+    },
   });
 }
 

--- a/mobile/hooks/queries/useDMChannels.ts
+++ b/mobile/hooks/queries/useDMChannels.ts
@@ -63,6 +63,30 @@ export function useDMChannels() {
   });
 }
 
+export function useAcceptDMRequest() {
+  const queryClient = useQueryClient();
+  const currentUser = useAppStore((s) => s.currentUser);
+  return useMutation({
+    mutationFn: async (dmChannelId: string) => {
+      if (!currentUser) {
+        throw new Error("No current user");
+      }
+      await invoke("accept_dm_request", {
+        dmChannelId,
+        userId: currentUser.id,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: dmQueryKeys.requests(currentUser?.id ?? null),
+      });
+      queryClient.invalidateQueries({
+        queryKey: dmQueryKeys.channels(currentUser?.id ?? null),
+      });
+    },
+  });
+}
+
 export function useCreateDM() {
   const queryClient = useQueryClient();
   const currentUser = useAppStore((s) => s.currentUser);

--- a/mobile/hooks/queries/useDevices.ts
+++ b/mobile/hooks/queries/useDevices.ts
@@ -1,0 +1,58 @@
+// Device list / revoke hooks for the Security screen. Backed by
+// `list_user_devices` and `revoke_device`.
+//
+// The Rust side blocks revoking the current device — `logout(delete_data:
+// true)` is the path for "sign out of this device" — so the UI's revoke
+// button is hidden on the row marked `is_current`.
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { invoke } from "../../lib/native";
+import { useAppStore } from "../../stores/appStore";
+
+export interface DeviceRow {
+  device_id: string;
+  device_name: string | null;
+  created_at: string;
+  last_seen: string;
+  is_current: boolean;
+}
+
+export const deviceQueryKeys = {
+  list: (userId: string | null) => ["devices", userId] as const,
+};
+
+export function useUserDevices() {
+  const currentUser = useAppStore((s) => s.currentUser);
+  return useQuery({
+    queryKey: deviceQueryKeys.list(currentUser?.id ?? null),
+    queryFn: async (): Promise<DeviceRow[]> => {
+      if (!currentUser) {
+        return [];
+      }
+      return await invoke<DeviceRow[]>("list_user_devices", {
+        userId: currentUser.id,
+      });
+    },
+    enabled: !!currentUser,
+    staleTime: 1000 * 60,
+  });
+}
+
+export function useRevokeDevice() {
+  const currentUser = useAppStore((s) => s.currentUser);
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (deviceId: string) => {
+      if (!currentUser) {
+        throw new Error("No current user");
+      }
+      await invoke("revoke_device", { userId: currentUser.id, deviceId });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: deviceQueryKeys.list(currentUser?.id ?? null),
+      });
+    },
+  });
+}

--- a/mobile/hooks/queries/useEnrollment.ts
+++ b/mobile/hooks/queries/useEnrollment.ts
@@ -1,0 +1,156 @@
+// Device enrollment hooks. Two sides of the same flow:
+//
+// 1. **New device** (auth/enrollment screen):
+//    - `useStartEnrollment` opens an enrollment request and returns a
+//      short verification code the user reads aloud to their existing
+//      device.
+//    - `useEnrollmentStatus` polls Turso for the approval-or-not.
+//    - `useFinalizeEnrollment` finishes setup once status flips to
+//      `approved`.
+//    - `useRecoverWithSecretKey` is the alternate path — enter the
+//      recovery key emitted at first signup.
+//
+// 2. **Existing device** (self/security screen):
+//    - `usePendingEnrollmentRequests` lists requests from sibling devices.
+//    - `useApproveEnrollment` / `useRejectEnrollment` decide them.
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { invoke } from "../../lib/native";
+import { useAppStore } from "../../stores/appStore";
+
+export interface EnrollmentHandle {
+  request_id: string;
+  verification_code: string;
+  expires_at: string;
+}
+
+export type EnrollmentStatusKind = "pending" | "approved" | "rejected" | "expired";
+export interface EnrollmentStatus {
+  status: EnrollmentStatusKind;
+}
+
+export interface PendingEnrollmentRequest {
+  request_id: string;
+  new_device_id: string;
+  verification_code: string;
+  created_at: string;
+  expires_at: string;
+}
+
+export const enrollmentQueryKeys = {
+  status: (requestId: string | null) => ["enrollment", "status", requestId] as const,
+  pending: (userId: string | null) => ["enrollment", "pending", userId] as const,
+};
+
+export function useStartEnrollment() {
+  const currentUser = useAppStore((s) => s.currentUser);
+  return useMutation({
+    mutationFn: async (): Promise<EnrollmentHandle> => {
+      if (!currentUser) {
+        throw new Error("No current user");
+      }
+      return await invoke<EnrollmentHandle>("start_device_enrollment", {
+        userId: currentUser.id,
+      });
+    },
+  });
+}
+
+/** Polls every 3s while the request is pending. Stops as soon as the
+ *  server reports a terminal state. */
+export function useEnrollmentStatus(requestId: string | null) {
+  return useQuery({
+    queryKey: enrollmentQueryKeys.status(requestId),
+    queryFn: async (): Promise<EnrollmentStatus> => {
+      if (!requestId) {
+        throw new Error("No request");
+      }
+      return await invoke<EnrollmentStatus>("poll_enrollment_status", {
+        requestId,
+      });
+    },
+    enabled: !!requestId,
+    refetchInterval: (q) => {
+      const data = q.state.data as EnrollmentStatus | undefined;
+      if (!data || data.status === "pending") {
+        return 3_000;
+      }
+      return false;
+    },
+  });
+}
+
+export function useFinalizeEnrollment() {
+  const currentUser = useAppStore((s) => s.currentUser);
+  return useMutation({
+    mutationFn: async () => {
+      if (!currentUser) {
+        throw new Error("No current user");
+      }
+      await invoke("finalize_device_enrollment", { userId: currentUser.id });
+    },
+  });
+}
+
+export function useRecoverWithSecretKey() {
+  const currentUser = useAppStore((s) => s.currentUser);
+  return useMutation({
+    mutationFn: async (secretKey: string) => {
+      if (!currentUser) {
+        throw new Error("No current user");
+      }
+      await invoke("recover_with_secret_key", {
+        userId: currentUser.id,
+        secretKey,
+      });
+    },
+  });
+}
+
+export function usePendingEnrollmentRequests() {
+  const currentUser = useAppStore((s) => s.currentUser);
+  return useQuery({
+    queryKey: enrollmentQueryKeys.pending(currentUser?.id ?? null),
+    queryFn: async (): Promise<PendingEnrollmentRequest[]> => {
+      if (!currentUser) {
+        return [];
+      }
+      return await invoke<PendingEnrollmentRequest[]>(
+        "list_pending_enrollment_requests",
+        { userId: currentUser.id },
+      );
+    },
+    enabled: !!currentUser,
+    staleTime: 1000 * 30,
+  });
+}
+
+export function useApproveEnrollment() {
+  const queryClient = useQueryClient();
+  const currentUser = useAppStore((s) => s.currentUser);
+  return useMutation({
+    mutationFn: async (vars: { requestId: string; verificationCode: string }) => {
+      await invoke("approve_device_enrollment", vars);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: enrollmentQueryKeys.pending(currentUser?.id ?? null),
+      });
+    },
+  });
+}
+
+export function useRejectEnrollment() {
+  const queryClient = useQueryClient();
+  const currentUser = useAppStore((s) => s.currentUser);
+  return useMutation({
+    mutationFn: async (requestId: string) => {
+      await invoke("reject_device_enrollment", { requestId });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: enrollmentQueryKeys.pending(currentUser?.id ?? null),
+      });
+    },
+  });
+}

--- a/mobile/hooks/queries/useGroupInvites.ts
+++ b/mobile/hooks/queries/useGroupInvites.ts
@@ -56,6 +56,15 @@ export function useAcceptGroupInvite() {
         throw new Error("No current user");
       }
       await invoke("accept_group_invite", { inviteId, userId: currentUser.id });
+      // The MLS welcome may have already landed in Turso (the inviter
+      // queued it when sending the invite). Pull it now so the new group
+      // appears in the user's sidebar immediately instead of waiting for
+      // the next ingest-on-focus.
+      try {
+        await invoke("poll_mls_welcomes", { userId: currentUser.id });
+      } catch (e) {
+        console.warn("[mls] poll_mls_welcomes after accept failed:", e);
+      }
     },
     onSuccess: () => {
       queryClient.invalidateQueries({

--- a/mobile/hooks/queries/useGroupInvites.ts
+++ b/mobile/hooks/queries/useGroupInvites.ts
@@ -282,6 +282,143 @@ export function useSetMemberRole(groupId: string | null) {
   });
 }
 
+export interface JoinRequest {
+  id: string;
+  group_id: string;
+  requester_id: string;
+  requester_username?: string;
+  status: "pending" | "approved" | "rejected";
+  created_at: string;
+}
+
+export const joinRequestQueryKeys = {
+  byGroup: (groupId: string | null) => ["join-requests", "group", groupId] as const,
+  mine: (groupId: string | null, userId: string | null) =>
+    ["join-requests", "mine", groupId, userId] as const,
+};
+
+export function useGroupJoinRequests(groupId: string | null) {
+  const currentUser = useAppStore((s) => s.currentUser);
+  return useQuery({
+    queryKey: joinRequestQueryKeys.byGroup(groupId),
+    queryFn: async (): Promise<JoinRequest[]> => {
+      if (!currentUser || !groupId) {
+        return [];
+      }
+      return await invoke<JoinRequest[]>("get_group_join_requests", {
+        groupId,
+        requesterId: currentUser.id,
+      });
+    },
+    enabled: !!(currentUser && groupId),
+    staleTime: 1000 * 30,
+  });
+}
+
+export function useMyJoinRequest(groupId: string | null) {
+  const currentUser = useAppStore((s) => s.currentUser);
+  return useQuery({
+    queryKey: joinRequestQueryKeys.mine(groupId, currentUser?.id ?? null),
+    queryFn: async (): Promise<JoinRequest | null> => {
+      if (!currentUser || !groupId) {
+        return null;
+      }
+      return await invoke<JoinRequest | null>("get_my_join_request", {
+        groupId,
+        requesterId: currentUser.id,
+      });
+    },
+    enabled: !!(currentUser && groupId),
+    staleTime: 1000 * 30,
+  });
+}
+
+export function useRequestGroupAccess() {
+  const queryClient = useQueryClient();
+  const currentUser = useAppStore((s) => s.currentUser);
+  return useMutation({
+    mutationFn: async (groupId: string) => {
+      if (!currentUser) {
+        throw new Error("No current user");
+      }
+      await invoke("request_group_access", {
+        groupId,
+        requesterId: currentUser.id,
+      });
+      return groupId;
+    },
+    onSuccess: (groupId) => {
+      queryClient.invalidateQueries({
+        queryKey: joinRequestQueryKeys.mine(groupId, currentUser?.id ?? null),
+      });
+    },
+  });
+}
+
+export function useApproveJoinRequest(groupId: string | null) {
+  const queryClient = useQueryClient();
+  const currentUser = useAppStore((s) => s.currentUser);
+  return useMutation({
+    mutationFn: async (requestId: string) => {
+      if (!currentUser) {
+        throw new Error("No current user");
+      }
+      await invoke("approve_join_request", {
+        requestId,
+        approverId: currentUser.id,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: joinRequestQueryKeys.byGroup(groupId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: groupInviteQueryKeys.members(groupId),
+      });
+    },
+  });
+}
+
+export function useRejectJoinRequest(groupId: string | null) {
+  const queryClient = useQueryClient();
+  const currentUser = useAppStore((s) => s.currentUser);
+  return useMutation({
+    mutationFn: async (requestId: string) => {
+      if (!currentUser) {
+        throw new Error("No current user");
+      }
+      await invoke("reject_join_request", {
+        requestId,
+        approverId: currentUser.id,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: joinRequestQueryKeys.byGroup(groupId),
+      });
+    },
+  });
+}
+
+export function useGroupBySlug(slug: string | null) {
+  return useQuery({
+    queryKey: ["group", "slug", slug] as const,
+    queryFn: async () => {
+      if (!slug) {
+        return null;
+      }
+      return await invoke<{
+        id: string;
+        slug: string;
+        name: string;
+        description?: string;
+      } | null>("search_group_by_slug", { slug });
+    },
+    enabled: !!slug && slug.length >= 2,
+    staleTime: 1000 * 60,
+  });
+}
+
 export function useLeaveGroup() {
   const queryClient = useQueryClient();
   const currentUser = useAppStore((s) => s.currentUser);

--- a/mobile/hooks/queries/useGroupInvites.ts
+++ b/mobile/hooks/queries/useGroupInvites.ts
@@ -1,0 +1,141 @@
+// Pending group-invite hooks for the receiving (invitee) side, plus the
+// send-side mutation for the inviter (used from group/[id]/invite). The
+// member-list + leave-group hooks live here too because they all sit on
+// the group detail screen and share invalidation patterns.
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { invoke } from "../../lib/native";
+import { useAppStore } from "../../stores/appStore";
+import { groupQueryKeys } from "./useUserGroups";
+
+export interface PendingInvite {
+  id: string;
+  group_id: string;
+  group_name: string;
+  inviter_id: string;
+  inviter_username?: string;
+  created_at: string;
+}
+
+export interface GroupMember {
+  user_id: string;
+  username?: string;
+  avatar_url?: string;
+  role: string;
+  joined_at: string;
+}
+
+export const groupInviteQueryKeys = {
+  pending: (userId: string | null) => ["group-invites", "pending", userId] as const,
+  members: (groupId: string | null) => ["groups", groupId, "members"] as const,
+};
+
+export function usePendingGroupInvites() {
+  const currentUser = useAppStore((s) => s.currentUser);
+  return useQuery({
+    queryKey: groupInviteQueryKeys.pending(currentUser?.id ?? null),
+    queryFn: async (): Promise<PendingInvite[]> => {
+      if (!currentUser) {
+        return [];
+      }
+      return await invoke<PendingInvite[]>("get_pending_invites", {
+        userId: currentUser.id,
+      });
+    },
+    enabled: !!currentUser,
+    staleTime: 1000 * 60,
+  });
+}
+
+export function useAcceptGroupInvite() {
+  const queryClient = useQueryClient();
+  const currentUser = useAppStore((s) => s.currentUser);
+  return useMutation({
+    mutationFn: async (inviteId: string) => {
+      if (!currentUser) {
+        throw new Error("No current user");
+      }
+      await invoke("accept_group_invite", { inviteId, userId: currentUser.id });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: groupInviteQueryKeys.pending(currentUser?.id ?? null),
+      });
+      queryClient.invalidateQueries({
+        queryKey: groupQueryKeys.userGroups(currentUser?.id ?? null),
+      });
+      queryClient.invalidateQueries({
+        queryKey: groupQueryKeys.userGroupsWithChannels(currentUser?.id ?? null),
+      });
+    },
+  });
+}
+
+export function useDeclineGroupInvite() {
+  const queryClient = useQueryClient();
+  const currentUser = useAppStore((s) => s.currentUser);
+  return useMutation({
+    mutationFn: async (inviteId: string) => {
+      if (!currentUser) {
+        throw new Error("No current user");
+      }
+      await invoke("decline_group_invite", { inviteId, userId: currentUser.id });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: groupInviteQueryKeys.pending(currentUser?.id ?? null),
+      });
+    },
+  });
+}
+
+export function useSendGroupInvite(groupId: string | null) {
+  const currentUser = useAppStore((s) => s.currentUser);
+  return useMutation({
+    mutationFn: async (inviteeIdentifier: string) => {
+      if (!currentUser || !groupId) {
+        throw new Error("No active group");
+      }
+      await invoke("send_group_invite", {
+        groupId,
+        inviterId: currentUser.id,
+        inviteeIdentifier,
+      });
+    },
+  });
+}
+
+export function useGroupMembers(groupId: string | null) {
+  return useQuery({
+    queryKey: groupInviteQueryKeys.members(groupId),
+    queryFn: async (): Promise<GroupMember[]> => {
+      if (!groupId) {
+        return [];
+      }
+      return await invoke<GroupMember[]>("get_group_members", { groupId });
+    },
+    enabled: !!groupId,
+    staleTime: 1000 * 60,
+  });
+}
+
+export function useLeaveGroup() {
+  const queryClient = useQueryClient();
+  const currentUser = useAppStore((s) => s.currentUser);
+  return useMutation({
+    mutationFn: async (groupId: string) => {
+      if (!currentUser) {
+        throw new Error("No current user");
+      }
+      await invoke("leave_group", { groupId, userId: currentUser.id });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: groupQueryKeys.userGroups(currentUser?.id ?? null),
+      });
+      queryClient.invalidateQueries({
+        queryKey: groupQueryKeys.userGroupsWithChannels(currentUser?.id ?? null),
+      });
+    },
+  });
+}

--- a/mobile/hooks/queries/useGroupInvites.ts
+++ b/mobile/hooks/queries/useGroupInvites.ts
@@ -128,6 +128,160 @@ export function useGroupMembers(groupId: string | null) {
   });
 }
 
+export function useUpdateGroup(groupId: string | null) {
+  const queryClient = useQueryClient();
+  const currentUser = useAppStore((s) => s.currentUser);
+  return useMutation({
+    mutationFn: async (vars: {
+      name?: string;
+      description?: string;
+      iconUrl?: string;
+    }) => {
+      if (!currentUser || !groupId) {
+        throw new Error("No active group");
+      }
+      await invoke("update_group", {
+        groupId,
+        requesterId: currentUser.id,
+        name: vars.name ?? null,
+        description: vars.description ?? null,
+        iconUrl: vars.iconUrl ?? null,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: groupQueryKeys.userGroups(currentUser?.id ?? null),
+      });
+      queryClient.invalidateQueries({
+        queryKey: groupQueryKeys.userGroupsWithChannels(currentUser?.id ?? null),
+      });
+    },
+  });
+}
+
+export function useDeleteGroup() {
+  const queryClient = useQueryClient();
+  const currentUser = useAppStore((s) => s.currentUser);
+  return useMutation({
+    mutationFn: async (groupId: string) => {
+      if (!currentUser) {
+        throw new Error("No current user");
+      }
+      await invoke("delete_group", {
+        groupId,
+        requesterId: currentUser.id,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: groupQueryKeys.userGroups(currentUser?.id ?? null),
+      });
+      queryClient.invalidateQueries({
+        queryKey: groupQueryKeys.userGroupsWithChannels(currentUser?.id ?? null),
+      });
+    },
+  });
+}
+
+export function useUpdateChannel(groupId: string | null) {
+  const queryClient = useQueryClient();
+  const currentUser = useAppStore((s) => s.currentUser);
+  return useMutation({
+    mutationFn: async (vars: {
+      channelId: string;
+      name?: string;
+      description?: string;
+    }) => {
+      if (!currentUser) {
+        throw new Error("No current user");
+      }
+      await invoke("update_channel", {
+        channelId: vars.channelId,
+        requesterId: currentUser.id,
+        name: vars.name ?? null,
+        description: vars.description ?? null,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: groupQueryKeys.channels(groupId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: groupQueryKeys.userGroupsWithChannels(currentUser?.id ?? null),
+      });
+    },
+  });
+}
+
+export function useDeleteChannel(groupId: string | null) {
+  const queryClient = useQueryClient();
+  const currentUser = useAppStore((s) => s.currentUser);
+  return useMutation({
+    mutationFn: async (channelId: string) => {
+      if (!currentUser) {
+        throw new Error("No current user");
+      }
+      await invoke("delete_channel", {
+        channelId,
+        requesterId: currentUser.id,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: groupQueryKeys.channels(groupId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: groupQueryKeys.userGroupsWithChannels(currentUser?.id ?? null),
+      });
+    },
+  });
+}
+
+export function useRemoveMember(groupId: string | null) {
+  const queryClient = useQueryClient();
+  const currentUser = useAppStore((s) => s.currentUser);
+  return useMutation({
+    mutationFn: async (userId: string) => {
+      if (!currentUser || !groupId) {
+        throw new Error("No active group");
+      }
+      await invoke("remove_member_from_group", {
+        groupId,
+        userId,
+        requesterId: currentUser.id,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: groupInviteQueryKeys.members(groupId),
+      });
+    },
+  });
+}
+
+export function useSetMemberRole(groupId: string | null) {
+  const queryClient = useQueryClient();
+  const currentUser = useAppStore((s) => s.currentUser);
+  return useMutation({
+    mutationFn: async (vars: { userId: string; role: "admin" | "member" }) => {
+      if (!currentUser || !groupId) {
+        throw new Error("No active group");
+      }
+      await invoke("set_member_role", {
+        groupId,
+        userId: vars.userId,
+        role: vars.role,
+        requesterId: currentUser.id,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: groupInviteQueryKeys.members(groupId),
+      });
+    },
+  });
+}
+
 export function useLeaveGroup() {
   const queryClient = useQueryClient();
   const currentUser = useAppStore((s) => s.currentUser);

--- a/mobile/hooks/queries/useMessages.ts
+++ b/mobile/hooks/queries/useMessages.ts
@@ -214,6 +214,141 @@ export function useSendMessage(
   });
 }
 
+/** React (toggle) helper. Returns a mutation that toggles a single emoji
+ *  on a message — checks the current reaction state by sending
+ *  add_reaction or remove_reaction. The caller is responsible for
+ *  tracking whether they already reacted; this hook just dispatches the
+ *  intent. */
+export function useToggleReaction(
+  conversationId: string | null,
+  kind: ConversationKind | null,
+) {
+  const queryClient = useQueryClient();
+  const currentUser = useAppStore((s) => s.currentUser);
+  return useMutation({
+    mutationFn: async (vars: {
+      messageId: string;
+      emoji: string;
+      mode: "add" | "remove";
+    }) => {
+      if (!currentUser) {
+        throw new Error("No current user");
+      }
+      const cmd = vars.mode === "add" ? "add_reaction" : "remove_reaction";
+      await invoke(cmd, {
+        messageId: vars.messageId,
+        userId: currentUser.id,
+        emoji: vars.emoji,
+      });
+    },
+    onSuccess: () => {
+      if (conversationId && kind) {
+        queryClient.invalidateQueries({
+          queryKey: messageQueryKeys.conversation(conversationId, kind),
+        });
+      }
+    },
+  });
+}
+
+export function useEditMessage(
+  conversationId: string | null,
+  kind: ConversationKind | null,
+) {
+  const queryClient = useQueryClient();
+  const currentUser = useAppStore((s) => s.currentUser);
+  return useMutation({
+    mutationFn: async (vars: { messageId: string; newContent: string }) => {
+      if (!currentUser || !conversationId) {
+        throw new Error("No active conversation");
+      }
+      await invoke("edit_message", {
+        conversationId,
+        messageId: vars.messageId,
+        userId: currentUser.id,
+        newContent: vars.newContent,
+      });
+      return vars;
+    },
+    onMutate: async (vars) => {
+      if (!conversationId || !kind) {
+        return;
+      }
+      const key = messageQueryKeys.conversation(conversationId, kind);
+      await queryClient.cancelQueries({ queryKey: key });
+      const previous = queryClient.getQueryData<{
+        messages: Message[];
+        nextCursor: MessagePage["next_cursor"];
+      }>(key);
+      queryClient.setQueryData(key, (cache: typeof previous) => {
+        if (!cache) {
+          return cache;
+        }
+        return {
+          ...cache,
+          messages: cache.messages.map((m) =>
+            m.id === vars.messageId
+              ? { ...m, content: vars.newContent, edited_at: Date.now() }
+              : m,
+          ),
+        };
+      });
+      return { previous, key };
+    },
+    onError: (_e, _vars, ctx) => {
+      if (ctx?.previous) {
+        queryClient.setQueryData(ctx.key, ctx.previous);
+      }
+    },
+  });
+}
+
+export function useDeleteMessage(
+  conversationId: string | null,
+  kind: ConversationKind | null,
+) {
+  const queryClient = useQueryClient();
+  const currentUser = useAppStore((s) => s.currentUser);
+  return useMutation({
+    mutationFn: async (messageId: string) => {
+      if (!currentUser) {
+        throw new Error("No current user");
+      }
+      await invoke("delete_message", {
+        messageId,
+        userId: currentUser.id,
+      });
+      return messageId;
+    },
+    onMutate: async (messageId) => {
+      if (!conversationId || !kind) {
+        return;
+      }
+      const key = messageQueryKeys.conversation(conversationId, kind);
+      await queryClient.cancelQueries({ queryKey: key });
+      const previous = queryClient.getQueryData<{
+        messages: Message[];
+        nextCursor: MessagePage["next_cursor"];
+      }>(key);
+      queryClient.setQueryData(key, (cache: typeof previous) => {
+        if (!cache) {
+          return cache;
+        }
+        return {
+          ...cache,
+          messages: cache.messages.filter((m) => m.id !== messageId),
+        };
+      });
+      return { previous, key };
+    },
+    onError: (_e, _vars, ctx) => {
+      if (ctx?.previous) {
+        queryClient.setQueryData(ctx.key, ctx.previous);
+      }
+    },
+  });
+}
+
 /**
  * Imperative ingest trigger — fire-and-forget. Called from `useFocusEffect`
  * in the chat screen when the screen mounts or refocuses, so the user sees

--- a/mobile/hooks/queries/useMessages.ts
+++ b/mobile/hooks/queries/useMessages.ts
@@ -102,7 +102,12 @@ export function useMessages(
 ) {
   const currentUser = useAppStore((s) => s.currentUser);
   const limit = opts?.limit ?? 50;
-  const refetchInterval = opts?.refetchIntervalMs ?? 10_000;
+  // No polling by default. Realtime push (a follow-on PR) will invalidate
+  // this query when a new envelope arrives; until then the focus-effect
+  // ingest in the chat screen covers the "open a chat and see what was
+  // sent while I was away" case. A periodic poll would just be ripped
+  // out the moment realtime lands.
+  const refetchInterval = opts?.refetchIntervalMs ?? false;
 
   return useQuery({
     queryKey: messageQueryKeys.conversation(conversationId, kind),

--- a/mobile/hooks/queries/useMessages.ts
+++ b/mobile/hooks/queries/useMessages.ts
@@ -1,9 +1,35 @@
-// Message read hook. Mirrors `frontend/src/hooks/queries/useMessages.ts`
-// for the chat screen's read path. Send / ingest / pagination come later
-// — this hook covers the "open a chat, see the recent messages" flow.
+// Message read + send + ingest hooks. Mirrors the read paths of
+// `frontend/src/hooks/queries/useMessages.ts` — `get_channel_messages` and
+// `get_dm_messages` both invoke envelope-ingest internally before reading
+// the local DB, so a single call gives a fresh page. Pagination (load
+// older history) and infinite-scroll come in a follow-on; this hook
+// returns the most-recent `limit` messages newest-first and exposes a
+// `useSendMessage` mutation for the composer.
 
-import { useQuery } from "@tanstack/react-query";
+import { useCallback } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { invoke } from "../../lib/native";
+import { useAppStore } from "../../stores/appStore";
+
+export type ConversationKind = "channel" | "dm";
+
+export interface RawChannelMessage {
+  id: string;
+  conversation_id: string;
+  sender_id: string;
+  sender_username?: string;
+  ciphertext?: string;
+  content?: string;
+  reply_to_id?: string | null;
+  sent_at: string;
+  edited_at?: string;
+  deleted_at?: string;
+}
+
+export interface MessagePage {
+  messages: RawChannelMessage[];
+  next_cursor: { sent_at: string; id: string } | null;
+}
 
 export interface Message {
   id: string;
@@ -12,33 +38,212 @@ export interface Message {
   sender_username?: string;
   content: string;
   reply_to_id?: string | null;
-  created_at: number | string;
-  updated_at: number | string;
+  created_at: number;
+  edited_at?: number;
+  deleted_at?: number;
+  /** Local-only optimistic stub flag. Replaced when `send_message` resolves. */
+  pending?: boolean;
+}
+
+function parseContent(raw: string | undefined): string {
+  if (!raw) {
+    return "";
+  }
+  // Desktop wraps attachments in a structured envelope; mobile doesn't
+  // upload attachments yet, so for now we just strip that envelope down
+  // to the text payload if it's present.
+  if (raw.startsWith("{")) {
+    try {
+      const parsed = JSON.parse(raw);
+      if (typeof parsed?._txt === "string") {
+        return parsed._txt;
+      }
+    } catch {
+      // Fall through — treat as plain text.
+    }
+  }
+  return raw;
+}
+
+function transform(raw: RawChannelMessage): Message {
+  return {
+    id: raw.id,
+    conversation_id: raw.conversation_id,
+    sender_id: raw.sender_id,
+    sender_username: raw.sender_username,
+    content: parseContent(raw.content),
+    reply_to_id: raw.reply_to_id ?? null,
+    created_at: new Date(raw.sent_at).getTime(),
+    edited_at: raw.edited_at ? new Date(raw.edited_at).getTime() : undefined,
+    deleted_at: raw.deleted_at ? new Date(raw.deleted_at).getTime() : undefined,
+  };
 }
 
 export const messageQueryKeys = {
   all: ["messages"] as const,
-  conversation: (conversationId: string | null) =>
-    ["messages", "conversation", conversationId] as const,
+  conversation: (
+    conversationId: string | null,
+    kind: ConversationKind | null,
+  ) => ["messages", kind, conversationId] as const,
 };
 
+/**
+ * Fetch the most recent `limit` messages for a channel or DM. `get_*_messages`
+ * runs envelope ingest itself before reading, so each call picks up newly
+ * delivered messages — no separate ingest hook is required for the basic
+ * polling path. The chat screen still triggers an explicit ingest via
+ * `useIngestConversation` on focus so a returning user sees fresh content
+ * immediately, without waiting for the next refetch.
+ */
 export function useMessages(
   conversationId: string | null,
-  opts?: { limit?: number },
+  kind: ConversationKind | null,
+  opts?: { limit?: number; refetchIntervalMs?: number | false },
 ) {
+  const currentUser = useAppStore((s) => s.currentUser);
+  const limit = opts?.limit ?? 50;
+  const refetchInterval = opts?.refetchIntervalMs ?? 10_000;
+
   return useQuery({
-    queryKey: messageQueryKeys.conversation(conversationId),
-    queryFn: async (): Promise<Message[]> => {
-      if (!conversationId) {
-        return [];
+    queryKey: messageQueryKeys.conversation(conversationId, kind),
+    queryFn: async (): Promise<{ messages: Message[]; nextCursor: MessagePage["next_cursor"] }> => {
+      if (!conversationId || !kind || !currentUser) {
+        return { messages: [], nextCursor: null };
       }
-      const messages = await invoke<Message[]>("list_messages", {
-        conversationId,
-        limit: opts?.limit ?? 50,
-      });
-      return messages ?? [];
+      const cmd =
+        kind === "channel" ? "get_channel_messages" : "get_dm_messages";
+      const args =
+        kind === "channel"
+          ? { userId: currentUser.id, channelId: conversationId, limit }
+          : { userId: currentUser.id, dmChannelId: conversationId, limit };
+      const page = await invoke<MessagePage>(cmd, args);
+      // Server returns newest-first; reverse for chronological render.
+      const transformed = (page.messages ?? []).map(transform).reverse();
+      return { messages: transformed, nextCursor: page.next_cursor };
     },
-    enabled: !!conversationId,
-    staleTime: 1000 * 30,
+    enabled: !!(conversationId && kind && currentUser),
+    staleTime: 1000 * 15,
+    refetchInterval,
   });
+}
+
+/**
+ * Send a text message. Optimistic: the new message is appended to the
+ * cache immediately with `pending: true`, then replaced with the
+ * server-confirmed row on success (or removed on failure).
+ */
+export function useSendMessage(
+  conversationId: string | null,
+  kind: ConversationKind | null,
+) {
+  const queryClient = useQueryClient();
+  const currentUser = useAppStore((s) => s.currentUser);
+
+  return useMutation({
+    mutationFn: async (vars: { content: string; replyToId?: string }) => {
+      if (!conversationId || !currentUser) {
+        throw new Error("No active conversation");
+      }
+      const raw = await invoke<RawChannelMessage>("send_message", {
+        conversationId,
+        senderId: currentUser.id,
+        content: vars.content,
+        replyToId: vars.replyToId ?? null,
+        senderUsername: currentUser.username ?? null,
+      });
+      return transform(raw);
+    },
+    onMutate: async (vars) => {
+      if (!conversationId || !kind || !currentUser) {
+        return;
+      }
+      const key = messageQueryKeys.conversation(conversationId, kind);
+      await queryClient.cancelQueries({ queryKey: key });
+      const optimisticId = `pending-${Date.now()}`;
+      const optimistic: Message = {
+        id: optimisticId,
+        conversation_id: conversationId,
+        sender_id: currentUser.id,
+        sender_username: currentUser.username,
+        content: vars.content,
+        reply_to_id: vars.replyToId ?? null,
+        created_at: Date.now(),
+        pending: true,
+      };
+      const previous = queryClient.getQueryData<{
+        messages: Message[];
+        nextCursor: MessagePage["next_cursor"];
+      }>(key);
+      queryClient.setQueryData(key, {
+        messages: [...(previous?.messages ?? []), optimistic],
+        nextCursor: previous?.nextCursor ?? null,
+      });
+      return { previous, optimisticId, key };
+    },
+    onSuccess: (confirmed, _vars, ctx) => {
+      if (!ctx) {
+        return;
+      }
+      queryClient.setQueryData<{
+        messages: Message[];
+        nextCursor: MessagePage["next_cursor"];
+      }>(ctx.key, (cache) => {
+        if (!cache) {
+          return cache;
+        }
+        return {
+          ...cache,
+          messages: cache.messages.map((m) =>
+            m.id === ctx.optimisticId ? confirmed : m,
+          ),
+        };
+      });
+    },
+    onError: (_e, _vars, ctx) => {
+      if (!ctx?.previous) {
+        return;
+      }
+      // Roll back the optimistic stub on failure.
+      queryClient.setQueryData(ctx.key, ctx.previous);
+    },
+  });
+}
+
+/**
+ * Imperative ingest trigger — fire-and-forget. Called from `useFocusEffect`
+ * in the chat screen when the screen mounts or refocuses, so the user sees
+ * any messages delivered while the app was backgrounded. The refetch
+ * interval in `useMessages` covers the steady-state polling.
+ */
+export function useIngestConversation() {
+  const currentUser = useAppStore((s) => s.currentUser);
+  const queryClient = useQueryClient();
+
+  return useCallback(
+    async (conversationId: string, kind: ConversationKind) => {
+      if (!currentUser) {
+        return;
+      }
+      try {
+        if (kind === "channel") {
+          await invoke("ingest_channel_envelopes", {
+            userId: currentUser.id,
+            channelId: conversationId,
+          });
+        } else {
+          await invoke("ingest_dm_envelopes", {
+            userId: currentUser.id,
+            dmChannelId: conversationId,
+          });
+        }
+        queryClient.invalidateQueries({
+          queryKey: messageQueryKeys.conversation(conversationId, kind),
+        });
+      } catch (e) {
+        // Best-effort — ingest is advisory. The next refetch will retry.
+        console.warn("[useIngestConversation] ingest failed:", e);
+      }
+    },
+    [currentUser, queryClient],
+  );
 }

--- a/mobile/hooks/queries/usePreferences.ts
+++ b/mobile/hooks/queries/usePreferences.ts
@@ -1,0 +1,107 @@
+// Mobile preferences hook. Reads + writes the user's free-form
+// preferences blob via the desktop-shared `get_preferences` /
+// `save_preferences` commands. Mobile and desktop share the same Turso
+// row keyed by `user_id` — to avoid clobbering desktop-side keys
+// (`accent_color`, `noise_suppression_level`, etc.) we always merge the
+// remote object with our mobile patch before writing back.
+//
+// The mobile UI persists:
+//   - `accent_hex`             — color picker, also drives ThemeProvider
+//   - `mobile_theme`           — Coal | Paper | System (cosmetic, not wired yet)
+//   - `mobile_density`         — Compact | Comfortable
+//   - `mobile_behavior`        — toggle map for the BEHAVIOR list
+//
+// Mobile-only keys are namespaced with `mobile_` so future desktop reads
+// see them as opaque pass-through, not interpretable preferences.
+
+import { useCallback } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { invoke } from "../../lib/native";
+import { useAppStore } from "../../stores/appStore";
+
+export interface MobilePreferencesPatch {
+  accent_hex?: string;
+  mobile_theme?: "Coal" | "Paper" | "System";
+  mobile_density?: "Compact" | "Comfortable";
+  mobile_behavior?: Record<string, boolean>;
+}
+
+/** The full blob as it lives in Turso. Mobile fields are typed; desktop
+ *  keys ride along as `unknown` so we don't drop them during merge. */
+export type PreferencesBlob = MobilePreferencesPatch & Record<string, unknown>;
+
+export const preferencesQueryKeys = {
+  all: ["preferences"] as const,
+  user: (userId: string | null) => ["preferences", userId] as const,
+};
+
+function parseBlob(raw: string | null | undefined): PreferencesBlob {
+  if (!raw) {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as PreferencesBlob;
+    }
+  } catch {
+    // Server returned malformed JSON — treat as empty.
+  }
+  return {};
+}
+
+export function usePreferences() {
+  const currentUser = useAppStore((s) => s.currentUser);
+  const queryClient = useQueryClient();
+
+  const query = useQuery({
+    queryKey: preferencesQueryKeys.user(currentUser?.id ?? null),
+    queryFn: async (): Promise<PreferencesBlob> => {
+      if (!currentUser) {
+        return {};
+      }
+      const raw = await invoke<string>("get_preferences", {
+        userId: currentUser.id,
+      });
+      return parseBlob(raw);
+    },
+    enabled: !!currentUser,
+    staleTime: 1000 * 60,
+  });
+
+  const save = useMutation({
+    mutationFn: async (patch: MobilePreferencesPatch) => {
+      if (!currentUser) {
+        throw new Error("No current user");
+      }
+      // Merge against the latest cached blob so desktop-side fields are
+      // preserved. If the cache is empty (first save after install) we
+      // start from `{}` — losing nothing.
+      const current =
+        queryClient.getQueryData<PreferencesBlob>(
+          preferencesQueryKeys.user(currentUser.id),
+        ) ?? {};
+      const merged: PreferencesBlob = { ...current, ...patch };
+      await invoke("save_preferences", {
+        userId: currentUser.id,
+        preferencesJson: JSON.stringify(merged),
+      });
+      return merged;
+    },
+    onSuccess: (merged) => {
+      queryClient.setQueryData(
+        preferencesQueryKeys.user(currentUser?.id ?? null),
+        merged,
+      );
+    },
+  });
+
+  const update = useCallback(
+    (patch: MobilePreferencesPatch) => {
+      save.mutate(patch);
+    },
+    [save],
+  );
+
+  return { ...query, save, update };
+}

--- a/mobile/hooks/queries/useSafety.ts
+++ b/mobile/hooks/queries/useSafety.ts
@@ -1,0 +1,91 @@
+// Safety-number hooks — used by the other-user profile screen to show
+// the 60-digit-ish fingerprint and a "Verified" toggle. Mirrors the
+// desktop verification pattern: we never display the *own* user's
+// safety number, only peer-vs-self pairs.
+//
+// `get_safety_number` returns an info struct with both fingerprints and
+// the current verification state from the local pin store. Marking a
+// peer verified writes a row to the local `peer_verification` table; the
+// listing hook surfaces those for the contacts list / banners elsewhere.
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { invoke } from "../../lib/native";
+import { useAppStore } from "../../stores/appStore";
+
+export interface SafetyNumberInfo {
+  my_fingerprint: string;
+  peer_fingerprint: string;
+  /** Concatenated fingerprint used for the QR / readable code display. */
+  combined: string;
+  /** Verification status pinned locally. */
+  verification: "unverified" | "verified" | "changed";
+  peer_identity_version: number;
+}
+
+export interface PeerVerification {
+  peer_user_id: string;
+  peer_username?: string;
+  status: "verified" | "changed";
+  verified_at: string;
+}
+
+export const safetyQueryKeys = {
+  number: (myId: string | null, peerId: string | null) =>
+    ["safety", "number", myId, peerId] as const,
+  list: (myId: string | null) => ["safety", "list", myId] as const,
+};
+
+export function useSafetyNumber(peerUserId: string | null) {
+  const currentUser = useAppStore((s) => s.currentUser);
+  return useQuery({
+    queryKey: safetyQueryKeys.number(currentUser?.id ?? null, peerUserId),
+    queryFn: async (): Promise<SafetyNumberInfo | null> => {
+      if (!currentUser || !peerUserId) {
+        return null;
+      }
+      return await invoke<SafetyNumberInfo>("get_safety_number", {
+        myUserId: currentUser.id,
+        peerUserId,
+      });
+    },
+    enabled: !!(currentUser && peerUserId),
+    staleTime: 1000 * 60,
+  });
+}
+
+export function useSetContactVerified() {
+  const queryClient = useQueryClient();
+  const currentUser = useAppStore((s) => s.currentUser);
+  return useMutation({
+    mutationFn: async (vars: { peerUserId: string; verified: boolean }) => {
+      await invoke("set_contact_verified", {
+        peerUserId: vars.peerUserId,
+        verified: vars.verified,
+      });
+      return vars;
+    },
+    onSuccess: (vars) => {
+      queryClient.invalidateQueries({
+        queryKey: safetyQueryKeys.number(currentUser?.id ?? null, vars.peerUserId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: safetyQueryKeys.list(currentUser?.id ?? null),
+      });
+    },
+  });
+}
+
+export function usePeerVerifications() {
+  const currentUser = useAppStore((s) => s.currentUser);
+  return useQuery({
+    queryKey: safetyQueryKeys.list(currentUser?.id ?? null),
+    queryFn: async (): Promise<PeerVerification[]> => {
+      if (!currentUser) {
+        return [];
+      }
+      return await invoke<PeerVerification[]>("list_peer_verifications");
+    },
+    enabled: !!currentUser,
+    staleTime: 1000 * 60,
+  });
+}

--- a/mobile/hooks/queries/useSearch.ts
+++ b/mobile/hooks/queries/useSearch.ts
@@ -1,0 +1,41 @@
+// Cross-content search hook. Backs the (tabs)/search screen.
+//
+// Today we wire just `search_messages` — it goes through the local FTS
+// index and returns SearchResult rows. User search (`search_user_by_username`)
+// is exposed via `useUserSearch` and groups can be filtered client-side
+// from the cached `useUserGroupsWithChannels` list, so a single Rust
+// invoke covers the typeahead.
+
+import { useQuery } from "@tanstack/react-query";
+import { invoke } from "../../lib/native";
+
+export interface SearchMessageResult {
+  message_id: string;
+  conversation_id: string;
+  sender_id: string;
+  content: string;
+  sent_at: string;
+  snippet: string;
+}
+
+export const searchQueryKeys = {
+  messages: (q: string) => ["search", "messages", q] as const,
+};
+
+export function useSearchMessages(query: string) {
+  const trimmed = query.trim();
+  return useQuery({
+    queryKey: searchQueryKeys.messages(trimmed),
+    queryFn: async (): Promise<SearchMessageResult[]> => {
+      if (!trimmed) {
+        return [];
+      }
+      return await invoke<SearchMessageResult[]>("search_messages", {
+        query: trimmed,
+        limit: 50,
+      });
+    },
+    enabled: trimmed.length >= 2,
+    staleTime: 1000 * 20,
+  });
+}

--- a/mobile/hooks/queries/useUserGroups.ts
+++ b/mobile/hooks/queries/useUserGroups.ts
@@ -2,7 +2,7 @@
 // for the read paths the mobile UI needs. Mutations (create_group,
 // invite_to_group, etc.) come later when we add those flows.
 
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { invoke } from "../../lib/native";
 import { useAppStore } from "../../stores/appStore";
 import type { Channel, Group } from "../../types";
@@ -52,6 +52,67 @@ export function useUserGroupsWithChannels() {
     },
     enabled: !!currentUser,
     staleTime: 1000 * 60,
+  });
+}
+
+export function useCreateGroup() {
+  const queryClient = useQueryClient();
+  const currentUser = useAppStore((s) => s.currentUser);
+
+  return useMutation({
+    mutationFn: async (vars: {
+      name: string;
+      description?: string;
+      createDefaultTextChannel?: boolean;
+    }) => {
+      if (!currentUser) {
+        throw new Error("No current user");
+      }
+      return await invoke<Group>("create_group", {
+        name: vars.name,
+        description: vars.description ?? null,
+        ownerId: currentUser.id,
+        createDefaultTextChannel: vars.createDefaultTextChannel ?? true,
+        // Mobile drops voice — never create the default voice channel.
+        createDefaultVoiceChannel: false,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: groupQueryKeys.userGroups(currentUser?.id ?? null),
+      });
+      queryClient.invalidateQueries({
+        queryKey: groupQueryKeys.userGroupsWithChannels(currentUser?.id ?? null),
+      });
+    },
+  });
+}
+
+export function useCreateChannel(groupId: string | null) {
+  const queryClient = useQueryClient();
+  const currentUser = useAppStore((s) => s.currentUser);
+
+  return useMutation({
+    mutationFn: async (vars: { name: string; description?: string }) => {
+      if (!currentUser || !groupId) {
+        throw new Error("No active group");
+      }
+      return await invoke<Channel>("create_channel", {
+        groupId,
+        name: vars.name,
+        description: vars.description ?? null,
+        channelType: "text",
+        creatorId: currentUser.id,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: groupQueryKeys.channels(groupId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: groupQueryKeys.userGroupsWithChannels(currentUser?.id ?? null),
+      });
+    },
   });
 }
 

--- a/mobile/hooks/queries/useUserSearch.ts
+++ b/mobile/hooks/queries/useUserSearch.ts
@@ -1,0 +1,38 @@
+// Username/email search hook for DM creation. Wraps the
+// `search_user_by_username` command — Rust matches against both username
+// and email (case-sensitive in current schema, see commands/user.rs).
+// Returns `null` when nothing matches; the create-DM screen shows an
+// empty-state row in that case.
+
+import { useQuery } from "@tanstack/react-query";
+import { invoke } from "../../lib/native";
+
+export interface FoundUser {
+  id: string;
+  email?: string;
+  username: string;
+  preferred_name?: string;
+  phone?: string;
+  avatar_url?: string;
+}
+
+export const userSearchQueryKeys = {
+  search: (q: string) => ["user-search", q] as const,
+};
+
+export function useUserSearch(query: string) {
+  const trimmed = query.trim();
+  return useQuery({
+    queryKey: userSearchQueryKeys.search(trimmed),
+    queryFn: async (): Promise<FoundUser | null> => {
+      if (!trimmed) {
+        return null;
+      }
+      return await invoke<FoundUser | null>("search_user_by_username", {
+        username: trimmed,
+      });
+    },
+    enabled: trimmed.length >= 2,
+    staleTime: 1000 * 30,
+  });
+}

--- a/mobile/stores/appStore.ts
+++ b/mobile/stores/appStore.ts
@@ -56,6 +56,13 @@ interface AppStore extends AppState {
   markRead: (id: string) => void;
   incrementUnread: (id: string) => void;
   logout: () => void;
+
+  // Transient first-signup state. The Rust side returns `new_secret_key`
+  // once on `verify_otp` — we shuttle it through the PIN setup screen to
+  // the Emergency Kit display, then drop it on the floor. Stored in memory
+  // only; never persisted.
+  pendingSecretKey: string | null;
+  setPendingSecretKey: (key: string | null) => void;
 }
 
 export const useAppStore = create<AppStore>((set) => ({
@@ -74,6 +81,7 @@ export const useAppStore = create<AppStore>((set) => ({
   isLoading: false,
   error: null,
   unreadCounts: {},
+  pendingSecretKey: null,
 
   // Actions
   setCurrentUser: (user) => set({ currentUser: user }),
@@ -135,6 +143,7 @@ export const useAppStore = create<AppStore>((set) => ({
     })),
 
   setReplyToMessageId: (messageId) => set({ replyToMessageId: messageId }),
+  setPendingSecretKey: (key) => set({ pendingSecretKey: key }),
 
   setLoading: (loading) => set({ isLoading: loading }),
   setError: (error) => set({ error }),

--- a/pollis-core/src/bridge.rs
+++ b/pollis-core/src/bridge.rs
@@ -284,6 +284,45 @@ pub async fn invoke(cmd: String, args_json: String) -> Result<String, BridgeErro
             )
             .await?)
         }
+        "get_group_members" => {
+            let group_id: String = arg(&args, "groupId")?;
+            ok(groups::get_group_members(group_id, &state()?).await?)
+        }
+        "leave_group" => {
+            let group_id: String = arg(&args, "groupId")?;
+            let user_id: String = arg(&args, "userId")?;
+            groups::leave_group(group_id, user_id, &state()?).await?;
+            ok(())
+        }
+        "send_group_invite" => {
+            let group_id: String = arg(&args, "groupId")?;
+            let inviter_id: String = arg(&args, "inviterId")?;
+            let invitee_identifier: String = arg(&args, "inviteeIdentifier")?;
+            groups::send_group_invite(
+                group_id,
+                inviter_id,
+                invitee_identifier,
+                &state()?,
+            )
+            .await?;
+            ok(())
+        }
+        "get_pending_invites" => {
+            let user_id: String = arg(&args, "userId")?;
+            ok(groups::get_pending_invites(user_id, &state()?).await?)
+        }
+        "accept_group_invite" => {
+            let invite_id: String = arg(&args, "inviteId")?;
+            let user_id: String = arg(&args, "userId")?;
+            groups::accept_group_invite(invite_id, user_id, &state()?).await?;
+            ok(())
+        }
+        "decline_group_invite" => {
+            let invite_id: String = arg(&args, "inviteId")?;
+            let user_id: String = arg(&args, "userId")?;
+            groups::decline_group_invite(invite_id, user_id, &state()?).await?;
+            ok(())
+        }
         "create_channel" => {
             let group_id: String = arg(&args, "groupId")?;
             let name: String = arg(&args, "name")?;
@@ -375,6 +414,12 @@ pub async fn invoke(cmd: String, args_json: String) -> Result<String, BridgeErro
         "list_dm_requests" => {
             let user_id: String = arg(&args, "userId")?;
             ok(dm::list_dm_requests(user_id, &state()?).await?)
+        }
+        "accept_dm_request" => {
+            let dm_channel_id: String = arg(&args, "dmChannelId")?;
+            let user_id: String = arg(&args, "userId")?;
+            dm::accept_dm_request(dm_channel_id, user_id, &state()?).await?;
+            ok(())
         }
         "create_dm_channel" => {
             let creator_id: String = arg(&args, "creatorId")?;

--- a/pollis-core/src/bridge.rs
+++ b/pollis-core/src/bridge.rs
@@ -183,6 +183,16 @@ pub async fn invoke(cmd: String, args_json: String) -> Result<String, BridgeErro
             ok(())
         }
         "list_known_accounts" => ok(auth::list_known_accounts()?),
+        "list_user_devices" => {
+            let user_id: String = arg(&args, "userId")?;
+            ok(auth::list_user_devices(&state()?, user_id).await?)
+        }
+        "revoke_device" => {
+            let user_id: String = arg(&args, "userId")?;
+            let device_id: String = arg(&args, "deviceId")?;
+            auth::revoke_device(&state()?, user_id, device_id).await?;
+            ok(())
+        }
 
         // ----- pin -----
         "set_pin" => {

--- a/pollis-core/src/bridge.rs
+++ b/pollis-core/src/bridge.rs
@@ -228,6 +228,20 @@ pub async fn invoke(cmd: String, args_json: String) -> Result<String, BridgeErro
             let username: String = arg(&args, "username")?;
             ok(user::search_user_by_username(username, &state()?).await?)
         }
+        "get_preferences" => {
+            let user_id: String = arg(&args, "userId")?;
+            // Rust returns a JSON-encoded string; the JS bridge will
+            // wrap it in JSON.stringify again to feed our serde_json
+            // ser path. The TS hook JSON.parses the outer wrapper to
+            // recover the raw blob.
+            ok(user::get_preferences(user_id, &state()?).await?)
+        }
+        "save_preferences" => {
+            let user_id: String = arg(&args, "userId")?;
+            let preferences_json: String = arg(&args, "preferencesJson")?;
+            user::save_preferences(user_id, preferences_json, &state()?).await?;
+            ok(())
+        }
 
         // ----- groups -----
         "list_user_groups" => {

--- a/pollis-core/src/bridge.rs
+++ b/pollis-core/src/bridge.rs
@@ -155,7 +155,7 @@ pub async fn invoke(cmd: String, args_json: String) -> Result<String, BridgeErro
         serde_json::from_str(&args_json)?
     };
 
-    use crate::commands::{auth, dm, groups, messages, pin, user};
+    use crate::commands::{auth, device_enrollment, dm, groups, messages, pin, user};
 
     match cmd.as_str() {
         "version" => ok(env!("CARGO_PKG_VERSION")),
@@ -183,6 +183,46 @@ pub async fn invoke(cmd: String, args_json: String) -> Result<String, BridgeErro
             ok(())
         }
         "list_known_accounts" => ok(auth::list_known_accounts()?),
+        // ----- device enrollment -----
+        "start_device_enrollment" => {
+            let user_id: String = arg(&args, "userId")?;
+            ok(device_enrollment::start_device_enrollment(&state()?, user_id).await?)
+        }
+        "poll_enrollment_status" => {
+            let request_id: String = arg(&args, "requestId")?;
+            ok(device_enrollment::poll_enrollment_status(&state()?, request_id).await?)
+        }
+        "finalize_device_enrollment" => {
+            let user_id: String = arg(&args, "userId")?;
+            device_enrollment::finalize_device_enrollment(&state()?, user_id).await?;
+            ok(())
+        }
+        "recover_with_secret_key" => {
+            let user_id: String = arg(&args, "userId")?;
+            let secret_key: String = arg(&args, "secretKey")?;
+            device_enrollment::recover_with_secret_key(&state()?, user_id, secret_key).await?;
+            ok(())
+        }
+        "list_pending_enrollment_requests" => {
+            let user_id: String = arg(&args, "userId")?;
+            ok(device_enrollment::list_pending_enrollment_requests(&state()?, user_id).await?)
+        }
+        "approve_device_enrollment" => {
+            let request_id: String = arg(&args, "requestId")?;
+            let verification_code: String = arg(&args, "verificationCode")?;
+            device_enrollment::approve_device_enrollment(
+                &state()?,
+                request_id,
+                verification_code,
+            )
+            .await?;
+            ok(())
+        }
+        "reject_device_enrollment" => {
+            let request_id: String = arg(&args, "requestId")?;
+            device_enrollment::reject_device_enrollment(&state()?, request_id).await?;
+            ok(())
+        }
         "list_user_devices" => {
             let user_id: String = arg(&args, "userId")?;
             ok(auth::list_user_devices(&state()?, user_id).await?)

--- a/pollis-core/src/bridge.rs
+++ b/pollis-core/src/bridge.rs
@@ -260,6 +260,54 @@ pub async fn invoke(cmd: String, args_json: String) -> Result<String, BridgeErro
             let user_id: String = arg(&args, "userId")?;
             ok(messages::list_channel_previews(user_id, &state()?).await?)
         }
+        "send_message" => {
+            let conversation_id: String = arg(&args, "conversationId")?;
+            let sender_id: String = arg(&args, "senderId")?;
+            let content: String = arg(&args, "content")?;
+            let reply_to_id: Option<String> = arg_opt(&args, "replyToId")?;
+            let sender_username: Option<String> = arg_opt(&args, "senderUsername")?;
+            ok(messages::send_message(
+                conversation_id,
+                sender_id,
+                content,
+                reply_to_id,
+                sender_username,
+                &state()?,
+            )
+            .await?)
+        }
+        "get_channel_messages" => {
+            let user_id: String = arg(&args, "userId")?;
+            let channel_id: String = arg(&args, "channelId")?;
+            let limit: Option<i64> = arg_opt(&args, "limit")?;
+            let cursor: Option<messages::MessageCursor> = arg_opt(&args, "cursor")?;
+            ok(messages::get_channel_messages(
+                user_id, channel_id, limit, cursor, &state()?,
+            )
+            .await?)
+        }
+        "get_dm_messages" => {
+            let user_id: String = arg(&args, "userId")?;
+            let dm_channel_id: String = arg(&args, "dmChannelId")?;
+            let limit: Option<i64> = arg_opt(&args, "limit")?;
+            let cursor: Option<messages::MessageCursor> = arg_opt(&args, "cursor")?;
+            ok(messages::get_dm_messages(
+                user_id, dm_channel_id, limit, cursor, &state()?,
+            )
+            .await?)
+        }
+        "ingest_channel_envelopes" => {
+            let user_id: String = arg(&args, "userId")?;
+            let channel_id: String = arg(&args, "channelId")?;
+            messages::ingest_channel_envelopes(user_id, channel_id, &state()?).await?;
+            ok(())
+        }
+        "ingest_dm_envelopes" => {
+            let user_id: String = arg(&args, "userId")?;
+            let dm_channel_id: String = arg(&args, "dmChannelId")?;
+            messages::ingest_dm_envelopes(user_id, dm_channel_id, &state()?).await?;
+            ok(())
+        }
 
         // ----- dm -----
         "list_dm_channels" => {

--- a/pollis-core/src/bridge.rs
+++ b/pollis-core/src/bridge.rs
@@ -331,6 +331,63 @@ pub async fn invoke(cmd: String, args_json: String) -> Result<String, BridgeErro
             )
             .await?)
         }
+        "update_group" => {
+            let group_id: String = arg(&args, "groupId")?;
+            let requester_id: String = arg(&args, "requesterId")?;
+            let name: Option<String> = arg_opt(&args, "name")?;
+            let description: Option<String> = arg_opt(&args, "description")?;
+            let icon_url: Option<String> = arg_opt(&args, "iconUrl")?;
+            ok(groups::update_group(
+                group_id,
+                requester_id,
+                name,
+                description,
+                icon_url,
+                &state()?,
+            )
+            .await?)
+        }
+        "delete_group" => {
+            let group_id: String = arg(&args, "groupId")?;
+            let requester_id: String = arg(&args, "requesterId")?;
+            groups::delete_group(group_id, requester_id, &state()?).await?;
+            ok(())
+        }
+        "update_channel" => {
+            let channel_id: String = arg(&args, "channelId")?;
+            let requester_id: String = arg(&args, "requesterId")?;
+            let name: Option<String> = arg_opt(&args, "name")?;
+            let description: Option<String> = arg_opt(&args, "description")?;
+            ok(groups::update_channel(
+                channel_id,
+                requester_id,
+                name,
+                description,
+                &state()?,
+            )
+            .await?)
+        }
+        "delete_channel" => {
+            let channel_id: String = arg(&args, "channelId")?;
+            let requester_id: String = arg(&args, "requesterId")?;
+            groups::delete_channel(channel_id, requester_id, &state()?).await?;
+            ok(())
+        }
+        "remove_member_from_group" => {
+            let group_id: String = arg(&args, "groupId")?;
+            let user_id: String = arg(&args, "userId")?;
+            let requester_id: String = arg(&args, "requesterId")?;
+            groups::remove_member_from_group(group_id, user_id, requester_id, &state()?).await?;
+            ok(())
+        }
+        "set_member_role" => {
+            let group_id: String = arg(&args, "groupId")?;
+            let user_id: String = arg(&args, "userId")?;
+            let role: String = arg(&args, "role")?;
+            let requester_id: String = arg(&args, "requesterId")?;
+            groups::set_member_role(group_id, user_id, role, requester_id, &state()?).await?;
+            ok(())
+        }
         "get_group_members" => {
             let group_id: String = arg(&args, "groupId")?;
             ok(groups::get_group_members(group_id, &state()?).await?)

--- a/pollis-core/src/bridge.rs
+++ b/pollis-core/src/bridge.rs
@@ -190,6 +190,19 @@ pub async fn invoke(cmd: String, args_json: String) -> Result<String, BridgeErro
             ok(())
         }
         "list_known_accounts" => ok(auth::list_known_accounts()?),
+        "request_email_change_otp" => {
+            let user_id: String = arg(&args, "userId")?;
+            let new_email: String = arg(&args, "newEmail")?;
+            auth::request_email_change_otp(&state()?, user_id, new_email).await?;
+            ok(())
+        }
+        "verify_email_change" => {
+            let user_id: String = arg(&args, "userId")?;
+            let new_email: String = arg(&args, "newEmail")?;
+            let code: String = arg(&args, "code")?;
+            auth::verify_email_change(&state()?, user_id, new_email, code).await?;
+            ok(())
+        }
         // ----- device enrollment -----
         "start_device_enrollment" => {
             let user_id: String = arg(&args, "userId")?;
@@ -378,6 +391,38 @@ pub async fn invoke(cmd: String, args_json: String) -> Result<String, BridgeErro
             let user_id: String = arg(&args, "userId")?;
             let requester_id: String = arg(&args, "requesterId")?;
             groups::remove_member_from_group(group_id, user_id, requester_id, &state()?).await?;
+            ok(())
+        }
+        "search_group_by_slug" => {
+            let slug: String = arg(&args, "slug")?;
+            ok(groups::search_group_by_slug(slug, &state()?).await?)
+        }
+        "request_group_access" => {
+            let group_id: String = arg(&args, "groupId")?;
+            let requester_id: String = arg(&args, "requesterId")?;
+            groups::request_group_access(group_id, requester_id, &state()?).await?;
+            ok(())
+        }
+        "get_group_join_requests" => {
+            let group_id: String = arg(&args, "groupId")?;
+            let requester_id: String = arg(&args, "requesterId")?;
+            ok(groups::get_group_join_requests(group_id, requester_id, &state()?).await?)
+        }
+        "get_my_join_request" => {
+            let group_id: String = arg(&args, "groupId")?;
+            let requester_id: String = arg(&args, "requesterId")?;
+            ok(groups::get_my_join_request(group_id, requester_id, &state()?).await?)
+        }
+        "approve_join_request" => {
+            let request_id: String = arg(&args, "requestId")?;
+            let approver_id: String = arg(&args, "approverId")?;
+            groups::approve_join_request(request_id, approver_id, &state()?).await?;
+            ok(())
+        }
+        "reject_join_request" => {
+            let request_id: String = arg(&args, "requestId")?;
+            let approver_id: String = arg(&args, "approverId")?;
+            groups::reject_join_request(request_id, approver_id, &state()?).await?;
             ok(())
         }
         "set_member_role" => {
@@ -596,6 +641,36 @@ pub async fn invoke(cmd: String, args_json: String) -> Result<String, BridgeErro
         "list_dm_requests" => {
             let user_id: String = arg(&args, "userId")?;
             ok(dm::list_dm_requests(user_id, &state()?).await?)
+        }
+        "get_dm_channel" => {
+            let dm_channel_id: String = arg(&args, "dmChannelId")?;
+            ok(dm::get_dm_channel(dm_channel_id, &state()?).await?)
+        }
+        "leave_dm_channel" => {
+            let dm_channel_id: String = arg(&args, "dmChannelId")?;
+            let user_id: String = arg(&args, "userId")?;
+            dm::leave_dm_channel(dm_channel_id, user_id, &state()?).await?;
+            ok(())
+        }
+        "add_user_to_dm_channel" => {
+            let dm_channel_id: String = arg(&args, "dmChannelId")?;
+            let user_id: String = arg(&args, "userId")?;
+            let added_by: String = arg(&args, "addedBy")?;
+            dm::add_user_to_dm_channel(dm_channel_id, user_id, added_by, &state()?).await?;
+            ok(())
+        }
+        "remove_user_from_dm_channel" => {
+            let dm_channel_id: String = arg(&args, "dmChannelId")?;
+            let user_id: String = arg(&args, "userId")?;
+            let requester_id: String = arg(&args, "requesterId")?;
+            dm::remove_user_from_dm_channel(
+                dm_channel_id,
+                user_id,
+                requester_id,
+                &state()?,
+            )
+            .await?;
+            ok(())
         }
         "accept_dm_request" => {
             let dm_channel_id: String = arg(&args, "dmChannelId")?;

--- a/pollis-core/src/bridge.rs
+++ b/pollis-core/src/bridge.rs
@@ -242,6 +242,40 @@ pub async fn invoke(cmd: String, args_json: String) -> Result<String, BridgeErro
             let group_id: String = arg(&args, "groupId")?;
             ok(groups::list_group_channels(group_id, &state()?).await?)
         }
+        "create_group" => {
+            let name: String = arg(&args, "name")?;
+            let description: Option<String> = arg_opt(&args, "description")?;
+            let owner_id: String = arg(&args, "ownerId")?;
+            let create_default_text_channel: Option<bool> =
+                arg_opt(&args, "createDefaultTextChannel")?;
+            let create_default_voice_channel: Option<bool> =
+                arg_opt(&args, "createDefaultVoiceChannel")?;
+            ok(groups::create_group(
+                name,
+                description,
+                owner_id,
+                create_default_text_channel,
+                create_default_voice_channel,
+                &state()?,
+            )
+            .await?)
+        }
+        "create_channel" => {
+            let group_id: String = arg(&args, "groupId")?;
+            let name: String = arg(&args, "name")?;
+            let description: Option<String> = arg_opt(&args, "description")?;
+            let channel_type: Option<String> = arg_opt(&args, "channelType")?;
+            let creator_id: String = arg(&args, "creatorId")?;
+            ok(groups::create_channel(
+                group_id,
+                name,
+                description,
+                channel_type,
+                creator_id,
+                &state()?,
+            )
+            .await?)
+        }
 
         // ----- messages -----
         "list_messages" => {
@@ -317,6 +351,11 @@ pub async fn invoke(cmd: String, args_json: String) -> Result<String, BridgeErro
         "list_dm_requests" => {
             let user_id: String = arg(&args, "userId")?;
             ok(dm::list_dm_requests(user_id, &state()?).await?)
+        }
+        "create_dm_channel" => {
+            let creator_id: String = arg(&args, "creatorId")?;
+            let member_ids: Vec<String> = arg(&args, "memberIds")?;
+            ok(dm::create_dm_channel(creator_id, member_ids, &state()?).await?)
         }
 
         _ => Err(BridgeError::Bridge(format!(

--- a/pollis-core/src/bridge.rs
+++ b/pollis-core/src/bridge.rs
@@ -179,6 +179,11 @@ pub async fn invoke(cmd: String, args_json: String) -> Result<String, BridgeErro
             let user_id: String = arg(&args, "userId")?;
             ok(auth::initialize_identity(&state()?, user_id).await?)
         }
+        "poll_mls_welcomes" => {
+            let user_id: String = arg(&args, "userId")?;
+            crate::commands::mls::poll_mls_welcomes(&state()?, user_id).await?;
+            ok(())
+        }
         "logout" => {
             let delete: bool = arg_opt(&args, "deleteData")?.unwrap_or(false);
             auth::logout(&state()?, delete).await?;

--- a/pollis-core/src/bridge.rs
+++ b/pollis-core/src/bridge.rs
@@ -155,7 +155,9 @@ pub async fn invoke(cmd: String, args_json: String) -> Result<String, BridgeErro
         serde_json::from_str(&args_json)?
     };
 
-    use crate::commands::{auth, device_enrollment, dm, groups, messages, pin, user};
+    use crate::commands::{
+        auth, blocks, device_enrollment, dm, groups, messages, pin, safety, user,
+    };
 
     match cmd.as_str() {
         "version" => ok(env!("CARGO_PKG_VERSION")),
@@ -451,6 +453,45 @@ pub async fn invoke(cmd: String, args_json: String) -> Result<String, BridgeErro
             let user_id: String = arg(&args, "userId")?;
             ok(dm::list_dm_channels(user_id, &state()?).await?)
         }
+        // ----- search -----
+        "search_messages" => {
+            let q: String = arg(&args, "query")?;
+            let limit: Option<i64> = arg_opt(&args, "limit")?;
+            ok(messages::search_messages(q, limit, &state()?).await?)
+        }
+
+        // ----- blocks -----
+        "block_user" => {
+            let blocker_id: String = arg(&args, "blockerId")?;
+            let blocked_id: String = arg(&args, "blockedId")?;
+            blocks::block_user(blocker_id, blocked_id, &state()?).await?;
+            ok(())
+        }
+        "unblock_user" => {
+            let blocker_id: String = arg(&args, "blockerId")?;
+            let blocked_id: String = arg(&args, "blockedId")?;
+            blocks::unblock_user(blocker_id, blocked_id, &state()?).await?;
+            ok(())
+        }
+        "list_blocked_users" => {
+            let user_id: String = arg(&args, "userId")?;
+            ok(blocks::list_blocked_users(user_id, &state()?).await?)
+        }
+
+        // ----- safety -----
+        "get_safety_number" => {
+            let my_user_id: String = arg(&args, "myUserId")?;
+            let peer_user_id: String = arg(&args, "peerUserId")?;
+            ok(safety::get_safety_number(my_user_id, peer_user_id, &state()?).await?)
+        }
+        "set_contact_verified" => {
+            let peer_user_id: String = arg(&args, "peerUserId")?;
+            let verified: bool = arg(&args, "verified")?;
+            safety::set_contact_verified(peer_user_id, verified, &state()?).await?;
+            ok(())
+        }
+        "list_peer_verifications" => ok(safety::list_peer_verifications(&state()?).await?),
+
         "list_dm_requests" => {
             let user_id: String = arg(&args, "userId")?;
             ok(dm::list_dm_requests(user_id, &state()?).await?)

--- a/pollis-core/src/bridge.rs
+++ b/pollis-core/src/bridge.rs
@@ -446,6 +446,45 @@ pub async fn invoke(cmd: String, args_json: String) -> Result<String, BridgeErro
             messages::ingest_channel_envelopes(user_id, channel_id, &state()?).await?;
             ok(())
         }
+        "add_reaction" => {
+            let message_id: String = arg(&args, "messageId")?;
+            let user_id: String = arg(&args, "userId")?;
+            let emoji: String = arg(&args, "emoji")?;
+            messages::add_reaction(message_id, user_id, emoji, &state()?).await?;
+            ok(())
+        }
+        "remove_reaction" => {
+            let message_id: String = arg(&args, "messageId")?;
+            let user_id: String = arg(&args, "userId")?;
+            let emoji: String = arg(&args, "emoji")?;
+            messages::remove_reaction(message_id, user_id, emoji, &state()?).await?;
+            ok(())
+        }
+        "get_reactions" => {
+            let message_id: String = arg(&args, "messageId")?;
+            ok(messages::get_reactions(message_id, &state()?).await?)
+        }
+        "edit_message" => {
+            let conversation_id: String = arg(&args, "conversationId")?;
+            let message_id: String = arg(&args, "messageId")?;
+            let user_id: String = arg(&args, "userId")?;
+            let new_content: String = arg(&args, "newContent")?;
+            messages::edit_message(
+                conversation_id,
+                message_id,
+                user_id,
+                new_content,
+                &state()?,
+            )
+            .await?;
+            ok(())
+        }
+        "delete_message" => {
+            let message_id: String = arg(&args, "messageId")?;
+            let user_id: String = arg(&args, "userId")?;
+            messages::delete_message(message_id, user_id, &state()?).await?;
+            ok(())
+        }
         "ingest_dm_envelopes" => {
             let user_id: String = arg(&args, "userId")?;
             let dm_channel_id: String = arg(&args, "dmChannelId")?;


### PR DESCRIPTION
## Summary

Mobile is now functionally complete — every screen reads/writes through the Rust core. No hardcoded mocks left. Realtime push + notifications are still TODO (called out below).

**Bridge:** ~50 new commands added to `pollis-core/src/bridge.rs` (messages, group/DM mutations, enrollment, search, safety, blocks, preferences, devices, join requests, email change).

**Auth flow:** verify_otp now routes to enrollment screen when `enrollment_required: true`. New screens — `(auth)/enrollment` (chooser → polling for sibling-device approval or recovery-key entry) and `(auth)/emergency-kit` (one-shot recovery key display after first-device PIN set).

**Chat:** real send via `send_message` with optimistic stubs; long-press a message for react / edit / delete (all optimistic). Tap a sender's avatar → user profile.

**Groups:** create-group → discover-by-slug → invite/accept → join-requests admin. Group detail shows real channels + members; settings screen for rename / channel delete / group delete (owner-only); members screen for role toggle + remove. Send invites by username/email.

**DMs:** create from user search; pending-requests bar above the inbox; info screen with leave; kebab in chat opens it.

**Self:** user-settings saves via `update_user_profile`; preferences (accent / theme / density / behavior) persist via shared `user_preferences` blob (merged with desktop-side keys); security shows real devices with revoke + sibling-device enrollment approver UI + sign out; change-email two-step OTP; blocked-users management.

**MLS welcome polling:** explicit `poll_mls_welcomes` after `accept_group_invite` and `accept_dm_request` so newly-keyed conversations appear immediately (Rust already auto-polls inside `initialize_identity`, `send_message`, and ingest paths).

## Test plan

Run the iOS build from a Mac with the ubrn toolchain, or run Android from the Linux dev box. The bridge schema only added new dispatcher arms — no need for ubrn regen if you regenerated for PR #303; the existing `invoke(cmd, args)` generic shape covers them.

- [ ] Sign in (new account): OTP → set PIN → Emergency Kit shows recovery key → save → initializing → tabs land on `/(tabs)/groups`.
- [ ] Sign in (returning user on same device): index restores session, routes to `/(auth)/pin` for unlock, lands on tabs.
- [ ] Sign in (returning user on new device): OTP → enrollment screen → approve from sibling device OR paste recovery key → PIN → initializing.
- [ ] Create group → land on group detail → invite another user by handle.
- [ ] Other user accepts invite — verify the group appears in their sidebar immediately (poll_mls_welcomes path).
- [ ] Send messages back and forth in the channel; long-press → react / edit / delete each behave optimistically and survive a refresh.
- [ ] Create DM via user search; pending-request bar shows on the other side; accept → DM appears in both inboxes.
- [ ] DM info screen → leave conversation → bounces back to `/(tabs)/direct`.
- [ ] Preferences: pick a different accent, force-quit the app, relaunch — accent restored from server.
- [ ] Security: list devices on a multi-device account; revoke a non-current device.
- [ ] User profile: tap a sender's avatar in chat → safety number renders → mark verified → ◆ shows in DM row.
- [ ] Group settings: rename group, delete a non-default channel, owner deletes group → back to groups tab.
- [ ] Group discover: enter a known group slug → request to join → approver sees it under group/[id] → approve → it lands in the requester's sidebar.
- [ ] Email change: enter new email → OTP delivered → submit code → profile reflects new email.

## Known leftovers (for follow-on PRs)

- Add-channel UI inside `group/settings` (only delete + rename are wired; `create_channel` dispatcher is there).
- Notification preferences page + APNs/FCM token registration.
- Biometrics / device-PIN management (no Rust commands yet).
- Realtime push so chat doesn't depend on focus-effect ingest.