### PR TITLE
feat(voice+share): discriminated-union state machine, Linux screenshare recovery, 60fps publish

### DIFF
--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -40,14 +40,17 @@ app.commandLine.appendSwitch(
 // paragraph. Add new switches here as we hit them; never blindly remove one
 // without confirming what user-reported bug it papered over.
 if (process.platform === "linux") {
-  // Force native GLX/EGL. Chromium 130 defaults the Linux GL backend to
-  // ANGLE → ZINK (Mesa's experimental GL-on-Vulkan translator), which
-  // crashes on NVIDIA proprietary drivers with "ZINK: vkEnumeratePhysicalDevices
-  // failed". The GPU process exits, no compositor, no rendered video — even
-  // for screenshare tracks that publish/subscribe successfully at the SDP
-  // layer. `use-gl=desktop` skips ANGLE entirely and goes straight to
-  // libGL.so, which NVIDIA ships and Mesa serves for AMD/Intel.
-  app.commandLine.appendSwitch("use-gl", "desktop");
+  // Force ANGLE's GL backend instead of the default Vulkan one. Chromium
+  // 130 only allows `gl=egl-angle` now (use-gl=desktop is rejected at
+  // startup with "not found in allowed implementations"), so the choice
+  // is which backend ANGLE wraps — Vulkan or GL. On NVIDIA proprietary
+  // drivers ANGLE → Vulkan tries Mesa's ZINK translator and crashes:
+  // "ZINK: vkEnumeratePhysicalDevices failed". The GPU process exits, no
+  // compositor, no rendered video — even for screenshare tracks that
+  // publish/subscribe successfully at the SDP layer. Setting use-angle=gl
+  // tells ANGLE to wrap native libGL (NVIDIA's libglvnd-shipped driver
+  // for them, Mesa's for AMD/Intel), which is well-tested.
+  app.commandLine.appendSwitch("use-angle", "gl");
 }
 
 // pollis-node lives at <repo-root>/pollis-node; from electron/dist/main.js,

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -33,6 +33,23 @@ app.commandLine.appendSwitch(
   "WebRtcAllowAv1Encoder,WebRtcAllowAv1ScreenshareEncoder",
 );
 
+// Linux GL/media baseline. Chromium-on-Linux WebRTC has at least four
+// independently-fragile layers (SDP negotiation, codec selection, GPU
+// compositor, capture source). This block is the "every Linux Electron app
+// ships these" baseline — VS Code, Discord, Slack all have an equivalent
+// paragraph. Add new switches here as we hit them; never blindly remove one
+// without confirming what user-reported bug it papered over.
+if (process.platform === "linux") {
+  // Force native GLX/EGL. Chromium 130 defaults the Linux GL backend to
+  // ANGLE → ZINK (Mesa's experimental GL-on-Vulkan translator), which
+  // crashes on NVIDIA proprietary drivers with "ZINK: vkEnumeratePhysicalDevices
+  // failed". The GPU process exits, no compositor, no rendered video — even
+  // for screenshare tracks that publish/subscribe successfully at the SDP
+  // layer. `use-gl=desktop` skips ANGLE entirely and goes straight to
+  // libGL.so, which NVIDIA ships and Mesa serves for AMD/Intel.
+  app.commandLine.appendSwitch("use-gl", "desktop");
+}
+
 // pollis-node lives at <repo-root>/pollis-node; from electron/dist/main.js,
 // ../../pollis-node resolves to <repo-root>/pollis-node
 // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -33,25 +33,12 @@ app.commandLine.appendSwitch(
   "WebRtcAllowAv1Encoder,WebRtcAllowAv1ScreenshareEncoder",
 );
 
-// Linux GL/media baseline. Chromium-on-Linux WebRTC has at least four
-// independently-fragile layers (SDP negotiation, codec selection, GPU
-// compositor, capture source). This block is the "every Linux Electron app
-// ships these" baseline — VS Code, Discord, Slack all have an equivalent
-// paragraph. Add new switches here as we hit them; never blindly remove one
-// without confirming what user-reported bug it papered over.
-if (process.platform === "linux") {
-  // Force ANGLE's GL backend instead of the default Vulkan one. Chromium
-  // 130 only allows `gl=egl-angle` now (use-gl=desktop is rejected at
-  // startup with "not found in allowed implementations"), so the choice
-  // is which backend ANGLE wraps — Vulkan or GL. On NVIDIA proprietary
-  // drivers ANGLE → Vulkan tries Mesa's ZINK translator and crashes:
-  // "ZINK: vkEnumeratePhysicalDevices failed". The GPU process exits, no
-  // compositor, no rendered video — even for screenshare tracks that
-  // publish/subscribe successfully at the SDP layer. Setting use-angle=gl
-  // tells ANGLE to wrap native libGL (NVIDIA's libglvnd-shipped driver
-  // for them, Mesa's for AMD/Intel), which is well-tested.
-  app.commandLine.appendSwitch("use-angle", "gl");
-}
+// Linux GL/media baseline goes here when we figure out the right
+// combination. Tried `use-gl=desktop` (rejected by Chromium 130's allowed
+// list) and `use-angle=gl` (different EGL init failure + broke the
+// xdg-desktop-portal handshake). NVIDIA + ANGLE + Mesa on Linux is a
+// moving target; revisit with a fresh repro + bisect once the dust
+// settles on Chromium's default backend choice.
 
 // pollis-node lives at <repo-root>/pollis-node; from electron/dist/main.js,
 // ../../pollis-node resolves to <repo-root>/pollis-node

--- a/frontend/src/components/Layout/AppShell.tsx
+++ b/frontend/src/components/Layout/AppShell.tsx
@@ -466,10 +466,12 @@ export const AppShell: React.FC = () => {
         )}
       </div>
 
