### PR TITLE
fix(call): kill ring-cancel race + persistent audio stream

### DIFF
--- a/frontend/src/pages/Call.tsx
+++ b/frontend/src/pages/Call.tsx
@@ -21,6 +21,16 @@ import { voiceSession } from "../voice";
  */
 const RINGING_TIMEOUT_MS = 30_000;
 
+// React.StrictMode double-invokes mount/unmount in dev, and TanStack Router
+// can re-mount routes on state churn even in prod. Either way, an unmount
+// is NOT a reliable signal that the user actually left the call — the same
+// component may re-mount on the next tick. Buffer the backstop cancel: if
+// the same callId re-mounts within DEFER_CANCEL_MS, the unmount was
+// transient and we abort the cancel. Keyed by callId so two simultaneous
+// Call pages (which shouldn't happen, but) don't collide.
+const DEFER_CANCEL_MS = 200;
+const pendingCancels = new Map<string, ReturnType<typeof setTimeout>>();
+
 export const CallPage: React.FC = () => {
   const navigate = useNavigate();
   const { callId } = useParams({ from: "/call/$callId" });
@@ -32,25 +42,35 @@ export const CallPage: React.FC = () => {
   const outgoingCall = useAppStore((s) => s.outgoingCall);
   const setOutgoingCall = useAppStore((s) => s.setOutgoingCall);
 
-  // Direct navigation to /call/<id> with no active voice → bounce back. Joining
-  // is initiated by the caller's DM page or the callee's accept button; we
-  // don't auto-join here because we have no caller/callee context for the
-  // backend handshake.
+  // Bounce-back guard. Three cases:
+  //   1. Voice is our room → stay.
+  //   2. Voice is a different room → step out immediately (user joined a
+  //      different voice channel while this page was open, or hangup from
+  //      the other side cleared activeVoiceChannelId via `call_canceled`).
+  //   3. Voice is idle → give `voiceSession.setIntent()` → `reconcile()` a
+  //      moment to transition out of 'idle' before assuming we don't belong
+  //      here. Both call entry points (caller in DM.tsx, callee in
+  //      AppShell.tsx) call setIntent and `navigate()` synchronously, but
+  //      reconcile() runs on the next tick — without the grace, the Call
+  //      page mounts, sees `idle`, bounces back to /dms, and the cleanup
+  //      effect below fires `cancel_call`, killing the callee's ring within
+  //      ~100ms of the invite. 1500ms covers a typical 300–1000ms join.
   useEffect(() => {
-    if (!activeVoiceChannelId) {
-      navigate({ to: "/dms" });
+    if (activeVoiceChannelId === roomName) {
+      return;
     }
-  }, [activeVoiceChannelId, navigate]);
-
-  // Triggered by either the local hang-up button OR a `call_canceled` event
-  // arriving on the inbox (the realtime handler clears activeVoiceChannelId
-  // when it matches this call). Either way, leave the page.
-  useEffect(() => {
-    if (activeVoiceChannelId !== null && activeVoiceChannelId !== roomName) {
-      // User joined a different voice channel while this call page was open —
-      // step out so we don't sit on a stale call screen.
+    if (activeVoiceChannelId !== null) {
       navigate({ to: "/dms" });
+      return;
     }
+    const timer = setTimeout(() => {
+      const cur = useAppStore.getState().voiceState;
+      const curChannel = cur.kind === 'idle' ? null : cur.channelId;
+      if (curChannel !== roomName) {
+        navigate({ to: "/dms" });
+      }
+    }, 1500);
+    return () => clearTimeout(timer);
   }, [activeVoiceChannelId, roomName, navigate]);
 
   // Ringing timeout: if nobody else is in the room after 30s, auto-hang-up so
@@ -85,13 +105,24 @@ export const CallPage: React.FC = () => {
   // Reads through the store directly inside cleanup so we always see the
   // latest outgoingCall, not a stale closure capture.
   useEffect(() => {
+    // If a deferred cancel from a previous (transient) unmount is queued
+    // for this callId, abort it — we're back.
+    const queued = pendingCancels.get(callId);
+    if (queued) {
+      clearTimeout(queued);
+      pendingCancels.delete(callId);
+    }
     return () => {
-      const pending = useAppStore.getState().outgoingCall;
-      if (pending && pending.callId === callId) {
-        const calleeId = pending.calleeId;
-        useAppStore.getState().setOutgoingCall(null);
-        invoke("cancel_call", { otherUserId: calleeId, callId }).catch(() => {});
-      }
+      const timer = setTimeout(() => {
+        pendingCancels.delete(callId);
+        const pending = useAppStore.getState().outgoingCall;
+        if (pending && pending.callId === callId) {
+          const calleeId = pending.calleeId;
+          useAppStore.getState().setOutgoingCall(null);
+          invoke("cancel_call", { otherUserId: calleeId, callId }).catch(() => {});
+        }
+      }, DEFER_CANCEL_MS);
+      pendingCancels.set(callId, timer);
     };
   }, [callId]);
 

--- a/pollis-core/src/commands/sfx.rs
+++ b/pollis-core/src/commands/sfx.rs
@@ -1,17 +1,81 @@
 use std::io::Cursor;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::mpsc::sync_channel;
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
+
+use rodio::{OutputStream, OutputStreamHandle};
 
 static PING: &[u8] = include_bytes!("../../../assets/sfx/ping_fx.wav");
 static JOIN: &[u8] = include_bytes!("../../../assets/sfx/join_fx.wav");
 static LEAVE: &[u8] = include_bytes!("../../../assets/sfx/leave-fx.wav");
 static CALL: &[u8] = include_bytes!("../../../assets/sfx/call.wav");
 
+// Process-wide audio output. `OutputStream` is `!Send`, so it lives on a
+// dedicated parked thread that opens the host audio device once at first
+// access and stays alive for the whole process. Every play_sfx / start_ring
+// borrows the `Send + Sync` handle and creates a fresh `Sink` on it —
+// avoiding the per-call cost of opening the audio device.
+//
+// Why this matters: on Linux (PulseAudio / PipeWire) and Windows after the
+// audio stack idles, `OutputStream::try_default()` can take seconds to
+// return on the first call after a sleep. The previous implementation
+// opened a fresh stream on every play, which manifested as ~5–10s delay
+// before the incoming-call ringtone started — and a silent failure when
+// the cold-open hung past the window the user cared about. The handle is
+// initialised once, lazily, and reused forever after.
+//
+// `None` means the audio backend failed to open and every subsequent call
+// silently no-ops. A missing audio device must never crash the app.
+static AUDIO_HANDLE: OnceLock<Option<OutputStreamHandle>> = OnceLock::new();
+
+fn ensure_audio() -> Option<&'static OutputStreamHandle> {
+    AUDIO_HANDLE
+        .get_or_init(|| {
+            let (tx, rx) = sync_channel::<Option<OutputStreamHandle>>(1);
+            let spawn_result = std::thread::Builder::new()
+                .name("pollis-audio".into())
+                .spawn(move || match OutputStream::try_default() {
+                    Ok((stream, handle)) => {
+                        let _ = tx.send(Some(handle));
+                        // `stream` is !Send and must outlive every Sink
+                        // created from `handle`. Bind it to a stack local
+                        // and park forever — the variable is dropped only
+                        // if this thread exits, which it never does.
+                        let _keep_alive = stream;
+                        loop {
+                            std::thread::park();
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("[sfx] OutputStream::try_default failed: {e}");
+                        let _ = tx.send(None);
+                    }
+                });
+            if let Err(e) = spawn_result {
+                eprintln!("[sfx] failed to spawn audio thread: {e}");
+                return None;
+            }
+            rx.recv().ok().flatten()
+        })
+        .as_ref()
+}
+
+/// Prewarm the audio backend so the first user-facing playback (typically
+/// an incoming-call ringtone) doesn't pay the cold-open cost. Call once at
+/// app startup. Idempotent — the underlying `OnceLock` only initialises
+/// once regardless of how many callers fire this.
+pub fn prewarm_audio() {
+    std::thread::spawn(|| {
+        let _ = ensure_audio();
+    });
+}
+
 /// Play a named sound effect on the host audio device.
 ///
-/// Runs on a detached thread so it never blocks the Tauri command thread.
-/// All errors are silently ignored — a missing audio device should never
+/// `Sink::detach()` hands the sink off to rodio's internal mixer thread
+/// so playback continues without a wrapper thread blocking on it. All
+/// errors are silently ignored — a missing audio device should never
 /// crash the app.
 pub fn play_sfx(sound: &str) {
     let bytes: &'static [u8] = match sound {
@@ -21,43 +85,38 @@ pub fn play_sfx(sound: &str) {
         _ => return,
     };
 
-    let sound_name = sound.to_string();
-    std::thread::spawn(move || {
-        let (_stream, handle) = match rodio::OutputStream::try_default() {
-            Ok(s) => s,
-            Err(e) => {
-                eprintln!("[sfx] OutputStream::try_default failed for {sound_name}: {e}");
-                return;
-            }
-        };
-        let sink = match rodio::Sink::try_new(&handle) {
-            Ok(s) => s,
-            Err(e) => {
-                eprintln!("[sfx] Sink::try_new failed for {sound_name}: {e}");
-                return;
-            }
-        };
-        let source = match rodio::Decoder::new(Cursor::new(bytes)) {
-            Ok(s) => s,
-            Err(e) => {
-                eprintln!("[sfx] Decoder::new failed for {sound_name}: {e}");
-                return;
-            }
-        };
-        sink.append(source);
-        sink.sleep_until_end();
-    });
+    let Some(handle) = ensure_audio() else {
+        return;
+    };
+    let sink = match rodio::Sink::try_new(handle) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("[sfx] play_sfx Sink::try_new failed for {sound}: {e}");
+            return;
+        }
+    };
+    let source = match rodio::Decoder::new(Cursor::new(bytes)) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("[sfx] play_sfx Decoder failed for {sound}: {e}");
+            return;
+        }
+    };
+    sink.append(source);
+    sink.detach();
 }
 
 /// Looping ringtone playback. The wav file has built-in inter-ring silence so
 /// looping the whole clip produces a natural ring-pause-ring pattern.
-/// `OutputStream` is `!Send`, so the stream + sink live entirely inside the
-/// playback thread; the outside world only ever flips an atomic flag.
 static RING_STOP: Mutex<Option<Arc<AtomicBool>>> = Mutex::new(None);
 
 /// Start the incoming-call ringtone on a loop. Idempotent — calling twice
 /// while already ringing is a no-op.
 pub fn start_ring() {
+    let Some(handle) = ensure_audio() else {
+        return;
+    };
+
     let stop = Arc::new(AtomicBool::new(false));
     {
         let mut guard = match RING_STOP.lock() {
@@ -70,18 +129,12 @@ pub fn start_ring() {
         *guard = Some(Arc::clone(&stop));
     }
 
+    let handle = handle.clone();
     std::thread::spawn(move || {
-        let (_stream, handle) = match rodio::OutputStream::try_default() {
-            Ok(s) => s,
-            Err(e) => {
-                eprintln!("[sfx] start_ring OutputStream failed: {e}");
-                return;
-            }
-        };
         let sink = match rodio::Sink::try_new(&handle) {
             Ok(s) => s,
             Err(e) => {
-                eprintln!("[sfx] start_ring Sink failed: {e}");
+                eprintln!("[sfx] start_ring Sink::try_new failed: {e}");
                 return;
             }
         };
@@ -94,8 +147,9 @@ pub fn start_ring() {
                 }
             };
             sink.append(source);
-            // Poll the stop flag while this iteration plays so a stop request
-            // is honored within ~100ms instead of waiting out the whole clip.
+            // Poll the stop flag while this iteration plays so a stop
+            // request is honored within ~100ms instead of waiting out the
+            // whole clip.
             while !sink.empty() && !stop.load(Ordering::Acquire) {
                 std::thread::sleep(Duration::from_millis(100));
             }

--- a/pollis-node/src/lib.rs
+++ b/pollis-node/src/lib.rs
@@ -32,6 +32,12 @@ pub async fn init(env_file: Option<String>) -> Result<()> {
         let _ = dotenvy::from_filename(&path);
     }
     ensure_state().await?;
+    // Open the host audio device in a background thread now so the first
+    // user-facing sound (typically an incoming-call ringtone) doesn't pay
+    // the cold-open cost. Linux/PulseAudio/PipeWire and idle Windows audio
+    // can take seconds to wake on first `try_default()`; doing it eagerly
+    // means the IPC for `start_ring` returns near-instantly.
+    pollis_core::commands::sfx::prewarm_audio();
     Ok(())
 }
 


### PR DESCRIPTION
Closes #297.

## Problem
Receiver gets the desktop notification on a DM call but the ringtone plays for ~100ms (or never), then silence. Verified via timing traces:

```
call_invite arrived → 1779942439166ms
start_ring entered  → 1779942439223ms
stop_ring entered   → 1779942439301ms   ← only 135ms after invite
```

Two compounding bugs, each independently sufficient to break the ring.

## Bug 1 — React StrictMode unmount fires `cancel_call`
`Call.tsx`'s cleanup effect calls `invoke("cancel_call", ...)` as a backstop for "join_voice_channel failed and no `left` event fired". But React 18 StrictMode double-invokes mount → unmount → mount in dev, and TanStack Router can re-mount routes even in prod on state churn. The transient unmount fires the backstop, the cancel arrives at the receiver, the ring stops.

Fix: defer the backstop cancel by 200ms with a module-level Map<callId, Timeout>. If the same callId re-mounts within the window, abort the cancel.

## Bug 2 — Call page bounces to /dms before voice transitions
`Call.tsx` reads `voiceState.kind === 'idle' ? null : voiceState.channelId` and bounces back to /dms when null. But `voiceSession.setIntent()` reconciles asynchronously (~50–1000ms before `voiceStartJoining` flips state), so the page mounts, sees idle, bounces, and the bounced unmount triggers Bug 1.

Fix: give voice a 1500ms grace period before bouncing.

## Bug 3 — Cold audio device open
While instrumenting, found that `rodio::OutputStream::try_default()` was called fresh on every `start_ring`. On Linux/PulseAudio cold opens take 1–5s and occasionally fail silently. Independent of the cancel race, this would have made the ring slow even when it did play.

Fix: open one `OutputStream` on a parked thread at app init (`prewarm_audio()` in `init`) and reuse the `Send + Sync` `OutputStreamHandle` for every `play_sfx` / `start_ring`. Per-call audio init dropped from "1–5s, sometimes hangs" to ~85µs.

## Test plan
- [x] Two-client call on KDE/Arch: ring plays continuously until pickup, decline, or 30s timeout.
- [ ] Caller-side STUN/DNS errors (`-105` resolving `global.stun.twilio.com` + `downpage.xyz`) — separate follow-up; orthogonal to the ring bug, blocks the actual audio path.