### PR TITLE
fix(mls): block revoked-device rejoin via external commit (#356)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -141,6 +141,19 @@ function MainApp() {
 
       const session = await api.getSession();
       if (session) {
+        // If this device was revoked while offline it never received the
+        // realtime "device_revoked" nudge — confirm registration on startup
+        // and sign out if its row is gone. Errors (offline) fall through, so a
+        // transient blip never signs anyone out.
+        const stillRegistered = await api
+          .isCurrentDeviceRegistered(session.user.id)
+          .catch(() => true);
+        if (!stillRegistered) {
+          await api.logout(false).catch(() => {});
+          useAppStore.getState().logout();
+          return;
+        }
+
         if (session.enrollmentRequired) {
           // Returning device that has never been enrolled (e.g. user
           // signed in once before the enrollment system shipped, or the

--- a/frontend/src/hooks/useLiveKitRealtime.ts
+++ b/frontend/src/hooks/useLiveKitRealtime.ts
@@ -40,6 +40,14 @@ type RealtimeEvent =
     sender_username: string | null;
   }
   | {
+    // Sent to every device on the user's inbox when one of their devices is
+    // revoked. Each device re-checks its own registration and only the
+    // revoked one signs out.
+    type: 'device_revoked';
+    device_id: string;
+    user_id: string;
+  }
+  | {
     type: 'dm_created';
     conversation_id: string;
   }
@@ -550,6 +558,34 @@ export function useLiveKitRealtime() {
         } else {
           useTypingStore.getState().clearTyping(roomKey, event.user_id);
         }
+        return;
+      }
+
+      // One of this user's devices was revoked. The inbox is per-user, so this
+      // reaches every device; authoritatively confirm with the backend whether
+      // it's THIS device that's gone (spoof-safe — a forged nudge can't sign
+      // out a still-valid device) and only then sign out. Errors (offline) are
+      // treated as "still registered" so we never sign out on a transient blip.
+      if (event.type === 'device_revoked') {
+        const userId = currentUserIdRef.current;
+        if (!userId) {
+          return;
+        }
+        // The handler is sync, so chain rather than await.
+        invoke<boolean>('is_current_device_registered', { userId })
+          .then((stillRegistered) => {
+            if (stillRegistered) {
+              return;
+            }
+            console.warn('[realtime] this device was revoked — signing out');
+            return invoke('logout', { deleteData: false })
+              .catch(() => {})
+              .then(() => {
+                useAppStore.getState().logout();
+              });
+          })
+          // Offline / transient error — never sign out on a blip.
+          .catch(() => {});
         return;
       }
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -206,6 +206,13 @@ export async function revokeDevice(userId: string, deviceId: string): Promise<vo
   await invoke('revoke_device', { userId, deviceId });
 }
 
+// Whether this device is still registered for `userId`. `false` means it was
+// revoked and the caller should sign out. Spoof-resistant: confirmed against
+// the backend rather than a (forgeable) realtime nudge.
+export async function isCurrentDeviceRegistered(userId: string): Promise<boolean> {
+  return invoke('is_current_device_registered', { userId });
+}
+
 // ── User ───────────────────────────────────────────────────────────────────
 
 export interface UserProfileData {

--- a/pollis-core/src/commands/auth.rs
+++ b/pollis-core/src/commands/auth.rs
@@ -1105,7 +1105,47 @@ pub async fn revoke_device(
         }
     }
 
+    // Cooperative "you've been signed out" nudge. The inbox is per-user, so
+    // this reaches every device; each one re-checks its own registration via
+    // `is_current_device_registered` and only the revoked device logs out.
+    // Advisory UX only — a hostile/offline device that ignores this is still
+    // evicted at the MLS layer (honest members reject its self-add). Non-fatal.
+    let payload = serde_json::json!({
+        "type": "device_revoked",
+        "device_id": device_id,
+        "user_id": user_id,
+    });
+    if let Err(e) =
+        crate::commands::livekit::publish_to_user_inbox(&state.config, &user_id, payload).await
+    {
+        eprintln!("[revoke_device] inbox nudge failed (non-fatal): {e}");
+    }
+
     Ok(())
