### PR TITLE
fix(ci): force bash for Windows electron-builder step

### DIFF
--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -241,6 +241,7 @@ jobs:
         run: pnpm --filter @pollis/electron build
 
       - name: Build + sign Windows
+        shell: bash
         env:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}


### PR DESCRIPTION
## Summary

v1.1.3 Windows build failed with `ParserError: Missing expression after unary operator '--'`. Windows runners default to PowerShell, which doesn't understand bash's `\` line continuation in the multiline `run:` block — pwsh parsed `--win` as a unary `--` followed by `win`.

## Fix

Added `shell: bash` to the `Build + sign Windows` step. Other Windows steps in the workflow already declare their shell explicitly.

## Test plan

- [ ] v1.1.4 Windows build reaches the signing stage.