### PR TITLE
feat(chat): live @all indicator in the composer

### DIFF
--- a/frontend/src/components/Layout/MainContent.tsx
+++ b/frontend/src/components/Layout/MainContent.tsx
@@ -713,6 +713,9 @@ export const MainContent: React.FC<MainContentProps> = ({ pendingDmRequest = nul
             onSend={handleSend}
             onValueChange={typing.notify}
             autoFocus
+            // @all fans out a notification only in group channels (DMs don't),
+            // so the live "@all notifies everyone" hint is gated on one.
+            canNotifyAll={!!selectedChannelId}
             draftKey={
               // Prefix with the room kind so the rare case of a channel id
               // and a DM conversation id colliding still routes to separate

--- a/frontend/src/components/ui/ChatInput.tsx
+++ b/frontend/src/components/ui/ChatInput.tsx
@@ -13,6 +13,7 @@ import { getFileIcon } from "../../utils/fileIcon";
 import { formatFileSize } from "../../utils/format";
 import { useDropTargetStore } from "../../stores/dropTargetStore";
 import { getDraft, setDraft } from "../../utils/drafts";
+import { mentionsAll } from "../../utils/mentions";
 
 // Attachment carries a filesystem path so Rust can read the file directly —
 // no bytes-over-IPC bottleneck, no size limit.
@@ -51,6 +52,11 @@ interface ChatInputProps {
   // the prop while the parent's room id is still loading — the component
   // re-syncs whenever this value changes within the same mount.
   draftKey?: string | null;
+  // True when a standalone `@all` in the message will actually notify every
+  // member — i.e. this is a group channel (DMs and other surfaces don't fan
+  // out an `all_mention`). Gates the live "@all notifies everyone" composer
+  // hint so it only appears where the mention does something.
+  canNotifyAll?: boolean;
 }
 
 function mimeFromName(name: string): string {
@@ -215,6 +221,7 @@ export const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(({
   maxAttachments = 10,
   onValueChange,
   draftKey = null,
+  canNotifyAll = false,
 }, ref) => {
   const [message, setMessage] = useState(() => getDraft(draftKey));
   // Re-sync message when draftKey changes within the same mount (e.g. the
@@ -466,6 +473,11 @@ export const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(({
 
   const hasLoadingAttachments = attachments.some((a) => a.loading);
 
+  // Live signal that the message, as typed, will ping every channel member.
+  // Mirrors the backend's `mentions_all()` so the sender sees the hint exactly
+  // when the send will fan out an `all_mention`.
+  const willNotifyEveryone = canNotifyAll && mentionsAll(message);
+
   const handleSend = () => {
     if (!message.trim() && attachments.length === 0) { return; }
     if (hasLoadingAttachments) { return; }
@@ -554,6 +566,21 @@ export const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(({
               onExpand={(url, type) => setExpandedPreview({ url, type })}
             />
           ))}
+        </div>
+      )}
+
+      {/* @all hint — appears live while the message contains a standalone
+          @all in a group channel, telling the sender the send will ping
+          everyone. Not a modal: an inline row in the composer. */}
+      {willNotifyEveryone && (
+        <div
+          className="px-3 py-1 flex items-center gap-1.5 text-xs font-mono"
+          style={{ color: "var(--c-accent)", borderBottom: "1px solid var(--c-border)" }}
+        >
+          <span style={{ fontWeight: 600 }}>@all</span>
+          <span style={{ color: "var(--c-text-muted)" }}>
+            notifies everyone in this channel
+          </span>
         </div>
       )}
 

--- a/frontend/src/utils/mentions.ts
+++ b/frontend/src/utils/mentions.ts
@@ -1,0 +1,14 @@
+// Mirror of `mentions_all()` in pollis-core/src/commands/messages/send.rs.
+// Keep the two in sync: the backend is the source of truth for whether a
+// message actually pings everyone, and this drives the composer hint that
+// tells the sender it will. A standalone `@all` token matches (whitespace-
+// delimited, trailing punctuation ignored) so "@all" and "@all," match but
+// "@allison" and "email@allcorp" do not. Case-insensitive.
+export function mentionsAll(content: string): boolean {
+  return content.split(/\s+/).some((word) => {
+    // Trim trailing characters that are neither alphanumeric nor '@', the
+    // same predicate the Rust matcher uses.
+    const trimmed = word.replace(/[^\p{L}\p{N}@]+$/u, "");
+    return trimmed.toLowerCase() === "@all";
+  });
+}


### PR DESCRIPTION
Follow-up to #362. `@all` pings every channel member, but the sender had no signal it would do anything while typing.

Adds a live inline hint in the composer: when a group-channel message contains a standalone `@all`, an accent row appears above the input reading **"@all notifies everyone in this channel"**, updating as you type and disappearing the moment the token is no longer valid.

- `utils/mentions.ts` — `mentionsAll()` mirrors the Rust `mentions_all()` matcher (standalone token, trailing punctuation ignored, case-insensitive; `@all,` matches, `@allison` doesn't).
- `ChatInput` — new optional `canNotifyAll` prop gates the hint. Inline composer row, not a modal.
- `MainContent` — passes `canNotifyAll={!!selectedChannelId}` so the hint only shows in group channels, where the backend actually fans out the ping (not DMs).

tsc clean (two pre-existing `RTCRtpCodecCapability` errors in `screenshare/codecPolicy.ts` are unrelated).