### PR TITLE
fix(electron): drop 'Developer ID Application:' prefix from mac.identity

### DIFF
--- a/electron/build/electron-builder.yml
+++ b/electron/build/electron-builder.yml
@@ -80,7 +80,9 @@ mac:
     LSApplicationCategoryType: public.app-category.social-networking
   # Signing identity matches the Tauri config; CI overrides via env vars.
   # Set CSC_IDENTITY_AUTO_DISCOVERY=false to skip signing locally.
-  identity: "Developer ID Application: Daniel Kral (9JF7WWYMU2)"
+  # electron-builder ≥26 rejects the "Developer ID Application:" prefix and
+  # auto-selects the cert type from the keychain — pass the common name only.
+  identity: "Daniel Kral (9JF7WWYMU2)"
   icon: ../../src-tauri/icons/AppIcon.icns
 
 win:


### PR DESCRIPTION
## Summary

v1.1.2 macOS build failed with: `Please remove prefix "Developer ID Application:" from the specified name — appropriate certificate will be chosen automatically`.

electron-builder ≥26 picks the matching cert from the keychain by common name and rejects the cert-type prefix.

## Fix

`identity: "Developer ID Application: Daniel Kral (9JF7WWYMU2)"` → `identity: "Daniel Kral (9JF7WWYMU2)"`.

## Test plan

- [ ] v1.1.3 macOS build passes signing.