+}
+
+/// Whether the current device (`state.device_id`) is still registered in
+/// `user_device` for `user_id`. `false` means this device was revoked and the
+/// caller should log out. Authoritative + spoof-resistant: a forged
+/// `device_revoked` inbox nudge cannot force a logout unless the device's row
+/// is genuinely gone. Returns `true` when the device id isn't known yet (early
+/// boot) so it never logs out a device that simply hasn't initialized.
+pub async fn is_current_device_registered(
+    state: &Arc<AppState>,
+    user_id: String,
+) -> Result<bool> {
+    let device_id = match state.device_id.lock().await.clone() {
+        Some(d) => d,
+        None => return Ok(true),
+    };
+    let conn = state.remote_db.conn().await?;
+    let mut rows = conn
+        .query(
+            "SELECT 1 FROM user_device WHERE user_id = ?1 AND device_id = ?2",
+            libsql::params![user_id, device_id],
+        )
+        .await?;
+    Ok(rows.next().await?.is_some())
 }
 
 #[cfg(test)]

--- a/pollis-core/src/commands/mls/group_state.rs
+++ b/pollis-core/src/commands/mls/group_state.rs
@@ -496,6 +496,38 @@ pub async fn process_pending_commits_inner(
     process_pending_commits_locked(state, mls_group_id, user_id).await
 }
 
