### PR TITLE
feat(frontend): in-app update indicator + dedicated /update page

### DIFF
--- a/frontend/src/components/Layout/AppShell.tsx
+++ b/frontend/src/components/Layout/AppShell.tsx
@@ -16,7 +16,8 @@ import { useAppStore } from "../../stores/appStore";
 import { useUserGroupsWithChannels } from "../../hooks/queries/useGroups";
 import { useLiveKitRealtime } from "../../hooks/useLiveKitRealtime";
 import { useBadge } from "../../hooks/useBadge";
-import { AlertTriangle, Mail, Phone, X } from "lucide-react";
+import { AlertTriangle, Download, Mail, Phone, X } from "lucide-react";
+import { startUpdatePolling, stopUpdatePolling } from "../../services/updatePoller";
 import { loadDeviceCallRingtone } from "../../utils/notify";
 import { usePreferences } from "../../hooks/queries/usePreferences";
 import { voiceSession } from "../../voice";
@@ -74,6 +75,7 @@ export const AppShell: React.FC = () => {
     viewingScreenShareTrackKey,
     setViewingScreenShareTrackKey,
     shareStopped,
+    availableUpdateVersion,
   } = useAppStore();
   // Channel id derives from the union. Replaces the standalone
   // activeVoiceChannelId field that used to be stored separately.
@@ -208,6 +210,22 @@ export const AppShell: React.FC = () => {
 
   // Maintain a LiveKit room connection for the active channel/conversation
   useLiveKitRealtime();
+
+  // Poll for app updates every 15 minutes once the user reaches the main
+  // app. The startup gate in App.tsx already covers the launch-time check;
+  // this picks up releases published while the user is signed in. The
+  // poller is a module-level singleton so StrictMode double-mount or
+  // AppShell remount can't duplicate the timer. Skip in dev — the updater
+  // bridge already returns null there, but no point burning a timer.
+  useEffect(() => {
+    if (import.meta.env.DEV) {
+      return;
+    }
+    startUpdatePolling();
+    return () => {
+      stopUpdatePolling();
+    };
+  }, []);
 
   // Sync unread count to OS dock/taskbar badge
   useBadge();
@@ -511,6 +529,26 @@ export const AppShell: React.FC = () => {
         }}
       >
         <StatusBarSummary color={isChatScreen ? "var(--c-accent)" : "black"} />
+        <div className="flex items-center gap-3">
+        {availableUpdateVersion && (
+          <button
+            data-testid="status-bar-update-available"
+            className="text-xs font-mono flex items-center gap-1 cursor-pointer"
+            style={{
+              color: isChatScreen ? "var(--c-accent)" : "var(--c-surface)",
+              background: "none",
+              border: "none",
+              padding: 0,
+              lineHeight: 0,
+            }}
+            onClick={() => router.navigate({ to: "/update" })}
+            aria-label={`Update available: ${availableUpdateVersion}`}
+            title={`Update available: ${availableUpdateVersion}`}
+          >
+            <Download className="w-4 h-4" />
+            <span>Update available</span>
+          </button>
+        )}
         {/* Fixed-height, always-rendered slot so the bar doesn't reflow as
             the status (incoming call / alert / syncing) appears and clears. */}
         <div className="flex items-center justify-end h-4 leading-none">
@@ -620,6 +658,7 @@ export const AppShell: React.FC = () => {
             <LoadingSpinner size="sm" />
           </div>
         ) : null}
+        </div>
         </div>
       </div>
     </div>

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -13,6 +13,7 @@ import {
   ShieldCheck,
   ShieldAlert,
   Keyboard,
+  Download,
 } from "lucide-react";
 import { useUserGroupsWithChannels } from "../../hooks/queries/useGroups";
 import { useDMConversations } from "../../hooks/queries/useMessages";
