### PR TITLE
fix(ci): point rust-cache at workspace root so target dir is actually cached

### DIFF
--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -50,9 +50,14 @@ jobs:
         with:
           targets: aarch64-apple-darwin,x86_64-apple-darwin
 
+      # The workspace lives at the repo root (root Cargo.toml lists
+      # pollis-node as a member), so `napi build` from pollis-node/ still
+      # writes outputs to ./target/. An earlier `workspaces: pollis-node`
+      # value pointed the action at a non-existent target dir and silently
+      # cached nothing useful. Default `.` keys on root Cargo.lock and
+      # caches the actual target dir; sccache still wraps individual
+      # rustc calls on top.
       - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: pollis-node
 
       # sccache wraps rustc so individual compile units are cached across
       # branches, not just whole-target-dir keyed on Cargo.lock. Wins big
@@ -187,9 +192,8 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
+      # See macOS job for why this is `.` rather than `pollis-node`.
       - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: pollis-node
 
       - name: Run sccache
         uses: mozilla-actions/sccache-action@v0.0.10
@@ -340,9 +344,8 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
+      # See macOS job for why this is `.` rather than `pollis-node`.
       - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: pollis-node
 
       - name: Run sccache
         uses: mozilla-actions/sccache-action@v0.0.10


### PR DESCRIPTION
## Summary
- The three release jobs configured `Swatinem/rust-cache@v2` with `workspaces: pollis-node`, but the Cargo workspace lives at the repo root. `napi build` writes outputs to `./target/`, not `./pollis-node/target/`, so the action was keyed on (and caching) a non-existent directory.
- Switching to the default (`.`) keys on root `Cargo.lock` and caches the real `./target/`. sccache continues to wrap individual `rustc` calls on top.

## Test plan
- [ ] Next release run on a tag: confirm rust-cache restore hits and `target/` is non-empty before the build step.