### PR TITLE
docs(electron): align prose docs to Electron+pollis-node runtime

### DIFF
--- a/.codesight/CODESIGHT.md
+++ b/.codesight/CODESIGHT.md
@@ -370,10 +370,10 @@
 # Middleware
 
 ## custom
-- migrate — `src-tauri/src/bin/migrate.rs`
+- migrate — `scripts/db-apply.sh` (runs against Turso during release; reads from `pollis-core/src/db/migrations/`)
 
 ## auth
-- auth — `src-tauri/src/commands/auth.rs`
+- auth — `pollis-core/src/commands/auth.rs`
 - auth.spec — `tests/e2e/auth.spec.ts`
 
 ---

--- a/.codesight/middleware.md
+++ b/.codesight/middleware.md
@@ -1,8 +1,8 @@
 # Middleware
 
 ## custom
-- migrate — `src-tauri/src/bin/migrate.rs`
+- migrate — `scripts/db-apply.sh` (runs against Turso during release; reads from `pollis-core/src/db/migrations/`)
 
 ## auth
-- auth — `src-tauri/src/commands/auth.rs`
+- auth — `pollis-core/src/commands/auth.rs`
 - auth.spec — `tests/e2e/auth.spec.ts`

--- a/.codesight/wiki/audio-processing.md
+++ b/.codesight/wiki/audio-processing.md
@@ -50,7 +50,7 @@ sync with what actually comes out of the speaker.
 
 - `pollis-core/src/commands/voice_apm.rs` — `ApmStage`, `ApmConfig`, helpers (`run_capture`, `analyze_render`).
 - `pollis-core/src/commands/voice_denoiser.rs` — `DenoiserStage` wrapping `nnnoiseless::DenoiseState`. 48 kHz only.
-- `pollis-core/src/commands/voice.rs` — pipeline wiring: `start_mic_stream`, `start_speaker_stream`, `run_drain_task`, `run_mixer_task`, `ensure_playback`, `register_remote_track`. Tauri commands `join_voice_channel` / `set_voice_audio_processing` / `set_voice_input_device` / `set_voice_output_device`.
+- `pollis-core/src/commands/voice.rs` — pipeline wiring: `start_mic_stream`, `start_speaker_stream`, `run_drain_task`, `run_mixer_task`, `ensure_playback`, `register_remote_track`. Backend commands `join_voice_channel` / `set_voice_audio_processing` / `set_voice_input_device` / `set_voice_output_device`.
 - `pollis-core/src/commands/voice_e2ee.rs` — derives the per-room shared symmetric key from the channel's MLS exporter secret (`MlsGroup::export_secret("pollis/voice/v1", epoch, 32)`), builds the `livekit::e2ee::E2eeOptions` passed into `Room::connect`, and rotates the live `KeyProvider` on MLS epoch advance.
 - `frontend/src/hooks/queries/usePreferences.ts` — `ApmConfig`, `preferencesToApmConfig`, `APM_DEFAULTS`.
 - `frontend/src/pages/VoiceSettingsPage.tsx` — UI surface (mic boost slider, AGC switch + target slider, NS dropdown, AEC switch, Click Suppression switch). Mid-call changes push via `set_voice_audio_processing`.

--- a/.codesight/wiki/capture-split.md
+++ b/.codesight/wiki/capture-split.md
@@ -162,6 +162,9 @@ helper, never killing the host app.
 
 ### Packaging
 
+The helper sidecar packaging story is in transition: the legacy `src-tauri/` build pipeline ships a working sidecar today, while the active Electron pipeline's strategy (extraResource via electron-builder, or fold-in to `pollis-node`) is still being decided. Both paths are documented here so the helper can be wired into the Electron build without re-discovering the constraints.
+
+**Legacy Tauri shell (still produces a runnable helper):**
 - `src-tauri/tauri.macos.conf.json`: `externalBin`
   `binaries/pollis-capture-macos`, Developer-ID signed, **same team
   9JF7WWYMU2**.
@@ -172,6 +175,9 @@ helper, never killing the host app.
   reused on the app job (ubuntu-22.04). No shell script wrapper — runs
   uniformly for `cargo check`, `tauri dev`, and `tauri build` on macOS
   and Linux. Windows is skipped (WGC is in-process).
+
+**Electron shell (active path; helper packaging is a TODO in `electron/build/electron-builder.yml`):**
+- The decision pending in the config TODO is whether to ship the helper as an `extraResources` entry next to `pollis-node`, embed it inside `pollis-node`, or drop the separate binary entirely if `pollis-node` performs the capture itself. Until that lands, screenshare under the Electron build will not have a packaged helper.
 
 ### Picker UX
 
@@ -248,6 +254,8 @@ share one wire format definition.
 - `frontend/src/screenshare/screenShareSession.ts` —
   `local_unsupported` event + distinct error message.
 - `src-tauri/tauri.linux.conf.json`, `src-tauri/tauri.macos.conf.json`
-  — sidecar packaging.
+  — sidecar packaging in the legacy Tauri build.
 - `src-tauri/build.rs` — auto-builds + stages the per-OS helper sidecar
-  during the main app's cargo build.
+  during the legacy Tauri shell's cargo build.
+- `electron/build/electron-builder.yml` — active build config; helper
+  packaging strategy is the open TODO described in "Packaging" above.

--- a/.codesight/wiki/commands.md
+++ b/.codesight/wiki/commands.md
@@ -1,8 +1,8 @@
-# Tauri Commands
+# Backend Commands
 
-All backend calls from the frontend use `invoke("command_name", { args })`. Commands are registered in `src-tauri/src/lib.rs`. The `#[tauri::command]` shims under `src-tauri/src/commands/` are thin forwarders — the real implementations live in `pollis-core/src/commands/` so a future CLI / TUI / mobile binary can call them without the Tauri runtime. Edit `pollis-core`, not the shims.
+All backend calls from the frontend use `invoke("command_name", { args })` (imported from `frontend/src/bridge`, which routes to `window.electronAPI.invoke` under Electron). The active dispatch happens in `pollis-node/src/dispatch/`: a one-line match arm per command forwards the JSON-shaped call from the Electron main process into `pollis-core/src/commands/`. The implementations live in `pollis-core` so a CLI / TUI / mobile binding (uniffi) can call them without any shell-runtime dependency. Edit `pollis-core`, not the shims.
 
-The path in each section header below points at the implementation in `pollis-core`. The shim with the same module name in `src-tauri/src/commands/` re-exports the types and forwards each command verbatim.
+The path in each section header below points at the implementation in `pollis-core`. The `pollis-node` dispatch arm with the same module name re-exports the types and forwards each command verbatim. Legacy `#[tauri::command]` shims under `src-tauri/src/commands/` exist for rollback but are not the active path.
 
 ## auth (`commands/auth.rs`)
 - `initialize_identity(user_id)` — ensure MLS credentials + KPs, poll welcomes. Requires the local DB to be open (post-`set_pin` / `unlock`).

--- a/.codesight/wiki/index.md
+++ b/.codesight/wiki/index.md
@@ -7,7 +7,7 @@ Start here. Navigate to the article you need.
 - [Overview](./overview.md) — Architecture, stack, project structure
 - [Database](./database.md) — Remote (Turso) and local (SQLite) schemas with all columns
 - [MLS](./mls.md) — Message Layer Security: encryption, group membership, multi-device
-- [Tauri Commands](./commands.md) — Rust backend command reference
+- [Backend Commands](./commands.md) — Rust backend command reference
 - [UI Components](./ui.md) — React component inventory
 - [Libraries](./libraries.md) — Frontend hooks, services, utilities
 - [Testing](./testing.md) — Integration harness for multi-client end-to-end tests
@@ -22,8 +22,10 @@ Start here. Navigate to the article you need.
 | Layer | Tech | Location |
 |-------|------|----------|
 | Frontend | React, TypeScript, Vite, TailwindCSS | `frontend/src/` |
+| Desktop shell | Electron 33 (main + preload + renderer) | `electron/src/` |
 | Backend (logic) | Rust workspace crate `pollis-core` | `pollis-core/src/` |
-| Backend (Tauri shell) | Rust, Tauri 2 — `#[tauri::command]` shims, plugins, lifecycle | `src-tauri/src/` |
+| Backend (host binding) | Rust napi-rs binding `pollis-node` loaded by the Electron main process | `pollis-node/src/` |
+| Backend (legacy shell, rollback only) | Rust, Tauri 2 — `#[tauri::command]` shims, plugins, lifecycle | `src-tauri/src/` |
 | Remote DB | Turso (libSQL) | `pollis-core/src/db/migrations/000000_baseline.sql` + `000*.sql` |
 | Local DB | SQLite (rusqlite) | `pollis-core/src/db/local_schema.sql` |
 | Encryption | OpenMLS (RFC 9420) | `pollis-core/src/commands/mls.rs` |

--- a/.codesight/wiki/libraries.md
+++ b/.codesight/wiki/libraries.md
@@ -30,6 +30,6 @@
 - `frontend/src/utils/fileIcon.ts` — getFileIcon
 
 ---
-**Note:** This only covers frontend libraries. The Rust backend lives in `pollis-core/src/commands/` (with `#[tauri::command]` shims in `src-tauri/src/commands/`); see [commands.md](./commands.md).
+**Note:** This only covers frontend libraries. The Rust backend lives in `pollis-core/src/commands/`, loaded into the Electron main process via `pollis-node` (napi-rs); see [commands.md](./commands.md). Legacy `#[tauri::command]` shims under `src-tauri/src/commands/` are preserved as a rollback path.
 
 _Back to [index.md](./index.md)_

