### PR TITLE
fix(electron): arch-suffix mac artifacts + drop renderer relaunch race

### DIFF
--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -443,7 +443,10 @@ jobs:
         run: |
           VERSION="${POLLIS_TAG}"
           ENDPOINT="https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com"
-          MAC_DMG=$(find artifacts/pollis-electron-macos -name "*.dmg" | head -1)
+          # install.sh hosts a single Apple-Silicon dmg — pick the arm64 one
+          # explicitly now that artifactName carries ${arch}. Intel-Mac
+          # support is gated in install.sh itself.
+          MAC_DMG=$(find artifacts/pollis-electron-macos -name "*-arm64.dmg" | head -1)
           WIN_EXE=$(find artifacts/pollis-electron-windows -name "*.exe" ! -name "*portable*" | head -1)
           LINUX_APPIMAGE=$(find artifacts/pollis-electron-linux -name "*.AppImage" | head -1)
           LINUX_DEB=$(find artifacts/pollis-electron-linux -name "*.deb" | head -1)

--- a/electron/build/electron-builder.yml
+++ b/electron/build/electron-builder.yml
@@ -14,7 +14,15 @@ copyright: "Copyright (c) 2026 Daniel Kral"
 # Without this, the scoped package name (@pollis/electron) ends up in the
 # filename → "@pollis/electron_1.1.0_amd64.deb". Pin to "Pollis-<version>-…"
 # parity with the Tauri pipeline artifacts.
-artifactName: "Pollis-${version}.${ext}"
+#
+# ${arch} is REQUIRED on macOS: --mac --arm64 --x64 builds two architectures
+# in one electron-builder run. Without ${arch} the two arm64/x64 dmg + zip
+# pairs share filenames, the second build overwrites the first on disk, and
+# the resulting latest-mac.yml lists duplicate entries with conflicting
+# hashes. Auto-update then downloads a cross-arch payload, ShipIt fails to
+# relaunch, and the user sees "Could not connect to the server". Linux and
+# Windows are single-arch today, so ${arch} just appends "x64" — harmless.
+artifactName: "Pollis-${version}-${arch}.${ext}"
 # electron-builder defaults the binary name to the package `name` field
 # ("@pollis/electron"), which it sanitises to "@polliselectron". That's
 # what you see in the .deb's /usr/bin entry — and why `pollis` isn't on

--- a/frontend/src/components/UpdateScreen.tsx
+++ b/frontend/src/components/UpdateScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { check, relaunch, invoke } from "../bridge";
+import { hasElectron } from "../bridge/runtime";
 import { LoadingSpinner } from "./ui/LoaderSpinner";
 
 type UpdatePhase = "preparing" | "checking" | "downloading" | "installing" | "relaunching" | "error";
@@ -70,7 +71,16 @@ export const UpdateScreen: React.FC = () => {
         }
 
         setPhase("relaunching");
-        await relaunch();
+        // Electron: main process already called autoUpdater.quitAndInstall()
+        // when the download finished — it will quit + relaunch the app
+        // itself. Calling relaunch() here (app.relaunch + app.exit(0))
+        // races with Squirrel.Mac's ShipIt handoff and can leave the
+        // install half-applied. Tauri's plugin has the opposite shape:
+        // downloadAndInstall completes the install but does NOT relaunch,
+        // so the renderer must.
+        if (!hasElectron()) {
+          await relaunch();
+        }
       } catch (err) {
         if (!cancelled) {
           console.error("[update] Auto-update failed:", err);


### PR DESCRIPTION
## Summary
- Add `${arch}` to electron-builder `artifactName` so `--mac --arm64 --x64` stops producing two `Pollis-<v>.dmg`/`zip` files that overwrite each other and break `latest-mac.yml`.
- Pin R2 cdn mac dmg to `*-arm64.dmg` (install.sh only supports Apple Silicon today).
- Drop renderer-side `relaunch()` on the Electron path — main process's `autoUpdater.quitAndInstall()` already owns the quit+relaunch handoff; calling `app.relaunch()+exit(0)` from the renderer races with Squirrel.Mac's ShipIt and surfaces as `Error: Could not connect to the server`.

## Test plan
- [ ] CI build succeeds on tag push
- [ ] Inspect resulting `latest-mac.yml` — should have 4 distinct filenames (arm64 + x64 × dmg + zip), distinct hashes
- [ ] Install prior release, trigger update from Settings, confirm app swaps + relaunches without "Could not connect to the server"