### PR TITLE
feat(chat): in-memory message drafts per room (#349)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -26,6 +26,7 @@ import { LoadingSpinner } from "./components/ui/LoaderSpinner";
 import { Button } from "./components/ui/Button";
 import { useQueryClient } from "@tanstack/react-query";
 import { installTrayVoiceBridge, installVoiceBridge } from "./voice";
+import { clearAllDrafts } from "./utils/drafts";
 
 type AppState =
   | "initializing"
@@ -246,6 +247,15 @@ function MainApp() {
       setAppState("email-auth");
     }
   }, [appState, currentUser]);
+
+  // Drop every in-memory message draft on any transition of the active user
+  // id — login (null → id), logout (id → null), account switch (id → other
+  // id). Drafts are intentionally not persisted, so this is the only thing
+  // a second user logging in on the same machine ever sees: an empty
+  // composer in every channel, including ones both users are members of.
+  useEffect(() => {
+    clearAllDrafts();
+  }, [currentUser?.id]);
 
   const handleAuthSuccess = useCallback(async (result: api.AuthResult) => {
     // Branch 1: first-device signup. Show the Secret Key screen and gate

--- a/frontend/src/components/Layout/MainContent.tsx
+++ b/frontend/src/components/Layout/MainContent.tsx
@@ -713,6 +713,17 @@ export const MainContent: React.FC<MainContentProps> = ({ pendingDmRequest = nul
             onSend={handleSend}
             onValueChange={typing.notify}
             autoFocus
+            draftKey={
+              // Prefix with the room kind so the rare case of a channel id
+              // and a DM conversation id colliding still routes to separate
+              // draft slots. Falls back to null when nothing is selected —
+              // ChatInput then skips draft persistence entirely.
+              selectedChannelId
+                ? `channel:${selectedChannelId}`
+                : selectedConversationId
+                  ? `conv:${selectedConversationId}`
+                  : null
+            }
           />
         </div>
       )}

--- a/frontend/src/components/ui/ChatInput.tsx
+++ b/frontend/src/components/ui/ChatInput.tsx
@@ -11,6 +11,7 @@ import {
 import { ChevronRight, Plus, X, Film, Music } from "lucide-react";
 import { getFileIcon } from "../../utils/fileIcon";
 import { formatFileSize } from "../../utils/format";
+import { getDraft, setDraft } from "../../utils/drafts";
 
 // Attachment carries a filesystem path so Rust can read the file directly —
 // no bytes-over-IPC bottleneck, no size limit.
@@ -41,6 +42,14 @@ interface ChatInputProps {
   // to drive the typing indicator publisher; it stays optional so simpler
   // call sites that don't need it can ignore it entirely.
   onValueChange?: (value: string) => void;
+  // Stable key for the in-memory draft store (`utils/drafts.ts`). When
+  // present, the initial textarea value is seeded from the draft for this
+  // key, every keystroke writes back, and a successful send clears the
+  // entry. When undefined or null, the component behaves exactly as before
+  // (no draft persistence between mounts). Pass `null` rather than omitting
+  // the prop while the parent's room id is still loading — the component
+  // re-syncs whenever this value changes within the same mount.
+  draftKey?: string | null;
 }
 
 function mimeFromName(name: string): string {
@@ -204,8 +213,20 @@ export const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(({
   className = "",
   maxAttachments = 10,
   onValueChange,
+  draftKey = null,
 }, ref) => {
-  const [message, setMessage] = useState("");
+  const [message, setMessage] = useState(() => getDraft(draftKey));
+  // Re-sync message when draftKey changes within the same mount (e.g. the
+  // user navigates from #general to #random without unmounting MainContent).
+  // Done during render via the "store previous prop in state" pattern so
+  // the textarea never shows a stale value for a frame — a useEffect would
+  // run after paint and produce a visible flash. Cheap: the compare is one
+  // string === and the setState bails out when values match.
+  const [prevDraftKey, setPrevDraftKey] = useState(draftKey);
+  if (draftKey !== prevDraftKey) {
+    setPrevDraftKey(draftKey);
+    setMessage(getDraft(draftKey));
+  }
   const [attachments, setAttachments] = useState<Attachment[]>([]);
   const [isFocused, setIsFocused] = useState(false);
   // Lightbox for previewing attachments before send.
@@ -439,6 +460,7 @@ export const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(({
     if (hasLoadingAttachments) { return; }
     onSend(message.trim(), attachments);
     setMessage("");
+    setDraft(draftKey, "");
     // Reset signals to "no longer typing" — covers the typing indicator
     // publisher in the parent so the receiver doesn't keep us in the
     // "still typing" state until TTL.
@@ -543,6 +565,7 @@ export const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(({
           onChange={(e) => {
             const next = e.target.value;
             setMessage(next);
+            setDraft(draftKey, next);
             onValueChange?.(next);
           }}
           onFocus={() => setIsFocused(true)}

--- a/frontend/src/utils/drafts.ts
+++ b/frontend/src/utils/drafts.ts
@@ -1,0 +1,45 @@
+// In-memory message drafts.
+//
+// A draft is the unsent text currently sitting in the composer for a given
+// room (a group channel id or a DM conversation id, prefixed with a "kind"
+// token to avoid the theoretical case of an id colliding across the two
+// tables). Drafts are NOT persisted: the Map lives in module scope, so it
+// dies on app close and on full page reload. There is no localStorage,
+// no IndexedDB, no Rust round-trip — by design.
+//
+// Lookup and mutation are both O(1) and synchronous, so the composer can
+// save the latest value in the same call stack as its own setState on
+// every keystroke. No effect, no async, no microtask gap where a tab
+// switch could lose the value.
+//
+// Drafts are cleared on every transition of the active user id (login,
+// logout, account switch). That covers the "user A logs out, user B logs
+// in on the same machine" case explicitly — user B never sees user A's
+// drafts in a channel they both happen to be members of. App.tsx wires
+// the `clearAllDrafts()` call to its `currentUser?.id` effect.
+
+const drafts = new Map<string, string>();
+
+export function getDraft(key: string | null | undefined): string {
+  if (!key) {
+    return "";
+  }
+  return drafts.get(key) ?? "";
+}
+
+export function setDraft(key: string | null | undefined, value: string): void {
+  if (!key) {
+    return;
+  }
+  if (value.length === 0) {
+    // Drop empty entries so the Map doesn't accumulate dead keys for every
+    // channel the user has ever opened.
+    drafts.delete(key);
+    return;
+  }
+  drafts.set(key, value);
+}
+
+export function clearAllDrafts(): void {
+  drafts.clear();
+}


### PR DESCRIPTION
Closes #349.

## Summary
- Module-level `Map<string, string>` in `frontend/src/utils/drafts.ts` holds the unsent text for each room. Lookup and mutation are O(1) and synchronous — no effect, no async, no localStorage / IndexedDB / Rust round-trip.
- `ChatInput` takes an optional `draftKey?: string | null` prop. `useState(() => getDraft(draftKey))` seeds the initial value; `onChange` calls `setDraft(draftKey, next)` in the **same call stack** as `setMessage`; `handleSend` clears it. A render-time prop-change check re-syncs without a stale-text flash if `draftKey` changes within the same mount.
- `MainContent` passes `draftKey={selectedChannelId ? "channel:${id}" : selectedConversationId ? "conv:${id}" : null}`. Prefix avoids any cross-table id collision.
- `App.tsx` adds `useEffect(() => clearAllDrafts(), [currentUser?.id])` — fires on login, logout, and account switch. Covers the "user A logs out, user B logs in on the same machine" case explicitly: B never sees A's drafts in any room.

## Test plan
- [ ] Type in #general, navigate to #random, navigate back — text restored.
- [ ] Type in a DM, navigate to a group channel, navigate back — text restored.
- [ ] Send a message — composer empties; navigate away and back — still empty.
- [ ] Log out — log back in as the same user — composer empty in every room.
- [ ] Log out as A, log in as B on the same machine, open a channel both are members of — composer empty for B.
- [ ] Fully quit the app and relaunch — composer empty (Map died with the process; no persistence).