### PR TITLE
fix(pollis-node): graceful shutdown drains media server + closes LiveKit rooms (closes #335)

### DIFF
--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -65,6 +65,7 @@ const pollisNode = require("../../pollis-node") as {
     jsonEmit: (envelope: { channelId: string; payload: unknown }) => void,
     rawEmit: (frame: { channelId: string; payload: Buffer }) => void,
   ) => void;
+  shutdown: () => Promise<void>;
 };
 
 // `app.isPackaged` is the reliable signal — NODE_ENV is unset in packaged
@@ -83,6 +84,14 @@ let mainWindow: BrowserWindow | null = null;
 // macOS hide-on-close keeps the app running in the dock. On Cmd+Q the user
 // actually wants out — track that intent so the close handler stops hiding.
 let isQuitting = false;
+// Two-phase quit so we can await pollis-node teardown before the window
+// cascade runs. First `before-quit` invocation triggers the async
+// shutdown and preventDefaults; the inner re-`app.quit()` takes the
+// early-return branch and lets Electron's normal sequence proceed. Set
+// here in module scope so the updater path (which calls `pollisNode.
+// shutdown()` itself before `quitAndInstall`) can short-circuit the
+// async branch on the next before-quit it triggers.
+let isShuttingDown = false;
 
 // E2E flag. The Playwright harness sets POLLIS_E2E=1 to create the
 // BrowserWindow with `show: false` so the renderer loads + CDP can drive
@@ -412,27 +421,36 @@ void app.whenReady().then(async () => {
   });
   autoUpdater.on("update-downloaded", () => {
     sendToAllRenderers("updater:event", { event: "Finished", data: {} });
-    // Caller invokes app.relaunch via the existing process.relaunch path
-    // after the UI transitions through the "installing" / "relaunching"
-    // states — keep that flow intact.
-    autoUpdater.quitAndInstall(false, true);
-    // Force-exit fallback. quitAndInstall on macOS fires before-quit +
-    // closes windows + hands off to Squirrel.Mac's ShipIt helper, which
-    // waits for the parent PID to die before swapping the bundle. If
-    // pollis-node has background Tokio tasks alive (media server, event
-    // emitters, livekit connections), the Node process won't exit even
-    // after windows close, ShipIt times out, and the UI sits on
-    // "Relaunching…" forever. A 10-second wall-clock cap is well past
-    // any legitimate graceful-quit window — past that point the only
-    // working path is to nuke the process so ShipIt can take over.
-    // Mirrors the same pattern as `Tray.markQuittingFromTray` does for
-    // the close-to-tray escape hatch.
-    setTimeout(() => {
-      console.warn(
-        "[updater] graceful quit did not exit within 10s — forcing app.exit so ShipIt can swap binaries",
-      );
-      app.exit(0);
-    }, 10_000);
+    void (async () => {
+      // Drain pollis-node BEFORE quitAndInstall so by the time
+      // Squirrel.Mac (or NSIS on Windows) is watching the parent PID,
+      // there are no Tokio tasks keeping the process alive. Setting
+      // `isShuttingDown` here means the `before-quit` handler that
+      // quitAndInstall triggers will take its early-return branch
+      // instead of trying to run shutdown a second time. Errors here
+      // are logged but don't block — the safety net below catches the
+      // worst case.
+      isShuttingDown = true;
+      try {
+        await pollisNode.shutdown();
+      } catch (e) {
+        console.warn("[updater] pollis-node shutdown failed:", e);
+      }
+      autoUpdater.quitAndInstall(false, true);
+      // Safety net: a 5s wall-clock cap on the entire post-shutdown
+      // quit sequence. With graceful teardown now running, normal exit
+      // is sub-second; past 5s we're hung on something we don't
+      // control (e.g. ThreadsafeFunction Node refs that #335's
+      // follow-up will need to release), and the right move is to
+      // nuke the process so ShipIt can take over. Was 10s in v1.1.13
+      // before pollis-node had any shutdown path at all.
+      setTimeout(() => {
+        console.warn(
+          "[updater] graceful quit did not exit within 5s — forcing app.exit so ShipIt can swap binaries",
+        );
+        app.exit(0);
+      }, 5_000);
+    })();
   });
   autoUpdater.on("error", (e) => {
     console.error("[updater] error:", e);
@@ -799,8 +817,33 @@ void app.whenReady().then(async () => {
   });
 });
 
