### PR TITLE
fix(mls): prevent same-epoch commit forks (CAS + fork recovery)

### DIFF
--- a/pollis-core/src/commands/mls/group_state.rs
+++ b/pollis-core/src/commands/mls/group_state.rs
@@ -115,6 +115,67 @@ pub async fn external_join_group(
     conversation_id: &str,
     user_id: &str,
 ) -> crate::error::Result<()> {
+    let _guard = state.mls_group_lock(conversation_id).await;
+    external_join_group_inner(state, conversation_id, user_id).await
+}
+
+/// Result of a single external-join attempt — see [`external_join_attempt`].
+enum ExternalJoinResult {
+    /// Our external commit won its epoch and was persisted.
+    Joined,
+    /// Another member already committed at the target epoch; our freshly
+    /// built local branch is doomed and must be discarded before retrying.
+    LostRace,
+}
+
+/// Body of [`external_join_group`]. Assumes the caller already holds the
+/// per-conversation MLS lock (`state.mls_group_lock`).
+///
+/// Submits the external commit as a compare-and-swap on the target epoch (see
+/// [`external_join_attempt`]). On a lost race we discard the doomed local
+/// branch, let the winner republish GroupInfo at the advanced epoch, and retry
+/// — bounded — from the new epoch. This is what stops two concurrent joins
+/// from forking the group.
+pub(crate) async fn external_join_group_inner(
+    state: &Arc<AppState>,
+    conversation_id: &str,
+    user_id: &str,
+) -> crate::error::Result<()> {
+    const MAX_JOIN_ATTEMPTS: u32 = 5;
+    for attempt in 0..MAX_JOIN_ATTEMPTS {
+        match external_join_attempt(state, conversation_id, user_id).await? {
+            ExternalJoinResult::Joined => return Ok(()),
+            ExternalJoinResult::LostRace => {
+                eprintln!(
+                    "[mls] external_join_group: lost epoch race for {conversation_id} \
+                     (attempt {}/{MAX_JOIN_ATTEMPTS}) — discarding local branch and retrying",
+                    attempt + 1
+                );
+                // Drop the doomed branch we just built so the next attempt
+                // re-joins cleanly from the advanced GroupInfo.
+                let _ = forget_local_mls_group(state, conversation_id).await;
+                // Brief backoff so the winner can publish GroupInfo at the new
+                // epoch before we re-read it.
+                tokio::time::sleep(std::time::Duration::from_millis(
+                    100 * (attempt as u64 + 1),
+                ))
+                .await;
+            }
+        }
+    }
+    Err(crate::error::Error::Other(anyhow::anyhow!(
+        "external-join for {conversation_id}: epoch contention, exhausted {MAX_JOIN_ATTEMPTS} attempts"
+    )))
+}
+
+/// One external-join attempt: read the current GroupInfo, build an external
+/// commit against it, and try to claim its epoch in `mls_commit_log` via
+/// `ON CONFLICT(conversation_id, epoch) DO NOTHING`. Returns [`ExternalJoinResult`].
+async fn external_join_attempt(
+    state: &Arc<AppState>,
+    conversation_id: &str,
+    user_id: &str,
+) -> crate::error::Result<ExternalJoinResult> {
     let device_id = state
         .device_id
         .lock()
@@ -216,23 +277,31 @@ pub async fn external_join_group(
             .map_err(|e| crate::error::Error::Other(anyhow::anyhow!("commit serialize: {e}")))?
     };
 
-    // 3. Post the commit to mls_commit_log so existing members will
-    //    process it on their next process_pending_commits pass.
+    // 3. Claim this epoch in mls_commit_log via compare-and-swap. If another
+    //    member already committed `stored_epoch`, the conflict makes this a
+    //    no-op (0 rows) and we report a lost race — the branch we just built
+    //    locally is doomed and the caller will discard it and retry.
     let conn = state.remote_db.conn().await?;
-    conn.execute(
-        "INSERT INTO mls_commit_log \
-         (conversation_id, epoch, sender_id, commit_data, added_user_id, added_device_ids) \
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-        libsql::params![
-            conversation_id,
-            stored_epoch,
-            user_id,
-            commit_bytes,
-            user_id,
-            device_id.clone()
-        ],
-    )
-    .await?;
+    let affected = conn
+        .execute(
+            "INSERT INTO mls_commit_log \
+             (conversation_id, epoch, sender_id, commit_data, added_user_id, added_device_ids) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6) \
+             ON CONFLICT(conversation_id, epoch) DO NOTHING",
+            libsql::params![
+                conversation_id,
+                stored_epoch,
+                user_id,
+                commit_bytes,
+                user_id,
+                device_id.clone()
+            ],
+        )
+        .await?;
+
+    if affected == 0 {
+        return Ok(ExternalJoinResult::LostRace);
+    }
 
     // 4. Refresh the stored GroupInfo at the new epoch so any NEXT
     //    new device joining via this same path sees the up-to-date
