### PR TITLE
fix(electron): restore chat file drag-and-drop after migration

### DIFF
--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -155,12 +155,13 @@ function createWindow(): BrowserWindow {
       preload: path.join(__dirname, "preload.js"),
       contextIsolation: true,
       nodeIntegration: false,
-      // sandbox:true restricts the preload to contextBridge + ipcRenderer
-      // (the only two things our preload uses), so we get the renderer
-      // sandbox for free. Bumping this back to false should never be
-      // necessary unless the preload adds direct Node API usage — which
-      // it shouldn't, since everything heavy lives in pollis-node behind
-      // ipcMain.handle handlers in the main process.
+      // sandbox:true restricts the preload to the sandboxed-preload module
+      // allowlist — contextBridge + ipcRenderer + webUtils (the only ones
+      // our preload uses), so we get the renderer sandbox for free. Bumping
+      // this back to false should never be necessary unless the preload adds
+      // direct Node API usage — which it shouldn't, since everything heavy
+      // lives in pollis-node behind ipcMain.handle handlers in the main
+      // process.
       sandbox: true,
     },
   });
@@ -182,6 +183,22 @@ function createWindow(): BrowserWindow {
       path.join(process.resourcesPath, "frontend", "index.html"),
     );
   }
+
+  // Safety net for stray file drops / accidental link navigations. The
+  // renderer's dropzone (bridge onDragDropEvent) preventDefaults OS file
+  // drops, so this normally never fires — but if a drop ever escapes that
+  // handler, Chromium's default action is to navigate the window to the
+  // dropped `file://…` path, blanking the app (the reported regression). In-
+  // app routing uses the history API, which does NOT trigger will-navigate,
+  // and the initial loadURL/loadFile is programmatic (also exempt), so
+  // blocking renderer-initiated full navigations away from the current
+  // document is safe for the SPA. External links go through
+  // shell.openExternal elsewhere.
+  win.webContents.on("will-navigate", (e, url) => {
+    if (url !== win.webContents.getURL()) {
+      e.preventDefault();
+    }
+  });
 
   // Close behaviour:
   //   macOS — always hide on close; the app stays in the dock until Cmd+Q
@@ -212,11 +229,12 @@ function createWindow(): BrowserWindow {
   win.on("moved", () => sendToAllRenderers("window:moved"));
 
   // OS file drag-drop: Chromium delivers files to the renderer through the
-  // standard DataTransfer API, so we don't need to intercept here. The
-  // `windowOnDragDropEvent` channel is wired for parity with Tauri but only
-  // fires from `will-prevent-unload`-style hooks if added later. The Phase
-  // 4 plumbing doc explicitly punts the producer-side rewrite — the bridge
-  // returns the listener handle for callers; main currently never emits.
+  // standard DataTransfer API, so the producer is the renderer, not main.
+  // The bridge's onDragDropEvent (frontend/src/bridge/window.ts) attaches DOM
+  // dragenter/over/leave/drop listeners, preventDefaults them, and resolves
+  // native paths via webUtils.getPathForFile — feeding the same
+  // DragDropPayload AppShell consumed under Tauri. The legacy
+  // `window:dragdrop` IPC channel is therefore dead and main never emits it.
 
   return win;
 }

--- a/electron/src/preload.ts
+++ b/electron/src/preload.ts
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer } from "electron";
+import { contextBridge, ipcRenderer, webUtils } from "electron";
 
 // All command IPC routes through a single "invoke" channel — main process
 // dispatches by name into pollis-node, same shape as Tauri's invoke_handler.