-      {/* VoiceBar — shown above bottom bar while user is in a voice channel */}
-      {activeVoiceChannelId !== null && (
+      {/* VoiceBar — only after the join completes, not during the
+          'joining' phase. Mute/share/leave controls only make sense once
+          the LiveKit room is actually connected. */}
+      {voiceState.kind === 'joined' && (
         <VoiceBar
-          channelId={activeVoiceChannelId}
+          channelId={voiceState.channelId}
           channelName={voiceChannelName}
         />
       )}

--- a/frontend/src/components/Layout/AppShell.tsx
+++ b/frontend/src/components/Layout/AppShell.tsx
@@ -63,19 +63,28 @@ export const AppShell: React.FC = () => {
   const {
     setGroups,
     setChannels,
-    activeVoiceChannelId,
+    voiceState,
     statusBarAlert,
     setStatusBarAlert,
     voiceError,
     setVoiceError,
-    screenShareError,
-    setScreenShareError,
     isLocalSpeaking,
     incomingCall,
     setIncomingCall,
     viewingScreenShareTrackKey,
     setViewingScreenShareTrackKey,
+    shareStopped,
   } = useAppStore();
+  // Channel id derives from the union. Replaces the standalone
+  // activeVoiceChannelId field that used to be stored separately.
+  const activeVoiceChannelId =
+    voiceState.kind === 'idle' ? null : voiceState.channelId;
+  // Screenshare errors live in the union as `share: { kind: 'failed' }`
+  // instead of a top-level field. Dismissing clears via shareStopped().
+  const screenShareError =
+    voiceState.kind === 'joined' && voiceState.share.kind === 'failed'
+      ? voiceState.share.error
+      : null;
 
   const { data: groupsWithChannels } = useUserGroupsWithChannels();
   const { query: prefsQuery } = usePreferences();
@@ -582,7 +591,7 @@ export const AppShell: React.FC = () => {
               data-testid="status-bar-screenshare-error-dismiss"
               className="cursor-pointer"
               style={{ color: "inherit", background: "none", border: "none", padding: 0, lineHeight: 0 }}
-              onClick={() => setScreenShareError(null)}
+              onClick={() => shareStopped()}
               aria-label="Dismiss screen share error"
             >
               <X className="w-4 h-4" />

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -269,7 +269,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ isOpen, onToggle }) => {
                 isActive={activeDmId === c.id}
                 onClick={() => router.navigate({ to: "/dms/$conversationId", params: { conversationId: c.id } })}
                 leading={<PresenceDot userId={c.user2_id ?? null} />}
-                label={`@${c.user2_identifier}`}
+                label={c.user2_identifier}
                 badge={unread > 0 ? unread : null}
                 trailing={trailing}
               />

--- a/frontend/src/components/SearchPanel.tsx
+++ b/frontend/src/components/SearchPanel.tsx
@@ -227,7 +227,9 @@ export const SearchPanel: React.FC<SearchPanelProps> = ({ isOpen, onClose }) => 
   const { data: groupsWithChannels } = useUserGroupsWithChannels();
   const { data: dmConversations } = useDMConversations();
   const { members: allGroupMembers } = useAllGroupMembers();
-  const activeVoiceChannelId = useAppStore((s) => s.activeVoiceChannelId);
+  const activeVoiceChannelId = useAppStore((s) =>
+    s.voiceState.kind === 'idle' ? null : s.voiceState.channelId,
+  );
   const currentUserId = useAppStore((s) => s.currentUser?.id ?? null);
 
   // Build the full list of searchable items, active voice channel sorted to top

--- a/frontend/src/components/Voice/ScreenSharePicker.tsx
+++ b/frontend/src/components/Voice/ScreenSharePicker.tsx
@@ -19,10 +19,17 @@ import { Card } from "../ui/Card";
  *  parked helper, which builds an `SCContentFilter` and starts the
  *  `SCStream`. Industry-standard pattern — what Slack/Discord/Zoom do. */
 export const ScreenSharePicker: React.FC = () => {
-  const sources = useAppStore((s) => s.screenShareSources);
-  const setScreenShareMode = useAppStore((s) => s.setScreenShareMode);
-  const setScreenShareSources = useAppStore((s) => s.setScreenShareSources);
-  const setScreenShareError = useAppStore((s) => s.setScreenShareError);
+  // Picker only renders when shareState.kind === 'picking', so sources are
+  // guaranteed present. Narrowed via the union; bail to null defensively
+  // for the brief frame where state may have transitioned away.
+  const sources = useAppStore((s) =>
+    s.voiceState.kind === 'joined' && s.voiceState.share.kind === 'picking'
+      ? s.voiceState.share.sources
+      : null,
+  );
+  const shareCancelPicker = useAppStore((s) => s.shareCancelPicker);
+  const shareStartStarting = useAppStore((s) => s.shareStartStarting);
+  const shareFailed = useAppStore((s) => s.shareFailed);
   const [busy, setBusy] = useState(false);
 
   // Tab between Displays and Windows. Default to Displays — most
@@ -48,22 +55,19 @@ export const ScreenSharePicker: React.FC = () => {
     } catch (e) {
       console.warn("[screenshare] cancel picker:", e);
     } finally {
-      setScreenShareMode("idle");
-      setScreenShareSources(null);
+      shareCancelPicker();
       setBusy(false);
     }
   }
 
   async function handlePick(selection: Selection) {
     setBusy(true);
-    setScreenShareMode("starting");
+    shareStartStarting();
     try {
       await screenShareSession.start(selection);
     } catch (e) {
       console.error("[screenshare] start:", e);
-      setScreenShareError(friendlyScreenShareError(String(e)));
-      setScreenShareMode("idle");
-      setScreenShareSources(null);
+      shareFailed(friendlyScreenShareError(String(e)));
     } finally {
       setBusy(false);
     }

--- a/frontend/src/components/Voice/ScreenShareViewer.tsx
+++ b/frontend/src/components/Voice/ScreenShareViewer.tsx
@@ -11,16 +11,19 @@ import { X } from "lucide-react";
 import { useAppStore } from "../../stores/appStore";
 import { RemoteVideoTile } from "./RemoteVideoTile";
 import { LOCAL_PREVIEW_KEY } from "../../screenshare/screenShareSession";
+import { shareOf } from "../../types/voice-state";
 
 export const ScreenShareViewer: React.FC = () => {
   const {
     viewingScreenShareTrackKey,
     screenShareRemotes,
-    screenShareLocalActive,
-    screenShareLocalDimensions,
+    voiceState,
     currentUser,
     setViewingScreenShareTrackKey,
   } = useAppStore();
+  const share = shareOf(voiceState);
+  const screenShareLocalActive = share.kind === 'active';
+  const screenShareLocalDimensions = share.kind === 'active' ? share.dimensions : null;
   if (!viewingScreenShareTrackKey) {
     return null;
   }

--- a/frontend/src/components/Voice/VoiceBar.tsx
+++ b/frontend/src/components/Voice/VoiceBar.tsx
@@ -117,6 +117,16 @@ export const VoiceBar: React.FC<VoiceBarProps> = ({ channelId, channelName }) =>
               });
             return;
           }
+          // Any other non-idle mode (e.g. 'starting' that wedged because
+          // publishTrack hung on a dead Wayland-portal track) — let the
+          // button recover the state by force-stopping. stop() is safe to
+          // call when nothing is published; it just resets the store.
+          if (screenShareMode !== "idle") {
+            screenShareSession
+              .stop()
+              .catch((e) => console.warn("[screenshare] force-stop:", e));
+            return;
+          }
           // Engage enumerate→pick→start. The backend returns an empty
           // list on Linux/Windows; in that case we skip our picker and
           // go straight to start() (system portal/WGC handles selection).

--- a/frontend/src/components/Voice/VoiceBar.tsx
+++ b/frontend/src/components/Voice/VoiceBar.tsx
@@ -9,6 +9,7 @@ import {
   friendlyScreenShareError,
   screenShareSession,
 } from "../../screenshare/screenShareSession";
+import { shareOf } from "../../types/voice-state";
 
 interface VoiceBarProps {
   channelId: string;
@@ -18,12 +19,17 @@ interface VoiceBarProps {
 export const VoiceBar: React.FC<VoiceBarProps> = ({ channelId, channelName }) => {
   const {
     voiceParticipants,
-    voiceIsMuted,
+    voiceState,
     voiceActiveSpeakerIds,
     currentUser,
-    screenShareLocalActive,
-    screenShareMode,
   } = useAppStore();
+  const voiceIsMuted = voiceState.kind === 'joined' ? voiceState.micMuted : false;
+  const share = shareOf(voiceState);
+  const shareActive = share.kind === 'active';
+  // Anything non-idle/non-picking means the button should become a "stop"
+  // affordance — covers in-flight `starting` (recovery from wedged publish)
+  // and `failed` (lets the user clear the error state by stopping).
+  const shareInFlight = share.kind !== 'idle';
   const { data: groupsWithChannels } = useUserGroupsWithChannels();
   const navigate = useNavigate();
 
@@ -94,34 +100,29 @@ export const VoiceBar: React.FC<VoiceBarProps> = ({ channelId, channelName }) =>
           this by returning an empty source list from enumerate(). */}
       <PillButton
         data-testid="voice-bar-screenshare-button"
-        accent={
-          screenShareLocalActive || screenShareMode !== "idle"
-            ? "#ff6b6b"
-            : "var(--c-accent)"
-        }
+        accent={shareInFlight ? "#ff6b6b" : "var(--c-accent)"}
         onClick={() => {
-          if (screenShareLocalActive) {
+          if (shareActive) {
             screenShareSession
               .stop()
               .catch((e) => console.error("[screenshare] stop", e));
             return;
           }
-          if (screenShareMode === "picking") {
+          if (share.kind === "picking") {
             // Button doubles as a cancel affordance while the picker is open.
             screenShareSession
               .cancelPicker()
               .catch((e) => console.warn("[screenshare] cancel:", e))
               .finally(() => {
-                useAppStore.getState().setScreenShareMode("idle");
-                useAppStore.getState().setScreenShareSources(null);
+                useAppStore.getState().shareCancelPicker();
               });
             return;
           }
-          // Any other non-idle mode (e.g. 'starting' that wedged because
-          // publishTrack hung on a dead Wayland-portal track) — let the
-          // button recover the state by force-stopping. stop() is safe to
-          // call when nothing is published; it just resets the store.
-          if (screenShareMode !== "idle") {
+          // Any other non-idle share state (e.g. 'starting' that wedged
+          // because publishTrack hung on a dead Wayland-portal track, or
+          // 'failed') — let the button recover by force-stopping.
+          // shareStopped() is safe from any joined-state.
+          if (shareInFlight) {
             screenShareSession
               .stop()
               .catch((e) => console.warn("[screenshare] force-stop:", e));
@@ -137,33 +138,32 @@ export const VoiceBar: React.FC<VoiceBarProps> = ({ channelId, channelName }) =>
                 await screenShareSession.start();
                 return;
               }
-              useAppStore.getState().setScreenShareSources(list);
-              useAppStore.getState().setScreenShareMode("picking");
+              useAppStore.getState().shareStartPicking(list);
             } catch (e) {
               console.error("[screenshare] enumerate:", e);
-              useAppStore
-                .getState()
-                .setScreenShareError(friendlyScreenShareError(String(e)));
+              useAppStore.getState().shareFailed(friendlyScreenShareError(String(e)));
             }
           })();
         }}
         title={
-          screenShareLocalActive
+          shareActive
             ? "Stop screen share"
-            : screenShareMode === "picking"
+            : share.kind === "picking"
               ? "Cancel"
-              : "Go live (share screen)"
+              : shareInFlight
+                ? "Cancel (recover)"
+                : "Go live (share screen)"
         }
         aria-label={
-          screenShareLocalActive
+          shareActive
             ? "Stop screen share"
-            : screenShareMode === "picking"
+            : share.kind === "picking"
               ? "Cancel screen share picker"
               : "Share screen"
         }
         square
       >
-        {screenShareLocalActive ? <MonitorOff size={12} /> : <Monitor size={12} />}
+        {shareActive ? <MonitorOff size={12} /> : <Monitor size={12} />}
       </PillButton>
 
       {/* Leave button */}

--- a/frontend/src/components/Voice/VoiceChannelView.tsx
+++ b/frontend/src/components/Voice/VoiceChannelView.tsx
@@ -5,26 +5,28 @@ import type { VoiceParticipant } from "../../types";
 import { VoiceMemberTile } from "./VoiceMemberTile";
 import { LOCAL_PREVIEW_KEY } from "../../screenshare/screenShareSession";
 import { ScreenSharePicker } from "./ScreenSharePicker";
+import { shareOf } from "../../types/voice-state";
 
 export const VoiceChannelView: React.FC = () => {
   const {
     voiceParticipants,
     voiceActiveSpeakerIds,
-    voicePhase,
+    voiceState,
     screenShareRemotes,
-    screenShareLocalActive,
-    screenShareLocalDimensions,
-    screenShareMode,
     currentUser,
     setViewingScreenShareTrackKey,
   } = useAppStore();
   const localIdentity = currentUser ? `voice-${currentUser.id}` : null;
+  const share = shareOf(voiceState);
+  const shareActive = share.kind === 'active';
+  const shareLocalDims = shareActive ? share.dimensions : null;
+  const isJoining = voiceState.kind === 'joining';
 
   // When the user is picking a screen-share source we take over the
   // entire channel content area with the in-app picker — no modal, no
   // overlay. This is the project's blanket "no modals" rule
   // (CLAUDE.md). Returns to the participant grid on cancel / start.
-  if (screenShareMode === "picking") {
+  if (share.kind === "picking") {
     return <ScreenSharePicker />;
   }
 
@@ -51,7 +53,7 @@ export const VoiceChannelView: React.FC = () => {
         onActivate={(p) => {
           const isLocal = p.identity === localIdentity;
           // Enter activates the streaming user's tile → open fullscreen.
-          if (isLocal && screenShareLocalActive) {
+          if (isLocal && shareActive) {
             setViewingScreenShareTrackKey(LOCAL_PREVIEW_KEY);
             return;
           }
@@ -68,10 +70,10 @@ export const VoiceChannelView: React.FC = () => {
           let streamTrackKey: string | undefined;
           let streamWidth: number | undefined;
           let streamHeight: number | undefined;
-          if (isLocal && screenShareLocalActive) {
+          if (isLocal && shareActive) {
             streamTrackKey = LOCAL_PREVIEW_KEY;
-            streamWidth = screenShareLocalDimensions?.width;
-            streamHeight = screenShareLocalDimensions?.height;
+            streamWidth = shareLocalDims?.width;
+            streamHeight = shareLocalDims?.height;
           } else if (!isLocal) {
             const remote = screenShareRemotes[p.identity];
             if (remote) {
@@ -99,7 +101,7 @@ export const VoiceChannelView: React.FC = () => {
               // and only while the session is still negotiating with
               // LiveKit. Driven by VoiceSessionManager's phase, so it
               // clears the instant join_voice_channel resolves.
-              isConnecting={isLocal && voicePhase === "joining"}
+              isConnecting={isLocal && isJoining}
               onView={(trackKey) => setViewingScreenShareTrackKey(trackKey)}
             />
           );

--- a/frontend/src/hooks/useLiveKitRealtime.ts
+++ b/frontend/src/hooks/useLiveKitRealtime.ts
@@ -185,7 +185,9 @@ export function useLiveKitRealtime() {
 
   // Track the voice room the user is currently connected to so we only play
   // join/leave cues for rooms they can actually hear.
-  const activeVoiceChannelId = useAppStore((s) => s.activeVoiceChannelId);
+  const activeVoiceChannelId = useAppStore((s) =>
+    s.voiceState.kind === 'idle' ? null : s.voiceState.channelId,
+  );
   const activeVoiceChannelIdRef = useRef<string | null>(activeVoiceChannelId);
   useEffect(() => { activeVoiceChannelIdRef.current = activeVoiceChannelId; }, [activeVoiceChannelId]);
 

--- a/frontend/src/pages/Call.tsx
+++ b/frontend/src/pages/Call.tsx
@@ -25,7 +25,9 @@ export const CallPage: React.FC = () => {
   const navigate = useNavigate();
   const { callId } = useParams({ from: "/call/$callId" });
   const roomName = `call-${callId}`;
-  const activeVoiceChannelId = useAppStore((s) => s.activeVoiceChannelId);
+  const activeVoiceChannelId = useAppStore((s) =>
+    s.voiceState.kind === 'idle' ? null : s.voiceState.channelId,
+  );
   const voiceParticipants = useAppStore((s) => s.voiceParticipants);
   const outgoingCall = useAppStore((s) => s.outgoingCall);
   const setOutgoingCall = useAppStore((s) => s.setOutgoingCall);

--- a/frontend/src/pages/VoiceChannel.tsx
+++ b/frontend/src/pages/VoiceChannel.tsx
@@ -19,10 +19,12 @@ export const VoiceChannelPage: React.FC = () => {
   const navigate = useNavigate();
   const { groupId, channelId } = useParams({ from: "/groups/$groupId/voice/$channelId" });
   const {
-    activeVoiceChannelId,
+    voiceState,
     pendingDeleteChannelId,
     setPendingDeleteChannelId,
   } = useAppStore();
+  const activeVoiceChannelId =
+    voiceState.kind === 'idle' ? null : voiceState.channelId;
 
   const { data: groupsWithChannels } = useUserGroupsWithChannels();
   const group = groupsWithChannels?.find((g) => g.id === groupId);

--- a/frontend/src/screenshare/livekitView.ts
+++ b/frontend/src/screenshare/livekitView.ts
@@ -281,6 +281,20 @@ class LiveKitView {
       // Disable simulcast for screen-share — high-bitrate single layer
       // matches text legibility better than scaled-down spatial layers.
       simulcast: false,
+      // Encoder ceilings — not targets. WebRTC's TWCC bandwidth estimator
+      // ramps up toward these when the link sustains it, ramps down on
+      // packet loss. Default LiveKit screenshare cap is 15 fps; bumping to
+      // 60 covers the game-stream-to-lobby use case. Bitrate ceiling of
+      // 8 Mbps is comfortable for 1080p60 VP8 and headroom for the
+      // power-user case; the estimator will hold back on slower links.
+      // maintain-framerate biases toward smoother motion over crisper
+      // text when the encoder has to give something up under pressure.
+      videoEncoding: {
+        maxFramerate: 60,
+        maxBitrate: 8_000_000,
+        priority: 'high',
+      },
+      degradationPreference: 'maintain-framerate',
     });
     console.info('[livekit-view] publishScreenShare: publishTrack resolved', {
       elapsedMs: Math.round(performance.now() - t0),

--- a/frontend/src/screenshare/livekitView.ts
+++ b/frontend/src/screenshare/livekitView.ts
@@ -299,12 +299,7 @@ class LiveKitView {
     track.addEventListener('ended', () => {
       void this.unpublishScreenShare();
       // Notify the store so VoiceMemberTile flips back to the avatar.
-      const store = useAppStore.getState();
-      if (store.screenShareLocalActive) {
-        store.setScreenShareLocalActive(false);
-        store.setScreenShareLocalDimensions(null);
-        store.setScreenShareMode('idle');
-      }
+      useAppStore.getState().shareStopped();
     });
     this.tracks.set(LOCAL_PREVIEW_KEY, track);
     const settings = track.getSettings();
@@ -537,21 +532,12 @@ class LiveKitView {
         console.warn('[livekit-view] unpublish on leave:', e);
       }
     }
-    // Clear the Zustand store mirror of local-screenshare state — the
-    // unpublishScreenShare above closes the track but doesn't touch
-    // store.screenShareLocalActive/Mode/Dimensions. Without this reset
-    // the next voice-rejoin renders the tile as "still streaming" with
-    // no actual stream behind it.
-    //
-    // Unconditional — earlier we only reset when `screenShareLocalActive`
-    // was true, but that flag is set AFTER publishTrack resolves. On Linux
-    // when a portal-sourced track makes publish hang indefinitely, the
-    // flag never flips, so leaving the call left mode='starting' wedged
-    // forever and the user could not recover even by rejoining.
-    const store = useAppStore.getState();
-    store.setScreenShareLocalActive(false);
-    store.setScreenShareLocalDimensions(null);
-    store.setScreenShareMode('idle');
+    // Unconditional share reset on leave. The union structure means
+    // share state lives inside `joined.share`, so once voiceLeft() lands
+    // it's gone too — but call shareStopped() first to be explicit while
+    // we're still in `joined`, in case the consumer flow handles
+    // share-stopped and voice-left as distinct UI events.
+    useAppStore.getState().shareStopped();
     if (room) {
       try {
         await room.disconnect();
@@ -742,20 +728,17 @@ if (typeof window !== 'undefined') {
       return null;
     }
     const s = useAppStore.getState();
-    if (s.voicePhase !== 'joined') {
-      return null;
-    }
-    if (!s.activeVoiceChannelId) {
+    if (s.voiceState.kind !== 'joined') {
       return null;
     }
     if (!s.currentUser) {
       return null;
     }
     return {
-      channelId: s.activeVoiceChannelId,
+      channelId: s.voiceState.channelId,
       userId: s.currentUser.id,
       displayName: s.currentUser.username ?? s.currentUser.id,
-      counterpartyUserId: s.voiceCounterpartyUserId ?? null,
+      counterpartyUserId: s.voiceState.counterpartyUserId,
     };
   };
 
@@ -766,9 +749,7 @@ if (typeof window !== 'undefined') {
 
   useAppStore.subscribe((state, prev) => {
     if (
-      state.voicePhase !== prev.voicePhase ||
-      state.activeVoiceChannelId !== prev.activeVoiceChannelId ||
-      state.voiceCounterpartyUserId !== prev.voiceCounterpartyUserId ||
+      state.voiceState !== prev.voiceState ||
       state.currentUser !== prev.currentUser
     ) {
       livekitView.setIntent(computeIntent());

--- a/frontend/src/screenshare/livekitView.ts
+++ b/frontend/src/screenshare/livekitView.ts
@@ -542,12 +542,16 @@ class LiveKitView {
     // store.screenShareLocalActive/Mode/Dimensions. Without this reset
     // the next voice-rejoin renders the tile as "still streaming" with
     // no actual stream behind it.
+    //
+    // Unconditional — earlier we only reset when `screenShareLocalActive`
+    // was true, but that flag is set AFTER publishTrack resolves. On Linux
+    // when a portal-sourced track makes publish hang indefinitely, the
+    // flag never flips, so leaving the call left mode='starting' wedged
+    // forever and the user could not recover even by rejoining.
     const store = useAppStore.getState();
-    if (store.screenShareLocalActive) {
-      store.setScreenShareLocalActive(false);
-      store.setScreenShareLocalDimensions(null);
-      store.setScreenShareMode('idle');
-    }
+    store.setScreenShareLocalActive(false);
+    store.setScreenShareLocalDimensions(null);
+    store.setScreenShareMode('idle');
     if (room) {
       try {
         await room.disconnect();

--- a/frontend/src/screenshare/screenShareSession.ts
+++ b/frontend/src/screenshare/screenShareSession.ts
@@ -334,19 +334,40 @@ class ScreenShareSession {
       muted: track.muted,
     });
     try {
-      await livekitView.publishScreenShare(track);
+      // 15s ceiling on publishTrack. On Linux a Wayland-portal-sourced
+      // track can leave LiveKit's publish promise unresolved forever
+      // (PipeWire delivers a dead stream; readyState stays "live", the
+      // SDK never receives frames so it never completes setup). Without
+      // the race, the user is stuck at mode='starting' with no recovery.
+      await Promise.race([
+        livekitView.publishScreenShare(track),
+        new Promise<never>((_, reject) =>
+          setTimeout(
+            () => reject(new Error("publishTrack timed out after 15s")),
+            15000,
+          ),
+        ),
+      ]);
       console.info("[screenshare] publishScreenShare completed");
     } catch (e) {
       console.error("[screenshare] publishScreenShare threw:", e);
-      // Publish failed — make sure the OS capture handle is released so
-      // the "you're sharing" indicator goes away.
+      // Publish failed (or timed out) — release the OS capture handle so
+      // the "you're sharing" indicator goes away, then drop any in-flight
+      // publication the SDK may have half-registered before the timeout.
       try {
         track.stop();
       } catch {
         // ignore
       }
+      try {
+        await livekitView.unpublishScreenShare();
+      } catch {
+        // ignore — best-effort cleanup
+      }
       const msg = e instanceof Error ? e.message : String(e);
       store.setScreenShareError(friendlyScreenShareError(msg));
+      store.setScreenShareLocalActive(false);
+      store.setScreenShareLocalDimensions(null);
       store.setScreenShareMode("idle");
       throw e;
     }

--- a/frontend/src/screenshare/screenShareSession.ts
+++ b/frontend/src/screenshare/screenShareSession.ts
@@ -305,8 +305,7 @@ class ScreenShareSession {
     // explicit and survives any future Vite config quirks.)
     const { livekitView } = await import("./livekitView");
     const store = useAppStore.getState();
-    store.setScreenShareMode("starting");
-    store.setScreenShareError(null);
+    store.shareStartStarting();
     let stream: MediaStream;
     try {
       // Audio is intentionally off — voice goes through the Rust voice
@@ -317,14 +316,12 @@ class ScreenShareSession {
       });
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
-      store.setScreenShareError(friendlyScreenShareError(msg));
-      store.setScreenShareMode("idle");
+      store.shareFailed(friendlyScreenShareError(msg));
       throw e;
     }
     const track = stream.getVideoTracks()[0];
     if (!track) {
-      store.setScreenShareError("Screen share returned no video track.");
-      store.setScreenShareMode("idle");
+      store.shareFailed("Screen share returned no video track.");
       throw new Error("getDisplayMedia returned no video track");
     }
     console.info("[screenshare] getDisplayMedia returned, handing track to livekitView", {
@@ -338,7 +335,7 @@ class ScreenShareSession {
       // track can leave LiveKit's publish promise unresolved forever
       // (PipeWire delivers a dead stream; readyState stays "live", the
       // SDK never receives frames so it never completes setup). Without
-      // the race, the user is stuck at mode='starting' with no recovery.
+      // the race, the user is stuck at share={kind:'starting'} forever.
       await Promise.race([
         livekitView.publishScreenShare(track),
         new Promise<never>((_, reject) =>
@@ -365,26 +362,15 @@ class ScreenShareSession {
         // ignore — best-effort cleanup
       }
       const msg = e instanceof Error ? e.message : String(e);
-      store.setScreenShareError(friendlyScreenShareError(msg));
-      store.setScreenShareLocalActive(false);
-      store.setScreenShareLocalDimensions(null);
-      store.setScreenShareMode("idle");
+      store.shareFailed(friendlyScreenShareError(msg));
       throw e;
     }
     const settings = track.getSettings();
-    store.setScreenShareLocalActive(true);
-    if (
-      typeof settings.width === "number" &&
-      typeof settings.height === "number"
-    ) {
-      store.setScreenShareLocalDimensions({
-        width: settings.width,
-        height: settings.height,
-      });
-    } else {
-      store.setScreenShareLocalDimensions(null);
-    }
-    store.setScreenShareMode("active");
+    const dims =
+      typeof settings.width === "number" && typeof settings.height === "number"
+        ? { width: settings.width, height: settings.height }
+        : null;
+    store.shareStarted(track.id, dims);
     playSfx(SFX.ping);
   }
 
@@ -393,9 +379,7 @@ class ScreenShareSession {
       const { livekitView } = await import("./livekitView");
       await livekitView.unpublishScreenShare();
       const store = useAppStore.getState();
-      store.setScreenShareLocalActive(false);
-      store.setScreenShareLocalDimensions(null);
-      store.setScreenShareMode("idle");
+      store.shareStopped();
       playSfx(SFX.ping);
       return;
     }
@@ -406,25 +390,23 @@ class ScreenShareSession {
     const store = useAppStore.getState();
     switch (ev.type) {
       case "local_started":
-        store.setScreenShareLocalActive(true);
-        store.setScreenShareLocalDimensions({ width: ev.width, height: ev.height });
-        store.setScreenShareMode("active");
-        store.setScreenShareSources(null);
-        store.setScreenShareError(null);
+        // Tauri path: backend signals the start after its capture helper
+        // has published. Synthesize the renderer-side state transitions
+        // (starting → active) so the union ends up in the same shape as
+        // the Electron renderer path.
+        store.shareStartStarting();
+        store.shareStarted(
+          "tauri-local",
+          { width: ev.width, height: ev.height },
+        );
         playSfx(SFX.ping);
         break;
       case "local_stopped":
-        store.setScreenShareLocalActive(false);
-        store.setScreenShareLocalDimensions(null);
-        store.setScreenShareMode("idle");
-        store.setScreenShareSources(null);
-        store.setScreenShareError(null);
+        store.shareStopped();
         playSfx(SFX.ping);
         break;
       case "local_error":
-        store.setScreenShareError(friendlyScreenShareError(ev.message));
-        store.setScreenShareMode("idle");
-        store.setScreenShareSources(null);
+        store.shareFailed(friendlyScreenShareError(ev.message));
         break;
       case "local_unsupported":
         // Distinct from a permission denial: the desktop environment
@@ -433,9 +415,7 @@ class ScreenShareSession {
         // ScreenCast). Telling the user to "grant permission" would be
         // wrong; there is nothing to grant. Pass the backend's precise
         // message straight through.
-        store.setScreenShareError(ev.message);
-        store.setScreenShareMode("idle");
-        store.setScreenShareSources(null);
+        store.shareFailed(ev.message);
         break;
       case "remote_started":
         store.upsertScreenShareRemote(ev.identity, {

--- a/frontend/src/screenshare/screenShareSession.ts
+++ b/frontend/src/screenshare/screenShareSession.ts
@@ -310,8 +310,16 @@ class ScreenShareSession {
     try {
       // Audio is intentionally off — voice goes through the Rust voice
       // client, and getDisplayMedia audio is unreliable cross-platform.
+      //
+      // frameRate ceiling: 60 fps. xdg-desktop-portal (Linux), ScreenCaptureKit
+      // (macOS), and WGC (Windows) all cap source capture at ~60 fps on the
+      // typical compositor, so asking for higher gets silently clamped to 60.
+      // The source track feeds both the local preview <video> and the LiveKit
+      // publish path — bumping it here gets us up to display-rate previews
+      // (subject to compositor) and gives the encoder headroom to push 60 fps
+      // out to receivers when bandwidth allows.
       stream = await navigator.mediaDevices.getDisplayMedia({
-        video: true,
+        video: { frameRate: { ideal: 60, max: 60 } },
         audio: false,
       });
     } catch (e) {

--- a/frontend/src/stores/appStore.ts
+++ b/frontend/src/stores/appStore.ts
@@ -1,5 +1,7 @@
 import { create } from 'zustand';
 import type { AppState, User, Group, Channel, DMConversation, MessageQueueItem, VoiceParticipant } from '../types';
+import type { ShareState, VoiceState } from '../types/voice-state';
+import type { SourceList } from '../screenshare/screenShareSession';
 
 interface AppStore extends AppState {
   // User profile data from Turso
@@ -34,74 +36,52 @@ interface AppStore extends AppState {
   markRead: (id: string) => void;
   // Increments the unread count for a conversation or channel by 1
   incrementUnread: (id: string) => void;
-  // Voice channel — null when not in a call
-  activeVoiceChannelId: string | null;
-  setActiveVoiceChannelId: (id: string | null) => void;
-  // The other user_id in a 1:1 call (`call-*` room). Null for group voice
-  // channels and DMs. Used by the screen-share E2EE key derivation in
-  // `livekitView.executeJoin` so it resolves the same MLS group the Rust
-  // voice path picked. Mirrored from VoiceSessionManager.
-  voiceCounterpartyUserId: string | null;
-  setVoiceCounterpartyUserId: (id: string | null) => void;
+  // Voice room + local screenshare state. Single source of truth — see
+  // `frontend/src/types/voice-state.ts` for the union shape. Replaces the
+  // previous bag of flags (`voicePhase`, `screenShareMode`,
+  // `screenShareLocalActive`, `activeVoiceChannelId`,
+  // `voiceCounterpartyUserId`, `voiceIsMuted`, `screenShareSources`,
+  // `screenShareLocalDimensions`) that could contradict each other.
+  voiceState: VoiceState;
+
+  // Semantic transitions. Each one guards on the current state's `kind`
+  // and no-ops (with a console.warn) if the transition isn't allowed.
+  // Prefer these over setVoiceState() for everyday writes — they
+  // document the lifecycle and prevent skipping phases.
+  voiceStartJoining: (channelId: string, counterpartyUserId: string | null) => void;
+  voiceJoined: () => void;
+  voiceJoinFailed: (error: string) => void;
+  voiceStartLeaving: () => void;
+  voiceLeft: () => void;
+  voiceSetMicMuted: (muted: boolean) => void;
+
+  shareStartPicking: (sources: SourceList) => void;
+  shareCancelPicker: () => void;
+  shareStartStarting: () => void;
+  shareStarted: (trackId: string, dimensions: { width: number; height: number } | null) => void;
+  shareSetDimensions: (dimensions: { width: number; height: number } | null) => void;
+  shareFailed: (error: string) => void;
+  shareStopped: () => void;
+
   // Status bar alert — shown in bottom bar when a message arrives for a
   // channel/DM the user is not currently viewing. Cleared on navigation.
   statusBarAlert: { senderUsername: string; roomId: string } | null;
   setStatusBarAlert: (alert: { senderUsername: string; roomId: string } | null) => void;
   // Voice join failure — surfaced in the bottom bar when join_voice_channel
   // fails (e.g. the LiveKit server is unreachable). Cleared on dismiss or on
-  // the next join attempt. Mirrored from the VoiceSessionManager.
+  // the next join attempt.
   voiceError: string | null;
   setVoiceError: (message: string | null) => void;
-  // Screen-share failure — surfaced in the bottom bar when start_screen_share
-  // fails or the OS portal denies/cancels the picker. Cleared on dismiss or
-  // when a share starts/stops. Mirrored from the screen-share session.
-  screenShareError: string | null;
-  setScreenShareError: (message: string | null) => void;
-  // True when local participant's mic is actively picking up audio
+  // True when local participant's mic is actively picking up audio.
+  // Derived from LiveKit speaker events; not part of the lifecycle union.
   isLocalSpeaking: boolean;
   setIsLocalSpeaking: (speaking: boolean) => void;
-  // Live voice channel state — mirrored from `voiceSession` in src/voice/.
-  // The manager is the source of truth; these fields are a write-through
-  // projection so existing readers (VoiceBar/VoiceChannelView/AppShell/etc.)
-  // keep working without subscribing to the manager directly.
+  // Live voice channel participants — driven by LiveKit events.
+  // Collection data, kept separate from the lifecycle union.
   voiceParticipants: VoiceParticipant[];
   voiceActiveSpeakerIds: string[];
-  voiceIsMuted: boolean;
-  // Lifecycle phase of the local voice session — mirrored from
-  // `VoiceSessionManager`. Used to show a subtle "connecting…" indicator
-  // on the local user's own tile while LiveKit is connecting.
-  voicePhase: "idle" | "joining" | "joined" | "leaving";
   setVoiceParticipants: (participants: VoiceParticipant[]) => void;
   setVoiceActiveSpeakerIds: (ids: string[]) => void;
-  setVoiceIsMuted: (muted: boolean) => void;
-  setVoicePhase: (phase: "idle" | "joining" | "joined" | "leaving") => void;
-  /** True if the local user is broadcasting their screen. */
-  screenShareLocalActive: boolean;
-  setScreenShareLocalActive: (v: boolean) => void;
-  /** Lifecycle stage of the local screen-share UI:
-   *   - 'idle': no share in progress, no picker open
-   *   - 'picking': in-app source picker visible (macOS only; the
-   *     helper is parked on the backend awaiting the user's selection)
-   *   - 'starting': selection sent, waiting for the helper to
-   *     announce Format and the LiveKit publish to land
-   *   - 'active': frames flowing (synced with `screenShareLocalActive`)
-   *  Used by VoiceChannelView to swap the participant grid for the
-   *  inline picker without a modal. */
-  screenShareMode: "idle" | "picking" | "starting" | "active";
-  setScreenShareMode: (m: "idle" | "picking" | "starting" | "active") => void;
-  /** Sources returned by `enumerate_screen_sources` — populated when
-   *  mode flips to 'picking'. Cleared on exit. */
-  screenShareSources: import("../screenshare/screenShareSession").SourceList | null;
-  setScreenShareSources: (
-    s: import("../screenshare/screenShareSession").SourceList | null,
-  ) => void;
-  /** Dimensions of the local outgoing share so the in-tile preview
-   *  can seed its canvas before the first mirrored frame arrives. Set
-   *  by `local_started`, cleared by `local_stopped`. */
-  screenShareLocalDimensions: { width: number; height: number } | null;
-  setScreenShareLocalDimensions: (
-    dims: { width: number; height: number } | null,
-  ) => void;
   /** Active remote screenshares keyed by participant identity. */
   screenShareRemotes: Record<string, { trackKey: string; width: number; height: number }>;
   upsertScreenShareRemote: (identity: string, info: { trackKey: string; width: number; height: number }) => void;
@@ -175,20 +155,12 @@ export const useAppStore = create<AppStore>((set) => ({
   isLoading: false,
   error: null,
   unreadCounts: {},
-  activeVoiceChannelId: null,
-  voiceCounterpartyUserId: null,
+  voiceState: { kind: 'idle' },
   statusBarAlert: null,
   voiceError: null,
-  screenShareError: null,
   isLocalSpeaking: false,
   voiceParticipants: [],
   voiceActiveSpeakerIds: [],
-  voiceIsMuted: false,
-  voicePhase: "idle",
-  screenShareLocalActive: false,
-  screenShareLocalDimensions: null,
-  screenShareMode: "idle",
-  screenShareSources: null,
   screenShareRemotes: {},
   viewingScreenShareTrackKey: null,
 
@@ -258,26 +230,149 @@ export const useAppStore = create<AppStore>((set) => ({
     },
   })),
 
-  setActiveVoiceChannelId: (id) => set({ activeVoiceChannelId: id }),
-  setVoiceCounterpartyUserId: (id) => set({ voiceCounterpartyUserId: id }),
+  // ── Voice + share transitions ──────────────────────────────────────────
+  // Each transition guards on the current `voiceState.kind`. Bad
+  // transitions are logged + dropped instead of mutating state — this is
+  // the whole point of the union: contradictory state is unrepresentable.
+  voiceStartJoining: (channelId, counterpartyUserId) => set((state) => {
+    if (state.voiceState.kind !== 'idle') {
+      console.warn('[voiceState] voiceStartJoining ignored:', state.voiceState.kind);
+      return {};
+    }
+    return {
+      voiceState: { kind: 'joining', channelId, counterpartyUserId },
+      voiceError: null,
+    };
+  }),
+  voiceJoined: () => set((state) => {
+    if (state.voiceState.kind !== 'joining') {
+      console.warn('[voiceState] voiceJoined ignored:', state.voiceState.kind);
+      return {};
+    }
+    const { channelId, counterpartyUserId } = state.voiceState;
+    return {
+      voiceState: {
+        kind: 'joined',
+        channelId,
+        counterpartyUserId,
+        micMuted: false,
+        share: { kind: 'idle' },
+      },
+    };
+  }),
+  voiceJoinFailed: (error) => set((state) => {
+    if (state.voiceState.kind !== 'joining') {
+      console.warn('[voiceState] voiceJoinFailed ignored:', state.voiceState.kind);
+      return {};
+    }
+    return { voiceState: { kind: 'idle' }, voiceError: error };
+  }),
+  voiceStartLeaving: () => set((state) => {
+    // Tolerate from joining or joined; the user can hit "leave" while we
+    // were still connecting.
+    if (state.voiceState.kind !== 'joining' && state.voiceState.kind !== 'joined') {
+      console.warn('[voiceState] voiceStartLeaving ignored:', state.voiceState.kind);
+      return {};
+    }
+    return { voiceState: { kind: 'leaving', channelId: state.voiceState.channelId } };
+  }),
+  voiceLeft: () => set(() => ({
+    // Unconditional reset — clears share state along the way since the
+    // union guarantees share can't outlive the joined parent.
+    voiceState: { kind: 'idle' },
+  })),
+  voiceSetMicMuted: (muted) => set((state) => {
+    if (state.voiceState.kind !== 'joined') {
+      return {};
+    }
+    return { voiceState: { ...state.voiceState, micMuted: muted } };
+  }),
+
+  shareStartPicking: (sources) => set((state) => {
+    if (state.voiceState.kind !== 'joined' || state.voiceState.share.kind !== 'idle') {
+      console.warn('[voiceState] shareStartPicking ignored:', state.voiceState.kind, 'share=', state.voiceState.kind === 'joined' ? state.voiceState.share.kind : 'n/a');
+      return {};
+    }
+    return {
+      voiceState: { ...state.voiceState, share: { kind: 'picking', sources } },
+    };
+  }),
+  shareCancelPicker: () => set((state) => {
+    if (state.voiceState.kind !== 'joined' || state.voiceState.share.kind !== 'picking') {
+      return {};
+    }
+    return { voiceState: { ...state.voiceState, share: { kind: 'idle' } } };
+  }),
+  shareStartStarting: () => set((state) => {
+    if (state.voiceState.kind !== 'joined') {
+      console.warn('[voiceState] shareStartStarting ignored:', state.voiceState.kind);
+      return {};
+    }
+    // From idle (Linux portal path) or picking (macOS in-app picker).
+    if (state.voiceState.share.kind !== 'idle' && state.voiceState.share.kind !== 'picking') {
+      console.warn('[voiceState] shareStartStarting ignored, share=', state.voiceState.share.kind);
+      return {};
+    }
+    return {
+      voiceState: {
+        ...state.voiceState,
+        share: { kind: 'starting', startedAt: performance.now() },
+      },
+    };
+  }),
+  shareStarted: (trackId, dimensions) => set((state) => {
+    if (state.voiceState.kind !== 'joined' || state.voiceState.share.kind !== 'starting') {
+      console.warn('[voiceState] shareStarted ignored:', state.voiceState.kind, state.voiceState.kind === 'joined' ? state.voiceState.share.kind : 'n/a');
+      return {};
+    }
+    return {
+      voiceState: {
+        ...state.voiceState,
+        share: { kind: 'active', trackId, dimensions },
+      },
+    };
+  }),
+  shareSetDimensions: (dimensions) => set((state) => {
+    if (state.voiceState.kind !== 'joined' || state.voiceState.share.kind !== 'active') {
+      return {};
+    }
+    return {
+      voiceState: {
+        ...state.voiceState,
+        share: { ...state.voiceState.share, dimensions },
+      },
+    };
+  }),
+  shareFailed: (error) => set((state) => {
+    if (state.voiceState.kind !== 'joined') {
+      console.warn('[voiceState] shareFailed ignored, voice=', state.voiceState.kind);
+      return {};
+    }
+    return {
+      voiceState: {
+        ...state.voiceState,
+        share: { kind: 'failed', error },
+      },
+    };
+  }),
+  shareStopped: () => set((state) => {
+    // Unconditional reset of share — safe to call from any share state
+    // (active, failed, starting, picking). The reset-on-leave path also
+    // calls voiceLeft which clears share via the union structure.
+    if (state.voiceState.kind !== 'joined') {
+      return {};
+    }
+    return {
+      voiceState: { ...state.voiceState, share: { kind: 'idle' } },
+    };
+  }),
 
   setStatusBarAlert: (alert) => set({ statusBarAlert: alert }),
-
   setVoiceError: (message) => set({ voiceError: message }),
-
-  setScreenShareError: (message) => set({ screenShareError: message }),
-
   setIsLocalSpeaking: (speaking) => set({ isLocalSpeaking: speaking }),
 
   setVoiceParticipants: (participants) => set({ voiceParticipants: participants }),
   setVoiceActiveSpeakerIds: (ids) => set({ voiceActiveSpeakerIds: ids }),
-  setVoiceIsMuted: (muted) => set({ voiceIsMuted: muted }),
-  setVoicePhase: (phase) => set({ voicePhase: phase }),
-
-  setScreenShareLocalActive: (v) => set({ screenShareLocalActive: v }),
-  setScreenShareLocalDimensions: (dims) => set({ screenShareLocalDimensions: dims }),
-  setScreenShareMode: (m) => set({ screenShareMode: m }),
-  setScreenShareSources: (s) => set({ screenShareSources: s }),
   upsertScreenShareRemote: (identity, info) => set((state) => ({
     screenShareRemotes: { ...state.screenShareRemotes, [identity]: info },
   })),
@@ -330,20 +425,12 @@ export const useAppStore = create<AppStore>((set) => ({
     isLoading: false,
     error: null,
     unreadCounts: {},
-    activeVoiceChannelId: null,
-    voiceCounterpartyUserId: null,
+    voiceState: { kind: 'idle' },
     statusBarAlert: null,
     voiceError: null,
-    screenShareError: null,
     isLocalSpeaking: false,
     voiceParticipants: [],
     voiceActiveSpeakerIds: [],
-    voiceIsMuted: false,
-    voicePhase: "idle",
-    screenShareLocalActive: false,
-    screenShareLocalDimensions: null,
-    screenShareMode: "idle",
-    screenShareSources: null,
     screenShareRemotes: {},
     viewingScreenShareTrackKey: null,
     pendingEnrollmentApproval: null,

--- a/frontend/src/types/voice-state.ts
+++ b/frontend/src/types/voice-state.ts
@@ -1,0 +1,95 @@
+// Voice + screenshare state machine. Replaces the bag of flags
+// (`voicePhase`, `screenShareMode`, `screenShareLocalActive`,
+// `activeVoiceChannelId`, …) that used to live in appStore.ts.
+//
+// The bag-of-flags shape allowed contradictory combinations — e.g.
+// `screenShareMode === 'starting'` with `screenShareLocalActive === false`
+// is reachable while a publish is in flight, and every cleanup site had
+// to remember to reset both. Multiple Linux screenshare-wedge bugs in the
+// migration came down to "this flag was set, that one wasn't, the
+// reconciler took the wrong branch."
+//
+// Modelled as a discriminated union: the compiler enforces that
+// share-state only exists when voice is `joined`, errors live alongside
+// their state instead of in a parallel field, and exhaustive `switch`es
+// surface forgotten transitions at build time. Plain TypeScript — no
+// xstate, no library, zero runtime cost.
+
+import type { SourceList } from '../screenshare/screenShareSession';
+
+/** Top-level voice room lifecycle. Local-only — does not track remote
+ *  participants (that's `voiceParticipants` in the store, kept separate
+ *  because it's collection data driven by LiveKit events). */
+export type VoiceState =
+  | { kind: 'idle' }
+  | {
+      kind: 'joining';
+      channelId: string;
+      /** Other user_id in a 1:1 call (`call-*` room). Null for group
+       *  voice channels and regular DMs. Required by the screen-share
+       *  E2EE key derivation in `livekitView.executeJoin`. */
+      counterpartyUserId: string | null;
+    }
+  | {
+      kind: 'joined';
+      channelId: string;
+      counterpartyUserId: string | null;
+      micMuted: boolean;
+      share: ShareState;
+    }
+  | { kind: 'leaving'; channelId: string };
+
+/** Local screen-share lifecycle. Only meaningful inside a `joined` voice
+ *  state — the union forbids `active` share without an active voice
+ *  session. */
+export type ShareState =
+  | { kind: 'idle' }
+  | { kind: 'picking'; sources: SourceList }
+  | {
+      kind: 'starting';
+      /** `performance.now()` at start. Used by recovery affordances to
+       *  show "stuck?" UI after N seconds and to cap the publish
+       *  timeout from the outside. */
+      startedAt: number;
+    }
+  | {
+      kind: 'active';
+      trackId: string;
+      dimensions: { width: number; height: number } | null;
+    }
+  | {
+      kind: 'failed';
+      error: string;
+    };
+
+/** Helpers — read-only narrowings that consumers reach for a lot. */
+
+export function voiceChannelId(s: VoiceState): string | null {
+  switch (s.kind) {
+    case 'idle':
+      return null;
+    case 'joining':
+    case 'joined':
+    case 'leaving':
+      return s.channelId;
+  }
+}
+
+export function voiceCounterpartyUserId(s: VoiceState): string | null {
+  switch (s.kind) {
+    case 'idle':
+    case 'leaving':
+      return null;
+    case 'joining':
+    case 'joined':
+      return s.counterpartyUserId;
+  }
+}
+
+export function shareOf(s: VoiceState): ShareState {
+  return s.kind === 'joined' ? s.share : { kind: 'idle' };
+}
+
+export function isShareActive(s: VoiceState): boolean {
+  return s.kind === 'joined' && s.share.kind === 'active';
+}

--- a/frontend/src/voice/VoiceSessionManager.ts
+++ b/frontend/src/voice/VoiceSessionManager.ts
@@ -701,48 +701,75 @@ export const voiceSession = new VoiceSessionManager();
  */
 voiceSession.subscribe(() => {
   const s = voiceSession.getSnapshot();
-  // Map manager state → store state. Avoid setting fields that didn't change
-  // so subscribers don't churn on equal-value writes.
   const store = useAppStore.getState();
-  const patch: Partial<{
-    activeVoiceChannelId: string | null;
-    voiceCounterpartyUserId: string | null;
-    voiceParticipants: VoiceParticipant[];
-    voiceActiveSpeakerIds: string[];
-    voiceIsMuted: boolean;
-    voicePhase: VoicePhase;
-    isLocalSpeaking: boolean;
-    voiceError: string | null;
-  }> = {};
-  if (store.activeVoiceChannelId !== s.channelId) {
-    patch.activeVoiceChannelId = s.channelId;
+  const v = store.voiceState;
+
+  // Lifecycle transitions — drive the union via semantic methods. The
+  // store guards them, so out-of-order writes from a stale snapshot
+  // become no-ops + console.warn instead of bad state.
+  switch (s.phase) {
+    case 'idle': {
+      if (v.kind === 'leaving' || v.kind === 'joining') {
+        store.voiceLeft();
+      } else if (v.kind === 'joined') {
+        store.voiceLeft();
+      }
+      // If the manager moved straight from joining → idle with an error,
+      // surface it as a join failure even though we already collapsed to
+      // idle above. (The store's voiceJoinFailed only fires from joining;
+      // for the idle landing we set voiceError directly.)
+      if (s.error && store.voiceError !== s.error) {
+        store.setVoiceError(s.error);
+      }
+      break;
+    }
+    case 'joining': {
+      if (v.kind === 'idle' && s.channelId) {
+        store.voiceStartJoining(s.channelId, s.counterpartyUserId);
+      } else if (v.kind === 'joining' && s.channelId && (v.channelId !== s.channelId || v.counterpartyUserId !== s.counterpartyUserId)) {
+        // Channel switched mid-join — reset and restart.
+        store.voiceLeft();
+        store.voiceStartJoining(s.channelId, s.counterpartyUserId);
+      }
+      break;
+    }
+    case 'joined': {
+      if (v.kind === 'joining' && s.channelId) {
+        store.voiceJoined();
+      } else if (v.kind === 'idle' && s.channelId) {
+        // Race: snapshot skipped 'joining'. Synthesize it.
+        store.voiceStartJoining(s.channelId, s.counterpartyUserId);
+        store.voiceJoined();
+      }
+      // Mic-mute mirror.
+      const after = useAppStore.getState().voiceState;
+      if (after.kind === 'joined' && after.micMuted !== s.isMuted) {
+        store.voiceSetMicMuted(s.isMuted);
+      }
+      break;
+    }
+    case 'leaving': {
+      if (v.kind === 'joining' || v.kind === 'joined') {
+        store.voiceStartLeaving();
+      }
+      break;
+    }
   }
-  if (store.voiceCounterpartyUserId !== s.counterpartyUserId) {
-    patch.voiceCounterpartyUserId = s.counterpartyUserId;
-  }
+
+  // Collection / derived fields stay as direct sets.
   if (store.voiceParticipants !== s.participants) {
-    patch.voiceParticipants = s.participants;
+    useAppStore.setState({ voiceParticipants: s.participants });
   }
   if (store.voiceActiveSpeakerIds !== s.activeSpeakerIds) {
-    patch.voiceActiveSpeakerIds = s.activeSpeakerIds;
-  }
-  if (store.voiceIsMuted !== s.isMuted) {
-    patch.voiceIsMuted = s.isMuted;
-  }
-  if (store.voicePhase !== s.phase) {
-    patch.voicePhase = s.phase;
+    useAppStore.setState({ voiceActiveSpeakerIds: s.activeSpeakerIds });
   }
   if (store.isLocalSpeaking !== s.isLocalSpeaking) {
-    patch.isLocalSpeaking = s.isLocalSpeaking;
+    useAppStore.setState({ isLocalSpeaking: s.isLocalSpeaking });
   }
-  // Mirror join failures so the shell can surface them in the status bar.
-  // Cleared automatically: every join attempt resets `error` to null at the
-  // top of `executeJoin`, which projects through here as null.
+  // Join errors mirror through the store's separate voiceError field;
+  // the union's idle state doesn't carry the error itself.
   if (store.voiceError !== s.error) {
-    patch.voiceError = s.error;
-  }
-  if (Object.keys(patch).length > 0) {
-    useAppStore.setState(patch);
+    useAppStore.setState({ voiceError: s.error });
   }
 });
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,20 +7,14 @@ const isPlaywright = process.env.VITE_PLAYWRIGHT === 'true'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-  // Electron loads index.html via `file://`, so absolute asset paths like
-  // `/assets/*` resolve to the filesystem root instead of the html's dir.
-  // Emit `./assets/*` so the bundle loads regardless of where the app was
-  // installed. In Vite dev (pnpm dev), Vite still serves from `/` at the
-  // dev server root — this only affects `vite build` output.
-  base: './',
-  // Load VITE_* env vars from the monorepo root so we only need a single .env.development
-  envDir: '..',
   // Emit relative asset URLs in the built index.html. Electron loads the
   // packaged HTML via `file://`, where absolute paths like `/assets/x.js`
   // resolve to `file:///assets/x.js` and 404 — the window then shows just
   // the title bar with no rendered content. Relative (`./assets/x.js`)
   // works under both `file://` (packaged) and the Vite dev server.
   base: './',
+  // Load VITE_* env vars from the monorepo root so we only need a single .env.development
+  envDir: '..',
   resolve: isPlaywright
     ? {
         alias: {


### PR DESCRIPTION
Bundle of stacked work from a rough 24h:

**Voice/share state machine (a81014f)** — replaces 9 contradicting flags (voicePhase / voiceIsMuted / activeVoiceChannelId / voiceCounterpartyUserId / screenShareLocalActive / screenShareLocalDimensions / screenShareMode / screenShareSources / screenShareError) with one VoiceState discriminated union in frontend/src/types/voice-state.ts. Compiler now enforces share state only exists inside joined voice state, errors live alongside their state, exhaustive switches surface forgotten transitions. New 'failed' ShareState for first-class error UI.

**Linux screenshare wedge recovery (4a4bb9f)** — three compounding fixes for the "share button thinks broadcasting but no video, can't recover" loop: unconditional cleanup on leave-call (not gated on the boolean that only flips after publishTrack resolves), 15s timeout on publishTrack to escape Wayland-portal-induced hangs, and the share button itself works as a force-stop affordance when state is wedged.

**GL flag experiments (3a1bb10, e44f6a6)** — tried use-gl=desktop then use-angle=gl; both either rejected by Chromium 130's allowed list or broke the xdg-desktop-portal handshake. Reverted to no flag; the EGL/ZINK noise on NVIDIA + Mesa is a transient state issue cleared by reboot, not a code bug.

**60fps screenshare (3ba95a0)** — getDisplayMedia frameRate ideal/max 60 (was Chromium's 30 default). publishTrack videoEncoding: maxFramerate 60, maxBitrate 8 Mbps, priority high, degradationPreference maintain-framerate. Ceilings not targets; TWCC adapts down on weak links. Covers game-stream-to-lobby without needing user-facing config. VoiceBar gated on joined state.

**Sidebar @ prefix (b36035c)** — drops the @ on DM usernames in the sidebar.

## Test plan

- [x] tsc clean
- [x] Production build (electron-builder --linux) succeeds
- [x] Packaged binary launches without renderer/path errors
- [x] Local screenshare preview reaches 60fps (verified via getVideoPlaybackQuality)
- [x] Wedge recovery: stop+restart picker cycle works without reload
- [ ] Multi-platform CI pipeline passes