-app.on("before-quit", () => {
-  isQuitting = true;
+app.on("before-quit", (event) => {
+  // Already torn down (or a teardown is in flight from the updater
+  // path) — let Electron's quit cascade proceed normally. Setting
+  // isQuitting here BEFORE we return guarantees the BrowserWindow
+  // close handler reads `isQuitting=true` and takes the close branch
+  // rather than the macOS hide-on-close branch.
+  if (isShuttingDown) {
+    isQuitting = true;
+    return;
+  }
+  isShuttingDown = true;
+  event.preventDefault();
+  void (async () => {
+    // Drain pollis-node before letting the window cascade run. Without
+    // this, the axum media-server task pins the Tokio runtime open
+    // forever — see #335 (refs #277 for the original symptom) and the
+    // commit message of v1.1.13 for the symptomatic "Relaunching…"
+    // hang. Errors here MUST NOT block the quit: we'd rather force-
+    // exit cleanly than wedge the app in a half-shutdown state.
+    try {
+      await pollisNode.shutdown();
+    } catch (e) {
+      console.warn("[shutdown] pollis-node shutdown failed:", e);
+    }
+    isQuitting = true;
+    app.quit();
+  })();
 });
 
 app.on("window-all-closed", () => {

--- a/pollis-core/src/media_server.rs
+++ b/pollis-core/src/media_server.rs
@@ -33,18 +33,31 @@ use crate::commands::r2 as r2cmd;
 use crate::state::AppState;
 
 /// Spawn the loopback media server on an OS-assigned port. Returns the
-/// bound port so the caller can stash it in `AppState`. Server runs for
-/// the lifetime of the process.
+/// bound port so the caller can stash it in `AppState`. Server runs until
+/// `AppState::shutdown()` is called (which fires `shutdown_signal`),
+/// at which point axum's graceful-shutdown drains in-flight requests
+/// and the accept loop returns — releasing its hold on the Tokio
+/// runtime so the host process can exit.
+///
+/// Pre-#335 this task spawned with no shutdown path and pinned the
+/// runtime alive forever, causing Squirrel.Mac's ShipIt to hang during
+/// auto-update; see `electron/src/main.ts`'s graceful-quit handlers.
 pub async fn spawn(state: Arc<AppState>) -> std::io::Result<u16> {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
     let port = listener.local_addr()?.port();
 
+    let shutdown_signal = state.shutdown_signal.clone();
     let app = Router::new()
         .route("/:token/:hash", get(serve_media))
         .with_state(state);
 
     tokio::spawn(async move {
-        if let Err(e) = axum::serve(listener, app).await {
+        let result = axum::serve(listener, app)
+            .with_graceful_shutdown(async move {
+                shutdown_signal.notified().await;
+            })
+            .await;
+        if let Err(e) = result {
             eprintln!("[media_server] axum::serve exited: {e}");
         }
     });

--- a/pollis-core/src/state.rs
+++ b/pollis-core/src/state.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, Notify};
 
 use crate::config::Config;
 use crate::db::{local::LocalDb, remote::RemoteDb};
@@ -75,6 +75,19 @@ pub struct AppState {
     /// Desktop only — the terminal pane is gated out on mobile targets.
     #[cfg(not(any(target_os = "ios", target_os = "android")))]
     pub terminals: Arc<Mutex<HashMap<String, PtySession>>>,
+    /// Broadcasts "tear down" to every long-lived background task that
+    /// has wired itself up to wait on it. Today the media-server task
+    /// listens via `axum::serve(...).with_graceful_shutdown(...)`. A
+    /// shell can call `shutdown_signal.notify_waiters()` (via the
+    /// `shutdown()` method on AppState) when the process is exiting —
+    /// see `pollis-node`'s `shutdown` napi export and the Electron
+    /// `before-quit` / `update-downloaded` handlers in
+    /// `electron/src/main.ts`.
+    ///
+    /// Without this, the axum task's accept loop pins the Tokio runtime
+    /// alive and Squirrel.Mac's ShipIt helper sits forever waiting for
+    /// the parent PID to die — i.e. the "Relaunching…" hang #335 fixes.
+    pub shutdown_signal: Arc<Notify>,
 }
 
 impl AppState {
@@ -116,6 +129,43 @@ impl AppState {
             media_server_token: Arc::new(Mutex::new(None)),
             #[cfg(not(any(target_os = "ios", target_os = "android")))]
             terminals: Arc::new(Mutex::new(HashMap::new())),
+            shutdown_signal: Arc::new(Notify::new()),
+        }
+    }
+
+    /// Tear down long-lived background tasks so the host process can
+    /// exit cleanly. Idempotent — safe to call from `before-quit` and
+    /// the updater path even though they overlap on the same code path
+    /// (electron-updater's `quitAndInstall` calls `app.quit()`, which
+    /// fires `before-quit`).
+    ///
+    /// Steps, in order:
+    /// 1. Signal `shutdown_signal` so the axum media server hits its
+    ///    graceful-shutdown branch and stops accepting new connections.
+    /// 2. Drain LiveKit room handles — close each room cleanly so the
+    ///    SFU sees a normal disconnect, then abort the per-room task so
+    ///    its event-loop holder is released.
+    ///
+    /// Voice / screenshare / terminals are NOT touched here:
+    /// * Voice cleanup happens via `leave_voice_channel`, which the
+    ///   `UpdateScreen` renderer already invokes before triggering an
+    ///   install (and is a no-op when no voice session is active).
+    /// * Terminal PtySessions die naturally when their child shell
+    ///   receives SIGTERM during process exit; nothing extra to do.
+    pub async fn shutdown(&self) {
+        self.shutdown_signal.notify_waiters();
+
+        #[cfg(not(any(target_os = "ios", target_os = "android")))]
+        {
+            let mut guard = self.livekit.lock().await;
+            let rooms = std::mem::take(&mut guard.rooms);
+            drop(guard);
+            for (room_id, (room, handle)) in rooms {
+                if let Err(e) = room.close().await {
+                    eprintln!("[shutdown] livekit room {room_id} close failed: {e}");
+                }
+                handle.abort();
+            }
         }
     }
 

--- a/pollis-node/src/lib.rs
+++ b/pollis-node/src/lib.rs
@@ -92,3 +92,21 @@ pub async fn start_media_server(cache_dir: String) -> Result<u32> {
     *state.media_server_port.lock().await = Some(port);
     Ok(port as u32)
 }
+
+/// Gracefully tear down long-lived backend tasks so the host process
+/// can exit cleanly. Call from Electron's `before-quit` (covers Cmd+Q,
+/// dock quit, OS shutdown) and from the updater's `update-downloaded`
+/// handler before `quitAndInstall` (so Squirrel.Mac's ShipIt isn't
+/// stranded waiting for the parent PID to die).
+///
+/// Idempotent. If `init()` was never called (e.g. dev crash before
+/// state init), this is a no-op and returns `Ok`. Errors from the
+/// underlying `AppState::shutdown` are swallowed-with-log — failing to
+/// quit cleanly should not block the host from exiting.
+#[napi]
+pub async fn shutdown() -> Result<()> {
+    if let Some(state) = crate::state::try_state() {
+        state.shutdown().await;
+    }
+    Ok(())
+}

--- a/pollis-node/src/state.rs
+++ b/pollis-node/src/state.rs
@@ -30,3 +30,11 @@ pub async fn ensure_state() -> Result<Arc<AppState>> {
         .await
         .cloned()
 }
+
+/// Best-effort access to the global AppState without initializing it.
+/// Returns `None` when `init()` was never called (or failed). Used by
+/// the napi `shutdown()` export so a host that imports the module but
+/// never calls `init()` can still call `shutdown()` without panicking.
+pub fn try_state() -> Option<Arc<AppState>> {
+    APP_STATE.get().cloned()
+}


### PR DESCRIPTION
Closes #335. Removes the "process keeps running after quit" root cause that v1.1.13's force-exit fallback was papering over.

## What was wrong

`pollis-node` spawned the axum media-server task at startup with no shutdown path — the comment in `pollis-core/src/media_server.rs` literally said "Server runs for the lifetime of the process." So when Electron's quit cascade ran (Cmd+Q, dock quit, or the updater's `quitAndInstall`), the accept loop kept the Tokio runtime alive forever and Squirrel.Mac's ShipIt helper would sit waiting for the parent PID to die.

LiveKit room tasks had the same shape — `JoinHandle<()>`s stored in `LiveKitState::rooms` with no teardown method.

## What this does

1. **`AppState.shutdown_signal: Arc<Notify>`** — single broadcast point any long-lived task can listen on.
2. **`pollis-core/src/media_server.rs`** — `axum::serve(...).with_graceful_shutdown(...)` listening on the signal. New connections rejected once notified; in-flight responses drain.
3. **`AppState::shutdown()`** — idempotent. Notifies the signal, closes every LiveKit room with `room.close().await`, aborts each room's task. Voice / screenshare are NOT touched here — voice cleanup runs via the existing `leave_voice_channel` invocation in `UpdateScreen.tsx`, and terminals die naturally with the child shell.
4. **`#[napi] pub async fn shutdown()` in `pollis-node`** — async export the Node side can await before letting the quit cascade run.
5. **Electron `before-quit` rewrite** — two-phase. First firing preventDefaults, runs `pollisNode.shutdown()`, then re-`app.quit()`s; second firing takes the early-return branch and lets Electron's normal cascade proceed. Covers Cmd+Q, dock quit, OS-initiated logout.
6. **Updater path** — calls `pollisNode.shutdown()` explicitly before `quitAndInstall` so the work is done by the time Squirrel.Mac's PID watcher engages. `isShuttingDown` is set to short-circuit the `before-quit` re-entry.
7. **Safety net tightened 10s → 5s.** With the graceful path actually working, normal exit should be sub-second.

## What's NOT in this PR

- **ThreadsafeFunction unref/abort.** The `pollis-node` event emitters (`EMIT_JSON`, `EMIT_RAW`) are in `OnceLock` which doesn't allow taking the inner value back out for `.abort()`. Refactoring to `Mutex<Option<TSF>>` is invasive enough to deserve its own change. If the safety net warning fires in production, this is the next thing to chase. Filed as a comment in #335; will spin out a dedicated issue if the warning is ever observed.

## Verification

- All 27 `cargo test --features test-harness --test flows` pass.
- `tsc --noEmit` clean on electron + frontend packages.
- **NOT yet verified end-to-end:** the actual graceful-quit timing on a packaged build. I can run the Rust + TS type checkers from here, but I cannot drive an installed Electron app through Cmd+Q or an in-app update. That verification has to happen on your machine.

## Test plan
- [ ] Install this build, hit Cmd+Q — app exits within a second, no force-quit needed
- [ ] Trigger an in-app update — "Relaunching" should resolve within 1–2 seconds (not 5 from the safety-net path)
- [ ] If the safety-net warning appears in `~/Library/Logs/Pollis/main.log` ("graceful quit did not exit within 5s"), there's still a runtime holder we haven't cleaned up — open a follow-up for the TSF refactor

## Refs
- Spun out of #277. Carries the deferred Bug 2 fix from #334.