### PR TITLE
fix(updater): don't silently install updates while the app is open

### DIFF
--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -493,6 +493,19 @@ void app.whenReady().then(async () => {
   // anything real. In dev (`pnpm dev:electron`), short-circuit so the UI's
   // mounted check call doesn't throw — same shape Tauri's plugin uses when
   // there's no update.
+
+  // Detect-only checks. `autoDownload` defaults to true, which makes a plain
+  // `checkForUpdates()` (run every 15 min by the renderer's updatePoller, whose
+  // sole job is to surface an "update available" banner) silently download the
+  // update in the background. The `update-downloaded` listener below then
+  // quitAndInstalls it — so a routine check would update the app out from under
+  // the user while it's open. Turning autoDownload off makes `checkForUpdates()`
+  // report-only; the actual download happens only via the explicit
+  // `updater:downloadAndInstall` consent path (UpdateScreen). autoInstallOnAppQuit
+  // is left at its default so an update fetched through that consent flow still
+  // installs cleanly on quit if the user doesn't restart immediately.
+  autoUpdater.autoDownload = false;
+
   ipcMain.handle("updater:check", async () => {
     if (!app.isPackaged) {
       return null;


### PR DESCRIPTION
The 15-min background update poller calls `autoUpdater.checkForUpdates()` only to surface an "update available" banner. But `autoDownload` was left at its default (`true`), so that routine check silently downloaded the update, and the `update-downloaded` handler then `quitAndInstall`ed it — updating the app out from under the user while it was open.

Set `autoUpdater.autoDownload = false` so checks are detect-only. The explicit consent/launch-gate path (`updater:downloadAndInstall` → `downloadUpdate()`) is unaffected and still installs normally; `autoInstallOnAppQuit` is left default so a consent-flow download still installs on quit if the user doesn't restart immediately.

Only ever affected self-updatable distributions (signed mac .app, Windows NSIS, Linux AppImage); package-manager installs and dev already skip the updater.