@@ -141,6 +142,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ isOpen, onToggle }) => {
     { id: "voice-settings", label: "Voice", icon: <Volume2 {...iconProps} />, to: "/voice-settings" as const, isActive: pathname === "/voice-settings" },
     { id: "security", label: "Security", icon: <ShieldCheck {...iconProps} />, to: "/security" as const, isActive: pathname === "/security" || pathname.startsWith("/security/") },
     { id: "shortcuts", label: "Key Bindings", icon: <Keyboard {...iconProps} />, to: "/shortcuts" as const, isActive: pathname === "/shortcuts" },
+    { id: "update", label: "Software Update", icon: <Download {...iconProps} />, to: "/update" as const, isActive: pathname === "/update" },
   ];
   const isOnAnySettings = isOnSettingsHub || settingsItems.some((s) => s.isActive);
 

--- a/frontend/src/components/SearchPanel.tsx
+++ b/frontend/src/components/SearchPanel.tsx
@@ -188,6 +188,7 @@ const PAGE_RESULTS: SearchResultItem[] = [
   { type: "page", id: "page-voice-settings", name: "Voice Settings", breadcrumb: "/settings/voice", path: "/voice-settings", keywords: "microphone speaker audio mic noise suppression echo cancellation agc auto join" },
   { type: "page", id: "page-security", name: "Security", breadcrumb: "/security", path: "/security", keywords: "audit log devices identity key rotation" },
   { type: "page", id: "page-shortcuts", name: "Key Bindings", breadcrumb: "/shortcuts", path: "/shortcuts", keywords: "key bindings keyboard shortcuts hotkeys keybindings cmd ctrl" },
+  { type: "page", id: "page-update", name: "Software Update", breadcrumb: "/update", path: "/update", keywords: "update version upgrade install release" },
   { type: "page", id: "page-invites", name: "Invites", breadcrumb: "/invites", path: "/invites", keywords: "pending invitations groups" },
   { type: "page", id: "page-join-requests", name: "Join Requests", breadcrumb: "/join-requests", path: "/join-requests", keywords: "pending group membership" },
   { type: "page", id: "page-dm-requests", name: "DM Requests", breadcrumb: "/dms/requests", path: "/dms/requests", keywords: "direct message pending" },

--- a/frontend/src/pages/UpdatePage.tsx
+++ b/frontend/src/pages/UpdatePage.tsx
@@ -1,0 +1,138 @@
+import React, { useState, useEffect, useCallback } from "react";
+import {
+  getVersion,
+  check as checkForUpdate,
+  invoke,
+} from "../bridge";
+import { PageShell } from "../components/Layout/PageShell";
+import { Button } from "../components/ui/Button";
+import { useAppStore } from "../stores/appStore";
+
+type Status = "checking" | "available" | "none" | "error";
+
+export const UpdatePage: React.FC = () => {
+  const setUpdateRequired = useAppStore((s) => s.setUpdateRequired);
+  const cachedAvailable = useAppStore((s) => s.availableUpdateVersion);
+  const setAvailableUpdateVersion = useAppStore((s) => s.setAvailableUpdateVersion);
+
+  const [appVersion, setAppVersion] = useState<string>("");
+  // Seed from the cached poller result so the page lands on "available"
+  // immediately when reached from the bottom-bar indicator — no flash of
+  // "checking…" before the user can click Install.
+  const [status, setStatus] = useState<Status>(cachedAvailable ? "available" : "checking");
+  const [version, setVersion] = useState<string>(cachedAvailable ?? "");
+  const [errorMessage, setErrorMessage] = useState<string>("");
+  const [isInstalling, setIsInstalling] = useState(false);
+
+  useEffect(() => {
+    getVersion().then(setAppVersion).catch(() => setAppVersion("unknown"));
+  }, []);
+
+  // Always re-check on mount so the displayed version is fresh even when
+  // the poller cache is stale. Does not block the seeded "available" UI.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const update = await checkForUpdate();
+        if (cancelled) {
+          return;
+        }
+        if (update) {
+          setStatus("available");
+          setVersion(update.version);
+          setAvailableUpdateVersion(update.version);
+        } else {
+          setStatus("none");
+          setVersion("");
+          setAvailableUpdateVersion(null);
+        }
+      } catch (err) {
+        if (cancelled) {
+          return;
+        }
+        setStatus("error");
+        setErrorMessage(err instanceof Error ? err.message : "Failed to check for updates");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [setAvailableUpdateVersion]);
+
+  const handleInstall = useCallback(async () => {
+    if (status !== "available") {
+      return;
+    }
+    setIsInstalling(true);
+    // Mark the Rust-side flag and flip the store so App.tsx takes over
+    // with the fullscreen UpdateScreen. The screen handles graceful
+    // voice/network teardown, download, install, and relaunch.
+    await invoke("mark_update_required").catch(() => {});
+    setUpdateRequired(true);
+  }, [status, setUpdateRequired]);
+
+  return (
+    <PageShell title="Software Update" scrollable>
+      <div
+        className="flex-1 flex flex-col overflow-auto"
+        style={{ background: "var(--c-bg)" }}
+      >
+        <div className="flex-1 flex justify-center overflow-auto px-6 py-8">
+          <div className="w-full max-w-md flex flex-col gap-8">
+            <section className="flex flex-col gap-4">
+              <h2
+                className="text-xs font-mono font-medium uppercase tracking-widest pb-1 border-b"
+                style={{ color: "var(--c-text-dim)", borderColor: "var(--c-border)" }}
+              >
+                Software Update
+              </h2>
+
+              <div className="flex flex-col gap-2">
+                <p className="text-xs font-mono" style={{ color: "var(--c-text-muted)" }}>
+                  Current version: <span style={{ color: "var(--c-text)" }}>{appVersion || "Loading..."}</span>
+                </p>
+
+                {status === "checking" && (
+                  <p className="text-xs font-mono" style={{ color: "var(--c-text-muted)" }}>
+                    Checking for updates…
+                  </p>
+                )}
+
+                {status === "available" && (
+                  <p className="text-xs font-mono" style={{ color: "var(--c-accent)" }}>
+                    Update available: {version}
+                  </p>
+                )}
+
+                {status === "none" && (
+                  <p className="text-xs font-mono" style={{ color: "var(--c-accent-dim)" }}>
+                    You're up to date!
+                  </p>
+                )}
+
+                {status === "error" && (
+                  <p className="text-xs font-mono" style={{ color: "var(--c-danger)" }}>
+                    {errorMessage}
+                  </p>
+                )}
+              </div>
+
+              {status === "available" && (
+                <Button
+                  onClick={handleInstall}
+                  disabled={isInstalling}
+                  isLoading={isInstalling}
+                  loadingText="Installing…"
+                  variant="primary"
+                >
+                  Install update
+                </Button>
+              )}
+            </section>
+          </div>
+        </div>
+      </div>
+    </PageShell>
+  );
+};

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -39,6 +39,7 @@ import { CallPage } from "./pages/Call";
 import { RenameChannelPage } from "./pages/RenameChannelPage";
 import { RenameGroupPage } from "./pages/RenameGroupPage";
 import { KeyboardShortcutsPage } from "./pages/KeyboardShortcutsPage";