+/// Whether this device's `user_device` row still exists remotely. Gates the
+/// external-join *recovery* paths so a revoked device (row deleted by
+/// `revoke_device`) can't auto-rejoin a group it was removed from — which would
+/// squat an epoch and wedge the group under the UNIQUE(conversation_id, epoch)
+/// constraint.
+///
+/// Fails OPEN (returns true) on a missing device_id or any query error: a
+/// transient inability to check must never lock a legitimate device out of
+/// recovery. The authoritative, fail-closed control is the inbound self-add
+/// rejection in `process_pending_commits_locked`; this is the cooperative
+/// "don't even try to climb back in" half.
+async fn local_device_registered(state: &Arc<AppState>, user_id: &str) -> bool {
+    let device_id = match state.device_id.lock().await.clone() {
+        Some(d) => d,
+        None => return true,
+    };
+    let conn = match state.remote_db.conn().await {
+        Ok(c) => c,
+        Err(_) => return true,
+    };
+    match conn
+        .query(
+            "SELECT 1 FROM user_device WHERE user_id = ?1 AND device_id = ?2",
+            libsql::params![user_id, device_id],
+        )
+        .await
+    {
+        Ok(mut rows) => matches!(rows.next().await, Ok(Some(_))),
+        Err(_) => true,
+    }
+}
+
 /// Body of [`process_pending_commits_inner`]. Assumes the caller already holds
 /// the per-conversation MLS lock (`state.mls_group_lock`).
 pub(crate) async fn process_pending_commits_locked(
@@ -519,10 +551,18 @@ pub(crate) async fn process_pending_commits_locked(
     let initial_epoch = match has_group {
         Some(epoch) => epoch,
         None => {
-            // No local group — external-join to create one. Lock already held
-            // by the wrapper, so call the unlocked inner variant.
-            if let Err(e) = external_join_group_inner(state, mls_group_id, user_id).await {
-                eprintln!("[mls] process_pending_commits: no local group for {mls_group_id}, external-join failed: {e}");
+            // No local group — external-join to create one, UNLESS this
+            // device has been revoked (its `user_device` row is gone). A
+            // revoked device must not climb back in: doing so squats an epoch
+            // and, under the UNIQUE(conversation_id, epoch) constraint, would
+            // wedge the group. Lock already held by the wrapper, so call the
+            // unlocked inner variant.
+            if local_device_registered(state, user_id).await {
+                if let Err(e) = external_join_group_inner(state, mls_group_id, user_id).await {
+                    eprintln!("[mls] process_pending_commits: no local group for {mls_group_id}, external-join failed: {e}");
+                }
+            } else {
+                eprintln!("[mls] process_pending_commits: device for {user_id} is no longer registered — not external-joining {mls_group_id} (revoked)");
             }
             return Ok(());
         }
@@ -535,7 +575,7 @@ pub(crate) async fn process_pending_commits_locked(
     //    local-DB await below.
     let conn = state.remote_db.conn().await?;
     let mut rows = conn.query(
-        "SELECT epoch, commit_data, added_user_id, added_device_ids \
+        "SELECT seq, epoch, commit_data, added_user_id, added_device_ids, sender_id \
          FROM mls_commit_log \
          WHERE conversation_id = ?1 AND epoch >= ?2 \
          ORDER BY epoch ASC, seq ASC",
@@ -544,18 +584,22 @@ pub(crate) async fn process_pending_commits_locked(
 
     #[derive(Debug)]
     struct PendingCommit {
+        seq: i64,
         epoch: i64,
         commit_data: Vec<u8>,
         added_user_id: Option<String>,
         added_device_ids: Vec<String>,
+        sender_id: Option<String>,
     }
 
     let mut pending: Vec<PendingCommit> = Vec::new();
     while let Some(row) = rows.next().await? {
-        let epoch: i64 = row.get(0)?;
-        let data: Vec<u8> = row.get(1)?;
-        let added_user_id: Option<String> = row.get::<Option<String>>(2).ok().flatten();
-        let ids_csv: Option<String> = row.get::<Option<String>>(3).ok().flatten();
+        let seq: i64 = row.get(0)?;
+        let epoch: i64 = row.get(1)?;
+        let data: Vec<u8> = row.get(2)?;
+        let added_user_id: Option<String> = row.get::<Option<String>>(3).ok().flatten();
+        let ids_csv: Option<String> = row.get::<Option<String>>(4).ok().flatten();
+        let sender_id: Option<String> = row.get::<Option<String>>(5).ok().flatten();
         let added_device_ids: Vec<String> = ids_csv
             .as_deref()
             .map(|s| {
@@ -566,10 +610,12 @@ pub(crate) async fn process_pending_commits_locked(
             })
             .unwrap_or_default();
         pending.push(PendingCommit {
+            seq,
             epoch,
             commit_data: data,
             added_user_id,
             added_device_ids,
+            sender_id,
         });
     }
     drop(rows);
@@ -590,30 +636,67 @@ pub(crate) async fn process_pending_commits_locked(
             break;
         }
 
-        // ── Inbound cert verification (advisory) ─────────────────
-        // Log a warning if cross-signing verification fails, but still
-        // process the commit. Blocking here causes epoch divergence
-        // because the commit was already applied by the sender.
+        // ── Inbound cert verification ────────────────────────────
         if let Some(ref added_user_id) = commit.added_user_id {
-            let ok = verify_added_devices(
+            let verified = match verify_added_devices(
                 &conn,
                 added_user_id,
                 &commit.added_device_ids,
             )
-            .await;
-            match ok {
-                Ok(true) => {}
-                Ok(false) => {
-                    eprintln!(
-                        "[mls] process_pending_commits: WARN cross-signing verification failed for {added_user_id} at epoch {} in {mls_group_id} — processing anyway",
-                        commit.epoch
-                    );
-                }
+            .await
+            {
+                Ok(v) => v,
                 Err(e) => {
                     eprintln!(
-                        "[mls] process_pending_commits: WARN cert verification error for {mls_group_id}: {e} — processing anyway"
+                        "[mls] process_pending_commits: cert verification error for {mls_group_id}: {e}"
                     );
+                    false
                 }
+            };
+
+            if !verified {
+                // A *self-add* (the committer adding its own device via an
+                // external commit) that fails cross-signing verification is the
+                // unambiguous "revoked device re-adding itself" shape: its
+                // `user_device` row is gone, so verification cannot pass.
+                // Reject it — do NOT apply — AND delete the squatting commit
+                // row, because under the UNIQUE(conversation_id, epoch)
+                // constraint a left-in-place poison row permanently wedges every
+                // future commit at this epoch. Deleting by `seq` is precise and
+                // idempotent across honest members. Honest first-joins and
+                // legitimate external-join recoveries keep their `user_device`
+                // row, so they verify and never hit this branch.
+                let is_self_add = commit
+                    .sender_id
+                    .as_deref()
+                    .map_or(false, |s| s == added_user_id.as_str());
+                if is_self_add {
+                    eprintln!(
+                        "[mls] process_pending_commits: REJECTING unverified self-add by {added_user_id} at epoch {} in {mls_group_id} (revoked device?) — dropping commit seq {}",
+                        commit.epoch, commit.seq
+                    );
+                    if let Err(e) = conn
+                        .execute(
+                            "DELETE FROM mls_commit_log WHERE seq = ?1",
+                            libsql::params![commit.seq],
+                        )
+                        .await
+                    {
+                        eprintln!(
+                            "[mls] process_pending_commits: failed to delete rejected self-add seq {}: {e}",
+                            commit.seq
+                        );
+                    }
+                    break;
+                }
+                // A third-party add (an admin/inviter adding someone else) that
+                // fails verification stays ADVISORY: the sender already merged
+                // it, so blocking would diverge us from the rest of the group.
+                // Only the self-add shape above is safe to hard-reject.
+                eprintln!(
+                    "[mls] process_pending_commits: WARN cross-signing verification failed for {added_user_id} at epoch {} in {mls_group_id} — processing anyway (third-party add)",
+                    commit.epoch
+                );
             }
         }
 
@@ -726,10 +809,18 @@ pub(crate) async fn process_pending_commits_locked(
         })
     };
     if !group_exists {
-        eprintln!("[mls] process_pending_commits: group {mls_group_id} was deleted during processing — external-joining to recover");
-        // Lock already held by the wrapper, so call the unlocked inner variant.
-        if let Err(e) = external_join_group_inner(state, mls_group_id, user_id).await {
-            eprintln!("[mls] process_pending_commits: recovery external-join failed for {mls_group_id}: {e}");
+        // Recover by external-join — UNLESS this device was revoked (its
+        // `user_device` row is gone), in which case it must stay out rather
+        // than squatting an epoch to climb back in. A legitimately-forked or
+        // freshly-wiped device keeps its row and recovers normally.
+        if local_device_registered(state, user_id).await {
+            eprintln!("[mls] process_pending_commits: group {mls_group_id} was deleted during processing — external-joining to recover");
+            // Lock already held by the wrapper, so call the unlocked inner variant.
+            if let Err(e) = external_join_group_inner(state, mls_group_id, user_id).await {
+                eprintln!("[mls] process_pending_commits: recovery external-join failed for {mls_group_id}: {e}");
+            }
+        } else {
+            eprintln!("[mls] process_pending_commits: group {mls_group_id} deleted and device for {user_id} is no longer registered — staying out (revoked)");
         }
     }
 

--- a/pollis-node/src/dispatch/auth.rs
+++ b/pollis-node/src/dispatch/auth.rs
@@ -25,6 +25,7 @@ pub async fn dispatch(
         "wipe_local_data" => Some(wipe_local_data(args).await),
         "list_user_devices" => Some(list_user_devices(args).await),
         "revoke_device" => Some(revoke_device(args).await),
+        "is_current_device_registered" => Some(is_current_device_registered(args).await),
         _ => None,
     }
 }
@@ -198,4 +199,17 @@ async fn revoke_device(args: &serde_json::Value) -> Result<serde_json::Value> {
         .await
         .map_err(core_err)?;
     Ok(serde_json::Value::Null)
+}
+
+async fn is_current_device_registered(args: &serde_json::Value) -> Result<serde_json::Value> {
+    #[derive(serde::Deserialize)]
+    struct Args {
+        user_id: String,
+    }
+    let Args { user_id } = serde_json::from_value(args.clone()).map_err(json_err)?;
+    let state = ensure_state().await?;
+    let out = pollis_core::commands::auth::is_current_device_registered(&state, user_id)
+        .await
+        .map_err(core_err)?;
+    serde_json::to_value(out).map_err(json_err)
 }

--- a/src-tauri/tests/flows/messages.rs
+++ b/src-tauri/tests/flows/messages.rs
@@ -1020,3 +1020,114 @@ async fn concurrent_commits_at_same_epoch_must_not_fork_a_member() {
     drop(dave);
     drop(erin);
 }
+
+/// #356 — a device whose `user_device` row has been deleted (the revoked-device
+/// state) must not be able to climb back into a group it was removed from.
+///
+/// Modeled cross-user: each `TestClient` user gets its own local DB, whereas
+/// the harness shares one local DB per `user_id` and so cannot represent two
+/// independent devices of the *same* user (that intra-user path is validated by
+/// manual multi-device testing). The MLS mechanics are identical either way —
+/// a leaf whose device cert is gone must fail cross-signing verification, so the
+/// device cannot rejoin. Before this fix the verification was advisory, so a
+/// removed device with live Turso write creds external-joined straight back in.
+///
+/// Asserts: after removal + cert deletion the device does NOT auto-rejoin,
+/// cannot read post-removal messages, and does not wedge the group (the
+/// rejected self-add must not be allowed to squat the epoch under the
+/// UNIQUE(conversation_id, epoch) constraint).
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn revoked_device_cannot_rejoin_group() {
+    wipe().await;
+
+    let mut alice = TestClient::new().await;
+    let mut bob = TestClient::new().await;
+    let mut carol = TestClient::new().await;
+    let _alice_p = alice.sign_up("alice@test.local").await;
+    let bob_p = bob.sign_up("bob@test.local").await;
+    let carol_p = carol.sign_up("carol@test.local").await;
+
+    let group_id = alice.create_group("Revoke").await;
+    let channel_id = alice.general_channel_id(&group_id).await;
+
+    // bob + carol join.
+    for (c, p) in [(&bob, &bob_p), (&carol, &carol_p)] {
+        alice.invite(&group_id, &p.username).await;
+        let invite_id = c
+            .first_pending_invite()
+            .await
+            .expect("invite")["id"]
+            .as_str()
+            .expect("invite id")
+            .to_string();
+        c.accept_invite(&invite_id).await;
+        c.poll().await;
+        alice.process_commits_for(&channel_id).await;
+    }
+    bob.process_commits_for(&channel_id).await;
+    carol.process_commits_for(&channel_id).await;
+
+    // Baseline: everyone decrypts.
+    alice.send_channel_message(&channel_id, "before").await;
+    for (c, label) in [(&alice, "alice"), (&bob, "bob"), (&carol, "carol")] {
+        let msgs = c.fetch_channel_messages(&channel_id).await;
+        let contents: Vec<&str> = msgs.iter().filter_map(|m| m["content"].as_str()).collect();
+        assert!(
+            contents.contains(&"before"),
+            "{label} should decrypt 'before', got: {contents:?}"
+        );
+    }
+
+    // Revoke bob's device: delete its `user_device` row so cross-signing
+    // verification can no longer pass for it (the revoked-device state).
+    {
+        let conn = alice.state.remote_db.conn().await.expect("remote conn");
+        conn.execute(
+            "DELETE FROM user_device WHERE user_id = ?1",
+            libsql::params![bob_p.id.clone()],
+        )
+        .await
+        .expect("delete bob user_device");
+    }
+
+    // Remove bob from the group — reconcile prunes his leaf.
+    alice.remove_member(&group_id, &bob_p.id).await;
+    alice.process_commits_for(&channel_id).await;
+    carol.process_commits_for(&channel_id).await;
+
+    // bob syncs: evicted → must NOT external-join back in (device row gone).
+    bob.fetch_channel_messages(&channel_id).await;
+
+    // alice sends after the revoke.
+    alice.send_channel_message(&channel_id, "after-revoke").await;
+
+    // alice + carol read it; bob (revoked, out of the tree) does not.
+    for (c, label) in [(&alice, "alice"), (&carol, "carol")] {
+        let msgs = c.fetch_channel_messages(&channel_id).await;
+        let contents: Vec<&str> = msgs.iter().filter_map(|m| m["content"].as_str()).collect();
+        assert!(
+            contents.contains(&"after-revoke"),
+            "{label} should decrypt 'after-revoke', got: {contents:?}"
+        );
+    }
+    let bob_msgs = bob.fetch_channel_messages(&channel_id).await;
+    let bob_contents: Vec<&str> = bob_msgs.iter().filter_map(|m| m["content"].as_str()).collect();
+    assert!(
+        !bob_contents.contains(&"after-revoke"),
+        "REVOCATION BYPASS: revoked bob decrypted a post-revoke message — it rejoined the group. got: {bob_contents:?}"
+    );
+
+    // No wedge: the group keeps advancing after the rejected rejoin attempt.
+    alice.send_channel_message(&channel_id, "after-2").await;
+    let carol_msgs = carol.fetch_channel_messages(&channel_id).await;
+    let carol_contents: Vec<&str> = carol_msgs.iter().filter_map(|m| m["content"].as_str()).collect();
+    assert!(
+        carol_contents.contains(&"after-2"),
+        "group wedged after revoke — carol could not receive a new message. got: {carol_contents:?}"
+    );
+
+    drop(alice);
+    drop(bob);
+    drop(carol);
+}


### PR DESCRIPTION
Refs #356. **Not for blind-merge** — needs manual multi-device testing (see below) before merging.

## The hole
`revoke_device` removes a device's leaf, but the revoked device rejoined itself within seconds: evicted → delete local group → external-join → self-add commit, which honest members **applied** because inbound cross-signing verification was advisory-only. Net effect: revoke was a brief blip; a stolen/compromised device kept reading and sending.

## Fix
**A (read side, security core):** reject an external **self-add** (`added_user_id == sender_id`) whose cross-signing verification fails, and **delete the squatting commit row by `seq`**. Third-party adds stay advisory (blocking one the sender already merged would diverge us).

**B-lite (our side):** before external-join *recovery*, verify our own device is still in `user_device`; if it's gone, stay out instead of climbing back. Fails open on transient errors so legit recovery (fork-repair, DB wipe) is never blocked.

**B (cooperative UX — "you've been signed out"):** `revoke_device` publishes a `device_revoked` nudge to the user's (per-user) inbox; each device re-checks its OWN registration via the new `is_current_device_registered` command and only the revoked one logs out. App.tsx runs the same check on startup for the offline case. **Not a security control** — a hostile device ignores it; fix A is what actually evicts. It's spoof-resistant: a forged nudge can't sign out a still-valid device (the backend confirms the row is genuinely gone).

## ⚠️ Interaction with v1.1.18 (important)
The `UNIQUE(conversation_id, epoch)` CAS shipped *after* #356 was written. That changes the issue's "just drop the commit" fix: a left-in-place poison row would **permanently wedge** every future commit at that epoch. So fix A also deletes the poison row (by `seq`), and B-lite stops the squat at the source. Without both, every revoke would wedge the group at the next epoch — including when revoking a not-yet-updated old-binary device during rollout.

## Tests
`revoked_device_cannot_rejoin_group` (flows): a member whose `user_device` row is deleted + who is removed cannot rejoin, cannot read post-removal messages, and does not wedge the group. Full suite green: 27 MLS unit + 5 multi-device + 29 flows; cargo check + tsc clean.

**Needs your manual testing (harness can't):** the integration harness shares one local DB per `user_id`, so it can't model two independent devices of the *same* user. That's the real revoke-your-own-device path — including the part-B logout UX, which has no automated coverage.

## Residual (acknowledged, not blocking)
- Adversarial DoS: a custom binary that keeps re-posting self-adds can squat epochs (availability only, **no data access**). Bounded by baked Turso write creds; the real close is per-user scoped creds (#211 territory).
- Part B is best-effort coverage: it signs out honest devices that are online (live nudge) or that boot later (startup check). A device that's offline forever, or running modified code, won't self-sign-out — but fix A keeps it out of the group regardless.