### PR TITLE
feat(mobile/media): file-path media transport for attachments (#346)

### DIFF
--- a/mobile/components/Media.tsx
+++ b/mobile/components/Media.tsx
@@ -1,0 +1,86 @@
+// Media renderers for message attachments (issue #346).
+//
+// `<MediaImage>` is the mobile counterpart to the desktop `<img>` in
+// MessageItem: it resolves the attachment to a local `file://` URI via
+// `useMediaUri` and hands it to `expo-image`, showing the blurhash as a
+// placeholder while the decrypt-to-path round-trips through Rust.
+//
+// All attachment rendering should go through this seam so the transport
+// (file path today, possibly an expo-image cache delegate later — see the
+// issue) can change without touching screens.
+
+import { useMemo } from "react";
+import { View, Text, StyleSheet } from "react-native";
+import { Image } from "expo-image";
+import type { ImageStyle, StyleProp } from "react-native";
+import { useMediaUri } from "../hooks/useMediaUri";
+import { semantic, r, type as ty } from "../theme/tokens";
+import type { MessageAttachment } from "../types";
+
+export function MediaImage({
+  attachment,
+  style,
+  contentFit = "cover",
+}: {
+  attachment: MessageAttachment;
+  style?: StyleProp<ImageStyle>;
+  contentFit?: "cover" | "contain";
+}) {
+  // While an optimistic send is still uploading there's no object key to
+  // fetch — render the local preview directly and skip the transport.
+  const isPending = !attachment.object_key && !!attachment.localPreviewUri;
+  const { uri, error } = useMediaUri(isPending ? null : attachment);
+
+  const displayUri = isPending ? attachment.localPreviewUri ?? null : uri;
+
+  // expo-image takes blurhash as a placeholder source. Memoize so the
+  // placeholder object identity is stable across renders.
+  const placeholder = useMemo(
+    () => (attachment.blurhash ? { blurhash: attachment.blurhash } : undefined),
+    [attachment.blurhash],
+  );
+
+  if (error) {
+    return (
+      <View style={[styles.fallback, style]}>
+        <Text style={styles.fallbackText}>Image unavailable</Text>
+      </View>
+    );
+  }
+
+  return (
+    <Image
+      source={displayUri ? { uri: displayUri } : undefined}
+      placeholder={placeholder}
+      placeholderContentFit={contentFit}
+      contentFit={contentFit}
+      // Plaintext on disk is unlinked on unmount (see lib/media/cache), so
+      // expo-image must not keep its own copy of the decrypted bytes.
+      cachePolicy="none"
+      transition={150}
+      style={[styles.image, style]}
+      accessibilityLabel={attachment.filename}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  image: {
+    borderRadius: r.lg,
+    backgroundColor: semantic.fieldBg,
+  },
+  fallback: {
+    borderRadius: r.lg,
+    borderWidth: 1,
+    borderColor: semantic.hair,
+    backgroundColor: semantic.fieldBg,
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 12,
+  },
+  fallbackText: {
+    fontFamily: ty.rowSub.fontFamily,
+    fontSize: 11,
+    color: semantic.mute,
+  },
+});

--- a/mobile/hooks/useMediaUri.ts
+++ b/mobile/hooks/useMediaUri.ts
@@ -1,0 +1,77 @@
+// React lifecycle hook over the media transport (issue #346).
+//
+// Resolves a `MessageAttachment` to a local `file://` URI for rendering
+// and — crucially — releases its reference when the component unmounts or
+// the attachment changes, so the decrypted plaintext file gets unlinked
+// once nothing is showing it. This is the "unlink-on-unmount" half of the
+// file-path approach; the cache bookkeeping lives in `lib/media/cache`.
+//
+//   const { uri, loading, error } = useMediaUri(attachment);
+//
+// Pass `null` (e.g. for a non-media message, or while an optimistic send
+// has no object key yet) to no-op cleanly.
+
+import { useEffect, useState } from "react";
+import { resolveMediaUri, releaseMediaUri } from "../lib/media/cache";
+import type { MessageAttachment } from "../types";
+
+export interface MediaUriState {
+  uri: string | null;
+  loading: boolean;
+  error: Error | null;
+}
+
+export function useMediaUri(
+  attachment: Pick<
+    MessageAttachment,
+    "object_key" | "content_hash" | "content_type"
+  > | null,
+): MediaUriState {
+  const [state, setState] = useState<MediaUriState>({
+    uri: null,
+    loading: !!attachment,
+    error: null,
+  });
+
+  // Re-resolve only when the underlying bytes change. content_hash is
+  // content-addressed, so it's the precise identity key — a new object_key
+  // for the same hash is the same file.
+  const contentHash = attachment?.content_hash ?? null;
+  const objectKey = attachment?.object_key ?? null;
+
+  useEffect(() => {
+    if (!attachment || !objectKey || !contentHash) {
+      setState({ uri: null, loading: false, error: null });
+      return;
+    }
+
+    let active = true;
+    setState({ uri: null, loading: true, error: null });
+
+    resolveMediaUri(attachment)
+      .then((uri) => {
+        if (active) {
+          setState({ uri, loading: false, error: null });
+        }
+      })
+      .catch((err: unknown) => {
+        if (active) {
+          setState({
+            uri: null,
+            loading: false,
+            error: err instanceof Error ? err : new Error(String(err)),
+          });
+        }
+      });
+
+    return () => {
+      active = false;
+      // Pairs with the reference taken inside resolveMediaUri. The last
+      // outstanding release unlinks the decrypted file.
+      void releaseMediaUri(contentHash);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [contentHash, objectKey]);
+
+  return state;
+}

--- a/mobile/lib/media/cache.ts
+++ b/mobile/lib/media/cache.ts
@@ -1,0 +1,167 @@
+// Mobile media transport — the file-path approach (issue #346).
+//
+// On desktop, `pollis-core` serves decrypted media over a loopback HTTP
+// server and the renderer uses `<img src="http://127.0.0.1:…">`. That
+// transport is blocked on iOS (App Transport Security) and Android
+// (cleartext-traffic restrictions), so mobile takes the other supported
+// route: Rust decrypts the R2-cached bytes to a file under the app's
+// sandbox cache dir and returns the path; the renderer points
+// `expo-image` at the resulting `file://` URI.
+//
+// This module owns the JS half of that contract:
+//
+//   - `resolveMediaUri(attachment)` invokes the Rust `get_media_path`
+//     command (analogous to desktop's `get_media_url`) and returns a
+//     `file://` URI. Concurrent callers for the same content hash share
+//     one in-flight promise — the desktop `getMediaUrl` dedup pattern.
+//   - Reference counting + `releaseMediaUri()` implement the issue's
+//     "unlink-on-unmount so the plaintext path never outlives the
+//     render" recommendation. The last release unlinks the file so
+//     decrypted plaintext doesn't linger in the cache dir.
+//
+// Nothing here knows whether the bytes came from a real Rust decrypt or
+// a dev mock (see ./mock.ts) — it only talks to the `invoke()` seam, so
+// the whole pipeline can be exercised before the Rust `get_media_path`
+// command lands.
+
+import * as FileSystem from "expo-file-system/legacy";
+import { invoke } from "../native";
+import type { MessageAttachment } from "../../types";
+
+// Decrypted media lives under the app sandbox cache dir, in a dedicated
+// subfolder so a cache wipe (or our own teardown) can't touch anything
+// else. `cacheDirectory` is OS-evictable storage — appropriate for
+// content-addressed, re-fetchable media.
+export const MEDIA_DIR = `${FileSystem.cacheDirectory ?? ""}pollis-media/`;
+
+// Args for the Rust `get_media_path` command. Snake/camel mix mirrors the
+// desktop `get_media_url` call exactly (`r2Key`, `contentHash`,
+// `contentType`) so the dispatch arm can be shared 1:1 when it's written.
+interface GetMediaPathArgs {
+  r2Key: string;
+  contentHash: string;
+  contentType: string;
+  // Absolute sandbox dir Rust should decrypt into. Passing it from JS
+  // keeps the cache location owned by the platform layer (Expo decides
+  // the sandbox path), not hardcoded in Rust.
+  destDir: string;
+}
+
+// One in-flight resolve per content hash. A second caller for the same
+// hash awaits the first instead of kicking off a redundant decrypt.
+const inFlight = new Map<string, Promise<string>>();
+
+// How many live consumers currently hold each resolved URI. The file is
+// unlinked when this hits zero. Keyed by content hash (content-addressed,
+// so identical bytes across messages share one file + one refcount).
+const refCounts = new Map<string, number>();
+
+// content hash → resolved `file://` URI, for resolved entries we still
+// hold a reference to. Lets `releaseMediaUri` find the path to unlink.
+const resolvedUris = new Map<string, string>();
+
+let dirEnsured: Promise<void> | null = null;
+
+// Create the media cache dir once. Idempotent across the app lifetime.
+function ensureDir(): Promise<void> {
+  if (!dirEnsured) {
+    dirEnsured = FileSystem.makeDirectoryAsync(MEDIA_DIR, {
+      intermediates: true,
+    }).catch((err) => {
+      // Reset so a transient failure (e.g. storage pressure) can retry on
+      // the next resolve instead of being cached forever.
+      dirEnsured = null;
+      throw err;
+    });
+  }
+  return dirEnsured;
+}
+
+// Resolve a media attachment to a local `file://` URI pointing at the
+// decrypted bytes, fetching + decrypting via Rust on first use and
+// reusing the cached file thereafter. Increments the reference count —
+// every successful resolve must be paired with a `releaseMediaUri()`
+// (the `useMediaUri` hook does this on unmount).
+export async function resolveMediaUri(
+  attachment: Pick<
+    MessageAttachment,
+    "object_key" | "content_hash" | "content_type"
+  >,
+): Promise<string> {
+  const { object_key, content_hash, content_type } = attachment;
+
+  // Optimistic sends with no object key yet can't be fetched — callers
+  // should use `localPreviewUri` for those. Guard so a half-built
+  // attachment doesn't reach Rust.
+  if (!object_key || !content_hash) {
+    throw new Error("resolveMediaUri: attachment has no object_key/content_hash");
+  }
+
+  const existing = inFlight.get(content_hash);
+  if (existing) {
+    // Count this caller too — it shares the same resolved file.
+    refCounts.set(content_hash, (refCounts.get(content_hash) ?? 0) + 1);
+    return existing;
+  }
+
+  const promise = (async () => {
+    await ensureDir();
+    const uri = await invoke<string>("get_media_path", {
+      r2Key: object_key,
+      contentHash: content_hash,
+      contentType: content_type,
+      destDir: MEDIA_DIR,
+    } satisfies GetMediaPathArgs);
+    if (!uri) {
+      throw new Error(`get_media_path returned empty path for ${content_hash}`);
+    }
+    resolvedUris.set(content_hash, uri);
+    return uri;
+  })();
+
+  inFlight.set(content_hash, promise);
+  refCounts.set(content_hash, (refCounts.get(content_hash) ?? 0) + 1);
+
+  promise.catch(() => {
+    // Drop the rejected promise so the next consumer retries instead of
+    // re-awaiting a permanent failure. The reference count is reconciled
+    // by the consumer's `releaseMediaUri` call in its cleanup.
+    inFlight.delete(content_hash);
+  });
+
+  return promise;
+}
+
+// Release one reference to a resolved attachment. When the last consumer
+// releases, the decrypted file is unlinked so plaintext doesn't outlive
+// the render (issue #346's lifecycle recommendation). Safe to call even
+// if the resolve failed.
+export async function releaseMediaUri(contentHash: string): Promise<void> {
+  const next = (refCounts.get(contentHash) ?? 0) - 1;
+  if (next > 0) {
+    refCounts.set(contentHash, next);
+    return;
+  }
+
+  refCounts.delete(contentHash);
+  inFlight.delete(contentHash);
+  const uri = resolvedUris.get(contentHash);
+  resolvedUris.delete(contentHash);
+  if (!uri) {
+    return;
+  }
+  // `idempotent` so a double-release or an already-evicted file doesn't
+  // throw.
+  await FileSystem.deleteAsync(uri, { idempotent: true });
+}
+
+// Drop every cached media file and reset bookkeeping. For sign-out /
+// account-switch teardown, where the sandbox should not retain decrypted
+// plaintext from the previous session.
+export async function clearMediaCache(): Promise<void> {
+  inFlight.clear();
+  refCounts.clear();
+  resolvedUris.clear();
+  dirEnsured = null;
+  await FileSystem.deleteAsync(MEDIA_DIR, { idempotent: true });
+}

--- a/mobile/lib/media/index.ts
+++ b/mobile/lib/media/index.ts
@@ -1,0 +1,14 @@
+// Mobile media transport (issue #346) — the file-path approach that
+// replaces desktop's loopback HTTP media server on iOS/Android.
+//
+//   import { resolveMediaUri } from "../lib/media";
+//   import { useMediaUri } from "../hooks/useMediaUri";
+//   import { MediaImage } from "../components/Media";
+
+export {
+  resolveMediaUri,
+  releaseMediaUri,
+  clearMediaCache,
+  MEDIA_DIR,
+} from "./cache";
+export { registerMediaMock } from "./mock";

--- a/mobile/lib/media/mock.ts
+++ b/mobile/lib/media/mock.ts
@@ -1,0 +1,49 @@
+// Dev-only mock for the `get_media_path` command (issue #346).
+//
+// The Rust side of the file-path transport doesn't exist yet — when it
+// does, it'll decrypt R2 bytes to a sandbox file and return the path.
+// Until then this mock writes a placeholder image into the same dest dir
+// and returns its `file://` URI, so the full mobile pipeline (resolve →
+// expo-image render → unlink-on-unmount) can be exercised end-to-end
+// against mock message data exactly as the real command will drive it.
+//
+// Registered via the bridge's mock registry, which always wins over the
+// native bridge — so this is safe to leave installed in dev even after
+// the real command lands, and trivially removed for production.
+//
+//   import { registerMediaMock } from "../lib/media/mock";
+//   registerMediaMock(); // e.g. in a dev-only effect in app/_layout
+
+import * as FileSystem from "expo-file-system/legacy";
+import { registerMockCommand } from "../native";
+
+// A small opaque PNG (amber square) — enough to confirm a real file was
+// written, read back by expo-image, and unlinked. Not representative of
+// any actual attachment; the real command returns decrypted user media.
+const PLACEHOLDER_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAGklEQVR42mP4tT/qPyWYYdSA" +
+  "UQNGDRguBgAAHKMSLu6egtEAAAAASUVORK5CYII=";
+
+interface GetMediaPathArgs {
+  contentHash: string;
+  destDir: string;
+}
+
+export function registerMediaMock(): () => void {
+  return registerMockCommand("get_media_path", async (args) => {
+    const { contentHash, destDir } = (args ?? {}) as Partial<GetMediaPathArgs>;
+    if (!contentHash || !destDir) {
+      throw new Error("mock get_media_path: missing contentHash/destDir");
+    }
+    await FileSystem.makeDirectoryAsync(destDir, { intermediates: true }).catch(
+      () => {
+        // Already exists — fine.
+      },
+    );
+    const uri = `${destDir}${contentHash}.png`;
+    await FileSystem.writeAsStringAsync(uri, PLACEHOLDER_PNG_BASE64, {
+      encoding: "base64",
+    });
+    return uri;
+  });
+}

--- a/mobile/types/index.ts
+++ b/mobile/types/index.ts
@@ -48,6 +48,28 @@ export interface DMConversation {
   updated_at: number;
 }
 
+// A file attached to a message. Mirrors `MessageAttachment` in
+// `frontend/src/types/index.ts` and the Rust struct in `pollis-core`.
+// `object_key` + `content_hash` are what the media transport (see
+// `lib/media`) needs to fetch + decrypt the bytes.
+export interface MessageAttachment {
+  id: string;
+  // R2 object key — empty string while an upload is still in progress.
+  object_key: string;
+  // SHA-256(plaintext) hex — used to derive the decryption key via HKDF.
+  content_hash: string;
+  filename: string;
+  content_type: string;
+  file_size: number;
+  uploaded_at: number;
+  blurhash?: string;
+  width?: number;
+  height?: number;
+  // Local `file://` preview for optimistic display before upload — never
+  // persisted or sent to the server.
+  localPreviewUri?: string;
+}
+
 export interface MessageQueueItem {
   id: string;
   message_id: string;


### PR DESCRIPTION
Mobile-side half of #346 — replaces desktop's loopback HTTP media server (blocked by iOS ATS / Android cleartext rules) with the file-path transport (issue's approach #1). Scoped entirely to \`mobile/\`; no \`pollis-core\`/electron/frontend changes.

- \`lib/media/cache.ts\` — \`resolveMediaUri\`/\`releaseMediaUri\`: invokes \`get_media_path\`, dedups in-flight per content hash, refcounted unlink so decrypted plaintext doesn't outlive the render.
- \`hooks/useMediaUri.ts\` — resolve on mount, release (→ unlink) on unmount.
- \`components/Media.tsx\` — \`<MediaImage>\` over expo-image w/ blurhash + \`cachePolicy="none"\`.
- \`lib/media/mock.ts\` — dev mock for \`get_media_path\` so the round-trip runs before the Rust command lands.
- \`types/index.ts\` — \`MessageAttachment\`.

Deferred (not in this PR): the Rust \`decrypt_to_path\` in \`r2.rs\` + dispatch arm, and wiring \`<MediaImage>\` into a message row. \`pnpm typecheck\` passes.

Epic #342.