### PR TITLE
fix(screenshare): in-app picker on every Electron platform

### DIFF
--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -237,32 +237,47 @@ void app.whenReady().then(async () => {
     ({ channelId, payload }) => broadcastChannel(channelId, payload),
   );
 
-  // navigator.mediaDevices.getDisplayMedia in the renderer doesn't work
-  // unless the main process registers a handler that picks a source. The
-  // v1 implementation hands back the first screen — Chromium then shows
-  // its own permission UI to the user, so the result is the standard
-  // browser flow (no custom picker required). TODO(phase-6-followup):
-  // build a custom in-app picker that lists all screens + windows so the
-  // user can pick a specific window or non-primary monitor.
-  session.defaultSession.setDisplayMediaRequestHandler(
-    async (_request, callback) => {
-      try {
-        const sources = await desktopCapturer.getSources({
-          types: ["screen", "window"],
-        });
-        const first = sources[0];
-        if (!first) {
-          callback({});
-          return;
-        }
-        callback({ video: first });
-      } catch (e) {
-        console.error("[displayMedia] getSources failed:", e);
-        callback({});
-      }
-    },
-    { useSystemPicker: true },
-  );
+  // Screenshare uses the in-app picker (frontend/src/components/Voice/
+  // ScreenSharePicker.tsx) on every platform. Sources come from the
+  // `desktopMedia:enumerate` IPC below; capture is initiated via
+  // `getUserMedia({ video: { mandatory: { chromeMediaSourceId } } })` in
+  // the renderer, which targets a specific source directly and never
+  // routes through `setDisplayMediaRequestHandler`.
+  //
+  // The handler still has to exist — if it's absent, the renderer can't
+  // even call `getDisplayMedia` (Electron returns NotSupportedError).
+  // Deny every request to make sure no code path silently auto-picks the
+  // primary display (the previous "callback({ video: first })" was the
+  // bug behind grabbing the wrong monitor on macOS <15, where
+  // useSystemPicker is a no-op).
+  session.defaultSession.setDisplayMediaRequestHandler((_request, callback) => {
+    callback({});
+  });
+
+  ipcMain.handle("desktopMedia:enumerate", async () => {
+    // 320x200 thumbnails — large enough for the picker tiles, small
+    // enough to keep enumeration snappy even with many windows. Without
+    // a thumbnailSize argument desktopCapturer returns full-screen
+    // captures, which on a 5K display can stall the picker for seconds.
+    const sources = await desktopCapturer.getSources({
+      types: ["screen", "window"],
+      thumbnailSize: { width: 320, height: 200 },
+    });
+    return sources.map((s) => ({
+      id: s.id,
+      name: s.name,
+      // Electron tags screen sources with ids like "screen:0:0" and
+      // window sources with "window:<hwnd>:<n>". The prefix is the
+      // authoritative kind.
+      kind: s.id.startsWith("screen:") ? "display" : "window",
+      // `display_id` is populated for screen sources on macOS/Windows;
+      // pass through for callers that want to match against
+      // `screen.getAllDisplays()`.
+      displayId: s.display_id || null,
+      // PNG data URL of the thumbnail at the size requested above.
+      thumbnailDataUrl: s.thumbnail.toDataURL(),
+    }));
+  });
 
   ipcMain.handle(
     "invoke",

--- a/electron/src/preload.ts
+++ b/electron/src/preload.ts
@@ -132,6 +132,25 @@ contextBridge.exposeInMainWorld("electronAPI", {
   clipboardReadImageToTemp: () =>
     ipcRenderer.invoke("clipboard:readImageToTemp") as Promise<string | null>,
 
+  // ── Desktop media (screenshare source enumeration) ────────────────────────
+  // Returns the raw Electron source list for screen+window capture. The
+  // renderer pairs each `id` with the value of `chromeMediaSourceId` in a
+  // `getUserMedia({ video: { mandatory: {...} } })` call to capture that
+  // specific source. The handler in main never resolves
+  // `setDisplayMediaRequestHandler` for these — the renderer goes through
+  // the legacy mediaSource API instead, which is the same path
+  // Slack/Discord/VSCode use for custom pickers.
+  desktopMediaEnumerate: () =>
+    ipcRenderer.invoke("desktopMedia:enumerate") as Promise<
+      Array<{
+        id: string;
+        name: string;
+        kind: "display" | "window";
+        displayId: string | null;
+        thumbnailDataUrl: string;
+      }>
+    >,
+
   // ── Auto-updater ───────────────────────────────────────────────────────────
   updaterCheck: () =>
     ipcRenderer.invoke("updater:check") as Promise<{ version: string } | null>,

--- a/frontend/src/bridge/runtime.ts
+++ b/frontend/src/bridge/runtime.ts
@@ -88,6 +88,17 @@ export interface ElectronAPI {
   // ── Clipboard ──────────────────────────────────────────────────────────
   clipboardReadFiles: () => Promise<string[]>;
   clipboardReadImageToTemp: () => Promise<string | null>;
+
+  // ── Desktop media (screenshare source enumeration) ────────────────────
+  desktopMediaEnumerate: () => Promise<
+    Array<{
+      id: string;
+      name: string;
+      kind: "display" | "window";
+      displayId: string | null;
+      thumbnailDataUrl: string;
+    }>
+  >;
 }
 
 declare global {

--- a/frontend/src/screenshare/screenShareSession.ts
+++ b/frontend/src/screenshare/screenShareSession.ts
@@ -167,6 +167,12 @@ class ScreenShareSession {
   private lastDims = new Map<string, { width: number; height: number }>();
   private lastBytes = new Map<string, number>();
   private statsListeners = new Map<string, Set<StatsListener>>();
+  // Under Electron, our picker hands back numeric ids from the
+  // DisplaySource/WindowSource shape, but the underlying capture API needs
+  // Electron's opaque source.id string (`"screen:0:0"` / `"window:<n>"`).
+  // Cache the mapping each time enumerate() runs so start(selection) can
+  // recover the right Electron id.
+  private electronSourceIds = new Map<string, string>();
 
   /** Idempotent. Call once after auth so the backend Channels are wired.
    *  Under Electron this is a no-op — the Rust event/frame channels are
@@ -257,14 +263,48 @@ class ScreenShareSession {
   /** Enumerate capturable displays + windows. On macOS (under Tauri) this
    *  spawns the helper, parks it waiting for our selection, and returns
    *  the list to render in our in-app picker. On Linux/Windows the system
-   *  portal / WGC picker handles selection — the backend returns an empty
-   *  list as a signal to skip the in-app picker and go straight to
-   *  `start()`. Under Electron we always return an empty list: Chromium's
-   *  `getDisplayMedia` (driven by `setDisplayMediaRequestHandler` in
-   *  electron/src/main.ts) handles selection itself. */
+   *  portal / WGC picker handles selection — the Tauri backend returns an
+   *  empty list as a signal to skip the in-app picker and go straight to
+   *  `start()`. Under Electron, we enumerate sources through
+   *  `desktopCapturer.getSources()` over IPC and route them to the same
+   *  in-app picker so the UX is identical on every platform. */
   async enumerate(): Promise<SourceList> {
     if (hasMediaDevices()) {
-      return { displays: [], windows: [] };
+      const api = (window as Window & { electronAPI?: { desktopMediaEnumerate?: () => Promise<Array<{ id: string; name: string; kind: "display" | "window" }>> } }).electronAPI;
+      if (!api?.desktopMediaEnumerate) {
+        return { displays: [], windows: [] };
+      }
+      const raw = await api.desktopMediaEnumerate();
+      this.electronSourceIds.clear();
+      const displays: DisplaySource[] = [];
+      const windows: WindowSource[] = [];
+      for (const s of raw) {
+        if (s.kind === "display") {
+          const id = displays.length;
+          // Thumbnails are PNG data URLs at the size requested in
+          // electron/src/main.ts. ScreenSharePicker currently shows
+          // name-only tiles — wiring the thumbnail through to the
+          // component is a follow-up (#TODO).
+          this.electronSourceIds.set(`display:${id}`, s.id);
+          // Electron's desktopCapturer doesn't surface per-source
+          // dimensions; pass 0 and let downstream code treat it as
+          // "unknown". Live dimensions come from the MediaStreamTrack's
+          // getSettings() after capture starts.
+          displays.push({ id, width: 0, height: 0, name: s.name });
+        } else {
+          const id = windows.length;
+          this.electronSourceIds.set(`window:${id}`, s.id);
+          windows.push({
+            id,
+            width: 0,
+            height: 0,
+            title: s.name,
+            app_name: "",
+            bundle_id: "",
+          });
+        }
+      }
+      return { displays, windows };
     }
     return await invoke<SourceList>("enumerate_screen_sources");
   }
@@ -279,26 +319,49 @@ class ScreenShareSession {
     await invoke("cancel_screen_share_picker");
   }
 
-  /** Start the share. Under Electron this opens Chromium's
-   *  `getDisplayMedia`, then publishes the resulting track via
-   *  livekit-client on the view connection. Under Tauri the call is
-   *  delegated to the Rust capture helper: on macOS the `selection`
-   *  carries the user's pick from our in-app picker; on Linux/Windows
-   *  it must be undefined so the system portal / WGC picker can show. */
+  /** Start the share. Under Electron the `selection` carries the user's
+   *  pick from the in-app picker (required — without it, capture cannot
+   *  target a specific source). Under Tauri the call is delegated to the
+   *  Rust capture helper: on macOS the `selection` is the picker result;
+   *  on Linux/Windows it must be undefined so the system portal / WGC
+   *  picker can show. */
   async start(selection?: Selection): Promise<void> {
     if (hasMediaDevices()) {
-      await this.startElectron();
+      await this.startElectron(selection);
       return;
     }
     await invoke("start_screen_share", { selection: selection ?? null });
   }
 
-  /** Renderer-side publish path. Captures via `getDisplayMedia`, hands
-   *  the track to the livekit-client view connection, and mirrors the
-   *  lifecycle into the Zustand store (so VoiceBar / VoiceMemberTile
-   *  switch to the streaming state) without going through the Rust
-   *  event channel. */
-  private async startElectron(): Promise<void> {
+  /** Renderer-side publish path. Captures the picked source via
+   *  `getUserMedia` with `chromeMediaSourceId`, hands the track to the
+   *  livekit-client view connection, and mirrors the lifecycle into the
+   *  Zustand store (so VoiceBar / VoiceMemberTile switch to the
+   *  streaming state) without going through the Rust event channel. */
+  private async startElectron(selection?: Selection): Promise<void> {
+    // The in-app picker (ScreenSharePicker.tsx) always supplies a
+    // selection on the Electron path; this is the safety net for any
+    // future code path that forgets to enumerate first. We deliberately
+    // do NOT fall back to `getDisplayMedia` here — without a selection,
+    // Chromium's default behavior is "auto-pick the first source",
+    // which silently captures the primary display and was the symptom
+    // we just fixed. Fail loudly instead.
+    if (!selection) {
+      const store = useAppStore.getState();
+      const msg = "Screen share requires a picked source.";
+      store.shareFailed(msg);
+      throw new Error(msg);
+    }
+    const electronSourceId = this.electronSourceIds.get(
+      `${selection.kind}:${selection.id}`,
+    );
+    if (!electronSourceId) {
+      const store = useAppStore.getState();
+      const msg = "Screen share selection no longer available — re-open the picker.";
+      store.shareFailed(msg);
+      throw new Error(msg);
+    }
+
     // Imported lazily so the Tauri build doesn't pull in the
     // livekit-client SDK when it'd never use it. (Tree-shaking would
     // ordinarily do this for us, but the dynamic import makes it
@@ -309,18 +372,35 @@ class ScreenShareSession {
     let stream: MediaStream;
     try {
       // Audio is intentionally off — voice goes through the Rust voice
-      // client, and getDisplayMedia audio is unreliable cross-platform.
+      // client, and screenshare audio is unreliable cross-platform.
       //
-      // frameRate ceiling: 60 fps. xdg-desktop-portal (Linux), ScreenCaptureKit
-      // (macOS), and WGC (Windows) all cap source capture at ~60 fps on the
-      // typical compositor, so asking for higher gets silently clamped to 60.
-      // The source track feeds both the local preview <video> and the LiveKit
-      // publish path — bumping it here gets us up to display-rate previews
-      // (subject to compositor) and gives the encoder headroom to push 60 fps
-      // out to receivers when bandwidth allows.
-      stream = await navigator.mediaDevices.getDisplayMedia({
-        video: { frameRate: { ideal: 60, max: 60 } },
+      // Why getUserMedia + chromeMediaSourceId instead of getDisplayMedia:
+      // getDisplayMedia routes through setDisplayMediaRequestHandler in
+      // the main process, which would either show the system picker
+      // (macOS 15+ only) or — on every other platform/version — need a
+      // deferred-callback dance to surface our in-app picker. The
+      // legacy mediaSource API skips that entirely and lets us target a
+      // specific source directly. This is the same pattern Slack,
+      // Discord, and VSCode use for their custom screenshare pickers.
+      //
+      // frameRate ceiling: 60 fps. xdg-desktop-portal (Linux),
+      // ScreenCaptureKit (macOS), and WGC (Windows) all cap source
+      // capture at ~60 fps on the typical compositor, so asking for
+      // higher gets silently clamped to 60.
+      //
+      // TS lib.dom.d.ts dropped the typing for the legacy `mandatory`
+      // constraints bag; cast through `unknown` to a partial
+      // MediaTrackConstraints to satisfy strict TS without lying to
+      // callers about the runtime shape.
+      stream = await navigator.mediaDevices.getUserMedia({
         audio: false,
+        video: {
+          mandatory: {
+            chromeMediaSource: "desktop",
+            chromeMediaSourceId: electronSourceId,
+            maxFrameRate: 60,
+          },
+        } as unknown as MediaTrackConstraints,
       });
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);


### PR DESCRIPTION
## Summary

Replaces the v1 \"auto-pick first source\" `setDisplayMediaRequestHandler` with the same in-app `ScreenSharePicker` already used by the macOS/Tauri path.

**The bug:** On macOS 14 (Sonoma), clicking screenshare auto-shares the primary display with no picker. `useSystemPicker: true` only works on macOS 15+ — on <15 it's silently a no-op, and the handler's callback was unconditionally returning `sources[0]`.

**The fix:** Drop `setDisplayMediaRequestHandler` selection entirely. The renderer enumerates via new `desktopMedia:enumerate` IPC, shows `ScreenSharePicker`, and captures the picked source via `getUserMedia({ video: { mandatory: { chromeMediaSource: \"desktop\", chromeMediaSourceId } } })` — the standard Electron pattern (Slack/Discord/VSCode). One UX, every platform, every macOS version.

The handler is now a deny-all so a stray `getDisplayMedia` call can never silently auto-pick again.

## Test plan
- [ ] macOS 14.7.4 Sonoma: click screenshare → picker appears with displays + windows → pick non-primary monitor → that monitor is shared
- [ ] macOS 15.x Sequoia: same flow (no longer the native picker, but the in-app one matches the rest of the app)
- [ ] Cancel from the picker returns to the participant grid
- [ ] No regression on Linux (system portal flow lives under `!hasMediaDevices()`, unchanged)

## Follow-ups (not blocking)
- Picker tile thumbnails are plumbed through (`thumbnailDataUrl`) but not yet rendered — `ScreenSharePicker.tsx` still shows name-only tiles
- `width`/`height` come from `track.getSettings()` post-capture; picker shows `0×0` per-source until then