### PR TITLE
fix(call): stop ring on user's other devices when accepting/declining

### DIFF
--- a/frontend/src/components/Layout/AppShell.tsx
+++ b/frontend/src/components/Layout/AppShell.tsx
@@ -567,13 +567,25 @@ export const AppShell: React.FC = () => {
                 // before activeVoiceChannelId flips and any in-flight Call
                 // page useEffect tries to bounce off a transient mismatch),
                 // then swap the voice room, then clear the alert.
-                router.navigate({ to: "/call/$callId", params: { callId: incomingCall.callId } });
+                const callId = incomingCall.callId;
+                router.navigate({ to: "/call/$callId", params: { callId } });
                 voiceSession.setIntent({
                   channelId: incomingCall.roomName,
                   groupId: null,
                   counterpartyUserId: incomingCall.callerId,
                 });
                 setIncomingCall(null);
+                // Stop ringing on this user's other devices. The renderer's
+                // own `call_canceled` handler is idempotent (no-ops when the
+                // local incomingCall is null) so re-receiving our own
+                // dismissal here is safe; every other device clears within
+                // the data-packet RTT.
+                if (currentUser) {
+                  invoke("dismiss_call_on_my_devices", {
+                    userId: currentUser.id,
+                    callId,
+                  }).catch(() => {});
+                }
               }}
               aria-label={`Answer call from @${incomingCall.callerUsername}`}
             >
@@ -588,6 +600,14 @@ export const AppShell: React.FC = () => {
                 const callId = incomingCall.callId;
                 setIncomingCall(null);
                 invoke("cancel_call", { otherUserId: callerId, callId }).catch(() => {});
+                // Stop ringing on this user's other devices — same idempotent
+                // path the answer button uses; see comment there.
+                if (currentUser) {
+                  invoke("dismiss_call_on_my_devices", {
+                    userId: currentUser.id,
+                    callId,
+                  }).catch(() => {});
+                }
               }}
               aria-label="Decline call"
             >

--- a/frontend/src/hooks/useLiveKitRealtime.ts
+++ b/frontend/src/hooks/useLiveKitRealtime.ts
@@ -18,8 +18,12 @@ import { useKeyChangeStore } from '../stores/keyChangeStore';
 import { useRosterChangeStore, type RosterBanner } from '../stores/rosterChangeStore';
 import { peerVerificationKeys } from './queries/useUserProfile';
 
-// Mirrors the RealtimeEvent enum in src-tauri/src/realtime.rs.
+// Mirrors the RealtimeEvent enum in pollis-core/src/realtime.rs.
 // Add new variants here as new event types are added on the Rust side.
