### PR TITLE
feat(notifications): @all pings every group member

### DIFF
--- a/frontend/src/hooks/useLiveKitRealtime.ts
+++ b/frontend/src/hooks/useLiveKitRealtime.ts
@@ -33,6 +33,13 @@ type RealtimeEvent =
     sender_username: string | null;
   }
   | {
+    type: 'all_mention';
+    group_id: string;
+    channel_id: string;
+    sender_id: string;
+    sender_username: string | null;
+  }
+  | {
     type: 'dm_created';
     conversation_id: string;
   }
@@ -543,6 +550,27 @@ export function useLiveKitRealtime() {
         } else {
           useTypingStore.getState().clearTyping(roomKey, event.user_id);
         }
+        return;
+      }
+
+      // @all mention in a group. Arrives on the per-user inbox room (so it
+      // reaches members even when they're not in the group's LiveKit room),
+      // separate from the new_message event. Fires an OS ping that normal
+      // channel messages don't — notify() still suppresses it if the user has
+      // notifications off. Skip our own @all; the notifications-off pref and
+      // cooldown are enforced in notify().
+      if (event.type === 'all_mention') {
+        if (event.sender_id === currentUserIdRef.current) {
+          return;
+        }
+        const senderUsername = event.sender_username ?? 'Someone';
+        const title = roomNameMapRef.current.get(event.channel_id) ?? 'New mention';
+        notify('all_mention', {
+          roomId: event.channel_id,
+          title,
+          body: `${senderUsername} mentioned @all`,
+          senderUsername,
+        });
         return;
       }
 

--- a/frontend/src/utils/notify.ts
+++ b/frontend/src/utils/notify.ts
@@ -12,7 +12,8 @@ export type Category =
   | 'dm_request'
   | 'group_invite'
   | 'enrollment'
-  | 'incoming_call';
+  | 'incoming_call'
+  | 'all_mention';
 
 type CategoryConfig = {
   sound?: 'ping' | 'join' | 'leave';
@@ -50,6 +51,10 @@ const CATEGORIES: Record<Category, CategoryConfig> = {
   group_invite:      { sound: 'ping',  osNotif: true                                              },
   enrollment:        { sound: 'ping',  osNotif: true,                            overlay: true    },
   incoming_call:     {                  osNotif: true,                            honorsRingtonePref: true },
+  // @all in a group: the one channel event that DOES raise an OS ping (unlike
+  // channel_message). Badge is left to the accompanying new_message event so a
+  // connected client doesn't double-count unread.
+  all_mention:       { sound: 'ping',  osNotif: true,                            cooldownMs: 2500 },
 };
 
 export type NotifyPayload = {

--- a/pollis-core/src/commands/messages/send.rs
+++ b/pollis-core/src/commands/messages/send.rs
@@ -166,6 +166,42 @@ pub async fn send_message(
         }
     }
 
+    // @all mention: group messages don't raise OS notifications for every
+    // new message, but an explicit `@all` pings every group member's inbox so
+    // they get one. Per-user "notifications off" is enforced client-side in
+    // notify.ts. Inbox publish (one per member) is fire-and-forget; failures
+    // are logged, never fatal to the send. Only meaningful for group channels.
+    if is_channel && mentions_all(&content) {
+        let member_ids: Vec<String> = {
+            let conn = state.remote_db.conn().await?;
+            let mut rows = conn.query(
+                "SELECT user_id FROM group_member WHERE group_id = ?1 AND user_id <> ?2",
+                libsql::params![mls_group_id.clone(), sender_id.clone()],
+            ).await?;
+            let mut ids = Vec::new();
+            while let Some(row) = rows.next().await? {
+                ids.push(row.get::<String>(0)?);
+            }
+            ids
+        };
+        let payload = serde_json::json!({
+            "type": "all_mention",
+            "group_id": mls_group_id,
+            "channel_id": conversation_id,
+            "sender_id": sender_id,
+            "sender_username": sender_username,
+        });
+        for uid in member_ids {
+            if let Err(e) = crate::commands::livekit::publish_to_user_inbox(
+                &state.config,
+                &uid,
+                payload.clone(),
+            ).await {
+                eprintln!("[realtime] send_message: @all inbox publish to {uid}: {e}");
+            }
+        }
+    }
+
     Ok(Message {
         id,
         conversation_id,
@@ -173,5 +209,15 @@ pub async fn send_message(
         content: Some(content),
         reply_to_id,
         sent_at: now,
+    })
+}
+
+/// True when `content` contains an `@all` mention as a standalone token —
+/// i.e. whitespace-delimited and ignoring trailing punctuation, so "@all" and
+/// "@all," match but "@allison" and "email@allcorp" do not. Case-insensitive.
+fn mentions_all(content: &str) -> bool {
+    content.split_whitespace().any(|w| {
+        w.trim_end_matches(|c: char| !c.is_alphanumeric() && c != '@')
+            .eq_ignore_ascii_case("@all")
     })
 }


### PR DESCRIPTION
Closes #267.

Group messages don't raise OS notifications by default (only the unread badge). An explicit `@all` in a group message now pings every member.

- **Backend** (`send.rs`): when a group-channel message's plaintext contains a standalone `@all` token, fan out an `all_mention` event to each group member's inbox (`publish_to_user_inbox`), excluding the sender. Fire-and-forget; non-fatal. `mentions_all()` matches `@all`/`@all,` but not `@allison`/`email@allcorp`.
- **Frontend**: new `all_mention` realtime event → `notify('all_mention')`, a new category with `osNotif: true` (the one channel event that pings). Badge is left to the accompanying `new_message` event to avoid double-counting. The per-user notifications-off pref and cooldown are enforced in `notify()`, so "notifications off entirely" still suppresses it.

Descoped per the issue: no custom tags, no per-member granularity. cargo check + tsc clean.