### PR TITLE
fix(voice): clear fullscreen on leave + name DM calls in the voice bar

### DIFF
--- a/frontend/src/components/Layout/AppShell.tsx
+++ b/frontend/src/components/Layout/AppShell.tsx
@@ -65,6 +65,7 @@ export const AppShell: React.FC = () => {
     setGroups,
     setChannels,
     voiceState,
+    voiceParticipants,
     statusBarAlert,
     setStatusBarAlert,
     voiceError,
@@ -417,7 +418,25 @@ export const AppShell: React.FC = () => {
       return "voice";
     }
     if (activeVoiceChannelId.startsWith("call-")) {
-      return "call";
+      // 1:1 DM call — show the other person's name, not a generic "call".
+      const peerId =
+        voiceState.kind === "joined" || voiceState.kind === "joining"
+          ? voiceState.counterpartyUserId
+          : null;
+      if (peerId) {
+        const peer = voiceParticipants.find(
+          (p) => p.identity === `voice-${peerId}`,
+        );
+        if (peer?.name) {
+          return peer.name;
+        }
+        // Peer hasn't joined the room yet (outgoing ring) — fall back to the
+        // caller name from the incoming-call slot when it's the same person.
+        if (incomingCall && incomingCall.callerId === peerId) {
+          return incomingCall.callerUsername;
+        }
+      }
+      return "Call";
     }
     for (const g of groupsWithChannels ?? []) {
       const ch = g.channels.find((c) => c.id === activeVoiceChannelId);
@@ -426,7 +445,7 @@ export const AppShell: React.FC = () => {
       }
     }
     return "voice";
-  }, [activeVoiceChannelId, groupsWithChannels]);
+  }, [activeVoiceChannelId, groupsWithChannels, voiceState, voiceParticipants, incomingCall]);
 
   return (
     <div

--- a/frontend/src/components/Voice/VoiceChannelView.tsx
+++ b/frontend/src/components/Voice/VoiceChannelView.tsx
@@ -22,6 +22,15 @@ export const VoiceChannelView: React.FC = () => {
   const shareLocalDims = shareActive ? share.dimensions : null;
   const isJoining = voiceState.kind === 'joining';
 
+  // Navigating away from the voice/call view drops any fullscreen stream.
+  // The viewer lives in AppShell (global overlay) so it would otherwise stay
+  // pinned over other pages when the user leaves this view without closing the
+  // stream first. Runs on unmount only — `setViewingScreenShareTrackKey` is a
+  // stable Zustand setter.
+  React.useEffect(() => {
+    return () => setViewingScreenShareTrackKey(null);
+  }, [setViewingScreenShareTrackKey]);
+
   // When the user is picking a screen-share source we take over the
   // entire channel content area with the in-app picker — no modal, no
   // overlay. This is the project's blanket "no modals" rule


### PR DESCRIPTION
Two small voice UX fixes.

**1. Fullscreen screenshare stays pinned after navigating away.** The fullscreen stream viewer is a global overlay in `AppShell`, so leaving the voice/call view without closing the stream first left it covering other pages. `VoiceChannelView` (the only opener, shared by group voice + DM calls) now clears `viewingScreenShareTrackKey` on unmount.

**2. DM call shows "call" in the voice bar.** The far-left "return to room" pill rendered a generic `"call"` for `call-*` rooms. It now resolves the 1:1 peer's name from `voiceState.counterpartyUserId` → `voiceParticipants` (falls back to the incoming-call caller name while ringing, then "Call").

tsc clean.