### PR TITLE
fix(electron): five v1.1.0 ship-breakers

### DIFF
--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -392,9 +392,19 @@ jobs:
 
       - name: Resolve version
         run: |
+          # Same tag-or-override resolution as the build jobs. Earlier this
+          # fell back to `jq -r .version electron/package.json` — that reads
+          # the committed file (1.1.0) because the build jobs' bump-version.sh
+          # mutations are job-local, so on-disk package.json on main never
+          # advances. That mismatch caused R2 paths + AUR pkgver to be stuck
+          # at 1.1.0 while the artifacts inside were stamped correctly.
           VERSION="${{ github.event.inputs.version_override }}"
+          if [ -z "$VERSION" ] && [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          fi
           if [ -z "$VERSION" ]; then
-            VERSION=$(jq -r .version electron/package.json)
+            echo "error: no version available (push a v* tag or pass version_override)" >&2
+            exit 1
           fi
           echo "POLLIS_VERSION=$VERSION" >> $GITHUB_ENV
           echo "POLLIS_TAG=v$VERSION" >> $GITHUB_ENV

--- a/electron/build/electron-builder.yml
+++ b/electron/build/electron-builder.yml
@@ -15,6 +15,11 @@ copyright: "Copyright (c) 2026 Daniel Kral"
 # filename → "@pollis/electron_1.1.0_amd64.deb". Pin to "Pollis-<version>-…"
 # parity with the Tauri pipeline artifacts.
 artifactName: "Pollis-${version}.${ext}"
+# electron-builder defaults the binary name to the package `name` field
+# ("@pollis/electron"), which it sanitises to "@polliselectron". That's
+# what you see in the .deb's /usr/bin entry — and why `pollis` isn't on
+# $PATH after install. Force the bin name to plain "pollis".
+executableName: pollis
 
 directories:
   buildResources: build
@@ -23,8 +28,6 @@ directories:
 files:
   # Compiled electron main + preload bundles (output of @pollis/electron build)
   - "dist/**/*"
-  # Compiled React frontend (output of `pnpm --filter frontend build`)
-  - "../frontend/dist/**/*"
   - "node_modules/**/*"
   - "package.json"
 
@@ -37,6 +40,13 @@ extraResources:
       - "*.node"
       - "index.js"
       - "index.d.ts"
+  # Compiled React frontend (output of `pnpm --filter frontend build`).
+  # NOT inside `files:` because electron-builder's appDir is `electron/`
+  # and `..`-prefixed globs in `files:` get silently dropped from the
+  # asar. As an extraResource it lands at process.resourcesPath/frontend/
+  # — main.ts loadFile path matches.
+  - from: "../frontend/dist"
+    to: "frontend"
   # TODO: package the screenshare capture helper that today lives in
   # src-tauri/binaries/pollis-capture-{linux,macos}. Decide in Phase 7
   # whether to ship as an extraResource, embed inside pollis-node, or

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -52,7 +52,10 @@ const pollisNode = require("../../pollis-node") as {
   ) => void;
 };
 
-const isDev = process.env.NODE_ENV !== "production";
+// `app.isPackaged` is the reliable signal — NODE_ENV is unset in packaged
+// builds, so the previous `NODE_ENV !== "production"` test was always true
+// in shipped binaries, opening DevTools and trying to load the Vite dev URL.
+const isDev = !app.isPackaged;
 const VITE_DEV_URL = "http://localhost:5173";
 // In dev, .env.development sits at the repo root (one level up from electron/).
 // In prod, env values are baked into the Rust binary at compile time via
@@ -124,8 +127,12 @@ function createWindow(): BrowserWindow {
     void win.loadURL(VITE_DEV_URL);
     win.webContents.openDevTools({ mode: "detach" });
   } else {
+    // Packaged: frontend lands at <resources>/frontend (see
+    // electron-builder.yml extraResources). The previous path traversed
+    // outside the asar and 404'd, which is why the shipped app showed
+    // the blank-frame + auto-opened DevTools fallback.
     void win.loadFile(
-      path.join(__dirname, "..", "..", "frontend", "dist", "index.html"),
+      path.join(process.resourcesPath, "frontend", "index.html"),
     );
   }
 


### PR DESCRIPTION
## Summary

v1.1.0 deployed all green but shipped broken: AUR pkgver stuck at 1.1.0, app launched into blank DevTools window, no \`pollis\` on PATH, R2 paths versioned wrong. Five distinct bugs, one commit.

## Fixes

| # | Symptom | Cause | Fix |
|---|---------|-------|-----|
| 1 | R2 path \`releases/v1.1.0/\`, AUR \`pkgver=1.1.0\` | release job read committed package.json — bump-version.sh changes are job-local | Tag-derive in release job |
| 2 | App: blank window + DevTools fallback | Frontend not in package — \`files: ../frontend/dist/**\` silently dropped (\`..\` prefix unsupported) | Move to \`extraResources\` |
| 3 | DevTools auto-open in prod | \`isDev = NODE_ENV !== "production"\` always true (NODE_ENV unset in packaged builds) | \`isDev = !app.isPackaged\` |
| 4 | loadFile path 404s | Old dev path with too many \`..\`s, points outside asar | \`path.join(process.resourcesPath, "frontend", "index.html")\` |
| 5 | \`pollis: command not found\` | Binary named \`@polliselectron\` (sanitised scoped name) | \`executableName: pollis\` |

## Test plan

- [x] Local AppImage rebuilds, binary is \`pollis\`, \`resources/frontend/index.html\` present, launches without crash.
- [ ] v1.1.5 ships: R2 paths versioned 1.1.5, AUR pkgver=1.1.5, installed app launches into actual UI.