### PR TITLE
ci: wrap rustc with sccache on all three build platforms

### DIFF
--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -54,6 +54,19 @@ jobs:
         with:
           workspaces: pollis-node
 
+      # sccache wraps rustc so individual compile units are cached across
+      # branches, not just whole-target-dir keyed on Cargo.lock. Wins big
+      # when Cargo.lock changes a single dep — Swatinem misses the whole
+      # target dir, sccache rebuilds only the touched crates from cache.
+      # GHA backend uses the same actions cache quota as Swatinem.
+      - name: Run sccache
+        uses: mozilla-actions/sccache-action@v0.0.6
+      - name: Enable sccache wrapper
+        shell: bash
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+
       - name: Resolve + stamp version
         run: |
           # Tag-driven by default. Manual workflow_dispatch can override
@@ -147,6 +160,14 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: pollis-node
+
+      - name: Run sccache
+        uses: mozilla-actions/sccache-action@v0.0.6
+      - name: Enable sccache wrapper
+        shell: bash
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
 
       - name: Resolve + stamp version
         shell: bash
@@ -279,6 +300,14 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: pollis-node
+
+      - name: Run sccache
+        uses: mozilla-actions/sccache-action@v0.0.6
+      - name: Enable sccache wrapper
+        shell: bash
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
 
       - name: Resolve + stamp version
         run: |


### PR DESCRIPTION
Adds `mozilla-actions/sccache-action` + `RUSTC_WRAPPER=sccache` to each platform's build job. Uses the GH Actions cache as backend (same ~10 GB quota Swatinem already shares).

Wins most when Cargo.lock changes a single dep — Swatinem misses the whole target/ key and rebuilds everything, sccache hits ~70-90% of individual crates from prior runs. Expected wallclock drop on that path: 12-20 min → 5-7 min. Tag-driven releases with no dep changes stay the same (Swatinem's target/ restore already wins).

Not wiring C/C++ caching (`webrtc-sys` cxx_build, `webrtc-audio-processing-sys` meson) — measure this first, layer in if needed.