+import { UpdatePage } from "./pages/UpdatePage";
 
 // Re-export RouterContext so callers can import from either location.
 export type { RouterContext };
@@ -247,6 +248,12 @@ const keyboardShortcutsRoute = createRoute({
   component: KeyboardShortcutsPage,
 });
 
+const updateRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/update",
+  component: UpdatePage,
+});
+
 const callRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/call/$callId",
@@ -297,6 +304,7 @@ const routeTree = rootRoute.addChildren([
   allJoinRequestsRoute,
   searchRoute,
   keyboardShortcutsRoute,
+  updateRoute,
   callRoute,
   terminalRoute,
 ]);

--- a/frontend/src/services/updatePoller.ts
+++ b/frontend/src/services/updatePoller.ts
@@ -1,0 +1,56 @@
+import { check as checkForUpdate } from "../bridge";
+import { useAppStore } from "../stores/appStore";
+
+// The update poller lives outside React on purpose: a singleton timer is
+// resilient to StrictMode double-mounts, route changes, and component
+// unmount/remount churn that would otherwise duplicate or drop polls. The
+// only thing React touches is the resulting Zustand field.
+
+const POLL_INTERVAL_MS = 15 * 60 * 1000;
+// Wait briefly after sign-in before the first check so we don't pile on top
+// of the startup update gate in App.tsx (which already ran a check). If
+// THAT check found something the app is already on the UpdateScreen; if it
+// didn't, give the network a moment before we re-ask.
+const FIRST_CHECK_DELAY_MS = 30 * 1000;
+
+let intervalId: number | null = null;
+let firstCheckTimeoutId: number | null = null;
+let started = false;
+
+async function runCheck(): Promise<void> {
+  try {
+    const update = await checkForUpdate();
+    const setAvailable = useAppStore.getState().setAvailableUpdateVersion;
+    setAvailable(update ? update.version : null);
+  } catch (err) {
+    // Network blips are expected; log once and move on. Don't clear an
+    // already-known available version on a transient failure.
+    console.warn("[updatePoller] check failed:", err);
+  }
+}
+
+export function startUpdatePolling(): void {
+  if (started) {
+    return;
+  }
+  started = true;
+
+  firstCheckTimeoutId = window.setTimeout(() => {
+    firstCheckTimeoutId = null;
+    runCheck();
+  }, FIRST_CHECK_DELAY_MS);
+
+  intervalId = window.setInterval(runCheck, POLL_INTERVAL_MS);
+}
+
+export function stopUpdatePolling(): void {
+  if (firstCheckTimeoutId !== null) {
+    window.clearTimeout(firstCheckTimeoutId);
+    firstCheckTimeoutId = null;
+  }
+  if (intervalId !== null) {
+    window.clearInterval(intervalId);
+    intervalId = null;
+  }
+  started = false;
+}

