### PR TITLE
fix(ui): render Cmd+K / Cmd+B hints from resolved shortcut overrides

### DIFF
--- a/frontend/src/components/Layout/BreadcrumbNav.tsx
+++ b/frontend/src/components/Layout/BreadcrumbNav.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
 import { useRouter, useRouterState } from "@tanstack/react-router";
 import { ChevronLeft, Search as SearchIcon, Settings as SettingsIcon } from "lucide-react";
-import { shortcutLabel } from "../../utils/platform";
+import { useShortcutLabel } from "../../keyboard";
 import { useAppStore } from "../../stores/appStore";
 import { useUserGroupsWithChannels } from "../../hooks/queries/useGroups";
 import { useDMConversations } from "../../hooks/queries/useMessages";
@@ -23,6 +23,7 @@ export const BreadcrumbNav: React.FC = () => {
   const { data: groupsWithChannels } = useUserGroupsWithChannels();
   const { data: dmConversations = [] } = useDMConversations();
   const channels = useAppStore((s) => s.channels);
+  const searchLabel = useShortcutLabel("app.toggleSearch");
 
   const segments = useMemo<Segment[]>(() => {
     const out: Segment[] = [{ label: "Home", to: "/" }];
@@ -212,8 +213,8 @@ export const BreadcrumbNav: React.FC = () => {
       <button
         data-testid="breadcrumb-search-button"
         onClick={() => window.dispatchEvent(new CustomEvent("pollis:open-search"))}
-        aria-label={`Search (${shortcutLabel("K")})`}
-        title={`Search (${shortcutLabel("K")})`}
+        aria-label={`Search (${searchLabel})`}
+        title={`Search (${searchLabel})`}
         className="flex items-center gap-1.5 transition-colors text-[var(--c-text)] hover:text-[var(--c-accent)]"
         style={{
           height: 20,
@@ -236,7 +237,7 @@ export const BreadcrumbNav: React.FC = () => {
             lineHeight: 1.2,
           }}
         >
-          {shortcutLabel("K")}
+          {searchLabel}
         </kbd>
       </button>
       <button

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -21,7 +21,7 @@ import { useVoiceRoomCounts } from "../../hooks/queries/useVoiceParticipants";
 import { usePeerVerifications } from "../../hooks/queries/useUserProfile";
 import { useAppStore } from "../../stores/appStore";
 import { usePresenceStatus, type PresenceStatus } from "../../stores/presenceStore";
-import { shortcutLabel } from "../../utils/platform";
+import { useShortcutLabel } from "../../keyboard";
 
 const SIDEBAR_WIDTH = 220;
 const COLLAPSED_GROUPS_KEY = "pollis.sidebar.collapsedGroups";
@@ -48,6 +48,7 @@ interface SidebarProps {
 export const Sidebar: React.FC<SidebarProps> = ({ isOpen, onToggle }) => {
   const router = useRouter();
   const pathname = useRouterState({ select: (s) => s.location.pathname });
+  const toggleSidebarLabel = useShortcutLabel("app.toggleSidebar");
 
   const { data: groupsWithChannels = [] } = useUserGroupsWithChannels();
   const { data: dmConversations = [] } = useDMConversations();
@@ -302,8 +303,8 @@ export const Sidebar: React.FC<SidebarProps> = ({ isOpen, onToggle }) => {
         type="button"
         data-testid="sidebar-close"
         onClick={onToggle}
-        aria-label={`Close sidebar (${shortcutLabel("B")})`}
-        title={`Close sidebar (${shortcutLabel("B")})`}
+        aria-label={`Close sidebar (${toggleSidebarLabel})`}
+        title={`Close sidebar (${toggleSidebarLabel})`}
         className="transition-colors text-[var(--c-text-muted)] hover:text-[var(--c-text)]"
         style={{
           flexShrink: 0,
@@ -333,7 +334,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ isOpen, onToggle }) => {
             lineHeight: 1.2,
           }}
         >
-          {shortcutLabel("B")}
+          {toggleSidebarLabel}
         </kbd>
       </button>
     </aside>

--- a/frontend/src/keyboard/index.ts
+++ b/frontend/src/keyboard/index.ts
@@ -16,3 +16,4 @@ export {
   subscribeShortcutOverrides,
 } from "./bindings";
 export { formatCombo } from "./keyCombo";
+export { useShortcutLabel } from "./useShortcutLabel";

--- a/frontend/src/keyboard/keyCombo.ts
+++ b/frontend/src/keyboard/keyCombo.ts
@@ -117,8 +117,9 @@ const KEY_LABELS: Record<string, string> = {
 };
 
 /**
- * Human-facing label for a combo, e.g. "⌘K" on macOS / "Ctrl+K" elsewhere.
- * Matches the style of the existing utils/platform `shortcutLabel`.
+ * Human-facing label for a combo, e.g. "⌘ K" on macOS / "Ctrl+K" elsewhere.
+ * Thin space (U+2009) between modifier glyphs and key on macOS gives the
+ * kbd badge some breathing room; other platforms use the conventional "+".
  */
 export function formatCombo(combo: string): string {
   const p = parseCombo(combo);

--- a/frontend/src/keyboard/useShortcutLabel.ts
+++ b/frontend/src/keyboard/useShortcutLabel.ts
@@ -1,0 +1,24 @@
+// Render-side helper that turns a stable command id into a display label
+// honoring the user's override map. Calls `resolveCombo(id)` (the same
+// resolver the keydown listener uses) and pipes the result through
+// `formatCombo`, so a UI hint like the Cmd+K badge in the breadcrumb or
+// the Cmd+B badge on the sidebar collapse handle automatically picks up
+// any override the user has set in Preferences — and falls back to the
+// `defaultCombo` from `commands.ts` when no override exists.
+//
+// Subscribes to `subscribeShortcutOverrides` so the badge re-renders
+// without a page reload when the user edits a binding.
+
+import { useSyncExternalStore } from "react";
+
+import { resolveCombo, subscribeShortcutOverrides } from "./bindings";
+import type { ShortcutCommandId } from "./commands";
+import { formatCombo } from "./keyCombo";
+
+export function useShortcutLabel(id: ShortcutCommandId): string {
+  return useSyncExternalStore(
+    subscribeShortcutOverrides,
+    () => formatCombo(resolveCombo(id)),
+    () => formatCombo(resolveCombo(id)),
+  );
+}

--- a/frontend/src/pages/Preferences.tsx
+++ b/frontend/src/pages/Preferences.tsx
@@ -17,7 +17,8 @@ import { Button } from "../components/ui/Button";
 import { useAppStore } from "../stores/appStore";
 import { loadDeviceCallRingtone, saveDeviceCallRingtone } from "../utils/notify";
 import { electron, hasElectron } from "../bridge/runtime";
-import { isMac, shortcutLabel } from "../utils/platform";
+import { isMac } from "../utils/platform";
+import { useShortcutLabel } from "../keyboard";
 
 function getRootVar(name: string): string {
   return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
@@ -30,6 +31,7 @@ function isValidHex(val: string): boolean {
 export const Preferences: React.FC = () => {
   const navigate = useNavigate();
   const currentUser = useAppStore((state) => state.currentUser);
+  const toggleSidebarLabel = useShortcutLabel("app.toggleSidebar");
   const [hue, setHue] = useState<number>(38);
   const [saturation, setSaturation] = useState<number>(90);
   const [bgHue, setBgHue] = useState<number>(38);
@@ -462,7 +464,7 @@ export const Preferences: React.FC = () => {
                 onChange={handleSidebarOpenByDefault}
               />
               <p className="text-xs font-mono" style={{ color: "var(--c-text-muted)" }}>
-                Controls whether the left sidebar is open when the app starts. Toggle ad-hoc with {shortcutLabel("B")}.
+                Controls whether the left sidebar is open when the app starts. Toggle ad-hoc with {toggleSidebarLabel}.
               </p>
             </div>
             {!isMac && (

--- a/frontend/src/utils/platform.ts
+++ b/frontend/src/utils/platform.ts
@@ -5,10 +5,3 @@ export const isMac =
 export const isWindows =
   typeof navigator !== "undefined" &&
   navigator.userAgent.toLowerCase().includes("windows");
-
-// macOS condenses ⌘ tight against the next glyph; a thin space (U+2009)
-// gives the kbd badge a little air without affecting Ctrl+ layout. Matches
-// the convention used by formatCombo() in keyboard/keyCombo.ts.
-export function shortcutLabel(key: string): string {
-  return isMac ? `⌘ ${key}` : `Ctrl+${key}`;
-}


### PR DESCRIPTION
## Summary
- The Cmd+K badge in the breadcrumb, the Cmd+B badge on the sidebar collapse handle, and the Preferences sidebar-default helper text all hard-coded the key letter through `utils/platform`'s `shortcutLabel()`. The helper had no knowledge of the shortcut-override system, so users who remapped `app.toggleSearch` or `app.toggleSidebar` still saw the default badges while the actual binding fired on a different key.
- Add a small `useShortcutLabel(id)` hook in the keyboard module that calls `resolveCombo(id)` (the same resolver the keydown listener uses) and pipes the result through `formatCombo`. Subscribes via `useSyncExternalStore` to `subscribeShortcutOverrides`, so the badge re-renders the moment the user edits a binding.
- Replace `shortcutLabel("K")` and `shortcutLabel("B")` callsites in `BreadcrumbNav.tsx`, `Sidebar.tsx`, and `Preferences.tsx`.
- Delete the `shortcutLabel()` helper. It was a competing API to the canonical resolver and the only thing keeping the hard-coded path alive — removing it means future hint badges have one obvious place to come from.

## Test plan
- [ ] Default state: badges still read "⌘ K" / "⌘ B" on macOS, "Ctrl+K" / "Ctrl+B" elsewhere.
- [ ] Set a `shortcut_overrides` entry for `app.toggleSearch` (e.g. `mod+j`) — badge in breadcrumb updates to "⌘ J" without reload.
- [ ] Same for `app.toggleSidebar` (e.g. `mod+shift+s`) — Sidebar and Preferences hint both reflect the new combo.