@@ -87,6 +87,12 @@ contextBridge.exposeInMainWorld("electronAPI", {
     subscribe("window:dragdrop", (payload) =>
       cb(payload as { payload: { type: "enter" | "over" | "drop" | "leave"; paths: string[] } }),
     ),
+
+  // Resolve a dropped File to its absolute path. `webUtils` is on Electron's
+  // sandboxed-preload allowlist, so this works under `sandbox: true`. The
+  // bridge's onDragDropEvent (frontend/src/bridge/window.ts) calls this for
+  // each dropped file to rebuild the native-path payload AppShell expects.
+  getPathForFile: (file: File) => webUtils.getPathForFile(file),
 
   // ── Monitors ───────────────────────────────────────────────────────────────
   availableMonitors: () =>

--- a/frontend/src/bridge/runtime.ts
+++ b/frontend/src/bridge/runtime.ts
@@ -95,6 +95,11 @@ export interface ElectronAPI {
   // ── File URL conversion (sync) ─────────────────────────────────────────
   convertFileSrc: (path: string) => string;
 
+  // Resolve the absolute filesystem path of a dropped/selected File. Electron
+  // 32+ removed the non-standard `File.path`; `webUtils.getPathForFile` is the
+  // replacement. Sync, mirrors Tauri's native-path drag-drop payload.
+  getPathForFile: (file: File) => string;
+
   // ── Clipboard ──────────────────────────────────────────────────────────
   clipboardReadFiles: () => Promise<string[]>;
   clipboardReadImageToTemp: () => Promise<string | null>;

--- a/frontend/src/bridge/window.ts
+++ b/frontend/src/bridge/window.ts
@@ -96,7 +96,72 @@ function electronWindow(): WindowProxy {
     scaleFactor: () => e.windowGetScaleFactor(),
     onResized: async (cb) => e.windowOnResized(cb),
     onMoved: async (cb) => e.windowOnMoved(cb),
-    onDragDropEvent: async (cb) => e.windowOnDragDropEvent(cb),
+    // Unlike Tauri (whose runtime intercepts OS drag-drop and pushes native
+    // paths over an event), Electron delivers file drops to the renderer as
+    // standard DOM drag events — main never emits the `window:dragdrop`
+    // channel. So we translate DOM drag events into the same DragDropPayload
+    // AppShell consumes. Crucially we preventDefault dragover/drop: without
+    // it Chromium's default action navigates the window to the dropped
+    // `file://` path (the "file opens in a blank window" regression). Only
+    // file drags trigger the overlay — text/selection drags pass through so
+    // normal in-app text dragging still works.
+    onDragDropEvent: async (cb) => {
+      const isFileDrag = (ev: DragEvent) =>
+        !!ev.dataTransfer && Array.from(ev.dataTransfer.types).includes("Files");
+      const emit = (type: DragDropPayload["type"], paths: string[] = []) =>
+        cb({ payload: { type, paths } });
+
+      // dragenter/dragleave fire for every child element crossed; track a
+      // depth counter so the overlay shows once on real window-enter and
+      // hides once on real window-leave instead of flickering per element.
+      let depth = 0;
+
+      const onEnter = (ev: DragEvent) => {
+        if (!isFileDrag(ev)) { return; }
+        ev.preventDefault();
+        depth += 1;
+        if (depth === 1) { emit("enter"); }
+      };
+      const onOver = (ev: DragEvent) => {
+        if (!isFileDrag(ev)) { return; }
+        // Must preventDefault on EVERY dragover or the subsequent drop is
+        // rejected and Chromium falls back to navigation.
+        ev.preventDefault();
+        if (ev.dataTransfer) { ev.dataTransfer.dropEffect = "copy"; }
+        emit("over");
+      };
+      const onLeave = (ev: DragEvent) => {
+        if (!isFileDrag(ev)) { return; }
+        ev.preventDefault();
+        depth = Math.max(0, depth - 1);
+        if (depth === 0) { emit("leave"); }
+      };
+      const onDrop = (ev: DragEvent) => {
+        if (!isFileDrag(ev)) { return; }
+        ev.preventDefault();
+        depth = 0;
+        const files = ev.dataTransfer?.files;
+        const paths: string[] = [];
+        if (files) {
+          for (let i = 0; i < files.length; i++) {
+            const p = e.getPathForFile(files[i]);
+            if (p) { paths.push(p); }
+          }
+        }
+        emit("drop", paths);
+      };
+
+      window.addEventListener("dragenter", onEnter);
+      window.addEventListener("dragover", onOver);
+      window.addEventListener("dragleave", onLeave);
+      window.addEventListener("drop", onDrop);
+      return () => {
+        window.removeEventListener("dragenter", onEnter);
+        window.removeEventListener("dragover", onOver);
+        window.removeEventListener("dragleave", onLeave);
+        window.removeEventListener("drop", onDrop);
+      };
+    },
     setBadgeCount: (n) => e.windowSetBadgeCount(n ?? null),
     setIcon: async (img) => {
       if (img.bytes) {

--- a/frontend/src/components/Layout/AppShell.tsx
+++ b/frontend/src/components/Layout/AppShell.tsx
@@ -13,6 +13,7 @@ import { LoadingSpinner } from "../ui/LoaderSpinner";
 import { SearchPanel } from "../SearchPanel";
 import { TerminalView } from "../TerminalView";
 import { useAppStore } from "../../stores/appStore";
+import { isDropTargetActive } from "../../stores/dropTargetStore";
 import { useUserGroupsWithChannels } from "../../hooks/queries/useGroups";
 import { useLiveKitRealtime } from "../../hooks/useLiveKitRealtime";
 import { useBadge } from "../../hooks/useBadge";
@@ -142,12 +143,23 @@ export const AppShell: React.FC = () => {
     }
   }, [isTerminal]);
 
-  // Global file drop — Tauri intercepts OS drag-drop before the browser sees it.
+  // Global file drop. The bridge's onDragDropEvent normalizes OS drag-drop
+  // (DOM events under Electron, native events under Tauri) into a common
+  // payload; we show the overlay and rebroadcast dropped paths to the mounted
+  // ChatInput via `pollis:pathdrop`.
   useEffect(() => {
     let unlisten: (() => void) | undefined;
     let cancelled = false;
 
     getCurrentWindow().onDragDropEvent((event) => {
+      // Only react when a ChatInput is mounted to receive the file. Otherwise
+      // (e.g. a voice/stream view) the drop has nowhere to go, so suppress the
+      // overlay. The bridge still preventDefaults the drop, so the window
+      // never navigates to the dropped file regardless of view.
+      if (!isDropTargetActive()) {
+        setIsDragOver(false);
+        return;
+      }
       if (event.payload.type === "enter" || event.payload.type === "over") {
         setIsDragOver(true);
       } else if (event.payload.type === "drop") {

--- a/frontend/src/components/ui/ChatInput.tsx
+++ b/frontend/src/components/ui/ChatInput.tsx
@@ -11,6 +11,7 @@ import {
 import { ChevronRight, Plus, X, Film, Music } from "lucide-react";
 import { getFileIcon } from "../../utils/fileIcon";
 import { formatFileSize } from "../../utils/format";
+import { useDropTargetStore } from "../../stores/dropTargetStore";
 
 // Attachment carries a filesystem path so Rust can read the file directly —
 // no bytes-over-IPC bottleneck, no size limit.
@@ -414,7 +415,17 @@ export const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(({
     focus: () => { textareaRef.current?.focus(); },
   }), [handleBrowserFile]);
 
-  // Global drop zone — AppShell fires this when Tauri intercepts an OS file drop.
+  // Register as the active file-drop target while mounted, so AppShell only
+  // shows the drag overlay on views that can actually receive a file (not,
+  // e.g., the voice/stream view where there's no input).
+  useEffect(() => {
+    const { register, unregister } = useDropTargetStore.getState();
+    register();
+    return unregister;
+  }, []);
+
+  // Global drop zone — AppShell fires this when an OS file drop lands while a
+  // ChatInput is mounted.
   useEffect(() => {
     const handler = (e: Event) => {
       const paths: string[] = (e as CustomEvent<{ paths: string[] }>).detail.paths;

--- a/frontend/src/stores/dropTargetStore.ts
+++ b/frontend/src/stores/dropTargetStore.ts
@@ -1,0 +1,28 @@
+import { create } from "zustand";
+
+// Tracks whether a file-drop target (a mounted ChatInput) currently exists, so
+// the global drag-over overlay in AppShell only appears on views that can
+// actually receive a dropped file. Without this the overlay showed app-wide —
+// e.g. while watching a stream in a voice channel, where there's no chat input
+// and a dropped file goes nowhere (confusing).
+//
+// Ref-counted rather than a plain boolean so transient double-mounts (React
+// StrictMode) and any future layout with more than one input don't clear the
+// flag prematurely.
+interface DropTargetStore {
+  count: number;
+  register: () => void;
+  unregister: () => void;
+}
+
+export const useDropTargetStore = create<DropTargetStore>((set) => ({
+  count: 0,
+  register: () => set((s) => ({ count: s.count + 1 })),
+  unregister: () => set((s) => ({ count: Math.max(0, s.count - 1) })),
+}));
+
+// Read the current value outside React (e.g. inside the AppShell drag-event
+// callback, which is registered once and would otherwise close over a stale
+// value).
+export const isDropTargetActive = (): boolean =>
+  useDropTargetStore.getState().count > 0;


### PR DESCRIPTION
Fixes a drag-and-drop regression from the Electron migration: dropping a file into the chat did nothing (no overlay), and dropping onto the input made Chromium navigate the window to the `file://` path (blank window).

## Cause
The Tauri runtime used to intercept OS drag-drop and push file *paths* to the renderer via the `window:dragdrop` channel. Under Electron, main never emits that channel, so the dropzone was wired to a dead event — no overlay, no drop, and nothing `preventDefault`ing the browser's default file-navigation.

## Fix
- **`bridge/window.ts`** — Electron `onDragDropEvent` now handles real DOM `dragenter/over/leave/drop`, `preventDefault`s them (kills the navigation), distinguishes file vs text drags, depth-counts enter/leave to avoid flicker, and resolves native paths via `getPathForFile`. Emits the same `DragDropPayload` the app already consumed under Tauri — AppShell/ChatInput unchanged.
- **`preload.ts` / `runtime.ts`** — expose `getPathForFile` via `webUtils.getPathForFile` (Electron 32+ removed `File.path`; `webUtils` is on the sandboxed-preload allowlist).
- **`main.ts`** — `will-navigate` guard as a safety net so a stray drop can never blank the window again.
- **Overlay scoping** — a small ref-counted `dropTargetStore` that `ChatInput` registers into, so the "drop files to send" overlay only appears on views that can actually receive a file (not, e.g., the voice/stream view).

## Tests
`tsc` clean (renderer + electron), full frontend `vite build` clean. Live-verified: overlay appears on chat/DM, file attaches on drop, no window navigation; no overlay on the voice view.