--- a/.codesight/wiki/notifications.md
+++ b/.codesight/wiki/notifications.md
@@ -31,7 +31,7 @@ RealtimeEvent (Rust → JS Channel)         Local action (e.g. self voice join)
                           (Rust)   (Rust)   (Zustand) (Zustand) (Zustand)
 ```
 
-There is **no parallel dispatcher in Rust**. All decisions happen in JS. Rust is just the transport for LiveKit events (via `tauri::ipc::Channel`) and the executor for sound (`play_sfx` rodio command) and OS notifications (`tauri-plugin-notification`).
+There is **no parallel dispatcher in Rust**. All decisions happen in JS. Rust is just the transport for LiveKit events (pushed through `pollis-node`'s Rust → Node `ThreadsafeFunction`, forwarded by the Electron main process via `webContents.send("channel:<id>", payload)` to the renderer's `channelOn` subscriber) and the executor for sound (`play_sfx` rodio command). OS notifications fire through the bridge — the renderer calls `window.electronAPI.notify({ title, body, icon })`, which the main process implements via Electron's native `Notification` API.
 
 ## The category table
 
@@ -56,7 +56,7 @@ const CATEGORIES: Record<Category, CategoryConfig> = {
 | Field | What it does | Pref gate | Notes |
 |---|---|---|---|
 | `sound` | Plays a sfx (`'ping'`/`'join'`/`'leave'`) via the `play_sfx` Rust command | `allow_sound_effects` | Cooldownable |
-| `osNotif` | Fires an OS notification banner via `plugin:notification\|notify` | `allow_desktop_notifications` + OS permission | Cooldownable |
+| `osNotif` | Fires an OS notification banner via the bridge's `sendNotification` (→ `window.electronAPI.notify`) | `allow_desktop_notifications` + OS permission | Cooldownable |
 | `badge` | Increments the per-room unread count (`useAppStore.incrementUnread`) | none | Drives dock/taskbar badge via `useBadge` |
 | `alert` | Sets the blinking status-bar alert (`useAppStore.setStatusBarAlert`) | none | Cleared on navigation |
 | `overlay` | Sets `pendingEnrollmentApproval` so the UI takes over | none | Used only by enrollment |
@@ -100,7 +100,7 @@ if (event.kind === 'invite') {
 `useLiveKitRealtime.ts` owns the React-side state and pushes it into `notify.ts` via `setNotifyPrefs(...)`. The effect re-runs whenever `allow_sound_effects` or `allow_desktop_notifications` changes:
 
 1. Read current prefs from `usePreferences()`.
-2. Call `plugin:notification|is_permission_granted` — if not granted *and* the user has notifications enabled, request permission.
+2. Call the bridge's `isPermissionGranted` (→ `window.electronAPI.notificationsPermissionGranted`) — if not granted *and* the user has notifications enabled, request permission via `requestPermission`.
 3. Push `{ allowSound, allowOsNotif, osPermissionGranted }` into the dispatcher.
 
 Result: toggling notifications "on" in Preferences → granting the OS prompt → next event uses the new state, no restart needed.

--- a/.codesight/wiki/overview.md
+++ b/.codesight/wiki/overview.md
@@ -2,24 +2,29 @@
 
 ## Stack
 
-**Tauri 2** desktop app: Rust backend + React/TypeScript frontend in a webview.
+**Electron 33** desktop app: React/TypeScript renderer + Node main process + a native Rust addon (`pollis-node`) loaded into the main process via `require('pollis-node')`. The renderer reaches the Rust backend through the preload bridge `window.electronAPI`.
 
-- **No backend server.** The Tauri Rust process connects directly to Turso (1 network hop). All business logic runs in the Tauri process via `invoke()` commands.
-- **No WebRTC in webview.** Tauri's Linux webview (WebKitGTK) lacks WebRTC. All media (voice, video) runs in Rust via the `livekit` crate. Never suggest using JS-based media APIs.
+- **No backend server.** The Rust core (loaded into the Electron main process by `pollis-node`) connects directly to Turso (1 network hop). All business logic runs in the main process; the renderer invokes commands via `window.electronAPI.invoke(cmd, args)`.
+- **Media stays in Rust.** Voice and screenshare run inside `pollis-core` via the `livekit` + `libwebrtc` crates, not in the renderer. Two reasons: (a) cross-platform parity — the same Rust pipeline is consumed by mobile through uniffi bindings; (b) predictable allocation — multi-MB media buffers passed through V8's heap produce visible GC stutter, while Rust's manual allocation does not. The renderer's Chromium does have WebRTC available, but JS-based media APIs are reserved for small UI previews, not capture/publish/render.
 
 ## Data Flow
 
 ```
 React component
