### PR TITLE
feat(voice): allow multiple devices from the same user in one room (#140)

### DIFF
--- a/.codesight/wiki/commands.md
+++ b/.codesight/wiki/commands.md
@@ -10,6 +10,7 @@ The path in each section header below points at the implementation in `pollis-co
 - `request_otp(email)` — send OTP code to email
 - `verify_otp(email, code)` → `AuthResult` — verify OTP, register the device. Does **not** open the local DB; `set_pin` (signup) or `unlock` (resume) does.
 - `get_session()` → `AuthResult | null` — rebuild profile from `accounts.json`. Does not open the local DB.
+- `get_device_id()` → `string | null` — this device's stable `device_id` (or null pre-registration). Used by the frontend to build its per-device voice identity (`voice-{user_id}:{device_id}`) so it can tell which voice participant is itself (#140).
 - `logout(delete_data)` — clear session, optionally delete local data
 - `delete_account(user_id)` — delete account from Turso + local
 - `wipe_local_data()` — delete all local databases and keystore entries
@@ -98,7 +99,8 @@ Every path that produces a fresh `account_id_key` (signup, approval, Secret-Key 
 - `connect_rooms(room_ids, user_id, username)`
 
 ## voice (`commands/voice.rs`)
-- `prepare_voice_connection(channel_id, user_id, display_name)` — best-effort warmup fired on user "intent" (hover, route entry). Mints + caches a LiveKit token and runs a one-shot HTTPS probe to warm DNS / TLS / connection pool. Idempotent; safe to call eagerly. Consumed by the next `join_voice_channel` for the same channel + identity.
+**Participant identity** is per-device: `voice-{user_id}:{device_id}` (device_id from `AppState.device_id`; falls back to legacy `voice-{user_id}` pre-login). This lets two devices of the same user coexist in one room instead of colliding on the SFU (#140) — mirrors the realtime/inbox scheme in `livekit/realtime.rs`. Parse the user back out with `voice::user_id_from_voice_identity` (Rust) / `voice/identity.ts` (frontend). The voice event loop **does not play back** audio tracks whose parsed user_id is the local user's (self-hear mute) but still shows them as participants. `RoomEvent::Disconnected` now fully tears down the room + mic stream via `release_voice_resources` (previously leaked).
+- `prepare_voice_connection(channel_id, user_id, display_name)` — best-effort warmup fired on user "intent" (hover, route entry). Mints + caches a LiveKit token (with the per-device identity, so it matches the join) and runs a one-shot HTTPS probe to warm DNS / TLS / connection pool. Idempotent; safe to call eagerly. Consumed by the next `join_voice_channel` for the same channel + identity.
 - `join_voice_channel(channel_id, user_id, display_name, input_device, output_device, audio_processing)` — connect to LiveKit and publish the local mic. `audio_processing` is the `ApmConfig` struct (AGC + NS + AEC settings) — see [Audio Processing](./audio-processing.md). Consumes a fresh warmup if present and runs `Room::connect` + cpal mic init concurrently to minimise cold-start latency.
 - `leave_voice_channel()`
 - `toggle_voice_mute()`

--- a/frontend/src/components/Layout/AppShell.tsx
+++ b/frontend/src/components/Layout/AppShell.tsx
@@ -22,6 +22,7 @@ import { startUpdatePolling, stopUpdatePolling } from "../../services/updatePoll
 import { loadDeviceCallRingtone } from "../../utils/notify";
 import { usePreferences } from "../../hooks/queries/usePreferences";
 import { voiceSession } from "../../voice";
+import { userIdFromVoiceIdentity } from "../../voice/identity";
 import { useGlobalShortcut } from "../../keyboard";
 import type { RouterContext } from "../../types/router";
 
@@ -437,7 +438,7 @@ export const AppShell: React.FC = () => {
           : null;
       if (peerId) {
         const peer = voiceParticipants.find(
-          (p) => p.identity === `voice-${peerId}`,
+          (p) => userIdFromVoiceIdentity(p.identity) === peerId,
         );
         if (peer?.name) {
           return peer.name;

--- a/frontend/src/components/Voice/RemoteUserVolumeSlider.tsx
+++ b/frontend/src/components/Voice/RemoteUserVolumeSlider.tsx
@@ -4,12 +4,12 @@ import { Volume2 } from "lucide-react";
 import {
   usePreferences,
   clampRemoteUserVolume,
-  userIdFromVoiceIdentity,
   REMOTE_USER_VOLUME_MIN,
   REMOTE_USER_VOLUME_MAX,
   REMOTE_USER_VOLUME_DEFAULT,
   type PreferencesData,
 } from "../../hooks/queries/usePreferences";
+import { userIdFromVoiceIdentity } from "../../voice/identity";
 
 interface RemoteUserVolumeSliderProps {
   identity: string;

--- a/frontend/src/components/Voice/VoiceBar.tsx
+++ b/frontend/src/components/Voice/VoiceBar.tsx
@@ -5,6 +5,7 @@ import { useUserGroupsWithChannels } from "../../hooks/queries/useGroups";
 import { Volume2, Mic, MicOff, PhoneOff, SlidersHorizontal, Monitor, MonitorOff } from "lucide-react";
 import { PillButton } from "../ui/PillButton";
 import { voiceSession } from "../../voice";
+import { disambiguateVoiceNames } from "../../voice/disambiguateNames";
 import {
   friendlyScreenShareError,
   screenShareSession,
@@ -21,7 +22,6 @@ export const VoiceBar: React.FC<VoiceBarProps> = ({ channelId, channelName }) =>
     voiceParticipants,
     voiceState,
     voiceActiveSpeakerIds,
-    currentUser,
   } = useAppStore();
   const voiceIsMuted = voiceState.kind === 'joined' ? voiceState.micMuted : false;
   const share = shareOf(voiceState);
@@ -41,8 +41,10 @@ export const VoiceBar: React.FC<VoiceBarProps> = ({ channelId, channelName }) =>
   const leave = () => voiceSession.leave();
 
   // The voice bar is feedback about *other* speakers, so always exclude self.
-  // Local participant identity is `voice-${userId}` (see VoiceSessionManager).
-  const localIdentity = currentUser ? `voice-${currentUser.id}` : null;
+  // The local participant is flagged `isLocal` by VoiceSessionManager (which
+  // owns the device-suffixed identity), so we read it off the list rather than
+  // reconstructing `voice-${userId}`.
+  const localIdentity = voiceParticipants.find((p) => p.isLocal)?.identity ?? null;
   const remoteActiveSpeakerIds = voiceActiveSpeakerIds.filter((id) => id !== localIdentity);
   const lastRemoteSpeakerId = remoteActiveSpeakerIds.at(-1);
 
@@ -194,7 +196,8 @@ export const VoiceBar: React.FC<VoiceBarProps> = ({ channelId, channelName }) =>
         {lastRemoteSpeakerId
           ? <>
             <Volume2 size={12} style={{ verticalAlign: "middle" }} />
-            {voiceParticipants.find(p => p.identity === lastRemoteSpeakerId)?.name}
+            {disambiguateVoiceNames(voiceParticipants).get(lastRemoteSpeakerId)
+              ?? voiceParticipants.find(p => p.identity === lastRemoteSpeakerId)?.name}
           </>
           : null}
       </span>

--- a/frontend/src/components/Voice/VoiceChannelView.tsx
+++ b/frontend/src/components/Voice/VoiceChannelView.tsx
@@ -6,6 +6,8 @@ import { VoiceMemberTile } from "./VoiceMemberTile";
 import { LOCAL_PREVIEW_KEY } from "../../screenshare/screenShareSession";
 import { ScreenSharePicker } from "./ScreenSharePicker";
 import { shareOf } from "../../types/voice-state";
+import { disambiguateVoiceNames } from "../../voice/disambiguateNames";
+import { voiceUserKey } from "../../voice/identity";
 
 export const VoiceChannelView: React.FC = () => {
   const {
@@ -13,14 +15,15 @@ export const VoiceChannelView: React.FC = () => {
     voiceActiveSpeakerIds,
     voiceState,
     screenShareRemotes,
-    currentUser,
     setViewingScreenShareTrackKey,
   } = useAppStore();
-  const localIdentity = currentUser ? `voice-${currentUser.id}` : null;
   const share = shareOf(voiceState);
   const shareActive = share.kind === 'active';
   const shareLocalDims = shareActive ? share.dimensions : null;
   const isJoining = voiceState.kind === 'joining';
+  // Suffix duplicate display names (`name`, `name (1)`, …) so two devices of
+  // the same user are distinguishable in the grid (#140). Presentational only.
+  const displayNames = disambiguateVoiceNames(voiceParticipants);
 
   // Navigating away from the voice/call view drops any fullscreen stream.
   // The viewer lives in AppShell (global overlay) so it would otherwise stay
@@ -60,19 +63,21 @@ export const VoiceChannelView: React.FC = () => {
         minCellWidth={180}
         maxCellWidth={240}
         onActivate={(p) => {
-          const isLocal = p.identity === localIdentity;
+          const isLocal = p.isLocal;
           // Enter activates the streaming user's tile → open fullscreen.
           if (isLocal && shareActive) {
             setViewingScreenShareTrackKey(LOCAL_PREVIEW_KEY);
             return;
           }
-          const share = screenShareRemotes[p.identity];
+          // screenShareRemotes is keyed by the publisher's user (voice-{userId}),
+          // not their specific device, so collapse the device suffix to match.
+          const share = screenShareRemotes[voiceUserKey(p.identity)];
           if (share) {
             setViewingScreenShareTrackKey(share.trackKey);
           }
         }}
         renderCell={(p, { focused }) => {
-          const isLocal = p.identity === localIdentity;
+          const isLocal = p.isLocal;
           // Resolve which (if any) stream this participant is publishing
           // and pass it down as a unified shape so the tile doesn't care
           // whether it's our own preview track or a remote's.
@@ -84,7 +89,7 @@ export const VoiceChannelView: React.FC = () => {
             streamWidth = shareLocalDims?.width;
             streamHeight = shareLocalDims?.height;
           } else if (!isLocal) {
-            const remote = screenShareRemotes[p.identity];
+            const remote = screenShareRemotes[voiceUserKey(p.identity)];
             if (remote) {
               streamTrackKey = remote.trackKey;
               streamWidth = remote.width;
@@ -94,7 +99,7 @@ export const VoiceChannelView: React.FC = () => {
           return (
             <VoiceMemberTile
               identity={p.identity}
-              name={p.name}
+              name={displayNames.get(p.identity) ?? p.name}
               avatarKey={p.avatarKey ?? null}
               isMuted={p.isMuted}
               isLocal={isLocal}

--- a/frontend/src/hooks/queries/usePreferences.ts
+++ b/frontend/src/hooks/queries/usePreferences.ts
@@ -78,18 +78,9 @@ export interface PreferencesData {
   shortcut_overrides?: { [commandId: string]: string };
 }
 
-/**
- * Strip the LiveKit voice-channel identity wrapper down to the bare
- * `user_id`. Mirrors `user_id_from_voice_identity` in the Rust voice
- * module — keep the two in sync.
- */
-export function userIdFromVoiceIdentity(identity: string): string {
-  const stripped = identity.startsWith("voice-")
-    ? identity.slice("voice-".length)
-    : identity;
-  const colon = stripped.indexOf(":");
-  return colon >= 0 ? stripped.slice(0, colon) : stripped;
-}
+// Voice-identity parsing (`userIdFromVoiceIdentity`) lives in
+// `voice/identity.ts` — the canonical home shared with the rest of the voice
+// layer. Import it from there.
 
 /** Volume slider range used by the per-remote-user output volume control. */
 export const REMOTE_USER_VOLUME_MIN = 0.0;

--- a/frontend/src/voice/VoiceSessionManager.ts
+++ b/frontend/src/voice/VoiceSessionManager.ts
@@ -82,6 +82,10 @@ export interface LeftEvent {
   groupId: string | null;
   userId: string;
   displayName: string;
+  /** Our full per-device voice identity (`voice-{userId}:{deviceId}`) for this
+   *  session, so observers can drop exactly this device — not the user's other
+   *  devices that may still be in the room. */
+  identity: string;
 }
 
 type ManagerEventMap = {
@@ -165,6 +169,22 @@ class VoiceSessionManager {
 
   /** True after we've called `subscribe_voice_events` for this process. */
   private eventsAttached = false;
+  /**
+   * This device's stable `device_id`, used to build the per-device voice
+   * identity `voice-{userId}:{deviceId}` (#140) so we can tell which
+   * participant is ourselves. Lazily fetched once via `get_device_id`; stays
+   * null (→ legacy `voice-{userId}` identity) only if the backend can't supply
+   * one yet.
+   */
+  private deviceId: string | null = null;
+  /**
+   * Our own full voice identity (`voice-{userId}:{deviceId}`) for the active
+   * session. Set in `executeJoin` *before* `invoke('join_voice_channel')` so
+   * that `handleEvent` can flag the local participant `isLocal` even when the
+   * backend's seed `ParticipantJoined` arrives mid-join — i.e. before
+   * `this.current` is populated. Cleared when the session ends.
+   */
+  private localIdentity: string | null = null;
   /** Optional preferences source; lets the manager read APM config + user volumes. */
   private preferencesProvider: (() => PreferencesData | undefined) | null = null;
 
@@ -245,7 +265,7 @@ class VoiceSessionManager {
     }
     try {
       const muted = await invoke<boolean>('toggle_voice_mute');
-      const localIdentity = this.current ? `voice-${this.current.userId}` : null;
+      const localIdentity = this.localIdentity;
       const participants = localIdentity
         ? this.state.participants.map((p) =>
             p.identity === localIdentity ? { ...p, isMuted: muted } : p,
@@ -342,10 +362,17 @@ class VoiceSessionManager {
     }
     const userId = user.id;
     const displayName = user.username ?? user.id;
-    const localIdentity = `voice-${userId}`;
     const avatarKey = store.userAvatarUrl ?? null;
 
     await this.ensureEventsChannel();
+    // Resolve our device id before building the optimistic local participant
+    // so its identity matches the device-suffixed one the backend will emit —
+    // otherwise the seed ParticipantJoined would land as a second tile.
+    await this.ensureDeviceId();
+    const localIdentity = this.localVoiceIdentity(userId);
+    // Record it now, before the seed ParticipantJoined events can arrive, so
+    // `handleEvent` resolves `isLocal` correctly during the join window.
+    this.localIdentity = localIdentity;
 
     const intentTs = this.intentTs ?? performance.now();
     this.intentTs = null;
@@ -390,6 +417,7 @@ class VoiceSessionManager {
       // Best-effort cleanup in case the Rust side partially set up state
       // before failing.
       invoke('leave_voice_channel').catch(() => {});
+      this.localIdentity = null;
       this.setState({
         phase: 'idle',
         channelId: null,
@@ -413,6 +441,7 @@ class VoiceSessionManager {
       } catch {
         // Swallow — we're already on a transition path.
       }
+      this.localIdentity = null;
       this.setState({
         phase: 'idle',
         channelId: null,
@@ -477,6 +506,7 @@ class VoiceSessionManager {
     }
 
     this.current = null;
+    this.localIdentity = null;
     this.setState({
       phase: 'idle',
       channelId: null,
@@ -494,11 +524,39 @@ class VoiceSessionManager {
         groupId: left.intent.groupId,
         userId: left.userId,
         displayName: left.displayName,
+        identity: this.localVoiceIdentity(left.userId),
       });
     }
   }
 
   // ── Voice-event channel ───────────────────────────────────────────────────
+
+  /**
+   * Build this device's voice identity: `voice-{userId}:{deviceId}` once the
+   * device id is known, else the legacy `voice-{userId}`. Must match exactly
+   * what the Rust side mints (`voice/lifecycle.rs::voice_identity`) so the
+   * local participant's events resolve as `isLocal`.
+   */
+  private localVoiceIdentity(userId: string): string {
+    return this.deviceId ? `voice-${userId}:${this.deviceId}` : `voice-${userId}`;
+  }
+
+  /**
+   * Fetch and cache this device's `device_id`. Retries on a null/failed result
+   * (device_id is stable once login completes, so a non-null value is cached
+   * for the process); cheap enough to call before every join.
+   */
+  private async ensureDeviceId(): Promise<void> {
+    if (this.deviceId) {
+      return;
+    }
+    try {
+      this.deviceId = (await invoke<string | null>('get_device_id')) ?? null;
+    } catch (e) {
+      console.warn('[voice] get_device_id failed; using user-scoped voice identity:', e);
+      this.deviceId = null;
+    }
+  }
 
   private async ensureEventsChannel(): Promise<void> {
     if (this.eventsAttached) {
@@ -511,7 +569,10 @@ class VoiceSessionManager {
   }
 
   private handleEvent(event: VoiceEvent): void {
-    const localIdentity = this.current ? `voice-${this.current.userId}` : null;
+    // Read the cached local identity (set at join time) rather than deriving it
+    // from `this.current`, which isn't populated until the join resolves — the
+    // seed ParticipantJoined for ourselves arrives before that.
+    const localIdentity = this.localIdentity;
 
     switch (event.type) {
       case 'participant_joined': {

--- a/frontend/src/voice/disambiguateNames.ts
+++ b/frontend/src/voice/disambiguateNames.ts
@@ -1,0 +1,22 @@
+/**
+ * Disambiguate display names for a voice participant list. When two or more
+ * participants share a display name — the multi-device case (#140), e.g. one
+ * user present from two devices — the first keeps the bare name and each
+ * subsequent one gets a ` (1)`, ` (2)`, … suffix in list (join) order.
+ *
+ * Purely presentational: the underlying participant `identity` is always the
+ * stable `voice-{userId}:{deviceId}` and is never touched. Returns a map keyed
+ * by participant identity → the label to render.
+ */
+export function disambiguateVoiceNames(
+  participants: ReadonlyArray<{ identity: string; name: string }>,
+): Map<string, string> {
+  const seen = new Map<string, number>();
+  const labels = new Map<string, string>();
+  for (const p of participants) {
+    const count = seen.get(p.name) ?? 0;
+    labels.set(p.identity, count === 0 ? p.name : `${p.name} (${count})`);
+    seen.set(p.name, count + 1);
+  }
+  return labels;
+}

--- a/frontend/src/voice/identity.ts
+++ b/frontend/src/voice/identity.ts
@@ -1,0 +1,28 @@
+/**
+ * Frontend mirror of the voice-identity helpers in
+ * `pollis-core/src/commands/voice/types.rs`. Voice participant identities are
+ * `voice-{userId}:{deviceId}` (per-device, #140) or the legacy `voice-{userId}`
+ * when no device id is known.
+ *
+ * This is the single canonical home for *parsing* voice identities on the
+ * renderer — keep `userIdFromVoiceIdentity` in lockstep with the Rust
+ * `user_id_from_voice_identity`. (Construction of the local identity lives once
+ * in `VoiceSessionManager`, mirroring Rust `voice_identity`.)
+ */
+
+/** Bare `userId` from a voice identity. `voice-u1:dev-a` → `u1`,
+ *  `voice-u1` → `u1`. Anything without the `voice-` prefix is returned
+ *  unchanged (degrades to a no-op). Mirrors Rust `user_id_from_voice_identity`. */
+export function userIdFromVoiceIdentity(identity: string): string {
+  const stripped = identity.startsWith('voice-') ? identity.slice('voice-'.length) : identity;
+  const colon = stripped.indexOf(':');
+  return colon === -1 ? stripped : stripped.slice(0, colon);
+}
+
+/** The user-scoped `voice-{userId}` key for a voice identity, dropping any
+ *  `:deviceId` suffix. `voice-u1:dev-a` → `voice-u1`, `voice-u1` → `voice-u1`.
+ *  Used to match user-keyed maps (e.g. `screenShareRemotes`, which is keyed by
+ *  the publisher's user, not their specific device). */
+export function voiceUserKey(identity: string): string {
+  return `voice-${userIdFromVoiceIdentity(identity)}`;
+}

--- a/frontend/src/voice/voiceBridge.ts
+++ b/frontend/src/voice/voiceBridge.ts
@@ -92,11 +92,11 @@ export function installVoiceBridge(opts: VoiceBridgeOptions): BridgeHandle {
 
     // Optimistically remove ourselves from the cached observer list so the UI
     // drops us immediately instead of waiting for the LiveKit RoomService
-    // refetch to round-trip.
-    const localIdentity = `voice-${event.userId}`;
+    // refetch to round-trip. event.identity is our full per-device identity, so
+    // a sibling device of ours still in the room is left in place.
     queryClient.setQueryData<Array<{ identity: string; name: string }>>(
       ['voice-participants', event.channelId],
-      (prev) => (prev ? prev.filter((p) => p.identity !== localIdentity) : prev),
+      (prev) => (prev ? prev.filter((p) => p.identity !== event.identity) : prev),
     );
 
     if (event.groupId) {

--- a/pollis-core/src/commands/auth.rs
+++ b/pollis-core/src/commands/auth.rs
@@ -418,6 +418,15 @@ pub async fn dev_login(
 /// also read a `session_{uid}` keystore blob — a redundant second
 /// source of truth whose transient read failures were a direct cause
 /// of issue #184 kicking users back to OTP. The blob is gone.
+/// Return this device's stable `device_id` (the one registered in
+/// `user_device` and used to scope per-device identities), or `None` if the
+/// device hasn't been registered yet this process. The frontend uses it to
+/// build its own per-device voice identity (`voice-{user_id}:{device_id}`) so
+/// it can tell which voice participant is itself (#140).
+pub async fn get_device_id(state: &Arc<AppState>) -> Result<Option<String>> {
+    Ok(state.device_id.lock().await.clone())
+}
+
 pub async fn get_session(state: &Arc<AppState>) -> Result<Option<UserProfile>> {
     // In development, DEV_EMAIL bypasses the normal session check and logs in directly.
     // Set DEV_EMAIL=user@example.com in .env.development to auto-login on every startup.

--- a/pollis-core/src/commands/voice/lifecycle.rs
+++ b/pollis-core/src/commands/voice/lifecycle.rs
@@ -29,7 +29,23 @@ use crate::{
 use super::devices::get_device;
 use super::playback::{ensure_playback, register_remote_track};
 use super::streams::start_mic_stream;
-use super::types::{JoinTimings, VoiceEvent, VoiceWarmup, VOICE_WARMUP_TTL};
+use super::types::{
+    user_id_from_voice_identity, JoinTimings, VoiceEvent, VoiceWarmup, VOICE_WARMUP_TTL,
+};
+
+/// Build the per-device LiveKit identity for a voice participant:
+/// `voice-{user_id}:{device_id}` when a device id is known (the normal case
+/// once logged in), falling back to the legacy `voice-{user_id}` when it
+/// isn't yet. The `:device_id` suffix is what lets two devices of the same
+/// user coexist in one room instead of colliding on the SFU and kicking each
+/// other (#140) — it mirrors the realtime/inbox flow in `livekit/realtime.rs`.
+/// Parse the `user_id` back out with `types::user_id_from_voice_identity`.
+fn voice_identity(user_id: &str, device_id: Option<&str>) -> String {
+    match device_id {
+        Some(d) => format!("voice-{user_id}:{d}"),
+        None => format!("voice-{user_id}"),
+    }
+}
 
 // ── Tauri commands ────────────────────────────────────────────────────────
 
@@ -99,10 +115,14 @@ pub async fn prepare_voice_connection(
         }
     }
 
+    // Identity must match the one `join_voice_channel` will mint, or the
+    // warmed token is useless. device_id is stable for the process lifetime,
+    // so it doesn't need to be part of the warmup cache key above.
+    let device_id = state.device_id.lock().await.clone();
     let token = make_token(
         &state.config,
         &channel_id,
-        &format!("voice-{user_id}"),
+        &voice_identity(&user_id, device_id.as_deref()),
         &display_name,
     )?;
 
@@ -222,6 +242,15 @@ pub async fn join_voice_channel(
         return Err(anyhow::anyhow!("LiveKit is not configured on this server").into());
     }
 
+    // Per-device LiveKit identity (#140): `voice-{user_id}:{device_id}`. Lets a
+    // second device of the same user join the room as a distinct participant
+    // instead of getting kicked on an identity collision. Stable for the
+    // process, so it's resolved once here and reused for the token, the local
+    // speaking-indicator identity, the seed ParticipantJoined, and the
+    // self-hear filter below.
+    let device_id = state.device_id.lock().await.clone();
+    let local_identity = voice_identity(&user_id, device_id.as_deref());
+
     // Try to consume a fresh warmup for this exact channel + identity. If
     // the warmup is stale or for a different room/user we mint a new token.
     // VoiceWarmup implements Drop (to abort its background task) so we can't
@@ -262,7 +291,7 @@ pub async fn join_voice_channel(
             let t = make_token(
                 &state.config,
                 &channel_id,
-                &format!("voice-{user_id}"),
+                &local_identity,
                 &display_name,
             )?;
             jwt_mint_ms = jwt_start.elapsed().as_millis() as u64;
@@ -407,7 +436,7 @@ pub async fn join_voice_channel(
     // the user's effective level (after AGC + NS) rather than raw input.
     let audio_source_task = audio_source.clone();
     let voice_arc_frame = Arc::clone(&state.voice);
-    let local_identity = format!("voice-{user_id}");
+    let local_identity_for_speaking = local_identity.clone();
     let apm_for_capture = apm_handle.clone();
     let denoiser_for_capture = Arc::clone(&denoiser_arc);
     let frame_task = tokio::spawn(async move {
@@ -462,9 +491,9 @@ pub async fn join_voice_channel(
                     let voice = voice_arc_frame.lock().await;
                     if let Some(ch) = &voice.channel {
                         if is_speaking {
-                            let _ = ch.send(VoiceEvent::SpeakingStarted { identity: local_identity.clone() });
+                            let _ = ch.send(VoiceEvent::SpeakingStarted { identity: local_identity_for_speaking.clone() });
                         } else {
-                            let _ = ch.send(VoiceEvent::SpeakingStopped { identity: local_identity.clone() });
+                            let _ = ch.send(VoiceEvent::SpeakingStopped { identity: local_identity_for_speaking.clone() });
                         }
                     }
                 }
@@ -530,7 +559,7 @@ pub async fn join_voice_channel(
         let voice = state.voice.lock().await;
         if let Some(ch) = &voice.channel {
             let _ = ch.send(VoiceEvent::ParticipantJoined {
-                identity: format!("voice-{user_id}"),
+                identity: local_identity.clone(),
                 name: display_name.clone(),
                 is_muted: false,
                 avatar_url: local_avatar_url,
@@ -550,6 +579,9 @@ pub async fn join_voice_channel(
     let voice_arc = Arc::clone(&state.voice);
     let state_for_room = Arc::clone(state);
     let apm_rate_for_room = mic_rate;
+    // Captured for the self-hear filter on TrackSubscribed: audio published by
+    // this user's *other* devices must not be played back locally (#140).
+    let local_user_id = user_id.clone();
     let room_task = tokio::spawn(async move {
         while let Some(event) = events.recv().await {
             match event {
@@ -587,6 +619,19 @@ pub async fn join_voice_channel(
                 RoomEvent::TrackSubscribed { track, publication: _, participant } => {
                     match track {
                         RemoteTrack::Audio(audio_track) => {
+                            let participant_identity = participant.identity().to_string();
+                            // Self-hear mute (#140): never attach a playback
+                            // stream for audio published by our own user's other
+                            // devices. The participant still shows in the UI (its
+                            // ParticipantConnected event already fired) — we just
+                            // don't route its mic back into our speakers, which
+                            // would otherwise echo us to ourselves.
+                            if user_id_from_voice_identity(&participant_identity) == local_user_id {
+                                eprintln!(
+                                    "[voice] skipping own-device audio track for self-hear mute: {participant_identity}"
+                                );
+                                continue;
+                            }
                             let track_key = format!("{}-{}", participant.identity(), audio_track.sid());
                             eprintln!("[voice] track subscribed: {track_key}");
                             register_remote_track(
@@ -660,6 +705,15 @@ pub async fn join_voice_channel(
                         }
                     }
                     crate::commands::screenshare::on_room_disconnected(&state_for_room).await;
+                    // Tear down our own Rust-side resources on a server-initiated
+                    // disconnect (network drop, duplicate identity, room close).
+                    // Previously this branch only emitted the event and broke,
+                    // leaking VoiceState.room + the cpal mic stream until the
+                    // user manually left or quit. Pass abort_room_task=false:
+                    // we ARE room_task and `break` right after, so it ends on
+                    // its own. The frontend's reconciler may also call
+                    // leave_voice_channel; release_voice_resources is idempotent.
+                    let _ = release_voice_resources(&state_for_room, false).await;
                     break;
                 }
                 RoomEvent::ConnectionStateChanged(conn_state) => {
@@ -740,26 +794,37 @@ pub async fn get_last_join_timings(
 }
 
 /// Disconnect from the current voice room and release all audio resources.
-pub async fn leave_voice_channel(state: &Arc<AppState>) -> Result<()> {
-    // Stop any active screen share first. We abort room_task below, so the
-    // RoomEvent::Disconnected -> on_room_disconnected path never fires on an
-    // explicit leave; without this, the share keeps capturing after the call
-    // ends. Done before we take/close the room so the track unpublishes
-    // gracefully while the connection is still alive. No-ops cheaply (the
-    // had_session guard) when nothing is being shared.
-    crate::commands::screenshare::stop_screen_share(state).await.ok();
-
+/// Tear down all live voice resources and return the room handle (if any) for
+/// the caller to close. Stops the mic frame feed, takes the cpal input/output
+/// streams and drops them on a blocking thread (CoreAudio dispose must not run
+/// on a tokio worker — see the macOS mic-indicator note below), and clears the
+/// playback + e2ee state while holding the lock only briefly.
+///
+/// `abort_room_task` controls whether the room event-loop task is aborted.
+/// `leave_voice_channel` passes `true`. The `RoomEvent::Disconnected` handler
+/// — which runs *inside* that task and is about to `break` on its own — passes
+/// `false` so it doesn't abort itself mid-teardown.
+///
+/// Idempotent: a second call after teardown is a cheap no-op (every field is
+/// already `None`), so the Disconnected path and a racing `leave_voice_channel`
+/// can both run without harm.
+async fn release_voice_resources(
+    state: &Arc<AppState>,
+    abort_room_task: bool,
+) -> Option<Arc<Room>> {
     // Extract everything that needs cleanup while holding the lock, then release
-    // the lock before awaiting room.close(). If the network is broken (e.g. VPN
-    // dropped), room.close() hangs sending a disconnect signal — holding the lock
-    // during that await deadlocks every subsequent command that needs voice state.
+    // the lock before awaiting. If the network is broken (e.g. VPN dropped),
+    // room.close() (in the caller) hangs sending a disconnect signal — holding
+    // the lock across that await would deadlock every subsequent voice command.
     let (room, input_stream, output_stream) = {
         let mut voice = state.voice.lock().await;
 
         // Kill the frame feed first so no more frames are pushed into the
         // audio source / room while we tear them down.
         if let Some(t) = voice.frame_task.take() { t.abort(); }
-        if let Some(t) = voice.room_task.take() { t.abort(); }
+        if abort_room_task {
+            if let Some(t) = voice.room_task.take() { t.abort(); }
+        }
 
         // Take the cpal output stream out of playback state so we can drop
         // it on a blocking thread (CoreAudio dispose isn't safe to run on a
@@ -803,6 +868,21 @@ pub async fn leave_voice_channel(state: &Arc<AppState>) -> Result<()> {
         })
         .await;
     }
+
+    room
+}
+
+pub async fn leave_voice_channel(state: &Arc<AppState>) -> Result<()> {
+    // Stop any active screen share first. We abort room_task in
+    // release_voice_resources below, so the RoomEvent::Disconnected ->
+    // on_room_disconnected path never fires on an explicit leave; without this,
+    // the share keeps capturing after the call ends. Done before we take/close
+    // the room so the track unpublishes gracefully while the connection is
+    // still alive. No-ops cheaply (the had_session guard) when nothing is
+    // being shared.
+    crate::commands::screenshare::stop_screen_share(state).await.ok();
+
+    let room = release_voice_resources(state, true).await;
 
     // Close outside the lock with a timeout so a broken connection (dropped VPN,
     // network change) can't stall a reconnect attempt indefinitely.
@@ -1066,4 +1146,45 @@ pub async fn set_voice_audio_processing(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn voice_identity_includes_device_suffix() {
+        assert_eq!(voice_identity("u1", Some("dev-a")), "voice-u1:dev-a");
+    }
+
+    #[test]
+    fn voice_identity_falls_back_without_device() {
+        // Legacy / pre-login shape — no `:device_id` suffix.
+        assert_eq!(voice_identity("u1", None), "voice-u1");
+    }
+
+    #[test]
+    fn identity_round_trips_back_to_user_id() {
+        // The minted identity must parse back to the bare user_id with the
+        // same helper the playback/volume paths use, both with and without a
+        // device suffix.
+        for id in [voice_identity("u1", Some("dev-a")), voice_identity("u1", None)] {
+            assert_eq!(user_id_from_voice_identity(&id), "u1");
+        }
+    }
+
+    #[test]
+    fn self_hear_predicate_matches_sibling_device_only() {
+        // The self-hear filter compares the *parsed* user_id of an inbound
+        // track's participant against the local user_id. A second device of
+        // the same user must match (→ skip playback); a different user must
+        // not (→ play normally).
+        let local_user_id = "u1";
+
+        let sibling_device = voice_identity("u1", Some("dev-b"));
+        assert_eq!(user_id_from_voice_identity(&sibling_device), local_user_id);
+
+        let other_user = voice_identity("u2", Some("dev-x"));
+        assert_ne!(user_id_from_voice_identity(&other_user), local_user_id);
+    }
 }

--- a/pollis-node/src/dispatch/auth.rs
+++ b/pollis-node/src/dispatch/auth.rs
@@ -19,6 +19,7 @@ pub async fn dispatch(
         "verify_email_change" => Some(verify_email_change(args).await),
         "dev_login" => Some(dev_login(args).await),
         "get_session" => Some(get_session(args).await),
+        "get_device_id" => Some(get_device_id(args).await),
         "logout" => Some(logout(args).await),
         "delete_account" => Some(delete_account(args).await),
         "list_known_accounts" => Some(list_known_accounts(args).await),
@@ -129,6 +130,14 @@ async fn dev_login(args: &serde_json::Value) -> Result<serde_json::Value> {
 async fn get_session(_args: &serde_json::Value) -> Result<serde_json::Value> {
     let state = ensure_state().await?;
     let out = pollis_core::commands::auth::get_session(&state)
+        .await
+        .map_err(core_err)?;
+    serde_json::to_value(out).map_err(json_err)
+}
+
+async fn get_device_id(_args: &serde_json::Value) -> Result<serde_json::Value> {
+    let state = ensure_state().await?;
+    let out = pollis_core::commands::auth::get_device_id(&state)
         .await
         .map_err(core_err)?;
     serde_json::to_value(out).map_err(json_err)


### PR DESCRIPTION
Closes #140.

Per-device LiveKit identity `voice-{user_id}:{device_id}` so two devices of the same user join as distinct participants instead of kicking each other on the SFU. Mirrors the existing realtime/inbox identity scheme.

- **Self-hear mute**: don't play back a sibling device's audio (still shown as a participant).
- **Name disambiguation**: duplicate display names get `UserA`, `UserA (1)`, …
- **Teardown on `RoomEvent::Disconnected`**: tears down room + mic stream (fixes a pre-existing leak).
- **`get_device_id`** command feeds the renderer's per-device identity; voice-identity parsing consolidated into `voice/identity.ts`.
- `isLocal` is now the single source of truth (manager-owned), fixing a latent race where the local participant's seed event landed before `this.current` was set.

Rust: 4 unit tests (identity construction/parse + self-hear predicate). tsc + cargo check clean.

Manual multi-device + live-LiveKit verification still needed (the harness can't model two devices of one user).