### PR TITLE
fix(update): missing % indicator + 'Relaunching' hang

### DIFF
--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -416,6 +416,23 @@ void app.whenReady().then(async () => {
     // after the UI transitions through the "installing" / "relaunching"
     // states — keep that flow intact.
     autoUpdater.quitAndInstall(false, true);
+    // Force-exit fallback. quitAndInstall on macOS fires before-quit +
+    // closes windows + hands off to Squirrel.Mac's ShipIt helper, which
+    // waits for the parent PID to die before swapping the bundle. If
+    // pollis-node has background Tokio tasks alive (media server, event
+    // emitters, livekit connections), the Node process won't exit even
+    // after windows close, ShipIt times out, and the UI sits on
+    // "Relaunching…" forever. A 10-second wall-clock cap is well past
+    // any legitimate graceful-quit window — past that point the only
+    // working path is to nuke the process so ShipIt can take over.
+    // Mirrors the same pattern as `Tray.markQuittingFromTray` does for
+    // the close-to-tray escape hatch.
+    setTimeout(() => {
+      console.warn(
+        "[updater] graceful quit did not exit within 10s — forcing app.exit so ShipIt can swap binaries",
+      );
+      app.exit(0);
+    }, 10_000);
   });
   autoUpdater.on("error", (e) => {
     console.error("[updater] error:", e);

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -387,9 +387,21 @@ void app.whenReady().then(async () => {
   });
 
   autoUpdater.on("download-progress", (p) => {
+    // electron-updater hands us `percent` (0–100, float) precomputed
+    // against the true CDN-reported content length. Forward it directly
+    // — the previous code only shipped `delta` (per-tick byte count)
+    // and the renderer had to sum + divide by an unknown total, which
+    // it couldn't because `update-available` doesn't carry the file
+    // size (the file hasn't downloaded yet at that point). Net result
+    // since the Electron migration: no percentage rendered, ever.
     sendToAllRenderers("updater:event", {
       event: "Progress",
-      data: { chunkLength: Math.round(p.delta ?? 0) },
+      data: {
+        chunkLength: Math.round(p.delta ?? 0),
+        percent: typeof p.percent === "number" ? p.percent : undefined,
+        transferred: typeof p.transferred === "number" ? p.transferred : undefined,
+        total: typeof p.total === "number" ? p.total : undefined,
+      },
     });
   });
   autoUpdater.on("update-available", (info) => {

--- a/electron/src/preload.ts
+++ b/electron/src/preload.ts
@@ -177,14 +177,29 @@ contextBridge.exposeInMainWorld("electronAPI", {
   updaterOnEvent: (
     cb: (envelope: {
       event: "Started" | "Progress" | "Finished";
-      data: { contentLength?: number; chunkLength?: number };
+      data: {
+        contentLength?: number;
+        chunkLength?: number;
+        // `percent` (0–100) is forwarded by main on every download-progress
+        // event when available. Renderers should prefer it over computing
+        // a percentage from chunkLength sums.
+        percent?: number;
+        transferred?: number;
+        total?: number;
+      };
     }) => void,
   ) =>
     subscribe("updater:event", (payload) =>
       cb(
         payload as {
           event: "Started" | "Progress" | "Finished";
-          data: { contentLength?: number; chunkLength?: number };
+          data: {
+            contentLength?: number;
+            chunkLength?: number;
+            percent?: number;
+            transferred?: number;
+            total?: number;
+          };
         },
       ),
     ),

--- a/frontend/src/bridge/updater.ts
+++ b/frontend/src/bridge/updater.ts
@@ -13,7 +13,23 @@ import { hasElectron } from "./runtime";
 
 export type DownloadEvent =
   | { event: "Started"; data: { contentLength?: number } }
-  | { event: "Progress"; data: { chunkLength: number } }
+  | {
+      event: "Progress";
+      data: {
+        chunkLength: number;
+        // Electron path forwards electron-updater's precomputed
+        // `percent` (0–100, float) directly when available. Renderers
+        // should prefer this over summing chunkLength because the
+        // `Started` event does NOT carry the file size on Electron
+        // (electron-updater learns it only when bytes start flowing),
+        // so the chunkLength-sum / contentLength compute can't run.
+        // Tauri's plugin still ships only chunkLength + an upfront
+        // contentLength — both code paths are handled below.
+        percent?: number;
+        transferred?: number;
+        total?: number;
+      };
+    }
   | { event: "Finished"; data: Record<string, never> };
 
 export interface PollisUpdate {

--- a/frontend/src/components/UpdateScreen.tsx
+++ b/frontend/src/components/UpdateScreen.tsx
@@ -56,7 +56,14 @@ export const UpdateScreen: React.FC = () => {
               break;
             case "Progress":
               downloadedBytes += event.data.chunkLength;
-              if (totalBytes > 0) {
+              // Prefer the precomputed `percent` Electron ships
+              // (electron-updater computes it against the true CDN
+              // content-length, which the `Started` event doesn't
+              // carry). Fall back to chunkLength-sum / totalBytes
+              // for the Tauri path where percent isn't included.
+              if (typeof event.data.percent === "number") {
+                setProgress(Math.round(event.data.percent));
+              } else if (totalBytes > 0) {
                 setProgress(Math.round((downloadedBytes / totalBytes) * 100));
               }
               break;


### PR DESCRIPTION
Two updater regressions surfaced shipping v1.1.12.

## Bug 1 — no percentage during download

`main.ts` shipped `contentLength: undefined` on `Started`, so the renderer's `totalBytes` stayed 0 and the `if (totalBytes > 0)` gate before `setProgress` never opened. Result: "Downloading update…" with no number, ever, since the Electron migration.

**Fix:** forward electron-updater's precomputed `p.percent` on every `download-progress`, prefer it in the renderer over the chunkLength-sum / total-divide path. Tauri's plugin still emits chunkLength-only — that path stays working as a fallback.

## Bug 2 — stuck on "Relaunching…"

`autoUpdater.quitAndInstall(false, true)` triggers Electron's graceful quit, which fires before-quit + closes windows. Squirrel.Mac's ShipIt then waits for the parent PID to die before swapping the bundle. But pollis-node owns several Tokio tasks (media server, event emitters, livekit) without a shutdown hook, so the Node process never exits — ShipIt times out, UI sits on "Relaunching…" forever.

**Fix in this PR:** 10s force-exit fallback after `quitAndInstall`. If graceful shutdown works, the timer never fires. If it hangs (today's case), `app.exit(0)` nukes the process and ShipIt picks up. Ugly but reliable.

**Proper fix (follow-up):** add a `shutdown()` export on `pollis-node` that cancels Tokio tasks and drains the runtime, call it from `before-quit`. Half-day's work, needs care to not deadlock on Tokio runtime drop, not safe to ship under release pressure. Will file a separate issue.

## Test plan
- [ ] Side-load this build manually, trigger an update from v1.1.12 → v1.1.13, observe the percentage tick from 0% → 100% during download
- [ ] Observe the app exits + relaunches into the new version within 10s of "Installing"
- [ ] If the graceful path works on your machine, the console will NOT print the "[updater] graceful quit did not exit within 10s" warning — verify both paths