--- a/frontend/src/stores/appStore.ts
+++ b/frontend/src/stores/appStore.ts
@@ -106,6 +106,12 @@ interface AppStore extends AppState {
   ) => void;
   updateRequired: boolean;
   setUpdateRequired: (v: boolean) => void;
+  // Latest version detected by the in-app poller while the user is signed in.
+  // null = no update detected (or not yet checked); a string = the version
+  // returned by the updater bridge's `check()`. Drives the discrete "Update
+  // available" indicator in the bottom bar.
+  availableUpdateVersion: string | null;
+  setAvailableUpdateVersion: (v: string | null) => void;
   // Channel id pending admin delete confirmation. When non-null and equal to
   // selectedChannelId, MainContent replaces the chat input with the
   // delete-channel confirm bar.
@@ -399,6 +405,9 @@ export const useAppStore = create<AppStore>((set) => ({
 
   updateRequired: false,
   setUpdateRequired: (v) => set({ updateRequired: v }),
+
+  availableUpdateVersion: null,
+  setAvailableUpdateVersion: (v) => set({ availableUpdateVersion: v }),
 
   pendingDeleteChannelId: null,
   setPendingDeleteChannelId: (channelId) => set({ pendingDeleteChannelId: channelId }),


### PR DESCRIPTION
## Summary

- Discrete "Update available" pill in the bottom-right status bar (renders alongside existing alerts, not in their slot).
- 15-min poll runs as a module-level singleton via `services/updatePoller.ts` — survives StrictMode double-mounts and AppShell remounts. Skipped in dev.
- Clicking the pill → `/update` page seeded from the cached poller version, two clicks to install (click pill → click Install) which then falls into the existing fullscreen `UpdateScreen` flow.
- Uses the runtime `bridge/updater.ts` so it works under both Electron (`electron-updater`) and the legacy Tauri path.

## Test plan
- [ ] Indicator appears within 30s of sign-in when a newer release is published, and persists across navigation.
- [ ] `/update` page lands with the available version pre-filled (no "checking…" flash) when reached from the indicator.
- [ ] Clicking **Install update** transitions to the existing `UpdateScreen` (which downloads + relaunches).
- [ ] No indicator and no poll traffic in `pnpm dev`.
- [ ] Indicator is reachable via Cmd+K ("Software Update") and from the sidebar's Settings group.