@@ -247,7 +316,7 @@ pub async fn external_join_group(
         "[mls] external_join_group: {user_id}:{device_id} joined {conversation_id} from epoch {stored_epoch}"
     );
 
-    Ok(())
+    Ok(ExternalJoinResult::Joined)
 }
 
 // ── Phase 3: Group / DM creation ─────────────────────────────────────────────
@@ -412,7 +481,24 @@ pub async fn forget_local_mls_group(
 /// falls back to external-join using the published GroupInfo.
 ///
 /// `user_id` is needed for the external-join fallback.
+///
+/// Acquires the per-conversation MLS lock for the duration so concurrent
+/// callers on this device (send, channel/DM ingest, the realtime inbox
+/// handler) can't race into a commit fork. The actual work is in
+/// [`process_pending_commits_locked`]; callers that already hold the lock
+/// (e.g. reconcile's lost-race recovery) must call that directly.
 pub async fn process_pending_commits_inner(
+    state: &Arc<AppState>,
+    mls_group_id: &str,
+    user_id: &str,
+) -> crate::error::Result<()> {
+    let _guard = state.mls_group_lock(mls_group_id).await;
+    process_pending_commits_locked(state, mls_group_id, user_id).await
+}
+
+/// Body of [`process_pending_commits_inner`]. Assumes the caller already holds
+/// the per-conversation MLS lock (`state.mls_group_lock`).
+pub(crate) async fn process_pending_commits_locked(
     state: &Arc<AppState>,
     mls_group_id: &str,
     user_id: &str,
@@ -433,8 +519,9 @@ pub async fn process_pending_commits_inner(
     let initial_epoch = match has_group {
         Some(epoch) => epoch,
         None => {
-            // No local group — external-join to create one.
-            if let Err(e) = external_join_group(state, mls_group_id, user_id).await {
+            // No local group — external-join to create one. Lock already held
+            // by the wrapper, so call the unlocked inner variant.
+            if let Err(e) = external_join_group_inner(state, mls_group_id, user_id).await {
                 eprintln!("[mls] process_pending_commits: no local group for {mls_group_id}, external-join failed: {e}");
             }
             return Ok(());
@@ -493,7 +580,7 @@ pub async fn process_pending_commits_inner(
     //    state.
     let mut current_epoch = initial_epoch;
     let mut any_applied = false;
-    'commit_loop: for commit in pending {
+    for commit in pending {
         if commit.epoch as u64 != current_epoch {
             eprintln!(
                 "[mls] process_pending_commits: epoch gap for {mls_group_id}: \
@@ -576,14 +663,37 @@ pub async fn process_pending_commits_inner(
                 }
                 Err(e) => {
                     let msg = format!("{e}");
-                    // If we were evicted (kicked), delete the stale group so
-                    // external-join recovery can create a fresh one.
+                    // Two distinct recoverable failures, both handled by
+                    // dropping the local group so the external-rejoin below
+                    // rebuilds it from the latest published GroupInfo:
+                    //
+                    //   1. Eviction — we were removed; our keys can't open the
+                    //      commit. Re-join only if we're still a roster member
+                    //      (external_join no-ops cleanly if GroupInfo is gone).
+                    //
+                    //   2. Fork — the commit is at our CURRENT epoch (it passed
+                    //      the epoch-gap check above) yet still won't apply, so
+                    //      our local tree has diverged from the canonical
+                    //      branch. This is the residue of a historical
+                    //      concurrent-commit race (prod incident: group
+                    //      `01KQYX89…`); the UNIQUE(conversation_id, epoch)
+                    //      constraint stops new forks, but already-forked
+                    //      devices only heal by re-joining the live branch.
+                    //
+                    // Deleting drops only this device's MLS crypto state, not
+                    // its decrypted message history (that lives in the local
+                    // `message` table). The rejoin lands at the latest epoch,
+                    // so the next pass filters `epoch >= new_epoch` and can't
+                    // re-fail on the same commit — no recovery loop.
                     if msg.contains("evicted") {
                         eprintln!("[mls] process_pending_commits: evicted from {mls_group_id} — deleting local group for recovery");
-                        let _ = group.delete(provider.storage());
                     } else {
-                        eprintln!("[mls] process_pending_commits: {e} for {mls_group_id} at epoch {} — stopping", commit.epoch);
+                        eprintln!(
+                            "[mls] process_pending_commits: commit at epoch {} for {mls_group_id} failed to apply ({e}) — local state diverged from canonical branch; deleting local group to re-join",
+                            commit.epoch
+                        );
                     }
+                    let _ = group.delete(provider.storage());
                     break;
                 }
             }
@@ -617,7 +727,8 @@ pub async fn process_pending_commits_inner(
     };
     if !group_exists {
         eprintln!("[mls] process_pending_commits: group {mls_group_id} was deleted during processing — external-joining to recover");
-        if let Err(e) = external_join_group(state, mls_group_id, user_id).await {
+        // Lock already held by the wrapper, so call the unlocked inner variant.
+        if let Err(e) = external_join_group_inner(state, mls_group_id, user_id).await {
             eprintln!("[mls] process_pending_commits: recovery external-join failed for {mls_group_id}: {e}");
         }
     }

--- a/pollis-core/src/commands/mls/reconcile.rs
+++ b/pollis-core/src/commands/mls/reconcile.rs
@@ -15,8 +15,16 @@ use ulid::Ulid;
 
 use crate::state::AppState;
 
-use super::group_state::{init_mls_group, publish_group_info};
+use super::group_state::{init_mls_group, process_pending_commits_locked, publish_group_info};
 use super::provider::{parse_credential_device_id, parse_credential_user_id, PollisProvider, CS};
+
+/// Result of the compare-and-swap commit submission in `reconcile_group_mls_impl`.
+enum SubmitOutcome {
+    /// Our commit claimed its epoch and was persisted (welcomes too).
+    Committed,
+    /// Another member already committed this epoch; nothing was written.
+    LostRace,
+}
 
 // ── Phase 4.5: MLS group self-repair ─────────────────────────────────────────
 
@@ -311,6 +319,13 @@ pub async fn reconcile_group_mls_impl(
 ) -> crate::error::Result<ReconcileOutcome> {
     let conversation_id = conversation_id.to_owned();
     let actor_user_id = actor_user_id.to_owned();
+
+    // Serialize all MLS mutations for this conversation on this device so two
+    // concurrent reconciles (or a reconcile racing the external-join path)
+    // can't both stage + commit from the same epoch. Held for the whole
+    // function; the lost-race recovery below calls the unlocked
+    // `process_pending_commits_locked` rather than re-acquiring.
+    let _mls_guard = state.mls_group_lock(&conversation_id).await;
 
     let conn = state.remote_db.conn().await?;
 
@@ -608,22 +623,33 @@ pub async fn reconcile_group_mls_impl(
         // connection here is not a retry — it's preventing a stale stream
         // from being our only attempt. On failure, roll back the local
         // pending commit before returning.
-        let remote_result: crate::error::Result<()> = async {
+        let remote_result: crate::error::Result<SubmitOutcome> = async {
             let write_conn = state.remote_db.conn().await?;
-            write_conn.execute(
-                "INSERT INTO mls_commit_log \
-                 (conversation_id, epoch, sender_id, commit_data, added_user_id, added_device_ids) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-                libsql::params![
-                    conversation_id.clone(),
-                    outcome.epoch_before as i64,
-                    actor_user_id.clone(),
-                    data.commit_bytes,
-                    added_uid,
-                    added_dids
-                ],
-            )
-            .await?;
+            // Claim this epoch via compare-and-swap. If another member already
+            // committed `epoch_before`, the conflict makes this a no-op (0
+            // rows) and we report a lost race instead of forking. We must NOT
+            // write the welcomes in that case — they'd point at a branch no one
+            // adopts.
+            let affected = write_conn
+                .execute(
+                    "INSERT INTO mls_commit_log \
+                     (conversation_id, epoch, sender_id, commit_data, added_user_id, added_device_ids) \
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6) \
+                     ON CONFLICT(conversation_id, epoch) DO NOTHING",
+                    libsql::params![
+                        conversation_id.clone(),
+                        outcome.epoch_before as i64,
+                        actor_user_id.clone(),
+                        data.commit_bytes,
+                        added_uid,
+                        added_dids
+                    ],
+                )
+                .await?;
+
+            if affected == 0 {
+                return Ok(SubmitOutcome::LostRace);
+            }
 
             if let Some(welcome_bytes) = data.welcome_bytes {
                 for (uid, did) in &outcome.added {
@@ -636,7 +662,7 @@ pub async fn reconcile_group_mls_impl(
                     .await?;
                 }
             }
-            Ok(())
+            Ok(SubmitOutcome::Committed)
         }
         .await;
 
@@ -672,7 +698,44 @@ pub async fn reconcile_group_mls_impl(
                 }
                 return Err(e);
             }
-            Ok(()) => {
+            Ok(SubmitOutcome::LostRace) => {
+                // Another member committed this epoch first. Our staged commit
+                // is on a branch no one will adopt, so roll it back (same as
+                // the remote-failure path) — do NOT merge, or we'd fork. We
+                // were already a member on the canonical branch; we just lost a
+                // commit race.
+                eprintln!(
+                    "[mls] reconcile: lost epoch {} race for {conversation_id} — rolling back local pending commit and converging on the winner",
+                    outcome.epoch_before
+                );
+                {
+                    let guard = state.local_db.lock().await;
+                    if let Some(db) = guard.as_ref() {
+                        let provider = PollisProvider::new(db.conn());
+                        let group_id = GroupId::from_slice(conversation_id.as_bytes());
+                        if let Ok(Some(mut group)) = MlsGroup::load(provider.storage(), &group_id) {
+                            if let Err(clear_err) = group.clear_pending_commit(provider.storage()) {
+                                eprintln!(
+                                    "[mls] reconcile: clear_pending_commit failed after lost race: {clear_err}"
+                                );
+                            }
+                        }
+                    }
+                }
+                // Apply the winning commit so we advance to the current epoch.
+                // The lock is already held, so use the unlocked variant. The
+                // pending invite / membership row persists, so a later
+                // reconcile re-applies our change at the new epoch.
+                if let Err(e) =
+                    process_pending_commits_locked(state, &conversation_id, &actor_user_id).await
+                {
+                    eprintln!(
+                        "[mls] reconcile: converge-after-lost-race failed for {conversation_id}: {e}"
+                    );
+                }
+                return Ok(ReconcileOutcome::default());
+            }
+            Ok(SubmitOutcome::Committed) => {
                 // Remote persisted — now merge locally to advance the epoch.
                 // Scope the provider + group tightly so neither crosses an
                 // await (PollisProvider wraps &rusqlite::Connection which

--- a/pollis-core/src/db/migrations/000003_mls_commit_log_unique_epoch.sql
+++ b/pollis-core/src/db/migrations/000003_mls_commit_log_unique_epoch.sql
@@ -1,0 +1,23 @@
+-- Collapse any historical commit forks. Where two or more commits share the
+-- same (conversation_id, epoch), keep the lowest seq -- the one every member
+-- that processed the log in (epoch ASC, seq ASC) order already merged -- and
+-- drop the rest. The dropped rows are the "losing branch" that no member on
+-- the canonical branch ever applied, so removing them is a no-op for those
+-- members and harmless for the forked author (whose divergent crypto state
+-- lives in their own local mls_kv, not here). Required before the unique
+-- index below, which would otherwise fail on the duplicates.
+DELETE FROM mls_commit_log
+WHERE seq NOT IN (
+    SELECT MIN(seq) FROM mls_commit_log GROUP BY conversation_id, epoch
+);
+
+-- One commit per epoch per conversation, enforced from here on. Two members
+-- racing to commit at the same epoch used to both land (no constraint),
+-- forking the group: each member applied the lower-seq commit while the
+-- higher-seq author merged its own and diverged permanently. With this index
+-- the second INSERT conflicts; the new client code treats the conflict as
+-- "lost the race", rolls back its local merge, and re-processes the winner.
+-- Backward-compatible: the previously shipped app's plain INSERT now fails
+-- fast on the conflict (and rolls back its pending commit) instead of forking.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mls_commit_conv_epoch
+    ON mls_commit_log (conversation_id, epoch);

--- a/pollis-core/src/db/mod.rs
+++ b/pollis-core/src/db/mod.rs
@@ -20,6 +20,11 @@ pub const POST_BASELINE_MIGRATIONS: &[(u32, &str, &str)] = &[
         "index_gm_user_and_channels_group",
         include_str!("migrations/000002_index_gm_user_and_channels_group.sql"),
     ),
+    (
+        3,
+        "mls_commit_log_unique_epoch",
+        include_str!("migrations/000003_mls_commit_log_unique_epoch.sql"),
+    ),
 ];
 
 pub mod queries {

--- a/pollis-core/src/state.rs
+++ b/pollis-core/src/state.rs
@@ -88,6 +88,18 @@ pub struct AppState {
     /// alive and Squirrel.Mac's ShipIt helper sits forever waiting for
     /// the parent PID to die — i.e. the "Relaunching…" hang #335 fixes.
     pub shutdown_signal: Arc<Notify>,
+    /// Per-conversation locks serializing MLS group mutations within this
+    /// process. The MLS sync path (`process_pending_commits`,
+    /// `external_join_group`, reconcile) has several independent callers —
+    /// `send_message`, channel + DM ingest, the realtime inbox handler, and
+    /// device-enrollment finalize. Without serialization two of them can both
+    /// observe "no local group", both external-join, and post two distinct
+    /// commits at the same epoch, forking the group (prod incident: group
+    /// `01KQYX89…`). One lock per `conversation_id` makes the
+    /// read-modify-write of an MLS group's local state + its commit-log INSERT
+    /// atomic on this device. Cross-device races are caught instead by the
+    /// `UNIQUE(conversation_id, epoch)` constraint on `mls_commit_log`.
+    pub mls_group_locks: Arc<Mutex<HashMap<String, Arc<Mutex<()>>>>>,
 }
 
 impl AppState {
@@ -130,7 +142,28 @@ impl AppState {
             #[cfg(not(any(target_os = "ios", target_os = "android")))]
             terminals: Arc::new(Mutex::new(HashMap::new())),
             shutdown_signal: Arc::new(Notify::new()),
+            mls_group_locks: Arc::new(Mutex::new(HashMap::new())),
         }
+    }
+
+    /// Acquire the per-conversation MLS lock. The returned guard must be held
+    /// for the full read-modify-write of the group's local MLS state plus its
+    /// `mls_commit_log` INSERT, so concurrent callers on this device can't race
+    /// into a commit fork. The lock is keyed by `conversation_id` (group_id for
+    /// channels, conversation_id for DMs — the same id used as the MLS group
+    /// id). Non-reentrant: a caller already holding this lock must call the
+    /// `*_locked` helper variants rather than re-acquiring.
+    pub async fn mls_group_lock(
+        &self,
+        conversation_id: &str,
+    ) -> tokio::sync::OwnedMutexGuard<()> {
+        let entry = {
+            let mut map = self.mls_group_locks.lock().await;
+            map.entry(conversation_id.to_string())
+                .or_insert_with(|| Arc::new(Mutex::new(())))
+                .clone()
+        };
+        entry.lock_owned().await
     }
 
     /// Tear down long-lived background tasks so the host process can

--- a/src-tauri/tests/flows/messages.rs
+++ b/src-tauri/tests/flows/messages.rs
@@ -883,3 +883,140 @@ async fn envelope_cleanup_ttl_or_watermark() {
     drop(alice);
     drop(bob);
 }
+
+/// Count distinct commit blobs at a given epoch for a conversation. Used to
+/// confirm the fork precondition (two competing commits at one epoch) was
+/// actually produced — diagnostic only, not an invariant.
+async fn distinct_commits_at_epoch(
+    remote: &Arc<pollis_lib::db::remote::RemoteDb>,
+    conversation_id: &str,
+    epoch: i64,
+) -> i64 {
+    let conn = remote.conn().await.expect("remote conn");
+    let mut rows = conn
+        .query(
+            "SELECT COUNT(DISTINCT hex(commit_data)) FROM mls_commit_log \
+             WHERE conversation_id = ?1 AND epoch = ?2",
+            libsql::params![conversation_id.to_string(), epoch],
+        )
+        .await
+        .expect("distinct commit query");
+    let row = rows.next().await.expect("row").expect("some row");
+    row.get::<i64>(0).expect("count")
+}
+
+/// Reproduces the Bluestone production fork (prod group `01KQYX89...`).
+///
+/// Two admins commit from the SAME MLS epoch before either has processed the
+/// other's commit. Both commits are posted to `mls_commit_log` at the same
+/// epoch — and because the log has no uniqueness on `(conversation_id, epoch)`,
+/// BOTH land. Every member then processes `ORDER BY epoch ASC, seq ASC` and
+/// applies the lower-`seq` commit (branch A), advancing past it. The author of
+/// the higher-`seq` commit already merged its OWN commit (branch B) locally,
+/// so it sits on a divergent epoch-N tree and can never apply branch A's later
+/// commits — it is permanently forked.
+///
+/// Symptom (matches the prod report): the forked member and the branch-A
+/// members cannot decrypt each other's messages, even though group membership
+/// never changed.
+///
+/// This asserts the product invariant — every CURRENT member can message every
+/// other current member — so it FAILS on today's forking code and should PASS
+/// once two commits racing for the same epoch are resolved by a
+/// compare-and-swap (only one wins; the loser rolls back its local merge and
+/// re-applies the winner before retrying).
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn concurrent_commits_at_same_epoch_must_not_fork_a_member() {
+    wipe().await;
+
+    let mut alice = TestClient::new().await;
+    let mut bob = TestClient::new().await;
+    let mut dave = TestClient::new().await;
+    let mut erin = TestClient::new().await;
+
+    let _alice_p = alice.sign_up("alice@test.local").await;
+    let bob_p = bob.sign_up("bob@test.local").await;
+    let dave_p = dave.sign_up("dave@test.local").await;
+    let erin_p = erin.sign_up("erin@test.local").await;
+
+    // alice creates the group and adds bob; both settle at the same epoch
+    // with the same tree {alice, bob}.
+    let group_id = alice.create_group("Fork").await;
+    let channel_id = alice.general_channel_id(&group_id).await;
+    alice.invite(&group_id, &bob_p.username).await;
+    let invite_id = bob
+        .first_pending_invite()
+        .await
+        .expect("bob invite")["id"]
+        .as_str()
+        .expect("invite id")
+        .to_string();
+    bob.accept_invite(&invite_id).await;
+    bob.poll().await;
+    alice.process_commits_for(&channel_id).await;
+    bob.process_commits_for(&channel_id).await;
+
+    // bob must be an admin to invite (mirrors Bluestone: all members admin).
+    alice
+        .set_member_role(&group_id, bob.user_id(), "admin")
+        .await;
+
+    // ── Concurrent commits from the same epoch ──
+    // alice invites dave: alice reconciles and commits (add dave) from the
+    // current epoch → branch A. This merges locally and gets the lower seq.
+    alice.invite(&group_id, &dave_p.username).await;
+    // bob has NOT processed alice's commit, so bob is still at the prior
+    // epoch. bob invites erin: bob reconciles and commits from that SAME
+    // epoch → branch B, higher seq. Two distinct commits now occupy one epoch.
+    bob.invite(&group_id, &erin_p.username).await;
+
+    // Precondition sanity (diagnostic): the fork was actually produced. The
+    // add-bob commit was epoch 0, so the concurrent adds race for epoch 1.
+    let remote = alice.state.remote_db.clone();
+    let distinct = distinct_commits_at_epoch(&remote, &group_id, 1).await;
+    eprintln!("[test] distinct commits at epoch 1 = {distinct} (fork iff > 1)");
+
+    // Membership never shrank — bob is still a current member.
+    let members = alice.group_member_ids(&group_id).await;
+    assert!(
+        members.contains(&bob.user_id().to_string()),
+        "precondition: bob must still be a current group member, got: {members:?}"
+    );
+
+    // alice sends from branch A.
+    alice.send_channel_message(&channel_id, "from-alice").await;
+
+    // INVARIANT: bob, a current member, must be able to read alice's message.
+    // On the forking code bob is stranded on branch B and cannot — its content
+    // comes back null.
+    bob.process_commits_for(&channel_id).await;
+    let bob_msgs = bob.fetch_channel_messages(&channel_id).await;
+    let bob_contents: Vec<&str> = bob_msgs
+        .iter()
+        .filter_map(|m| m["content"].as_str())
+        .collect();
+    assert!(
+        bob_contents.contains(&"from-alice"),
+        "FORK: bob (a current member) cannot decrypt alice's message — two \
+         commits landed at the same epoch and forked bob onto a divergent \
+         tree. got: {bob_msgs:#?}"
+    );
+
+    // And the reverse: bob sends, alice (branch A) must read it.
+    bob.send_channel_message(&channel_id, "from-bob").await;
+    let alice_msgs = alice.fetch_channel_messages(&channel_id).await;
+    let alice_contents: Vec<&str> = alice_msgs
+        .iter()
+        .filter_map(|m| m["content"].as_str())
+        .collect();
+    assert!(
+        alice_contents.contains(&"from-bob"),
+        "FORK: alice cannot decrypt current member bob's message. got: {alice_msgs:#?}"
+    );
+
+    drop(alice);
+    drop(bob);
+    drop(dave);
+    drop(erin);
+}


### PR DESCRIPTION
Fixes the Bluestone group drift: two members could commit from the same MLS epoch and both land in `mls_commit_log` (no uniqueness), forking the group — each member applied the lower-seq commit while the higher-seq author merged its own and diverged permanently, so the forked member and the rest couldn't decrypt each other.

## Changes
- **`UNIQUE(conversation_id, epoch)`** on `mls_commit_log` (migration 000003) — dedups any historical fork (keep MIN seq per epoch) then adds the index. The constraint the CAS targets.
- **Compare-and-swap** commit submission in reconcile + external_join (`ON CONFLICT … DO NOTHING`). Lost race → roll back the local merge and converge on the winner instead of forking. external_join retries from the advanced epoch.
- **Per-conversation MLS lock** on `AppState` serializes the in-process callers (send, channel/DM ingest, realtime inbox, enrollment) that could otherwise race into a double external-join — the original Bluestone cause.
- **Fork recovery**: a commit at the device's current epoch that fails to apply (non-evicted) drops the local group so the external-rejoin rebuilds from the latest canonical GroupInfo. Heals already-forked devices on next sync.

## Tests
27 MLS unit + 28 flows (incl. new `concurrent_commits_at_same_epoch_must_not_fork_a_member` regression) + 5 multi-device + electron e2e smoke — all green. Migration verified against the dev DB (dedup no-op, index created, no data loss).