-  → invoke("command_name", { args })
-    → #[tauri::command] shim (src-tauri/src/commands/*.rs)
-      → pollis_core::commands::* (pollis-core/src/commands/*.rs)
-        → Turso (remote, metadata) or SQLite (local, secrets)
+  → invoke("command_name", { args })            // from frontend/src/bridge
+    → window.electronAPI.invoke(...)            // preload (electron/src/preload.ts)
+      → ipcRenderer.invoke("invoke", cmd, args)
+        → ipcMain.handle("invoke", ...)         // main (electron/src/main.ts)
+          → pollis-node dispatch                // pollis-node/src/dispatch/*.rs
+            → pollis_core::commands::*          // pollis-core/src/commands/*.rs
+              → Turso (remote, metadata) or SQLite (local, secrets)
+            ← Result<T>
+        ← Result<T>
     ← Result<T>
   ← React Query cache
 ```
 
-The shim layer is mechanical — each `#[tauri::command]` unwraps `tauri::State<AppState>` to `&AppState` and forwards to the corresponding `pollis_core::commands::…` function. Real logic lives in the `pollis-core` workspace crate so future CLI / TUI / mobile binaries can consume it without dragging in the Tauri runtime.
+The dispatch layer in `pollis-node/src/dispatch/<module>.rs` is mechanical — one match arm per command, deserialising the JSON args and calling the corresponding `pollis_core::commands::…` function. Real logic lives in the `pollis-core` workspace crate so other front-ends — a CLI, a TUI, mobile via uniffi — can consume it without any shell-runtime dependency. Legacy `#[tauri::command]` shims under `src-tauri/src/commands/` are preserved for rollback.
 
 **React Query** is the source of truth for remote data. **Zustand** holds only UI state (current user ref, transient session data).
 
@@ -54,7 +59,17 @@ pollis-core/src/
   signal/            # MLS storage backend
   lib.rs             # uniffi exports for mobile bindings
 
-src-tauri/src/
+pollis-node/src/
+  lib.rs             # napi-rs addon entry; loads .env.development; ThreadsafeFunction registration
+  state.rs           # Per-process AppState shared with pollis-core
+  events.rs          # Rust → Node event channel plumbing
+  dispatch/          # invoke dispatch — one arm per command module (active path)
+
+electron/src/
+  main.ts            # Electron main process — loads pollis-node, registers ipcMain handlers, owns BrowserWindow + auto-updater
+  preload.ts         # Exposes window.electronAPI to the renderer
+
+src-tauri/src/       # Legacy Tauri shell (retained for rollback; not the active path)
   commands/          # Thin #[tauri::command] shims forwarding to pollis_core
   sink.rs            # ChannelSink adapter (Tauri's ipc::Channel → EventSink)
   test_harness.rs    # Multi-client integration harness (feature = "test-harness")
@@ -62,6 +77,7 @@ src-tauri/src/
   main.rs            # Binary entry
 
 frontend/src/
+  bridge/            # Runtime-host bridge — invoke/Channel/window/dialog/fs/shell/app/updater route through window.electronAPI; legacy Tauri fallback retained
   components/        # React components (Auth/, Layout/, Message/, ui/, Voice/, ...)
   hooks/queries/     # React Query hooks (useGroups, useMessages, usePreferences, ...)
   pages/             # Route pages
@@ -82,18 +98,18 @@ website/             # Static marketing site (Cloudflare Pages, not part of the 
 
 ## Security Model
 
-**Trusted:** User's device, local database, Tauri app code, OS keystore.
+**Trusted:** User's device, local database, the signed Electron app binary (main process + preload + `pollis-node`/`pollis-core` addon) at the installed version, OS keystore.
 **Untrusted:** Network, Turso, server operators.
 
 ## Realtime
 
-LiveKit rooms carry realtime events (new_message, membership_changed, voice_joined, etc.). The Rust event loop in `livekit.rs` receives data events, dispatches them to the frontend via a typed `tauri::ipc::Channel`, and triggers MLS operations (process commits, poll welcomes) as needed.
+LiveKit rooms carry realtime events (new_message, membership_changed, voice_joined, etc.). The Rust event loop in `livekit.rs` receives data events, dispatches them through `pollis-node`'s Rust → Node `ThreadsafeFunction`; the Electron main process forwards each envelope via `webContents.send("channel:<id>", payload)`; the renderer subscribes through `window.electronAPI.channelOn(id, handler)`. MLS operations (process commits, poll welcomes) fire as needed.
 
 Events are a **convenience for speed**, not a correctness requirement. All MLS state is also read from the DB on every message send/receive, so offline devices catch up when they next interact.
 
 ## Voice
 
-Voice channels run entirely in Rust — Tauri's WebKitGTK webview has no WebRTC, so there's no JS path for media. The capture pipeline is `cpal mic → optional RNNoise → WebRTC APM (AGC2 + NS + HPF + AEC) → LiveKit publish`; remote playback is `NativeAudioStream → per-track buffers → mixer task (10 ms tick) → single cpal output stream`, which is also where the AEC render reference is tapped. Settings (mic boost, AGC target, NS level, AEC, click suppression) live in user preferences and apply mid-call via `set_voice_audio_processing` without rejoining. See [audio-processing.md](./audio-processing.md) for the full pipeline, framing constraints, and tuning surface.
+Voice channels run entirely in Rust by design — cross-platform parity with mobile (same uniffi-exposed `pollis-core`) and predictable allocation under heavy media buffers. The capture pipeline is `cpal mic → optional RNNoise → WebRTC APM (AGC2 + NS + HPF + AEC) → LiveKit publish`; remote playback is `NativeAudioStream → per-track buffers → mixer task (10 ms tick) → single cpal output stream`, which is also where the AEC render reference is tapped. Settings (mic boost, AGC target, NS level, AEC, click suppression) live in user preferences and apply mid-call via `set_voice_audio_processing` without rejoining. See [audio-processing.md](./audio-processing.md) for the full pipeline, framing constraints, and tuning surface.
 
 Voice is end-to-end encrypted: each frame is AES-128-GCM-encrypted by libwebrtc's `FrameCryptor` post-Opus, keyed by a 32-byte secret derived from the channel's MLS group (`MlsGroup::export_secret("pollis/voice/v1", epoch, 32)`). The LiveKit SFU forwards ciphertext only; the key rotates automatically on every MLS epoch advance. See `pollis-core/src/commands/voice_e2ee.rs` and the "End-to-end encryption" section of [audio-processing.md](./audio-processing.md#end-to-end-encryption).
 

--- a/.codesight/wiki/pin-design.md
+++ b/.codesight/wiki/pin-design.md
@@ -9,7 +9,7 @@
 The rest of this document is the design note that drove the work — kept for context, not authoritative on the final shape. Where implementation diverges, the code wins. Notable divergences:
 
 - `verify_otp` does not return `pin_required_to_complete_signup`; the frontend reads `get_unlock_state` to decide between pin-create and pin-entry.
-- A new Tauri command, `finalize_device_enrollment`, runs the cert / key-package / external-join work after `set_pin` completes (formerly bundled into the enrollment commands themselves).
+- A new backend command, `finalize_device_enrollment`, runs the cert / key-package / external-join work after `set_pin` completes (formerly bundled into the enrollment commands themselves).
 - The "we just produced raw key material and have no PIN yet" handoff goes through `account_identity::unlock_state_with_fresh_db_key`, which generates a fresh `db_key` alongside the account_id_key and replaces `AppState.unlock`. `set_pin` reads from there instead of the legacy keystore slots (which remain only as a migration fallback for upgraders coming from a pre-PIN build).
 
 ---
@@ -231,7 +231,7 @@ Critically: the Turso-side account is untouched. Other devices for the same user
 
 ## New and changed commands
 
-Registered in `src-tauri/src/lib.rs`. The shim layer lives in `src-tauri/src/commands/pin.rs`; the real implementation is in `pollis-core/src/commands/pin.rs` (alongside `auth.rs` and `account_identity.rs` in the same crate).
+Dispatched in `pollis-node/src/dispatch/pin.rs` (the active path), with a parallel `#[tauri::command]` shim retained under `src-tauri/src/commands/pin.rs` for rollback. The real implementation is in `pollis-core/src/commands/pin.rs` (alongside `auth.rs` and `account_identity.rs` in the same crate).
 
 - `set_pin(old_pin: Option<String>, new_pin: String) -> Result<()>`
   - Initial set and change. See lifecycle above.
@@ -326,7 +326,7 @@ Commands the frontend uses:
 
 ## Testing
 
-All scenarios to add to `src-tauri/tests/flows.rs` under the `test-harness` feature. Each uses `tauri::test::get_ipc_response` against the real commands.
+All scenarios to add to `src-tauri/tests/flows.rs` under the `test-harness` feature. Each drives the real command implementations through the same dispatch path the runtime uses, without mocking the DB layer.
 
 - `pin_set_lock_unlock_roundtrip` — signup → set_pin → lock → unlock with correct PIN → assert `UserProfile` matches and local DB is queryable.
 - `pin_wrong_counter_and_lockout` — 9 wrong attempts return `PinIncorrect` with correct `attempts_remaining`; 10th wipes wrapped blobs and local DB; next `unlock` returns `PinNotSet`.
@@ -341,9 +341,9 @@ All scenarios to add to `src-tauri/tests/flows.rs` under the `test-harness` feat
 
 Grep targets, then audit each hit:
 
-- `const SESSION_KEY: &str = "session";` — `src-tauri/src/commands/auth.rs:10`. Delete.
-- All `SESSION_KEY` uses: auth.rs:277, 333, 372, 551, 631, 839, 875. Delete.
-- `identity_key_private` / `identity_key_public` string literals: auth.rs:647-648, auth.rs:883-884. Delete.
+- `const SESSION_KEY: &str = "session";` — `pollis-core/src/commands/auth.rs` (originally `src-tauri/src/commands/auth.rs:10`). Delete.
+- All `SESSION_KEY` uses in `pollis-core/src/commands/auth.rs` (originally auth.rs:277, 333, 372, 551, 631, 839, 875). Delete.
+- `identity_key_private` / `identity_key_public` string literals in `pollis-core/src/commands/auth.rs` (originally auth.rs:647-648, auth.rs:883-884). Delete.
 - `.unwrap_or_default()` on parse: `accounts.rs:31`, `keystore.rs:69`. Replace with loud-failure variants described above.
 - `std::fs::write(...)` on `accounts.json`: `accounts.rs:42`. Replace with tempfile+fsync+rename.
 - Unwrapped `db_key` generation at `state.rs:82-88`. Becomes an unwrap-existing-wrapped-blob path; the random-generate path moves into `set_pin`.

--- a/.codesight/wiki/testing.md
+++ b/.codesight/wiki/testing.md
@@ -3,7 +3,9 @@
 Pollis has two tiers of automated tests:
 
 1. **Unit tests** (in-crate `#[cfg(test)]` modules) — pure logic, in-memory rusqlite schemas, no I/O.
-2. **Integration harness** (`src-tauri/tests/flows.rs`) — drives real Tauri commands end-to-end against a disposable test Turso database. This document covers the harness.
+2. **Integration harness** (`src-tauri/tests/flows.rs`) — drives the real `pollis-core` commands end-to-end against a disposable test Turso database. This document covers the harness.
+
+> The harness is built on top of Tauri's test machinery (`tauri::test::get_ipc_response` + `MockRuntime`) because the underlying command logic lives in `pollis-core` and is reachable through either dispatcher. The shipping shell is Electron, but the harness drives the same commands through a headless Tauri runtime as a convenient test fixture — no separate Electron-side harness is needed because `pollis-core` is the unit under test in both cases.
 
 ## Integration harness — goals
 

--- a/.codesight/wiki/windows-signing.md
+++ b/.codesight/wiki/windows-signing.md
@@ -1,6 +1,8 @@
-# Windows Code Signing — Azure Artifact Signing
+# Windows Code Signing — Azure Trusted Signing
 
-Pollis signs Windows `.exe` artifacts (inner binary + NSIS installer) using **Azure Artifact Signing** (formerly Trusted Signing). Signing runs on the `windows-latest` GitHub Actions runner via `TAURI_WINDOWS_SIGN_COMMAND`. The private key lives in Azure's HSM — no PFX, no hardware token.
+Pollis signs Windows `.exe` artifacts (inner binary + NSIS installer) using **Azure Trusted Signing**. Signing runs on the `windows-latest` GitHub Actions runner via `electron-builder`'s `signtoolOptions.sign` hook (`electron/build/sign.js`), which wraps `signtool.exe` with Azure's `/dlib` + `/dmdf` integration. The private key lives in Azure's HSM — no PFX, no hardware token.
+
+> Note: in earlier names of the service this was called "Azure Artifact Signing". The Azure resources below still appear under that namespace in the `az` CLI surface (`az artifact-signing …`) even though Microsoft markets the service as Trusted Signing today.
 
 This article documents the Azure-side state so a future migration (e.g. individual → organization tenant) can be reproduced from a clean slate.
 
@@ -98,7 +100,7 @@ Steps 2 and 4 are **portal-only** — no CLI path exists. Everything else is scr
      --scope "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.CodeSigning/codeSigningAccounts/<account>/certificateProfiles/pollis-public"
    ```
 
-8. **Update Doppler** with the six secrets from the table above. The CI workflow (`.github/workflows/desktop-release.yml`) picks them up automatically.
+8. **Update Doppler** with the six secrets from the table above. The CI workflow (`.github/workflows/electron-release.yml`) picks them up automatically; `electron-builder`'s sign hook reads them at signing time and passes them into the Azure dlib.
 
 ## Migrating to an organization tenant
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -10,16 +10,17 @@ For deeper, file-anchored documentation see `.codesight/wiki/index.md`. For the 
 
 | Layer | Tech |
 |---|---|
-| Desktop shell | Tauri 2 (Rust backend + WebKit-based webview frontend) |
-| Frontend | React + TypeScript, Vite, TailwindCSS, TanStack Router (memory history), TanStack Query, Zustand (UI state only) |
-| Backend | Rust, Tauri commands invoked via `invoke()` from the frontend |
+| Desktop shell | Electron 33 (Node + Chromium renderer + preload bridge) |
+| Frontend | React 19 + TypeScript, Vite, TailwindCSS, TanStack Router (memory history), TanStack Query, Zustand (UI state only) |
+| Backend | Rust split into `pollis-core` (reusable crate; also exposed to mobile via uniffi) and `pollis-node` (napi-rs binding loaded into Electron's main process), invoked from the renderer via `window.electronAPI.invoke(cmd, args)` |
 | End-to-end encryption | MLS (RFC 9420) via OpenMLS 0.8 for messages and files; AES-128-GCM frame-level encryption via libwebrtc's `FrameCryptor` for voice, keyed by the MLS group's exporter secret |
 | Remote DB | Turso (libSQL) via `libsql` 0.6, native Hrana/HTTP2 protocol over TLS |
 | Local DB | SQLite via `rusqlite` 0.31 with bundled SQLCipher; per-user file `pollis_{user_id}.db` |
 | Auth | Email OTP (Resend) + 4-digit per-user local PIN unlocking PIN-wrapped key blobs in the OS keystore |
 | Object storage | Cloudflare R2 (S3-compatible) via AWS SigV4, with convergent encryption for attachments |
 | Real-time signalling + voice | LiveKit (Rust crate), JWT-signed room tokens |
-| Audio capture | `cpal` mic → optional RNNoise → WebRTC APM (AGC2 + NS + HPF + AEC) → LiveKit publish (all in Rust — no JS media path) |
+| Audio capture | `cpal` mic → optional RNNoise → WebRTC APM (AGC2 + NS + HPF + AEC) → LiveKit publish (all in Rust — the renderer never touches media) |
+| Packaging + auto-update | `electron-builder` (DMG + ZIP, NSIS + portable, AppImage + deb + rpm) and `electron-updater` against GitHub Releases; OS code signature (Apple Developer ID + notarization, Azure Trusted Signing) is the trust root |
 | Secrets | Doppler → GitHub Actions; local dev uses `.env.development` |
 
 The marketing site under `website/` is static HTML on Cloudflare Pages and is not part of the desktop app.
@@ -30,7 +31,7 @@ The marketing site under `website/` is static HTML on Cloudflare Pages and is no
 
 1. **End-to-end encrypted messaging, files, and voice.** All message content is MLS-encrypted on the device before it leaves; the server never sees plaintext. Files are convergent-encrypted with the key delivered inside the MLS-encrypted message. Voice frames are AES-128-GCM-encrypted by libwebrtc's `FrameCryptor`, keyed by the channel's MLS-exporter secret, so the LiveKit SFU forwards ciphertext only.
 2. **Zero-knowledge server.** Turso stores ciphertext envelopes, public MLS material, and metadata. It cannot read messages or recover any private key.
-3. **Direct to Turso.** The Tauri backend opens a libSQL connection directly to Turso — there is no intermediate API server. All business logic runs in the Tauri Rust process.
+3. **Direct to Turso.** The Rust backend, loaded into Electron's main process as a Node addon (`pollis-node` over `pollis-core`), opens a libSQL connection directly to Turso — there is no intermediate API server. All business logic runs in the main process.
 4. **Local-first secrets.** Private keys, MLS group state, and decrypted plaintext only exist on the user's device. Disk copies are protected by SQLCipher (local DB) and Argon2id-derived AEAD wrapping (keystore).
 5. **Bounded but reliable history.** Members joining at MLS epoch N cannot decrypt messages from epoch < N (an MLS property), and new devices for an existing user start empty (no Megolm-style key backup). Within those limits, every message that was sent while a member was a member must be deliverable and decryptable on every device that user owns. See `CLAUDE.md` § "Messages must work" for the product principle.
 
@@ -39,17 +40,22 @@ The marketing site under `website/` is static HTML on Cloudflare Pages and is no
 ## Network architecture
 
 ```
-┌────────────────────────────┐
-│ Tauri desktop app          │
-│  ├─ React webview (UI)     │
-│  └─ Rust backend           │ ◀──── invoke() commands ─────┐
-└──────┬─────────────────────┘                              │
-       │                                                    │
-       │ direct libSQL/Hrana over TLS                       │ no HTTP server in the middle —
-       ▼                                                    │ business logic runs inside
-┌────────────────┐   ┌──────────────┐   ┌────────────────┐  │ the Tauri process
-│ Turso          │   │ Cloudflare R2│   │ LiveKit (SFU)  │  │
-│ (metadata,     │   │ (encrypted   │   │ (signalling + │ ─┘
+┌─────────────────────────────────────────────┐
+│ Electron desktop app                        │
+│  ├─ Renderer (Chromium): React UI           │
+│  │     window.electronAPI.invoke(cmd, args) │
+│  │     window.electronAPI.channelOn(id, cb) │
+│  ├─ Preload bridge                          │
+│  └─ Main process (Node)                     │ ◀── ipcMain.handle("invoke", …) ──┐
+│        loads pollis-node (napi-rs)          │                                   │
+│        → pollis-core (Rust)                 │                                   │
+└──────┬──────────────────────────────────────┘                                   │
+       │                                                                          │
+       │ direct libSQL/Hrana over TLS                                              │ no HTTP server in
+       ▼                                                                          │ the middle — all
+┌────────────────┐   ┌──────────────┐   ┌────────────────┐                        │ logic runs in the
+│ Turso          │   │ Cloudflare R2│   │ LiveKit (SFU)  │                        │ main process via
+│ (metadata,     │   │ (encrypted   │   │ (signalling + │ ───────────────────────┘ pollis-node
 │ ciphertext,    │   │ attachments, │   │ voice frames   │
 │ MLS commit log,│   │ avatars)     │   │ AES-GCM        │
 │ welcomes,      │   └──────────────┘   │ E2EE at SFU)   │
@@ -57,9 +63,11 @@ The marketing site under `website/` is static HTML on Cloudflare Pages and is no
 └────────────────┘
 ```
 
-There is **no HTTP/gRPC backend between the desktop app and Turso.** All CRUD, MLS group operations, R2 uploads, LiveKit token minting, and Resend OTP requests run inside the Tauri Rust process and are exposed to React via Tauri commands.
+There is **no HTTP/gRPC backend between the desktop app and Turso.** All CRUD, MLS group operations, R2 uploads, LiveKit token minting, and Resend OTP requests run inside the Electron main process via the loaded `pollis-node` addon, and are reached by the renderer through the preload bridge.
 
-WebRTC is not available in Tauri's WebKitGTK webview on Linux, so voice (and any future video) is implemented in Rust using the `livekit` crate. JS-based media APIs are not an option on our target platforms.
+**IPC shape.** The renderer calls `window.electronAPI.invoke(cmd, args)` (defined in `electron/src/preload.ts`). The preload script forwards this to the main process as `ipcRenderer.invoke("invoke", cmd, args)`. The main process (`electron/src/main.ts`) handles the single `"invoke"` channel by dispatching by command name into `pollis-node`'s dispatch tree (`pollis-node/src/dispatch/<module>.rs`), which calls `pollis_core::commands::*`. Streaming events flow the other direction: `pollis-core` pushes envelopes through a Rust → Node `ThreadsafeFunction` registered once at startup; the main process forwards each envelope to renderers via `webContents.send("channel:<id>", payload)`; the renderer subscribes via `window.electronAPI.channelOn(id, handler)`. This is the path used for voice frames, screenshare frames, realtime events, and terminal output.
+
+Media stays in Rust by design. The renderer's Chromium does have WebRTC available, but voice and screenshare run inside `pollis-core` for two reasons: (a) **cross-platform parity** — the same media pipeline is consumed by mobile through uniffi, so one code path covers desktop and mobile, and (b) **predictable allocation** — multi-MB media buffers passed through the V8 heap produce visible GC stutter, while Rust's manual allocation does not. JS-based media APIs are reserved for the future when a small preview or thumbnail needs it.
 
 ---
 
@@ -122,17 +130,23 @@ For the full key-material taxonomy, KDF/AEAD parameters, and attack-surface anal
 
 ```
 React component
-  → invoke("command_name", { args })
-    → #[tauri::command] shim (src-tauri/src/commands/*.rs)
-      → pollis_core::commands::* (pollis-core/src/commands/*.rs)
-        → Turso (remote, metadata + ciphertext) and/or
-          SQLCipher local (secrets, MLS state)
+  → invoke("command_name", { args })            // from frontend/src/bridge
+    → window.electronAPI.invoke(...)            // preload (electron/src/preload.ts)
+      → ipcRenderer.invoke("invoke", cmd, args) // IPC over MessagePort
+        → ipcMain.handle("invoke", ...)         // main (electron/src/main.ts)
+          → pollis-node dispatch                // pollis-node/src/dispatch/*.rs
+            → pollis_core::commands::*          // pollis-core/src/commands/*.rs
+              → Turso (metadata + ciphertext) and/or
+                SQLCipher local (secrets, MLS state)
+            ← Result<T>
+          ← Result<T>
+        ← Result<T>
       ← Result<T>
     ← Result<T>
   ← TanStack Query cache
 ```
 
-The shim layer exists only to bridge `tauri::State` into a plain `&AppState` reference. Real business logic lives in `pollis-core`, which has no `tauri` runtime dependency and is also consumed by uniffi-generated mobile bindings.
+The renderer never imports `@tauri-apps/*` or Electron APIs directly. It imports `invoke` / `Channel` / window / dialog / fs / shell / app / updater from `frontend/src/bridge`, a thin runtime-host bridge that resolves to `window.electronAPI` under Electron and retains a legacy Tauri fallback. Real business logic lives in `pollis-core`, which has no shell-runtime dependency and is also consumed by uniffi-generated mobile bindings.
 
 **TanStack Query is the source of truth** for remote data. Components read through hooks in `frontend/src/hooks/queries/`. **Zustand** holds only UI state — selected group/channel, transient session data, current user reference. There is no parallel client-side store for remote data.
 
@@ -140,9 +154,9 @@ Routing uses TanStack Router with **memory history** (no browser URL bar in a de
 
 ---
 
-## Tauri commands (selected)
+## Backend commands (selected)
 
-Registered in `src-tauri/src/lib.rs`. The `#[tauri::command]` shims live under `src-tauri/src/commands/`; the real implementations are in `pollis-core/src/commands/` (one module per row in the table below).
+Dispatched in `pollis-node/src/dispatch/` (the active path) — one match arm per command, forwarding the JSON-shaped `invoke(cmd, args)` from the Electron main process into `pollis_core::commands::*`. The real implementations are in `pollis-core/src/commands/` (one module per row in the table below). The Tauri shims under `src-tauri/src/commands/` are retained as a rollback path but are not what runs in shipping binaries.
 
 | Module | Commands |
 |---|---|
@@ -166,10 +180,10 @@ For the full reference see `.codesight/wiki/commands.md`.
 
 ## Project structure
 
-The Rust workspace has two crates: `pollis-core` (reusable backend, no Tauri runtime) and `pollis` (the Tauri desktop binary). The split lets future front-ends — a CLI, a TUI, mobile via uniffi — consume the same command/state/db/MLS code without dragging in the Tauri runtime, plugins, and lifecycle.
+The Rust workspace splits the backend into `pollis-core` (reusable, no shell-runtime dependency) and two shell-specific layers: `pollis-node` (the napi-rs binding loaded into Electron's main process — the active shipping path) and `pollis` (the legacy Tauri desktop binary, kept for rollback). The split lets other front-ends — a CLI, a TUI, mobile via uniffi — consume the same command/state/db/MLS code without dragging in any particular shell.
 
 ```
-pollis-core/              # Reusable Rust backend (no tauri::* types)
+pollis-core/              # Reusable Rust backend (no shell-runtime types)
   src/
     commands/             # Real command implementations (auth, groups, messages, mls, voice, …)
     db/                   # libSQL (remote) + SQLCipher (local) + migrations
@@ -183,7 +197,22 @@ pollis-core/              # Reusable Rust backend (no tauri::* types)
     error.rs              # Error / Result types
     lib.rs                # uniffi exports for mobile bindings
 
-src-tauri/                # Tauri desktop binary
+pollis-node/              # napi-rs binding (active shipping path)
+  src/
+    lib.rs                # Addon entry; loads .env.development; ThreadsafeFunction registration
+    state.rs              # Per-process AppState shared with pollis-core
+    events.rs             # Rust → Node event channel plumbing
+    dispatch/             # invoke dispatch — one arm per command module
+
+electron/                 # Electron app
+  src/
+    main.ts               # Main process — loads pollis-node, registers ipcMain handlers, owns BrowserWindow + auto-updater
+    preload.ts            # Exposes window.electronAPI to the renderer
+  build/
+    electron-builder.yml  # Packaging config (DMG/ZIP/NSIS/AppImage/deb/rpm + signing hooks)
+    sign.js               # Windows signing hook (Azure Trusted Signing)
+
+src-tauri/                # Legacy Tauri desktop binary (retained for rollback; not the active shipping path)
   src/
     commands/             # Thin #[tauri::command] shims forwarding to pollis_core
     sink.rs               # ChannelSink adapter — wraps tauri::ipc::Channel into EventSink
@@ -193,10 +222,11 @@ src-tauri/                # Tauri desktop binary
 
 frontend/                 # React app
   src/
+    bridge/               # Runtime-host bridge — invoke/Channel/window/dialog/fs/shell/app/updater route through window.electronAPI; legacy Tauri fallback retained
     components/           # UI components (auth, layout, message, voice, ui/, …)
     pages/                # Route pages
     hooks/queries/        # TanStack Query hooks
-    services/             # invoke() wrappers, R2 upload helpers
+    services/             # Frontend-side helpers (R2 upload, etc.)
     stores/               # Zustand (UI state only)
     types/                # TypeScript types — kept aligned with Rust structs
     router.tsx, main.tsx  # TanStack Router setup, app entry
@@ -212,7 +242,9 @@ docs/security-whitepaper.md   # Auditor-facing protocol/threat model
 
 | | Trusted | Untrusted |
 |---|---|---|
-| | User's device, OS keystore, the SQLCipher local DB, the Tauri binary at install, the user-held Secret Key, the user-held PIN | Network, Turso, Cloudflare R2, LiveKit, Resend, server operators |
+| | User's device, OS keystore, the SQLCipher local DB, the signed Electron binary (main process + preload + `pollis-node`/`pollis-core` addon) at the installed version, the user-held Secret Key, the user-held PIN | Network, Turso, Cloudflare R2, LiveKit, Resend, server operators |
+
+Binary integrity at install and at every auto-update rests on the OS-native code signature: Apple Developer ID + notarization (Gatekeeper checks both at launch and at install) on macOS, Azure Trusted Signing (Authenticode) on Windows. `electron-updater` verifies the same signature before invoking the installer, so a tampered download cannot replace the running binary.
 
 What the server can see: user metadata, social graph, encrypted message envelopes (size, sender, timestamp), MLS commit/welcome timing, public keys.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,15 +2,15 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-> **Deep-dive docs:** See `.codesight/wiki/` for detailed documentation — database schemas, MLS flows, component inventory, and Tauri command reference. Start with `.codesight/wiki/index.md`. **Keep these docs updated** as features are developed — update the relevant wiki article alongside code changes without discussion.
+> **Deep-dive docs:** See `.codesight/wiki/` for detailed documentation — database schemas, MLS flows, component inventory, and backend command reference. Start with `.codesight/wiki/index.md`. **Keep these docs updated** as features are developed — update the relevant wiki article alongside code changes without discussion.
 
 ## Project Overview
 
-Pollis is a privacy-first desktop messaging app with end-to-end encryption using MLS (Message Layer Security). Built with Tauri 2 (Rust + React), it combines strong group encryption with Slack's group messaging features. The server never sees message plaintext.
+Pollis is a privacy-first desktop messaging app with end-to-end encryption using MLS (Message Layer Security). It's an Electron app with a Rust core: the renderer (React) calls into a native Rust backend loaded into Electron's main process as a Node addon (`pollis-node`, built with napi-rs over the reusable `pollis-core` crate). Strong group encryption with Slack-style channels. The server never sees message plaintext.
 
-**Stack**: Tauri 2, React/TypeScript, Rust, Turso (libSQL), MLS
+**Stack**: Electron 33, React/TypeScript, Rust (`pollis-core` + `pollis-node`), Turso (libSQL), MLS
 
-**Key Architecture**: Tauri Rust backend connects **directly** to Turso (1 hop) for all CRUD. No separate backend server. All operations go through Tauri commands invoked from the React frontend.
+**Key Architecture**: The Rust backend connects **directly** to Turso (1 hop) for all CRUD. No separate backend server. The renderer invokes commands through `window.electronAPI.invoke(cmd, args)` (defined by the preload bridge); the Electron main process dispatches into `pollis-node`, which calls the real implementation in `pollis-core`. Same JSON shape both ends.
 
 ## Development Commands
 
@@ -19,21 +19,30 @@ Pollis is a privacy-first desktop messaging app with end-to-end encryption using
 pnpm install              # Install JS dependencies
 ```
 
-`.env.development` is loaded automatically in dev builds via `dotenvy::from_filename(".env.development")` in `src-tauri/src/lib.rs`. No manual sourcing needed.
+`.env.development` is loaded automatically in dev builds via `dotenvy::from_filename` in `pollis-node/src/lib.rs` (the napi-rs addon's `init` path). No manual sourcing needed.
 
 ### Running
 ```bash
-pnpm dev                  # Run Tauri desktop app (Rust + React)
-pnpm dev:frontend         # Run frontend in browser only (no Tauri commands)
+pnpm dev                  # Builds pollis-node (debug), then runs Vite + Electron concurrently
+pnpm dev:frontend         # Frontend only, in the browser (no Electron main process, no Rust IPC)
 ```
 
 ### Building
 ```bash
-pnpm build                # Build for current platform
-pnpm build:linux          # Linux amd64
-pnpm build:macos          # Universal macOS binary
-pnpm build:windows        # Windows amd64
+# Build the Rust addon (release) and Electron main bundle
+pnpm build:pollis-node
+pnpm --filter @pollis/electron build
+
+# Package for the current platform
+pnpm --filter @pollis/electron exec electron-builder --config build/electron-builder.yml
+
+# Per-target
+pnpm --filter @pollis/electron exec electron-builder --config build/electron-builder.yml --mac
+pnpm --filter @pollis/electron exec electron-builder --config build/electron-builder.yml --win
+pnpm --filter @pollis/electron exec electron-builder --config build/electron-builder.yml --linux
 ```
+
+The packaging config lives at `electron/build/electron-builder.yml`; outputs are DMG + ZIP (mac), NSIS + portable (win), AppImage + deb + rpm (linux). Auto-update is electron-updater reading `latest.yml` / `latest-mac.yml` / `latest-linux.yml` from GitHub Releases; trust root is the OS code signature on the installer (Apple Developer ID, Azure Trusted Signing). The legacy `dev:tauri` / `build:tauri*` scripts in the root `package.json` still work but are not the active path.
 
 ### Secrets Management
 
@@ -45,19 +54,19 @@ Secrets are managed via **Doppler**, which syncs to GitHub Actions secrets autom
 cargo test --features test-harness --test flows   # Multi-client integration tests
 ```
 
-The integration harness (`src-tauri/tests/flows.rs`) drives real `#[tauri::command]` functions through `tauri::test::get_ipc_response` — no `_inner` shims, no mocked DB layer. Each test gets its own per-client `AppState` + `InMemoryKeystore` but shares a disposable Turso instance configured in `.env.test`. See `.codesight/wiki/testing.md` for the full architecture and how to add scenarios.
+The integration harness (`src-tauri/tests/flows.rs`) drives the real command implementations through the same dispatch path the runtime uses — no `_inner` shims, no mocked DB layer. Each test gets its own per-client `AppState` + `InMemoryKeystore` but shares a disposable Turso instance configured in `.env.test`. See `.codesight/wiki/testing.md` for the full architecture and how to add scenarios.
 
 ## Architecture
 
 ### Network Architecture
 
-**Tauri Rust backend → Turso (DIRECT libsql connection)**
+**Rust backend (in the Electron main process) → Turso (DIRECT libsql connection)**
 - 1 network hop — simple and fast
-- Rust backend has same DB access as any server
+- The Rust core has the same DB access any server would
 
-**No separate gRPC/HTTP server** — that has been removed. All backend logic runs in the Tauri process.
+**No separate gRPC/HTTP server** — that has been removed. All backend logic runs inside the Electron main process via `pollis-node`'s loaded `pollis-core`.
 
-**Tauri handles directly:**
+**The Rust core handles directly:**
 - User profile CRUD
 - Groups and channels CRUD
 - Reading/writing to Turso
@@ -84,7 +93,7 @@ The integration harness (`src-tauri/tests/flows.rs`) drives real `#[tauri::comma
 
 ### Frontend Data Fetching
 
-All backend calls use `invoke()` from `@tauri-apps/api/core`, wrapped in React Query hooks:
+All backend calls go through the host bridge — import `invoke` from `frontend/src/bridge` (which routes to `window.electronAPI.invoke` under Electron and retains a legacy Tauri fallback). Wrapped in React Query hooks:
 
 ```typescript
 // React Query hooks in frontend/src/hooks/queries/
@@ -95,15 +104,17 @@ useChannelMessages(channelId)       // invoke("list_messages", { channelId })
 useSendMessage()                    // invoke("send_message", ...)
 ```
 
+Never import directly from `@tauri-apps/*` — always go through `../bridge`. That way command call sites don't care which runtime is hosting them.
+
 **React Query is the source of truth** for remote data — don't duplicate in Zustand.
 
 **Zustand store**: Only holds UI state (selected group/channel), current user reference, temporary session data.
 
-### Tauri Commands
+### Backend Commands
 
-Backend logic lives in `pollis-core/src/commands/` (a workspace crate with **no Tauri-runtime dependency** — reusable from a future CLI / TUI / mobile binary). The Tauri binary in `src-tauri/src/commands/` holds thin `#[tauri::command]` shims that forward to `pollis_core::commands::*`. Commands are registered in `src-tauri/src/lib.rs`.
+Backend logic lives in `pollis-core/src/commands/` (a workspace crate with **no shell-runtime dependency** — reusable from a CLI / TUI / mobile binding). The active dispatch path is `pollis-node/src/dispatch/<module>.rs`: a one-line match arm per command that routes the JSON-shaped `invoke(cmd, args)` call from the Electron main process into `pollis_core::commands::*`. The Tauri shims in `src-tauri/src/commands/` are retained for rollback and remain wired through `src-tauri/src/lib.rs`, but they are not the active path.
 
-**Edit `pollis-core`, not the shims.** When adding a command: implement it in `pollis-core/src/commands/<module>.rs`, add a forwarding shim in `src-tauri/src/commands/<module>.rs`, and register it in `src-tauri/src/lib.rs` (and `src-tauri/src/test_harness.rs` if it's covered by integration tests).
+**Edit `pollis-core`, not the shims.** When adding a command: implement it in `pollis-core/src/commands/<module>.rs`, add a one-line dispatch arm in `pollis-node/src/dispatch/<module>.rs`, and register it in the test harness (`src-tauri/src/test_harness.rs`) if it's covered by integration tests. The Tauri shim is optional — only update it if you also want the rollback path to expose the new command.
 
 - **auth**: `initialize_identity`, `get_identity`, `request_otp`, `verify_otp`, `get_session`, `logout`
 - **user**: `get_user_profile`, `update_user_profile`, `search_user_by_username`
@@ -116,7 +127,7 @@ Backend logic lives in `pollis-core/src/commands/` (a workspace crate with **no 
 ### Project Structure
 
 ```
-pollis-core/            # Reusable Rust backend (no Tauri runtime)
+pollis-core/            # Reusable Rust backend (no shell-runtime dependency)
   src/
     commands/           # Command implementations (auth, groups, messages, mls, voice, …)
     config.rs           # Config from env vars
@@ -129,7 +140,20 @@ pollis-core/            # Reusable Rust backend (no Tauri runtime)
     accounts.rs         # accounts.json (atomic, crash-safe)
     error.rs            # Error / Result types
     lib.rs              # uniffi exports for mobile bindings
-src-tauri/              # Tauri desktop binary
+pollis-node/            # napi-rs binding — loads pollis-core into Node
+  src/
+    lib.rs              # Addon entry; .env.development load; ThreadsafeFunction registration
+    state.rs            # Per-process AppState shared with pollis-core
+    events.rs           # Rust → Node event channel plumbing
+    dispatch/           # `invoke` dispatch arms per command module
+electron/               # Electron app
+  src/
+    main.ts             # Main process — loads pollis-node, registers ipcMain handlers, owns BrowserWindow
+    preload.ts          # Exposes window.electronAPI to the renderer (invoke, channelOn, window, dialog, fs, shell, app, notifications, clipboard, updater)
+  build/
+    electron-builder.yml  # Packaging config (DMG/ZIP/NSIS/AppImage/deb/rpm + signing hooks)
+    sign.js             # Windows signing hook (Azure Trusted Signing)
+src-tauri/              # Legacy Tauri desktop binary (retained for rollback; not the active path)
   src/
     commands/           # Thin #[tauri::command] shims forwarding to pollis_core
     sink.rs             # ChannelSink adapter (Tauri's ipc::Channel → EventSink)
@@ -138,6 +162,7 @@ src-tauri/              # Tauri desktop binary
     main.rs             # Binary entry
 frontend/               # React app (Vite, TypeScript, TailwindCSS)
   src/
+    bridge/             # Runtime-host bridge — invoke/Channel/window/dialog/fs/shell/app/updater route through window.electronAPI under Electron; legacy Tauri fallback retained
     hooks/queries/      # React Query hooks
     types/              # TypeScript types
     components/         # React components
@@ -149,23 +174,25 @@ website/                # Static HTML marketing site (Cloudflare Pages)
 
 **All real-time media is handled in Rust, end to end.** Voice is implemented in `pollis-core/src/commands/voice.rs` using the `livekit` + `libwebrtc` crates (capture via `cpal`, publish via `NativeAudioSource` / `LocalAudioTrack`, playback via `NativeAudioStream` → cpal output).
 
-**Why Rust and not the webview**: Tauri's webview on Linux (WebKitGTK) does not support WebRTC. `getUserMedia`, `RTCPeerConnection`, etc. are unavailable. This means the "use livekit-client JS SDK in the webview" approach is NOT an option on our target platforms — do not suggest it. Any media feature (voice, video, screen share) must be implemented in Rust using the `livekit` crate directly and wired to Tauri commands. Frames are pushed to the frontend via `tauri::ipc::Channel` for UI purposes only (speaking indicators, participant events), never for rendering media itself.
+**Why Rust and not the renderer**: two reasons. First, **cross-platform parity** — the same media pipeline runs on desktop, and via uniffi the same `pollis-core` is consumed by mobile. One code path covers every target; the renderer's WebRTC stack would be desktop-only and would diverge from mobile's behavior on capture defaults, codec selection, and frame timing. Second, **predictable allocation** — multi-MB media buffers passed through the V8 heap create visible GC stutter; Rust's manual allocation does not. The renderer's Chromium does have full WebRTC available, but using it would mean re-implementing voice on mobile and re-introducing GC pauses. The Rust path is intentional.
 
-**Implication for future video**: video capture, publish, subscribe, and render must all run in Rust. Remote video frames cannot be handed to a `<video>` element via `srcObject` because there is no `MediaStream` in the webview. Rendering requires either a native OS surface layered behind the webview or pushing decoded frames to the frontend via IPC (latter is fine for small previews, not for real video).
+Frames are pushed to the renderer over IPC channels (`window.electronAPI.channelOn(id, handler)`) for UI purposes only — speaking indicators, participant events — never for rendering media itself.
+
+**Implication for future video**: video capture, publish, subscribe, and render are all expected to run in Rust for the same reasons. Pushing decoded frames over IPC is fine for small previews (avatars-during-call, picture-in-picture thumbnails), not for full video.
 
 ## Performance Architecture
 
-**Lean Rust for performance-critical paths.** The reason Pollis is on Tauri (not Electron, not Wails) is to leverage Rust's perf for I/O, crypto, media pipelines, and concurrency without GC pauses. When a feature is performance-sensitive, IPC-bandwidth-sensitive, or benefits from no-GC predictability — media decoding, encryption, file serving, real-time pipelines, large-buffer manipulation — put it in Rust. Use the webview as a thin presentation layer.
+**Lean Rust for performance-critical paths.** The Rust core exists to handle I/O, crypto, media pipelines, and concurrency without GC pauses. When a feature is performance-sensitive, IPC-bandwidth-sensitive, or benefits from no-GC predictability — media decoding, encryption, file serving, real-time pipelines, large-buffer manipulation — put it in `pollis-core`. Use the renderer as a thin presentation layer.
 
-Don't reach for JS-side equivalents (Web Crypto, IndexedDB, browser-side caching, JS-heap byte buffers) when an equivalent Rust path exists. If you do, you're giving up the main reason the stack was picked. V8's GC pressure on multi-MB byte arrays produces visible UI stutter; Rust's predictable allocation does not.
+Don't reach for JS-side equivalents (Web Crypto, IndexedDB, browser-side caching, JS-heap byte buffers) when an equivalent Rust path exists. V8's GC pressure on multi-MB byte arrays produces visible UI stutter; Rust's predictable allocation does not. The same code also runs on mobile via uniffi bindings, so a Rust-side implementation buys cross-platform parity for free.
 
-**Pattern for serving cached/encrypted media to the webview**: a Rust-side local-loopback HTTP server (`127.0.0.1:<auto-port>`). The webview embeds `<img>/<audio>/<video>` with `src="http://127.0.0.1:NNNN/<hash>"`. Rust handles disk cache (encrypted at rest), AES-GCM decrypt, HTTP Range requests, and any future on-the-fly transforms (thumbnails, transcoding, prefetch). One URL pattern across image/audio/video — no platform-branching, no custom URI schemes, no JSON IPC for bytes. CRUD continues to go through `invoke()`; the local HTTP server is for media transport, not data plane.
+**Pattern for serving cached/encrypted media to the renderer**: a Rust-side local-loopback HTTP server (`127.0.0.1:<auto-port>`). The renderer embeds `<img>/<audio>/<video>` with `src="http://127.0.0.1:NNNN/<hash>"`. Rust handles disk cache (encrypted at rest), AES-GCM decrypt, HTTP Range requests, and any future on-the-fly transforms (thumbnails, transcoding, prefetch). One URL pattern across image/audio/video — no platform-branching, no custom URI schemes, no JSON IPC for bytes. CRUD continues to go through `invoke()`; the local HTTP server is for media transport, not data plane.
 
 **Implication when adding new perf-sensitive features**: default to a Rust implementation that exposes either an `invoke()` command (for CRUD-shaped calls) or an HTTP endpoint on the local server (for byte-stream-shaped data). Reach for JS only after confirming the Rust path won't work.
 
 ## Security Model
 
-**Trusted**: User's device, local database (encrypted at rest), Tauri app code, OS keystore
+**Trusted**: User's device, local database (encrypted at rest), the signed Electron application binary (main process + preload + `pollis-node`/`pollis-core` addon) at the installed version, OS keystore
 
 **Untrusted**: Network, Turso database, server operators
 
@@ -196,23 +223,27 @@ Concrete implications:
 
 ## Key Files
 
-- `src-tauri/src/lib.rs` — Tauri app entry point, plugin setup, command registration
-- `src-tauri/src/commands/` — Thin `#[tauri::command]` shims (forward to `pollis_core::commands::*`)
+- `electron/src/main.ts` — Electron main process entry; loads `pollis-node`, registers `ipcMain` handlers, owns BrowserWindow + auto-updater lifecycle
+- `electron/src/preload.ts` — Exposes `window.electronAPI` to the renderer (invoke, channelOn, window controls, dialogs, fs, shell, app, notifications, clipboard, updater)
+- `pollis-node/src/lib.rs` — napi-rs addon entry; loads `.env.development`, wires the Rust → Node ThreadsafeFunction event channel
+- `pollis-node/src/dispatch/` — Active `invoke` dispatch — one arm per command, forwards into `pollis_core::commands::*`
 - `pollis-core/src/commands/` — Real command implementations (edit here)
 - `pollis-core/src/state.rs` — AppState shared across commands
 - `pollis-core/src/db/` — Turso + local SQLite + migrations
+- `frontend/src/bridge/` — Runtime-host bridge — all renderer code imports `invoke`/`Channel`/window/dialog/etc. from here
 - `frontend/src/main.tsx` — React app entry point
 - `frontend/src/hooks/queries/` — React Query hooks
+- `src-tauri/src/lib.rs` — Legacy Tauri app entry; preserved for rollback, not the active path
 - `ARCHITECTURE.md` — Detailed architecture documentation
 
 ## Important Notes
 
-- **Tauri backend connects DIRECTLY to Turso** — no server middleman for CRUD
-- **All backend calls from frontend use `invoke()`** — never fetch() to a local server
+- **Rust backend (in the Electron main process) connects DIRECTLY to Turso** — no server middleman for CRUD
+- **All backend calls from the renderer go through the bridge** — `import { invoke } from "../bridge"`, never `@tauri-apps/api/core` directly, and never `fetch()` to a local server
 - **React Query is the source of truth** for remote data — don't duplicate in Zustand
 - **Local DB should NOT have users/groups/channels tables** — those come from remote Turso
 - **TypeScript types should match Rust structs** — keep them synchronized
-- **Remote schema changes go in numbered migration files** in `pollis-core/src/db/migrations/` (e.g. `000019_my_change.sql`). `000000_baseline.sql` is the frozen canonical snapshot — never edit it. Dev: run new migrations by hand against your dev Turso. Prod: `.github/workflows/desktop-release.yml` runs `scripts/db-apply.sh` after all builds succeed; migration failure aborts the release. Nobody applies to prod by hand. The runner records the `schema_migrations` row automatically — do **not** put an `INSERT INTO schema_migrations` in the migration file.
+- **Remote schema changes go in numbered migration files** in `pollis-core/src/db/migrations/` (e.g. `000019_my_change.sql`). `000000_baseline.sql` is the frozen canonical snapshot — never edit it. Dev: run new migrations by hand against your dev Turso. Prod: `.github/workflows/electron-release.yml` runs `scripts/db-apply.sh` after all builds succeed; migration failure aborts the release. Nobody applies to prod by hand. The runner records the `schema_migrations` row automatically — do **not** put an `INSERT INTO schema_migrations` in the migration file.
 - **Migrations must be additive and backward-compatible with the currently-shipped desktop app.** Desktop users update on their own schedule, so after any release there will be old + new app versions hitting prod for days or weeks. Safe: `CREATE TABLE`, `ADD COLUMN` (nullable or with DEFAULT), `CREATE INDEX`, CHECK constraints already satisfied by every existing row. Unsafe — require a multi-release dance (first ship an app that stops using the thing, wait for uptake, then drop): `DROP TABLE`, `DROP COLUMN`, `RENAME`, tightening nullability or CHECKs, or any change that would make the previous app's SQL fail.
 - **NEVER commit on the local `main` branch** — always create a `fix/*` or `feature/*` branch first, even if the user does not explicitly ask for one. This is absolute. If you find yourself on `main` with changes to commit, create and switch to a branch before committing.
 - **Prefer editing existing files** over creating new ones

--- a/README.md
+++ b/README.md
@@ -1,17 +1,21 @@
 # Pollis
 
-A desktop messaging app with end-to-end encryption. Think Slack, but nobody — including the people running it — can read your messages. Built with Tauri 2, so it's a native app on macOS, Linux, and Windows with a Rust backend and React frontend.
+A desktop messaging app with end-to-end encryption. Think Slack, but nobody — including the people running it — can read your messages. Built as an Electron app on macOS, Linux, and Windows, with a React frontend and a native Rust backend loaded into Electron's main process as a Node addon — the heavy lifting (crypto, MLS state, voice/screenshare) runs in Rust, not in the renderer.
 
 ![Pollis App](readme/hero.png)
 
 ## How it works
 
-Messages are encrypted on your device using MLS (Messaging Layer Security) before they ever leave your machine. The backend connects directly to Turso (libSQL) for group and channel metadata. There is no intermediate server — the Tauri app is the backend. Encrypted message envelopes are stored remotely for offline delivery, and decrypted message history lives in a local SQLite database encrypted at rest.
+Messages are encrypted on your device using MLS (Messaging Layer Security) before they ever leave your machine. The Rust backend connects directly to Turso (libSQL) for group and channel metadata. There is no intermediate server — the desktop binary is the backend. Encrypted message envelopes are stored remotely for offline delivery, and decrypted message history lives in a local SQLite database encrypted at rest.
+
+The renderer calls into the Rust backend via a single IPC bridge: `window.electronAPI.invoke(cmd, args)` → preload → Electron main process → `pollis-node` (the napi-rs binding that loads `pollis-core` as a native Node addon) → real implementation in `pollis-core`. Same JSON shape on both ends.
 
 **Stack**
-- **Desktop**: Tauri 2 (Rust + React/TypeScript)
+- **Desktop shell**: Electron 33 (main process + Chromium renderer + preload bridge)
+- **Frontend**: React 19, TypeScript, Vite, TailwindCSS
+- **Backend**: Rust split into `pollis-core` (reusable crate; also consumed by mobile via uniffi) and `pollis-node` (napi-rs binding loaded into the Electron main process)
 - **Encryption**: MLS (Messaging Layer Security) for group channel encryption, AES-256-GCM. Voice channels are end-to-end encrypted too — per-frame AES-128-GCM via libwebrtc's `FrameCryptor`, keyed from the MLS group's exporter secret, so the LiveKit SFU forwards ciphertext only.
-- **Remote DB**: Turso (libSQL) — direct from the app, no middleman
+- **Remote DB**: Turso (libSQL) — direct from the Rust core, no middleman
 - **Local DB**: SQLite via rusqlite (encrypted at rest, key in OS keystore)
 - **Auth**: Email OTP, session stored in the OS keystore
 - **Real-time**: LiveKit (voice calls via Rust `livekit` crate, real-time presence)
@@ -27,7 +31,7 @@ Forward secrecy is provided by MLS's key schedule: each epoch advance rotates th
 
 ## Releases
 
-Builds for macOS (Apple Silicon), Windows, and Linux are published automatically on every version tag via GitHub Actions. Binaries are uploaded to Cloudflare R2, and a `latest.json` manifest is written alongside them. The marketing site at [pollis.com](https://pollis.com) reads that manifest on load to always show the current download links.
+Builds for macOS, Windows, and Linux are published automatically on every version tag via GitHub Actions (`.github/workflows/electron-release.yml`). `electron-builder` produces DMG + ZIP (mac), NSIS + portable (win), and AppImage + deb + rpm (linux); the workflow uploads them as GitHub Release assets along with the `latest.yml` / `latest-mac.yml` / `latest-linux.yml` manifests that `electron-updater` reads at runtime. The same workflow mirrors a `latest.json` to R2 so the marketing site at [pollis.com](https://pollis.com) can always show the current download links. Auto-update trust is rooted in the OS code signature on each installer — Apple Developer ID + notarization on macOS, Azure Trusted Signing on Windows.
 
 ![Pollis UI](readme/new_app.png)
 
@@ -38,7 +42,7 @@ Builds for macOS (Apple Silicon), Windows, and Linux are published automatically
 - Node.js 18+
 - pnpm 10.25+
 - Rust (stable, via rustup)
-- Tauri v2 system dependencies — see [tauri.app/start/prerequisites](https://tauri.app/start/prerequisites/)
+- A C/C++ toolchain so `napi-rs` can link the `pollis-node` addon: Xcode Command Line Tools on macOS, MSVC Build Tools on Windows, `build-essential` on Linux
 - Access to Doppler for secrets (ask the project owner)
 
 ### Setup
@@ -50,9 +54,11 @@ pnpm install          # Install JS dependencies
 ### Running
 
 ```bash
-pnpm dev              # Full desktop app (Rust + React)
-pnpm dev:frontend     # Frontend only in browser (no Tauri commands)
+pnpm dev              # Full desktop app — builds pollis-node (debug), then runs Vite + Electron concurrently
+pnpm dev:frontend     # Frontend only, in the browser (no Electron main process, no Rust IPC)
 ```
+
+Under the hood `pnpm dev` builds the Rust addon with `pnpm --filter @pollis/pollis-node build-debug`, then starts the Vite dev server on `:5173` and Electron's main process in parallel via `concurrently`. The first run also builds dependent Rust crates, which can take a few minutes; subsequent runs are fast.
 
 ### Skipping email OTP in development
 
@@ -97,11 +103,24 @@ All dev-only env vars. Set them in `.env.development` or pass inline.
 ### Building
 
 ```bash
-pnpm build            # Current platform
-pnpm build:macos      # Universal macOS binary
-pnpm build:linux      # amd64 AppImage, deb, rpm
-pnpm build:windows    # amd64 NSIS installer
+# Build the Rust addon (release) and the Electron main bundle
+pnpm build:pollis-node
+pnpm --filter @pollis/electron build
+
+# Package for the current platform
+pnpm --filter @pollis/electron exec electron-builder --config build/electron-builder.yml
+
+# Package for a specific target
+pnpm --filter @pollis/electron exec electron-builder --config build/electron-builder.yml --mac
+pnpm --filter @pollis/electron exec electron-builder --config build/electron-builder.yml --win
+pnpm --filter @pollis/electron exec electron-builder --config build/electron-builder.yml --linux
 ```
+
+The packaging config lives at `electron/build/electron-builder.yml`. Local builds skip code signing unless the relevant env vars (`CSC_LINK` / `CSC_KEY_PASSWORD` on macOS; `SIGNTOOL_PATH` / `SIGNING_DLIB_PATH` / `SIGN_METADATA_PATH` on Windows) are set — CI sets all of them.
+
+#### Legacy Tauri build (rollback only)
+
+The Tauri shell at `src-tauri/` is retained as a rollback path, not the active build. The `dev:tauri` / `build:tauri*` scripts in the root `package.json` still work, but Tauri is not what ships.
 
 ### Testing
 
@@ -117,9 +136,11 @@ The integration harness (`src-tauri/tests/flows.rs`) is gated behind the `test-h
 ## Project layout
 
 ```
-pollis-core/ # Reusable Rust backend — commands, DB, MLS encryption, auth (no Tauri runtime)
-src-tauri/   # Tauri desktop binary — #[tauri::command] shims, plugins, lifecycle
-frontend/    # React app — Vite, TypeScript, TailwindCSS
+pollis-core/  # Reusable Rust backend — commands, DB, MLS encryption, auth (no shell dependency; also exposed to mobile via uniffi)
+pollis-node/  # napi-rs binding — loads pollis-core into Node, dispatches `invoke` calls from the Electron main process
+electron/     # Electron app — main process, preload bridge, electron-builder config
+frontend/    # React app — Vite, TypeScript, TailwindCSS, runtime-host bridge at src/bridge/
+src-tauri/   # Legacy Tauri desktop binary — retained for rollback, not the active shell
 website/     # Static marketing site — plain HTML/CSS/JS, deployed to Cloudflare Pages
 ```
 

--- a/docs/security-whitepaper.md
+++ b/docs/security-whitepaper.md
@@ -14,12 +14,12 @@
 |---|---|
 | The user's device | Network (any path between the device and any remote service) |
 | The OS keystore (Keychain / Secret Service / Credential Manager) | Turso (libSQL) — the remote relational database |
-| The Tauri 2 application binary at the version the user installed | Cloudflare R2 — object storage for attachments |
+| The Electron application binary (renderer + preload + Rust sidecar `pollis-node`) at the version the user installed | Cloudflare R2 — object storage for attachments |
 | The local SQLCipher database file | LiveKit — SFU and signalling for voice and realtime events |
 | The user-held Secret Key (printed once, expected to be stored offline) | Resend — outbound email transit for OTPs |
 | The user-held PIN (in the user's head) | Anyone with read access to a copy of `accounts.json` or the keystore who does not also have the PIN |
 
-The application is built and shipped by the operators of the Pollis services. The trust delegation is the same as Signal Desktop or WhatsApp Desktop: the binary is trusted at install time, after which the cryptographic protocol is what defends against the *server* side of the same operator. Reproducible builds are not currently a goal; binary integrity rests on platform code-signing (Apple notarization on macOS, Azure Artifact Signing on Windows — see `.codesight/wiki/windows-signing.md`).
+The application is built and shipped by the operators of the Pollis services. The trust delegation is the same as Signal Desktop or WhatsApp Desktop: the binary is trusted at install time, after which the cryptographic protocol is what defends against the *server* side of the same operator. Reproducible builds are not currently a goal; binary integrity rests on platform code-signing (Apple Developer ID + notarization on macOS, Azure Trusted Signing on Windows — see `.codesight/wiki/windows-signing.md`). The auto-update path verifies the same OS-native signature on every downloaded installer before launch (Gatekeeper on macOS, Authenticode on Windows), so an attacker who tampers with a release artifact in transit cannot get the running binary to install it.
 
 ### 1.2 What the server can and cannot see
 
@@ -41,7 +41,7 @@ Pollis carries three nested identities. Distinguishing them is essential for the
 
 ### 2.1 Account identity (per user)
 
-A long-lived Ed25519 keypair (RFC 8032), generated on the device that completes signup. Source: `src-tauri/src/commands/account_identity.rs::generate_account_identity`. The public half is published to `users.account_id_pub` (BLOB, 32 bytes) at signup. The private half exists in exactly two places:
+A long-lived Ed25519 keypair (RFC 8032), generated on the device that completes signup. Source: `pollis-core/src/commands/account_identity.rs::generate_account_identity`. The public half is published to `users.account_id_pub` (BLOB, 32 bytes) at signup. The private half exists in exactly two places:
 
 1. On the user's enrolled devices, on disk only as ciphertext in the OS keystore slot `account_id_key_wrapped_{user_id}` (see §3 for wrapping).
 2. On the server, on disk only as ciphertext in the `account_recovery` table, wrapped under a key derived from a user-held *Secret Key* the server has never seen.
@@ -66,7 +66,7 @@ The local PIN is a *device-local unlock* factor, not a server credential. It doe
 
 ### 3.1 KDF and AEAD choices
 
-Source: `src-tauri/src/commands/pin.rs`.
+Source: `pollis-core/src/commands/pin.rs`.
 
 - **PIN format:** 4 ASCII digits — `validate_pin`. ~13 bits of entropy.
 - **KDF:** Argon2id (RFC 9106), Argon2 crate `0.5`, version 0x13. Parameters: `m_cost = 64 MiB`, `t_cost = 3`, `p_cost = 1`, output 32 bytes. Tuned to ~250 ms on a mid-range Apple-silicon or Ryzen 5 device, deliberately above the OWASP 2024 first-choice password-storage minimum (m=19 MiB, t=2). Parameters are stored inside the `pin_meta_{user_id}` blob, not hard-coded at unwrap time, so they can be bumped on any future re-wrap without a migration.
@@ -103,7 +103,7 @@ After PIN setup, raw `db_key` and raw `account_id_key` exist on disk only inside
 
 ## 4. Authentication Flow (OTP)
 
-Source: `src-tauri/src/commands/auth.rs::request_otp`, `verify_otp`.
+Source: `pollis-core/src/commands/auth.rs::request_otp`, `verify_otp`.
 
 The OTP factor exists only to prove control of an email address. It is *not* the device unlock factor (that's the PIN) and it is *not* the account-recovery factor (that's the Secret Key).
 
@@ -127,7 +127,7 @@ A user with an existing `account_id_pub` can add a second device through one of 
 
 ### 5.1 Approval path (in-band, sibling-device-mediated)
 
-Source: `src-tauri/src/commands/device_enrollment.rs`.
+Source: `pollis-core/src/commands/device_enrollment.rs`.
 
 1. New device generates an **ephemeral X25519 keypair** (`x25519-dalek` 2.0, `StaticSecret` from `OsRng` bytes). The private half is held in `AppState.enrollment_ephemeral_keys: HashMap<request_id, Vec<u8>>` — *in memory only*. App restart mid-enrollment forfeits the request.
 2. New device generates a 6-digit verification code (`OsRng` → `u32 mod 1_000_000`, zero-padded).
@@ -188,7 +188,7 @@ Verification failures currently log a warning and proceed (the comment block at 
 ### 6.1 Standard and library
 
 - **Specification:** RFC 9420 — The Messaging Layer Security (MLS) Protocol.
-- **Implementation:** `openmls` 0.8 (https://github.com/openmls/openmls), with `openmls_rust_crypto` 0.5 providing the crypto provider over the `RustCrypto` AEAD/HKDF/HPKE primitives, and a Pollis-defined `MlsStore` (`src-tauri/src/signal/mls_storage.rs`) implementing the `openmls_traits::storage::StorageProvider` trait against the local SQLCipher `mls_kv` table.
+- **Implementation:** `openmls` 0.8 (https://github.com/openmls/openmls), with `openmls_rust_crypto` 0.5 providing the crypto provider over the `RustCrypto` AEAD/HKDF/HPKE primitives, and a Pollis-defined `MlsStore` (`pollis-core/src/signal/mls_storage.rs`) implementing the `openmls_traits::storage::StorageProvider` trait against the local SQLCipher `mls_kv` table.
 - **Cipher suite:** `MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519` (single `const CS` at the top of `mls.rs`). This is suite 1 in RFC 9420 §17.1, MTI for MLS 1.0:
   - HPKE (RFC 9180): DHKEM(X25519, HKDF-SHA256), HKDF-SHA256, AES-128-GCM
   - Hash: SHA-256
@@ -259,7 +259,7 @@ The product principle in `CLAUDE.md` is exactly stated: messages sent before a m
 
 ## 7. Local Encrypted Storage (SQLCipher)
 
-Source: `src-tauri/src/db/local.rs`.
+Source: `pollis-core/src/db/local.rs`.
 
 - **Library:** `rusqlite` 0.31 with the `bundled-sqlcipher` feature, which links a vendored SQLCipher 4 (a fork of SQLite providing page-level AES-256-CBC with per-page HMAC-SHA512 for tamper detection; PBKDF2-HMAC-SHA512 page-key derivation is part of the default profile but is not used by Pollis — see "Key application" below).
 - **Key application:** `PRAGMA key = "x'{hex}'";` with the 32-byte raw key; this skips SQLCipher's own KDF and uses the raw key directly as the page key — appropriate because the input is a CSPRNG-generated 32-byte uniform key, not a passphrase.
@@ -281,10 +281,10 @@ User profile rows, group/channel metadata, membership, blocks: those live on Tur
 
 ## 8. Remote Database Transport (Turso / libSQL)
 
-Source: `src-tauri/src/db/remote.rs`.
+Source: `pollis-core/src/db/remote.rs`.
 
 - **Library:** `libsql` 0.6 with the `remote` feature, which uses Turso's **Hrana over HTTP/2** (the libSQL native protocol). The connection URL scheme is `libsql://...`. TLS is mandatory; `libsql` 0.6's `remote` feature uses `rustls` under the hood with the system trust store.
-- **Authentication:** a long-lived bearer `TURSO_TOKEN` baked into the desktop binary's environment (`src-tauri/src/config.rs::Config::load`). Per-user authentication is **not** layered on top of this — every Pollis client signs into the same Turso database with the same token. Row-level security is enforced at the *application* layer, in Rust commands, not by Turso.
+- **Authentication:** a long-lived bearer `TURSO_TOKEN` baked into the desktop binary's environment (`pollis-core/src/config.rs::Config::load`). Per-user authentication is **not** layered on top of this — every Pollis client signs into the same Turso database with the same token. Row-level security is enforced at the *application* layer, in Rust commands, not by Turso.
 - **Resilience:** `RemoteDb::with_retry` handles transient Hrana stream eviction (libsql idle-stream GC) by reconnecting and retrying once. Non-transient errors surface.
 
 ### 8.1 Threat consequence of a single shared token
@@ -293,7 +293,7 @@ A reverse-engineer who extracts `TURSO_TOKEN` from a built binary can open a lib
 
 - Read every public-metadata table (which is the same threat surface as a server-side database compromise).
 - Insert rows into tables not protected by application-level checks. The application enforces:
-  - Per-actor permission on group/channel CRUD inside Tauri commands (the actor's `user_id` is supplied by the frontend and trusted because the frontend got it from the unlocked `account_id_key`).
+  - Per-actor permission on group/channel CRUD inside the backend commands (the actor's `user_id` is supplied by the frontend and trusted because the frontend got it from the unlocked `account_id_key`).
   - Atomic claim semantics on `mls_key_package`.
   - `device_cert` cryptographic verification *on the read path*.
 - They cannot decrypt any message — those are MLS-encrypted.
@@ -305,7 +305,7 @@ The general shape — a desktop client carrying a credential to talk to backing 
 
 ## 9. Object Storage (Cloudflare R2)
 
-Source: `src-tauri/src/commands/r2.rs`.
+Source: `pollis-core/src/commands/r2.rs`.
 
 ### 9.1 Convergent encryption (attachments)
 
@@ -324,7 +324,7 @@ This is the same shape as MEGA's "Convergent Encrypted" layer (without its block
 
 R2 is reached over HTTPS with **AWS SigV4** (`sigv4_headers`): canonical request → string-to-sign → date-region-service-derived signing key (HMAC-SHA256) → signature in the `Authorization` header. The `R2_ACCESS_KEY_ID` and `R2_SECRET_KEY` are baked into the binary, like `TURSO_TOKEN`. Same shared-credential trust model (§8.1).
 
-The upload Tauri command (`upload_media`) reads files from disk by path, not over IPC, so arbitrary-size attachments do not hit IPC framing limits.
+The `upload_media` command reads files from disk by path inside the Rust sidecar, not over Electron IPC, so arbitrary-size attachments do not hit IPC framing limits.
 
 ### 9.4 Avatars and group icons
 
@@ -334,7 +334,7 @@ These go through `upload_file` / `download_file` (the non-`upload_media` path) a
 
 ## 10. Real-Time Media (LiveKit)
 
-Source: `src-tauri/src/commands/livekit.rs`, `voice.rs`, `realtime.rs`.
+Source: `pollis-core/src/commands/livekit.rs`, `voice.rs`, `realtime.rs`.
 
 ### 10.1 Authentication
 
@@ -369,7 +369,7 @@ The MLS group used is the same group that protects the channel's text messages (
 
 ### 10.3 Audio pipeline (defensive context)
 
-Mic capture: `cpal` in 10 ms i16 mono frames → optional RNNoise (`nnnoiseless`) → WebRTC AudioProcessing module (AGC2 + NS + HPF + AEC, via `webrtc-audio-processing`) → LiveKit `NativeAudioSource.capture_frame` → SRTP. There is no JS-layer media path because Tauri's WebKitGTK webview on Linux does not expose WebRTC; this is enforced by the architecture and is described in `CLAUDE.md`. Audio never enters the webview.
+Mic capture: `cpal` in 10 ms i16 mono frames → optional RNNoise (`nnnoiseless`) → WebRTC AudioProcessing module (AGC2 + NS + HPF + AEC, via `webrtc-audio-processing`) → LiveKit `NativeAudioSource.capture_frame` → SRTP. The entire pipeline runs in the Rust sidecar; audio never enters the renderer. This is a deliberate architecture choice (cross-platform parity with mobile, and predictable allocation that avoids V8 GC pressure on multi-MB media buffers), enforced by the surrounding code and described in `CLAUDE.md`.
 
 ### 10.4 Signalling channel
 

--- a/website/faq.html
+++ b/website/faq.html
@@ -177,7 +177,7 @@
             <p>A desktop messaging app with group channels and direct messages, like Slack, but your messages are encrypted on your device before they leave it. The people running Pollis can't read them.</p>
           </div>
           <div class="dev">
-            <p>Tauri 2 desktop client (Rust + React) that connects directly to a Turso/libSQL backend. Messages are end-to-end encrypted with MLS (RFC 9420) via <code>openmls</code>; the server only stores ciphertext envelopes plus routing metadata. No intermediate app server.</p>
+            <p>Electron desktop client with a React UI and a Rust core for cryptography, MLS group state, and real-time media. The Rust core connects directly to a Turso/libSQL backend. Messages are end-to-end encrypted with MLS (RFC 9420) via <code>openmls</code>; the server only stores ciphertext envelopes plus routing metadata. No intermediate app server.</p>
           </div>
         </div>
       </div>
@@ -230,7 +230,7 @@
             <p>macOS, Windows, and Linux.</p>
           </div>
           <div class="dev">
-            <p>macOS (universal binary — Apple Silicon + Intel), Windows x64, Linux (<code>.deb</code>, <code>.rpm</code>, <code>.AppImage</code>, AUR). Built with Tauri 2.</p>
+            <p>macOS (universal binary — Apple Silicon + Intel), Windows x64, Linux (<code>.deb</code>, <code>.rpm</code>, <code>.AppImage</code>, AUR). Binaries are code-signed: Apple Developer ID on macOS, Azure Trusted Signing on Windows.</p>
           </div>
         </div>
       </div>
@@ -302,7 +302,7 @@
             <p>Anyone can create a group inside the app. To add someone, invite them by their Pollis username — they need an account already.</p>
           </div>
           <div class="dev">
-            <p>Groups are created via the <code>create_group</code> Tauri command; members are added by username via <code>invite_to_group</code>. Adding someone generates an MLS Welcome that seeds their device into the group ratchet at the current epoch. DMs are implemented as 2-person MLS groups.</p>
+            <p>Groups are created via the <code>create_group</code> backend command; members are added by username via <code>invite_to_group</code>. Adding someone generates an MLS Welcome that seeds their device into the group ratchet at the current epoch. DMs are implemented as 2-person MLS groups.</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Documentation accuracy pass across CLAUDE.md, ARCHITECTURE.md, README.md, docs/security-whitepaper.md, website/faq.html, and .codesight/ (12 files). No source code, build configs, scripts, or CI workflows touched — pure prose.

- Stack and IPC descriptions reflect Electron 33 + Rust sidecar (`pollis-node` via napi-rs over `pollis-core`), with `window.electronAPI.invoke` as the renderer entry and `pollis-node/src/dispatch/` as the active dispatch arm.
- Auto-update story rewritten around electron-updater + GitHub Releases, with OS code signature as the trust root.
- Media-in-Rust rationale updated: cross-platform parity (uniffi mobile) + predictable allocation, dropping the now-stale WebKitGTK-no-WebRTC framing.
- `src-tauri/` deliberately preserved in docs as the legacy/rollback path — not removed.
- The three `docs/electron-migration*.md` files were not touched (they're the deliberate migration record).

## Test plan
- [ ] Skim CLAUDE.md and ARCHITECTURE.md headers — confirm the rewrite reads like Electron is the home shell, with src-tauri/ labelled as legacy.
- [ ] Spot-check .codesight/wiki/overview.md, commands.md, testing.md for accuracy of IPC + dispatch claims.
- [ ] Confirm the three electron-migration*.md files in docs/ are unchanged.