### PR TITLE
fix(electron): blank packaged window + install.sh DMG parsing

### DIFF
--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -171,7 +171,10 @@ void app.whenReady().then(async () => {
   // macOS dock icon in dev — packaged builds get this from the .icns
   // electron-builder bundles, but in `pnpm dev:electron` the dock shows
   // Electron's default mascot without this.
-  if (process.platform === "darwin" && app.dock) {
+  // Only needed in dev — packaged Mac bundles get the dock icon from the
+  // .icns electron-builder embeds, and the src-tauri/icons path doesn't
+  // exist inside the asar (it's not in extraResources).
+  if (isDev && process.platform === "darwin" && app.dock) {
     const iconPath = path.resolve(__dirname, "..", "..", "src-tauri", "icons", "icon.png");
     try {
       app.dock.setIcon(iconPath);

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -9,6 +9,12 @@ export default defineConfig({
   plugins: [react()],
   // Load VITE_* env vars from the monorepo root so we only need a single .env.development
   envDir: '..',
+  // Emit relative asset URLs in the built index.html. Electron loads the
+  // packaged HTML via `file://`, where absolute paths like `/assets/x.js`
+  // resolve to `file:///assets/x.js` and 404 — the window then shows just
+  // the title bar with no rendered content. Relative (`./assets/x.js`)
+  // works under both `file://` (packaged) and the Vite dev server.
+  base: './',
   resolve: isPlaywright
     ? {
         alias: {

--- a/website/install.sh
+++ b/website/install.sh
@@ -99,7 +99,12 @@ install_macos() {
 
     info "Mounting disk image..."
     mount_line=$(hdiutil attach "$dmg_path" -nobrowse -noautoopen | grep "/Volumes/")
-    mount_point=$(echo "$mount_line" | awk '{print $NF}')
+    # `hdiutil attach` outputs tab-separated columns, and the volume path is
+    # the last column. electron-builder titles the DMG volume "Pollis <ver>"
+    # — the embedded space breaks `awk '{print $NF}'` (it returns just the
+    # last whitespace-token). Strip everything up to the first `/Volumes/`
+    # so the entire path, spaces and all, comes through.
+    mount_point=$(echo "$mount_line" | sed -E 's|.*(/Volumes/.*)|\1|')
 
     info "Installing to /Applications..."
     if [[ -d "/Applications/$APP_NAME.app" ]]; then


### PR DESCRIPTION
## Summary
- `frontend/vite.config.ts`: set `base: './'` so the built `index.html` references its bundle relatively. Under `file://` (packaged), absolute `/assets/x.js` was resolving to `file:///assets/x.js` and 404'ing — chrome painted, nothing else did.
- `website/install.sh`: DMG mount path parsed with `sed` instead of `awk '{print $NF}'`. electron-builder titles the volume `Pollis <version>` (space), which `awk` was truncating to `1.1.5-arm64`, producing `cp: 1.1.5-arm64/Pollis.app: No such file or directory`.
- `electron/src/main.ts`: `app.dock.setIcon` now gated to dev. Packaged Mac bundles get the dock icon from the embedded `.icns`; the `src-tauri/icons/icon.png` path is not in `extraResources` and was logging a misleading error on every launch.