+// (When the same UX outcome already exists as a variant, reuse it — e.g.
+// "dismiss call on my other devices" reuses `call_canceled` because the
+// renderer-side handling is identical. Don't split logic just because the
+// trigger is different.)
 type RealtimeEvent =
   | {
     type: 'new_message';

--- a/pollis-core/src/commands/livekit/mod.rs
+++ b/pollis-core/src/commands/livekit/mod.rs
@@ -45,10 +45,11 @@ pub use participants::{
     list_voice_participants, list_voice_room_counts, VoiceParticipantInfo, VoiceRoomCount,
 };
 pub use publish::{
-    cancel_call, publish_deleted_message_to_room, publish_edited_message_to_room,
-    publish_member_role_changed_to_room, publish_membership_changed_to_room,
-    publish_new_message_to_room, publish_ping, publish_to_room_server, publish_to_user_inbox,
-    publish_typing, publish_voice_presence, start_call, StartCallResult,
+    cancel_call, dismiss_call_on_my_devices, publish_deleted_message_to_room,
+    publish_edited_message_to_room, publish_member_role_changed_to_room,
+    publish_membership_changed_to_room, publish_new_message_to_room, publish_ping,
+    publish_to_room_server, publish_to_user_inbox, publish_typing, publish_voice_presence,
+    start_call, StartCallResult,
 };
 pub use realtime::{connect_rooms, subscribe_realtime};
 

--- a/pollis-core/src/commands/livekit/publish.rs
+++ b/pollis-core/src/commands/livekit/publish.rs
@@ -521,3 +521,38 @@ pub async fn cancel_call(
 
     Ok(())
 }
+
+/// Tells THIS user's other devices that the incoming call has been handled
+/// here (answered or declined), so they should stop ringing. Posts a
+/// `call_canceled` payload to the caller's own inbox room — every device
+/// the user has connected receives it through the existing realtime path.
+///
+/// Reuses the `call_canceled` event variant rather than introducing a new
+/// one: the renderer's existing handler (`useLiveKitRealtime.ts`) is already
+/// idempotent — it no-ops when local `incomingCall` is null — so the
+/// originating device safely re-receives its own dismissal, and every other
+/// device clears its alert + stops the ring within the data-packet RTT.
+///
+/// Distinct from `cancel_call` because that one posts to the OTHER party.
+/// This one posts to ourselves. Calling `cancel_call(self_id, …)` would
+/// work mechanically but conflates the "tell the peer" semantics with the
+/// "fan out to my own devices" semantics, which the type signature should
+/// keep separate.
+pub async fn dismiss_call_on_my_devices(
+    user_id: String,
+    call_id: String,
+    state: &Arc<AppState>,
+) -> Result<()> {
+    if state.config.livekit_url.is_empty() {
+        return Ok(());
+    }
+
+    let payload = serde_json::json!({
+        "type": "call_canceled",
+        "call_id": call_id,
+    });
+
+    publish_to_user_inbox(&state.config, &user_id, payload).await?;
+
+    Ok(())
+}

--- a/pollis-node/src/dispatch/livekit.rs
+++ b/pollis-node/src/dispatch/livekit.rs
@@ -33,6 +33,7 @@ pub async fn dispatch(
         "list_voice_room_counts" => Some(list_voice_room_counts(args).await),
         "start_call" => Some(start_call(args).await),
         "cancel_call" => Some(cancel_call(args).await),
+        "dismiss_call_on_my_devices" => Some(dismiss_call_on_my_devices(args).await),
         _ => None,
     }
 }
@@ -277,6 +278,20 @@ async fn cancel_call(args: &serde_json::Value) -> Result<serde_json::Value> {
     } = serde_json::from_value(args.clone()).map_err(json_err)?;
     let state = ensure_state().await?;
     pollis_core::commands::livekit::cancel_call(other_user_id, call_id, &state)
+        .await
+        .map_err(core_err)?;
+    Ok(serde_json::Value::Null)
+}
+
+async fn dismiss_call_on_my_devices(args: &serde_json::Value) -> Result<serde_json::Value> {
+    #[derive(serde::Deserialize)]
+    struct Args {
+        user_id: String,
+        call_id: String,
+    }
+    let Args { user_id, call_id } = serde_json::from_value(args.clone()).map_err(json_err)?;
+    let state = ensure_state().await?;
+    pollis_core::commands::livekit::dismiss_call_on_my_devices(user_id, call_id, &state)
         .await
         .map_err(core_err)?;
     Ok(serde_json::Value::Null)


### PR DESCRIPTION
## Summary
- Call invites land in the per-user `inbox-{user_id}` LiveKit room, so every connected device of the callee rings. When the user answered on Device A, Device B kept ringing for the entire call; when the user declined on Device A, Device B rang until the caller's 30s empty-room timeout fired.
- Add `dismiss_call_on_my_devices(user_id, call_id)` which posts a `call_canceled` payload to the user's own inbox. The renderer's existing handler is idempotent (no-ops when local `incomingCall` is null), so the originating device safely re-receives its own dismissal and every other device clears within the data-packet RTT.
- Reused the `call_canceled` `RealtimeEvent` variant — same renderer-side handling, so splitting would just fork listener logic. Followed the standard pattern: `pollis-core/src/commands/livekit/publish.rs` → re-export in `mod.rs` → dispatch arm in `pollis-node/src/dispatch/livekit.rs` → two renderer callsites in `AppShell.tsx`. Updated the stale `RealtimeEvent` mirror comment in `useLiveKitRealtime.ts` to point at `pollis-core` and document the reuse-over-split rule.

## Test plan
- [ ] Two devices logged into the same account. Receive a call. Both ring.
- [ ] Answer on Device A. Device B's ring stops within ~RTT of the answer.
- [ ] Repeat. Decline on Device A. Device B's ring stops within ~RTT (not the previous ~30s).
- [ ] Caller hangs up before either device answers. Both stop (pre-existing path, regression check).