### PR TITLE
Migrate frontend state from Zustand to MobX (#365)

### DIFF
--- a/.codesight/wiki/notifications.md
+++ b/.codesight/wiki/notifications.md
@@ -28,7 +28,7 @@ RealtimeEvent (Rust → JS Channel)         Local action (e.g. self voice join)
                               │       │       │       │       │
                               ▼       ▼       ▼       ▼       ▼
                           play_sfx  notify  badge   alert   overlay
-                          (Rust)   (Rust)   (Zustand) (Zustand) (Zustand)
+                          (Rust)   (Rust)   (MobX)    (MobX)    (MobX)
 ```
 
 There is **no parallel dispatcher in Rust**. All decisions happen in JS. Rust is just the transport for LiveKit events (pushed through `pollis-node`'s Rust → Node `ThreadsafeFunction`, forwarded by the Electron main process via `webContents.send("channel:<id>", payload)` to the renderer's `channelOn` subscriber) and the executor for sound (`play_sfx` rodio command). OS notifications fire through the bridge — the renderer calls `window.electronAPI.notify({ title, body, icon })`, which the main process implements via Electron's native `Notification` API.
@@ -165,7 +165,7 @@ Cooldown is keyed by `${category}:${roomId ?? '_global'}`. It applies only to so
 | `frontend/src/utils/sfx.ts` | `playSfx()` wrapper around `play_sfx` Rust command |
 | `frontend/src/hooks/useLiveKitRealtime.ts` | Categorizes incoming Rust events, calls `notify(...)`, owns pref + permission sync |
 | `frontend/src/hooks/useVoiceChannel.ts` | Calls `notify('voice_self_join'/'voice_self_leave')` for local actions |
-| `frontend/src/hooks/useBadge.ts` | Reads `unreadCounts` from Zustand, applies dock/taskbar badge |
+| `frontend/src/hooks/useBadge.ts` | Reads `unreadCounts` from the MobX store, applies dock/taskbar badge |
 | `pollis-core/src/realtime.rs` | `RealtimeEvent` enum (Rust → JS wire format) |
 | `pollis-core/src/commands/livekit.rs` | `dispatch_data()` parses payloads, sends typed events to JS |
 | `pollis-core/src/commands/sfx.rs` | `play_sfx` rodio implementation |

--- a/.codesight/wiki/overview.md
+++ b/.codesight/wiki/overview.md
@@ -26,7 +26,7 @@ React component
 
 The dispatch layer in `pollis-node/src/dispatch/<module>.rs` is mechanical — one match arm per command, deserialising the JSON args and calling the corresponding `pollis_core::commands::…` function. Real logic lives in the `pollis-core` workspace crate so other front-ends — a CLI, a TUI, mobile via uniffi — can consume it without any shell-runtime dependency. Legacy `#[tauri::command]` shims under `src-tauri/src/commands/` are preserved for rollback.
 
-**React Query** is the source of truth for remote data. **Zustand** holds only UI state (current user ref, transient session data).
+**React Query** is the source of truth for remote data. **MobX** holds only UI state (current user ref, transient session data).
 
 ## Frontend Routing
 
@@ -82,7 +82,7 @@ frontend/src/
   hooks/queries/     # React Query hooks (useGroups, useMessages, usePreferences, ...)
   pages/             # Route pages
   services/          # api.ts (invoke wrappers), r2-upload.ts
-  stores/            # Zustand (appStore.ts)
+  stores/            # MobX class singletons (appStore.ts)
   types/             # TypeScript types
 
 website/             # Static marketing site (Cloudflare Pages, not part of the app)

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -11,7 +11,7 @@ For deeper, file-anchored documentation see `.codesight/wiki/index.md`. For the 
 | Layer | Tech |
 |---|---|
 | Desktop shell | Electron 33 (Node + Chromium renderer + preload bridge) |
-| Frontend | React 19 + TypeScript, Vite, TailwindCSS, TanStack Router (memory history), TanStack Query, Zustand (UI state only) |
+| Frontend | React 19 + TypeScript, Vite, TailwindCSS, TanStack Router (memory history), TanStack Query, MobX (UI state only) |
 | Backend | Rust split into `pollis-core` (reusable crate; also exposed to mobile via uniffi) and `pollis-node` (napi-rs binding loaded into Electron's main process), invoked from the renderer via `window.electronAPI.invoke(cmd, args)` |
 | End-to-end encryption | MLS (RFC 9420) via OpenMLS 0.8 for messages and files; AES-128-GCM frame-level encryption via libwebrtc's `FrameCryptor` for voice, keyed by the MLS group's exporter secret |
 | Remote DB | Turso (libSQL) via `libsql` 0.6, native Hrana/HTTP2 protocol over TLS |
@@ -150,7 +150,7 @@ React component
 
 The renderer never imports `@tauri-apps/*` or Electron APIs directly. It imports `invoke` / `Channel` / window / dialog / fs / shell / app / updater from `frontend/src/bridge`, a thin runtime-host bridge that resolves to `window.electronAPI` under Electron and retains a legacy Tauri fallback. Real business logic lives in `pollis-core`, which has no shell-runtime dependency and is also consumed by uniffi-generated mobile bindings.
 
-**TanStack Query is the source of truth** for remote data. Components read through hooks in `frontend/src/hooks/queries/`. **Zustand** holds only UI state — selected group/channel, transient session data, current user reference. There is no parallel client-side store for remote data.
+**TanStack Query is the source of truth** for remote data. Components read through hooks in `frontend/src/hooks/queries/`. **MobX** holds only UI state — selected group/channel, transient session data, current user reference. There is no parallel client-side store for remote data. The stores in `frontend/src/stores/` are MobX class singletons; components read them inside `observer()` wrappers.
 
 Routing uses TanStack Router with **memory history** (no browser URL bar in a desktop app). `AppShell` is the root route; key routes are documented in `.codesight/wiki/overview.md`.
 
@@ -233,7 +233,7 @@ frontend/                 # React app
     pages/                # Route pages
     hooks/queries/        # TanStack Query hooks
     services/             # Frontend-side helpers (R2 upload, etc.)
-    stores/               # Zustand (UI state only)
+    stores/               # MobX (UI state only)
     types/                # TypeScript types — kept aligned with Rust structs
     router.tsx, main.tsx  # TanStack Router setup, app entry
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,9 +106,9 @@ useSendMessage()                    // invoke("send_message", ...)
 
 Never import directly from `@tauri-apps/*` — always go through `../bridge`. That way command call sites don't care which runtime is hosting them.
 
-**React Query is the source of truth** for remote data — don't duplicate in Zustand.
+**React Query is the source of truth** for remote data — don't duplicate in the MobX store.
 
-**Zustand store**: Only holds UI state (selected group/channel), current user reference, temporary session data.
+**MobX store**: Only holds UI state (selected group/channel), current user reference, temporary session data. Stores in `frontend/src/stores/` are MobX class singletons (`makeAutoObservable(this, …, { autoBind: true })`) — import the singleton (e.g. `import { appStore } from '../stores/appStore'`) and read fields directly inside an `observer()`-wrapped component. Non-React managers read the singleton directly and react to changes with `autorun`/`reaction`; React hooks that must stay reactive outside an `observer` use `useObserver(() => store.x)`.
 
 ### Backend Commands
 
@@ -240,7 +240,7 @@ Concrete implications:
 
 - **Rust backend (in the Electron main process) connects DIRECTLY to Turso** — no server middleman for CRUD
 - **All backend calls from the renderer go through the bridge** — `import { invoke } from "../bridge"`, never `@tauri-apps/api/core` directly, and never `fetch()` to a local server
-- **React Query is the source of truth** for remote data — don't duplicate in Zustand
+- **React Query is the source of truth** for remote data — don't duplicate in the MobX store
 - **Local DB should NOT have users/groups/channels tables** — those come from remote Turso
 - **TypeScript types should match Rust structs** — keep them synchronized
 - **Remote schema changes go in numbered migration files** in `pollis-core/src/db/migrations/` (e.g. `000019_my_change.sql`). `000000_baseline.sql` is the frozen canonical snapshot — never edit it. Dev: run new migrations by hand against your dev Turso. Prod: `.github/workflows/electron-release.yml` runs `scripts/db-apply.sh` after all builds succeed; migration failure aborts the release. Nobody applies to prod by hand. The runner records the `schema_migrations` row automatically — do **not** put an `INSERT INTO schema_migrations` in the migration file.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,8 +32,7 @@
     "mobx-react-lite": "^4.1.1",
     "qrcode.react": "^4.2.0",
     "react": "^19.2.4",
-    "react-dom": "^19.2.4",
-    "zustand": "^4.5.0"
+    "react-dom": "^19.2.4"
   },
   "devDependencies": {
     "@types/react": "^19.1.10",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,8 @@
     "blurhash": "^2.0.5",
     "livekit-client": "^2.19.0",
     "lucide-react": "^0.344.0",
+    "mobx": "^6.16.0",
+    "mobx-react-lite": "^4.1.1",
     "qrcode.react": "^4.2.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,7 +5,8 @@ import React, {
   useRef,
 } from "react";
 import { invoke } from "./bridge";
-import { useAppStore } from "./stores/appStore";
+import { observer } from "mobx-react-lite";
+import { appStore } from "./stores/appStore";
 import { LoginScreen } from "./components/Auth/LoginScreen";
 import { SaveSecretKeyScreen } from "./components/Auth/SaveSecretKeyScreen";
 import { PinCreateScreen } from "./components/Auth/PinCreateScreen";
@@ -61,8 +62,8 @@ function MainApp() {
     setCurrentUser,
     pendingEnrollmentApproval,
     setPendingEnrollmentApproval,
-  } = useAppStore();
-  const updateRequired = useAppStore((s) => s.updateRequired);
+  } = appStore;
+  const updateRequired = appStore.updateRequired;
 
   const [appState, setAppState] = useState<AppState>("initializing");
   const [knownAccounts, setKnownAccounts] = useState<AccountInfo[]>([]);
@@ -150,7 +151,7 @@ function MainApp() {
           .catch(() => true);
         if (!stillRegistered) {
           await api.logout(false).catch(() => {});
-          useAppStore.getState().logout();
+          appStore.logout();
           return;
         }
 
@@ -382,7 +383,7 @@ function MainApp() {
     } catch (err) {
       console.error("[App] logout during pin switch-account failed:", err);
     }
-    useAppStore.getState().logout();
+    appStore.logout();
     try {
       const index = await api.listKnownAccounts();
       setKnownAccounts(index.accounts);
@@ -400,7 +401,7 @@ function MainApp() {
     } catch (err) {
       console.error("[App] logout during enrollment cancel failed:", err);
     }
-    useAppStore.getState().logout();
+    appStore.logout();
     try {
       const index = await api.listKnownAccounts();
       setKnownAccounts(index.accounts);
@@ -443,7 +444,7 @@ function MainApp() {
     } catch (error) {
       console.error("Failed to logout:", error);
     }
-    useAppStore.getState().logout();
+    appStore.logout();
     // Re-fetch known accounts so the login screen shows the switcher
     try {
       const index = await api.listKnownAccounts();
@@ -674,4 +675,4 @@ function MainApp() {
   );
 }
 
-export default MainApp;
+export default observer(MainApp);

--- a/frontend/src/components/Layout/AppShell.tsx
+++ b/frontend/src/components/Layout/AppShell.tsx
@@ -12,7 +12,8 @@ import { screenShareSession } from "../../screenshare/screenShareSession";
 import { LoadingSpinner } from "../ui/LoaderSpinner";
 import { SearchPanel } from "../SearchPanel";
 import { TerminalView } from "../TerminalView";
-import { useAppStore } from "../../stores/appStore";
+import { observer } from "mobx-react-lite";
+import { appStore } from "../../stores/appStore";
 import { isDropTargetActive } from "../../stores/dropTargetStore";
 import { useUserGroupsWithChannels } from "../../hooks/queries/useGroups";
 import { useLiveKitRealtime } from "../../hooks/useLiveKitRealtime";
@@ -33,7 +34,7 @@ import type { RouterContext } from "../../types/router";
  */
 const SIDEBAR_DEFAULT_LS_KEY = "pollis.sidebar_open_by_default";
 
-export const AppShell: React.FC = () => {
+export const AppShell: React.FC = observer(() => {
   const [isSyncing, setIsSyncing] = useState(false);
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [isDragOver, setIsDragOver] = useState(false);
@@ -79,7 +80,7 @@ export const AppShell: React.FC = () => {
     setViewingScreenShareTrackKey,
     shareStopped,
     availableUpdateVersion,
-  } = useAppStore();
+  } = appStore;
   // Channel id derives from the union. Replaces the standalone
   // activeVoiceChannelId field that used to be stored separately.
   const activeVoiceChannelId =
@@ -107,7 +108,7 @@ export const AppShell: React.FC = () => {
     }
   }, [sidebarDefault]);
 
-  const currentUser = useAppStore((s) => s.currentUser);
+  const currentUser = appStore.currentUser;
 
   // Drive the looping ringtone off the incomingCall slot. Rust owns the
   // playback thread (`start_ring` / `stop_ring`) so the loop survives any
@@ -715,4 +716,4 @@ export const AppShell: React.FC = () => {
       </div>
     </div>
   );
-};
+});

--- a/frontend/src/components/Layout/BreadcrumbNav.tsx
+++ b/frontend/src/components/Layout/BreadcrumbNav.tsx
@@ -1,8 +1,9 @@
 import React, { useMemo } from "react";
 import { useRouter, useRouterState } from "@tanstack/react-router";
 import { ChevronLeft, Search as SearchIcon, Settings as SettingsIcon } from "lucide-react";
+import { observer } from "mobx-react-lite";
 import { useShortcutLabel } from "../../keyboard";
-import { useAppStore } from "../../stores/appStore";
+import { appStore } from "../../stores/appStore";
 import { useUserGroupsWithChannels } from "../../hooks/queries/useGroups";
 import { useDMConversations } from "../../hooks/queries/useMessages";
 
@@ -17,12 +18,12 @@ interface Segment {
  * breadcrumb hierarchy (not browser-history back) plus the breadcrumb
  * trail itself ("Home / Direct Messages / @someone").
  */
-export const BreadcrumbNav: React.FC = () => {
+export const BreadcrumbNav: React.FC = observer(() => {
   const router = useRouter();
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const { data: groupsWithChannels } = useUserGroupsWithChannels();
   const { data: dmConversations = [] } = useDMConversations();
-  const channels = useAppStore((s) => s.channels);
+  const channels = appStore.channels;
   const searchLabel = useShortcutLabel("app.toggleSearch");
 
   const segments = useMemo<Segment[]>(() => {
@@ -258,4 +259,4 @@ export const BreadcrumbNav: React.FC = () => {
       </button>
     </div>
   );
-};
+});

--- a/frontend/src/components/Layout/MainContent.tsx
+++ b/frontend/src/components/Layout/MainContent.tsx
@@ -2,8 +2,9 @@ import React, { useRef, useMemo, useState, useEffect } from "react";
 import { X } from "lucide-react";
 import { useNavigate } from "@tanstack/react-router";
 import { useQueryClient } from "@tanstack/react-query";
+import { observer } from "mobx-react-lite";
 import { invoke } from "../../bridge";
-import { useAppStore } from "../../stores/appStore";
+import { appStore } from "../../stores/appStore";
 import { MessageList } from "../Message/MessageList";
 import { ReplyPreview } from "../Message/ReplyPreview";
 import { MessageQueue } from "../Message/MessageQueue";
@@ -55,7 +56,7 @@ interface MainContentProps {
   pendingDmRequest?: PendingDmRequest | null;
 }
 
-export const MainContent: React.FC<MainContentProps> = ({ pendingDmRequest = null }) => {
+export const MainContent: React.FC<MainContentProps> = observer(({ pendingDmRequest = null }) => {
   const {
     selectedChannelId,
     selectedConversationId,
@@ -65,7 +66,7 @@ export const MainContent: React.FC<MainContentProps> = ({ pendingDmRequest = nul
     currentUser,
     pendingDeleteChannelId,
     setPendingDeleteChannelId,
-  } = useAppStore();
+  } = appStore;
   const acceptDmRequestMutation = useAcceptDMRequest();
   const blockUserMutation = useBlockUser();
   const navigate = useNavigate();
@@ -729,4 +730,4 @@ export const MainContent: React.FC<MainContentProps> = ({ pendingDmRequest = nul
       )}
     </div>
   );
-};
+});

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -19,7 +19,8 @@ import { useUserGroupsWithChannels } from "../../hooks/queries/useGroups";
 import { useDMConversations } from "../../hooks/queries/useMessages";
 import { useVoiceRoomCounts } from "../../hooks/queries/useVoiceParticipants";
 import { usePeerVerifications } from "../../hooks/queries/useUserProfile";
-import { useAppStore } from "../../stores/appStore";
+import { observer } from "mobx-react-lite";
+import { appStore } from "../../stores/appStore";
 import { usePresenceStatus, type PresenceStatus } from "../../stores/presenceStore";
 import { useShortcutLabel } from "../../keyboard";
 
@@ -45,7 +46,7 @@ interface SidebarProps {
   onToggle: () => void;
 }
 
-export const Sidebar: React.FC<SidebarProps> = ({ isOpen, onToggle }) => {
+export const Sidebar: React.FC<SidebarProps> = observer(({ isOpen, onToggle }) => {
   const router = useRouter();
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const toggleSidebarLabel = useShortcutLabel("app.toggleSidebar");
@@ -66,7 +67,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ isOpen, onToggle }) => {
     }
     return map;
   }, [peerVerifications]);
-  const unreadCounts = useAppStore((s) => s.unreadCounts);
+  const unreadCounts = appStore.unreadCounts;
 
   // Stable list of voice channel ids across all groups; powers the live
   // "users connected" badge on voice channel rows. Realtime voice events
@@ -339,7 +340,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ isOpen, onToggle }) => {
       </button>
     </aside>
   );
-};
+});
 
 interface SectionHeaderProps {
   label: string;
@@ -509,7 +510,7 @@ const PRESENCE_COLORS: Record<PresenceStatus, string> = {
   offline: "var(--c-bg)",
 };
 
-const PresenceDot: React.FC<{ userId: string | null }> = ({ userId }) => {
+const PresenceDot: React.FC<{ userId: string | null }> = observer(({ userId }) => {
   const status = usePresenceStatus(userId);
   return (
     <span
@@ -527,4 +528,4 @@ const PresenceDot: React.FC<{ userId: string | null }> = ({ userId }) => {
       }}
     />
   );
-};
+});

--- a/frontend/src/components/Layout/StatusBarSummary.tsx
+++ b/frontend/src/components/Layout/StatusBarSummary.tsx
@@ -1,7 +1,8 @@
 import React, { useMemo } from "react";
 import { useRouter } from "@tanstack/react-router";
 import { Hash, MessageCircle, UserPlus, Mail } from "lucide-react";
-import { useAppStore } from "../../stores/appStore";
+import { observer } from "mobx-react-lite";
+import { appStore } from "../../stores/appStore";
 import { useUserGroupsWithChannels } from "../../hooks/queries/useGroups";
 import { useDMConversations } from "../../hooks/queries/useMessages";
 import { useAllPendingJoinRequests, usePendingInvites } from "../../hooks/queries/useGroups";
@@ -59,8 +60,8 @@ interface StatusBarSummaryProps {
  * join requests you need to act on. Zeros render as blank space so the
  * row doesn't jitter as counts change.
  */
-export const StatusBarSummary: React.FC<StatusBarSummaryProps> = ({ color }) => {
-  const unreadCounts = useAppStore((s) => s.unreadCounts);
+export const StatusBarSummary: React.FC<StatusBarSummaryProps> = observer(({ color }) => {
+  const unreadCounts = appStore.unreadCounts;
   const { data: groupsWithChannels = [] } = useUserGroupsWithChannels();
   const { data: dmConversations = [] } = useDMConversations();
   const { data: pendingJoinRequests = [] } = useAllPendingJoinRequests();
@@ -123,4 +124,4 @@ export const StatusBarSummary: React.FC<StatusBarSummaryProps> = ({ color }) => 
       />
     </div>
   );
-};
+});

--- a/frontend/src/components/Message/MessageItem.tsx
+++ b/frontend/src/components/Message/MessageItem.tsx
@@ -4,7 +4,8 @@ import { dialogSave, writeFile } from "../../bridge";
 import { Reply, Download, Film, Check, Edit2, Trash2 } from "lucide-react";
 import { getFileIcon } from "../../utils/fileIcon";
 import { formatFileSize, formatDuration } from "../../utils/format";
-import { useAppStore } from "../../stores/appStore";
+import { observer } from "mobx-react-lite";
+import { appStore } from "../../stores/appStore";
 import { downloadAndDecryptMedia, getMediaUrl } from "../../services/r2-upload";
 import { LinkifiedText } from "../ui/LinkifiedText";
 import { MediaLinkUnfurl } from "./MediaLinkUnfurl";
@@ -40,7 +41,7 @@ const formatFullTimestamp = (timestamp: number): string => {
   return new Date(tsMs).toLocaleString([], { dateStyle: "full", timeStyle: "short" });
 };
 
-export const MessageItem: React.FC<MessageItemProps> = ({
+export const MessageItem: React.FC<MessageItemProps> = observer(({
   message,
   allMessages = [],
   authorUsername = "unknown",
@@ -51,7 +52,7 @@ export const MessageItem: React.FC<MessageItemProps> = ({
   onDelete,
   onScrollToReply,
 }) => {
-  const { currentUser } = useAppStore();
+  const { currentUser } = appStore;
   const isOwn = message.sender_id === currentUser?.id;
   const isLightBg = useBackgroundIsLight();
 
@@ -252,7 +253,7 @@ export const MessageItem: React.FC<MessageItemProps> = ({
       {/* <MessageReactions messageId={message.id} /> */}
     </div>
   );
-};
+});
 
 // Co-located: only used by AttachmentDisplay.
 const BlurhashCanvas: React.FC<{ hash: string; width: number; height: number }> = ({

--- a/frontend/src/components/Message/MessageList.tsx
+++ b/frontend/src/components/Message/MessageList.tsx
@@ -2,7 +2,8 @@ import React, { useEffect, useLayoutEffect, useRef, useMemo } from "react";
 import { MessageItem } from "./MessageItem";
 import { useBlockedUsers } from "../../hooks/queries";
 import { useGroupMembers } from "../../hooks/queries/useGroups";
-import { useRosterChangeStore, type RosterBanner } from "../../stores/rosterChangeStore";
+import { observer } from "mobx-react-lite";
+import { rosterChangeStore, type RosterBanner } from "../../stores/rosterChangeStore";
 import type { Message } from "../../types";
 
 const toMs = (timestamp: number): number =>
@@ -111,7 +112,7 @@ interface MessageListProps {
   onLoadMore?: () => void;
 }
 
-export const MessageList: React.FC<MessageListProps> = ({
+export const MessageList: React.FC<MessageListProps> = observer(({
   messages,
   conversationId,
   groupIdForNames,
@@ -161,9 +162,8 @@ export const MessageList: React.FC<MessageListProps> = ({
   // for display-name resolution: groupIdForNames === conversationId for
   // group MLS, so this read is normally cached by the same query the
   // member list page uses.
-  const rosterBanners = useRosterChangeStore(
-    (s) => (conversationId ? s.byConversation[conversationId] : undefined) ?? [],
-  );
+  const rosterBanners =
+    (conversationId ? rosterChangeStore.byConversation[conversationId] : undefined) ?? [];
   const { data: groupMembers = [] } = useGroupMembers(groupIdForNames ?? null);
   const usernameByUserId = useMemo(() => {
     const map = new Map<string, string>();
@@ -361,4 +361,4 @@ export const MessageList: React.FC<MessageListProps> = ({
       <div ref={bottomRef} />
     </div>
   );
-};
+});

--- a/frontend/src/components/Message/MessageQueue.tsx
+++ b/frontend/src/components/Message/MessageQueue.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
 import { X, Clock, Send, AlertCircle } from 'lucide-react';
-import { useAppStore } from '../../stores/appStore';
+import { observer } from 'mobx-react-lite';
+import { appStore } from '../../stores/appStore';
 import { Button } from '../ui/Button';
 
-export const MessageQueue: React.FC = () => {
+export const MessageQueue: React.FC = observer(() => {
   const {
     messageQueue,
     removeFromMessageQueue,
     updateMessageQueueItem,
-  } = useAppStore();
+  } = appStore;
 
   const pendingMessages = messageQueue.filter(
     (item) => item.status === 'pending' || item.status === 'sending'
@@ -121,4 +122,4 @@ export const MessageQueue: React.FC = () => {
       </div>
     </div>
   );
-};
+});

--- a/frontend/src/components/Message/MessageReactions.tsx
+++ b/frontend/src/components/Message/MessageReactions.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from "react";
 import { useReactions, useAddReaction, useRemoveReaction } from "../../hooks/queries/useReactions";
-import { useAppStore } from "../../stores/appStore";
+import { observer } from "mobx-react-lite";
+import { appStore } from "../../stores/appStore";
 
 const COMMON_EMOJIS = ["👍", "❤️", "😂", "😮", "😢", "🔥", "🎉", "👀"];
 
@@ -8,8 +9,8 @@ interface MessageReactionsProps {
   messageId: string;
 }
 
-export const MessageReactions: React.FC<MessageReactionsProps> = ({ messageId }) => {
-  const { currentUser } = useAppStore();
+export const MessageReactions: React.FC<MessageReactionsProps> = observer(({ messageId }) => {
+  const { currentUser } = appStore;
   const { data: reactions = [] } = useReactions(messageId);
   const addReaction = useAddReaction();
   const removeReaction = useRemoveReaction();
@@ -142,4 +143,4 @@ export const MessageReactions: React.FC<MessageReactionsProps> = ({ messageId })
       </div>
     </div>
   );
-};
+});

--- a/frontend/src/components/SearchPanel.tsx
+++ b/frontend/src/components/SearchPanel.tsx
@@ -4,7 +4,8 @@ import { Hash, Search, ArrowUp, ArrowDown, Volume2, Settings as SettingsIcon } f
 import { PresenceAvatar } from "./ui/PresenceAvatar";
 import { useUserGroupsWithChannels, useAllGroupMembers, type GroupMemberWithGroup } from "../hooks/queries/useGroups";
 import { useDMConversations } from "../hooks/queries/useMessages";
-import { useAppStore } from "../stores/appStore";
+import { observer } from "mobx-react-lite";
+import { appStore } from "../stores/appStore";
 import type { GroupWithChannels } from "../services/api";
 import { warmVoiceChannel } from "../utils/voiceWarmup";
 
@@ -218,7 +219,7 @@ function filterResults(
 
 // ─── SearchPanel ─────────────────────────────────────────────────────────────
 
-export const SearchPanel: React.FC<SearchPanelProps> = ({ isOpen, onClose }) => {
+export const SearchPanel: React.FC<SearchPanelProps> = observer(({ isOpen, onClose }) => {
   const [query, setQuery] = useState("");
   const [selectedIndex, setSelectedIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -229,10 +230,9 @@ export const SearchPanel: React.FC<SearchPanelProps> = ({ isOpen, onClose }) => 
   const { data: groupsWithChannels } = useUserGroupsWithChannels();
   const { data: dmConversations } = useDMConversations();
   const { members: allGroupMembers } = useAllGroupMembers();
-  const activeVoiceChannelId = useAppStore((s) =>
-    s.voiceState.kind === 'idle' ? null : s.voiceState.channelId,
-  );
-  const currentUserId = useAppStore((s) => s.currentUser?.id ?? null);
+  const activeVoiceChannelId =
+    appStore.voiceState.kind === 'idle' ? null : appStore.voiceState.channelId;
+  const currentUserId = appStore.currentUser?.id ?? null;
 
   // Build the full list of searchable items, active voice channel sorted to top
   const allItems = useMemo(() => {
@@ -570,4 +570,4 @@ export const SearchPanel: React.FC<SearchPanelProps> = ({ isOpen, onClose }) => 
       </div>
     </div>
   );
-};
+});

--- a/frontend/src/components/Security/KeyChangeBanner.tsx
+++ b/frontend/src/components/Security/KeyChangeBanner.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { ShieldAlert, X } from "lucide-react";
-import { useKeyChangeStore } from "../../stores/keyChangeStore";
+import { observer } from "mobx-react-lite";
+import { keyChangeStore } from "../../stores/keyChangeStore";
 
 interface KeyChangeBannerProps {
   /// User id of the peer whose key has changed. Pass the DM's `user2_id`
@@ -19,13 +20,13 @@ interface KeyChangeBannerProps {
 /// to re-verify out-of-band via the profile page.
 ///
 /// Not a modal — this is an inline banner inside the conversation chrome.
-export const KeyChangeBanner: React.FC<KeyChangeBannerProps> = ({
+export const KeyChangeBanner: React.FC<KeyChangeBannerProps> = observer(({
   peerUserId,
   peerLabel,
 }) => {
   const navigate = useNavigate();
-  const flagged = useKeyChangeStore((s) => (peerUserId ? s.flagged[peerUserId] : undefined));
-  const acknowledge = useKeyChangeStore((s) => s.acknowledge);
+  const flagged = peerUserId ? keyChangeStore.flagged[peerUserId] : undefined;
+  const acknowledge = keyChangeStore.acknowledge;
 
   if (!peerUserId || !flagged) {
     return null;
@@ -83,4 +84,4 @@ export const KeyChangeBanner: React.FC<KeyChangeBannerProps> = ({
       </button>
     </div>
   );
-};
+});

--- a/frontend/src/components/Voice/ScreenSharePicker.tsx
+++ b/frontend/src/components/Voice/ScreenSharePicker.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Monitor, Square, X } from "lucide-react";
-import { useAppStore } from "../../stores/appStore";
+import { observer } from "mobx-react-lite";
+import { appStore } from "../../stores/appStore";
 import {
   friendlyScreenShareError,
   screenShareSession,
@@ -18,18 +19,17 @@ import { Card } from "../ui/Card";
  *  helper subprocess. Selecting a source sends `Selection` to the
  *  parked helper, which builds an `SCContentFilter` and starts the
  *  `SCStream`. Industry-standard pattern — what Slack/Discord/Zoom do. */
-export const ScreenSharePicker: React.FC = () => {
+export const ScreenSharePicker: React.FC = observer(() => {
   // Picker only renders when shareState.kind === 'picking', so sources are
   // guaranteed present. Narrowed via the union; bail to null defensively
   // for the brief frame where state may have transitioned away.
-  const sources = useAppStore((s) =>
-    s.voiceState.kind === 'joined' && s.voiceState.share.kind === 'picking'
-      ? s.voiceState.share.sources
-      : null,
-  );
-  const shareCancelPicker = useAppStore((s) => s.shareCancelPicker);
-  const shareStartStarting = useAppStore((s) => s.shareStartStarting);
-  const shareFailed = useAppStore((s) => s.shareFailed);
+  const sources =
+    appStore.voiceState.kind === 'joined' && appStore.voiceState.share.kind === 'picking'
+      ? appStore.voiceState.share.sources
+      : null;
+  const shareCancelPicker = appStore.shareCancelPicker;
+  const shareStartStarting = appStore.shareStartStarting;
+  const shareFailed = appStore.shareFailed;
   const [busy, setBusy] = useState(false);
 
   // Tab between Displays and Windows. Default to Displays — most
@@ -170,7 +170,7 @@ export const ScreenSharePicker: React.FC = () => {
       </div>
     </div>
   );
-};
+});
 
 interface SourceCardProps {
   disabled: boolean;

--- a/frontend/src/components/Voice/ScreenShareViewer.tsx
+++ b/frontend/src/components/Voice/ScreenShareViewer.tsx
@@ -8,19 +8,20 @@
 import React from "react";
 import { X } from "lucide-react";
 
-import { useAppStore } from "../../stores/appStore";
+import { observer } from "mobx-react-lite";
+import { appStore } from "../../stores/appStore";
 import { RemoteVideoTile } from "./RemoteVideoTile";
 import { LOCAL_PREVIEW_KEY } from "../../screenshare/screenShareSession";
 import { shareOf } from "../../types/voice-state";
 
-export const ScreenShareViewer: React.FC = () => {
+export const ScreenShareViewer: React.FC = observer(() => {
   const {
     viewingScreenShareTrackKey,
     screenShareRemotes,
     voiceState,
     currentUser,
     setViewingScreenShareTrackKey,
-  } = useAppStore();
+  } = appStore;
   const share = shareOf(voiceState);
   const screenShareLocalActive = share.kind === 'active';
   const screenShareLocalDimensions = share.kind === 'active' ? share.dimensions : null;
@@ -123,4 +124,4 @@ export const ScreenShareViewer: React.FC = () => {
       </div>
     </div>
   );
-};
+});

--- a/frontend/src/components/Voice/VoiceBar.tsx
+++ b/frontend/src/components/Voice/VoiceBar.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useNavigate } from "@tanstack/react-router";
-import { useAppStore } from "../../stores/appStore";
+import { observer } from "mobx-react-lite";
+import { appStore } from "../../stores/appStore";
 import { useUserGroupsWithChannels } from "../../hooks/queries/useGroups";
 import { Volume2, Mic, MicOff, PhoneOff, SlidersHorizontal, Monitor, MonitorOff } from "lucide-react";
 import { PillButton } from "../ui/PillButton";
@@ -17,12 +18,12 @@ interface VoiceBarProps {
   channelName: string;
 }
 
-export const VoiceBar: React.FC<VoiceBarProps> = ({ channelId, channelName }) => {
+export const VoiceBar: React.FC<VoiceBarProps> = observer(({ channelId, channelName }) => {
   const {
     voiceParticipants,
     voiceState,
     voiceActiveSpeakerIds,
-  } = useAppStore();
+  } = appStore;
   const voiceIsMuted = voiceState.kind === 'joined' ? voiceState.micMuted : false;
   const share = shareOf(voiceState);
   const shareActive = share.kind === 'active';
@@ -116,7 +117,7 @@ export const VoiceBar: React.FC<VoiceBarProps> = ({ channelId, channelName }) =>
               .cancelPicker()
               .catch((e) => console.warn("[screenshare] cancel:", e))
               .finally(() => {
-                useAppStore.getState().shareCancelPicker();
+                appStore.shareCancelPicker();
               });
             return;
           }
@@ -140,10 +141,10 @@ export const VoiceBar: React.FC<VoiceBarProps> = ({ channelId, channelName }) =>
                 await screenShareSession.start();
                 return;
               }
-              useAppStore.getState().shareStartPicking(list);
+              appStore.shareStartPicking(list);
             } catch (e) {
               console.error("[screenshare] enumerate:", e);
-              useAppStore.getState().shareFailed(friendlyScreenShareError(String(e)));
+              appStore.shareFailed(friendlyScreenShareError(String(e)));
             }
           })();
         }}
@@ -222,4 +223,4 @@ export const VoiceBar: React.FC<VoiceBarProps> = ({ channelId, channelName }) =>
       </button>
     </div>
   );
-};
+});

--- a/frontend/src/components/Voice/VoiceChannelView.tsx
+++ b/frontend/src/components/Voice/VoiceChannelView.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { useAppStore } from "../../stores/appStore";
+import { observer } from "mobx-react-lite";
+import { appStore } from "../../stores/appStore";
 import { NavigableGrid } from "../ui/NavigableGrid";
 import type { VoiceParticipant } from "../../types";
 import { VoiceMemberTile } from "./VoiceMemberTile";
@@ -9,14 +10,14 @@ import { shareOf } from "../../types/voice-state";
 import { disambiguateVoiceNames } from "../../voice/disambiguateNames";
 import { voiceUserKey } from "../../voice/identity";
 
-export const VoiceChannelView: React.FC = () => {
+export const VoiceChannelView: React.FC = observer(() => {
   const {
     voiceParticipants,
     voiceActiveSpeakerIds,
     voiceState,
     screenShareRemotes,
     setViewingScreenShareTrackKey,
-  } = useAppStore();
+  } = appStore;
   const share = shareOf(voiceState);
   const shareActive = share.kind === 'active';
   const shareLocalDims = shareActive ? share.dimensions : null;
@@ -123,4 +124,4 @@ export const VoiceChannelView: React.FC = () => {
       />
     </div>
   );
-};
+});

--- a/frontend/src/components/ui/ChatInput.tsx
+++ b/frontend/src/components/ui/ChatInput.tsx
@@ -11,7 +11,8 @@ import {
 import { ChevronRight, Plus, X, Film, Music } from "lucide-react";
 import { getFileIcon } from "../../utils/fileIcon";
 import { formatFileSize } from "../../utils/format";
-import { useDropTargetStore } from "../../stores/dropTargetStore";
+import { observer } from "mobx-react-lite";
+import { dropTargetStore } from "../../stores/dropTargetStore";
 import { getDraft, setDraft } from "../../utils/drafts";
 
 // Attachment carries a filesystem path so Rust can read the file directly —
@@ -206,7 +207,7 @@ const AttachmentPreview: React.FC<{
   );
 };
 
-export const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(({
+const ChatInputInner: React.ForwardRefRenderFunction<ChatInputHandle, ChatInputProps> = ({
   onSend,
   placeholder = "Type a message…",
   disabled = false,
@@ -440,7 +441,7 @@ export const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(({
   // shows the drag overlay on views that can actually receive a file (not,
   // e.g., the voice/stream view where there's no input).
   useEffect(() => {
-    const { register, unregister } = useDropTargetStore.getState();
+    const { register, unregister } = dropTargetStore;
     register();
     return unregister;
   }, []);
@@ -662,4 +663,6 @@ export const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(({
       )}
     </div>
   );
-});
+};
+
+export const ChatInput = observer(React.forwardRef(ChatInputInner));

--- a/frontend/src/components/ui/PresenceAvatar.tsx
+++ b/frontend/src/components/ui/PresenceAvatar.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { observer } from "mobx-react-lite";
 import { Avatar } from "./Avatar";
 import { usePresenceStatus } from "../../stores/presenceStore";
 
@@ -17,7 +18,7 @@ interface PresenceAvatarProps {
  * the dot sit silent when `userId` is null — the underlying Avatar handles
  * the no-presence case.
  */
-export const PresenceAvatar: React.FC<PresenceAvatarProps> = ({
+export const PresenceAvatar: React.FC<PresenceAvatarProps> = observer(({
   userId,
   avatarKey,
   size,
@@ -36,4 +37,4 @@ export const PresenceAvatar: React.FC<PresenceAvatarProps> = ({
       presence={userId ? status : undefined}
     />
   );
-};
+});

--- a/frontend/src/hooks/queries/useBlocks.ts
+++ b/frontend/src/hooks/queries/useBlocks.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { invoke } from "../../bridge";
-import { useAppStore } from "../../stores/appStore";
+import { appStore } from "../../stores/appStore";
+import { useObserver } from "mobx-react-lite";
 import type { BlockedUser, DmChannel } from "../../types";
 
 export const blocksQueryKeys = {
@@ -10,7 +11,7 @@ export const blocksQueryKeys = {
 
 // Query: inbound DM requests awaiting accept/decline.
 export function useDMRequests() {
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = useObserver(() => appStore.currentUser);
 
   return useQuery({
     queryKey: blocksQueryKeys.dmRequests(currentUser?.id ?? null),
@@ -31,7 +32,7 @@ export function useDMRequests() {
 // Mutation: accept a pending DM request, moving it into the conversations list.
 export function useAcceptDMRequest() {
   const queryClient = useQueryClient();
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = useObserver(() => appStore.currentUser);
 
   return useMutation({
     mutationFn: async (dmChannelId: string): Promise<void> => {
@@ -56,7 +57,7 @@ export function useAcceptDMRequest() {
 // disappear from the conversations list on next refetch.
 export function useBlockUser() {
   const queryClient = useQueryClient();
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = useObserver(() => appStore.currentUser);
 
   return useMutation({
     mutationFn: async (blockedId: string): Promise<void> => {
@@ -80,7 +81,7 @@ export function useBlockUser() {
 // Mutation: unblock a user.
 export function useUnblockUser() {
   const queryClient = useQueryClient();
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = useObserver(() => appStore.currentUser);
 
   return useMutation({
     mutationFn: async (blockedId: string): Promise<void> => {
@@ -103,7 +104,7 @@ export function useUnblockUser() {
 
 // Query: users the current user has blocked.
 export function useBlockedUsers() {
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = useObserver(() => appStore.currentUser);
 
   return useQuery({
     queryKey: blocksQueryKeys.blockedUsers(currentUser?.id ?? null),

--- a/frontend/src/hooks/queries/useGroups.ts
+++ b/frontend/src/hooks/queries/useGroups.ts
@@ -3,7 +3,8 @@ import { useMemo } from "react";
 import { invoke } from "../../bridge";
 import * as api from "../../services/api";
 import type { GroupWithChannels } from "../../services/api";
-import { useAppStore } from "../../stores/appStore";
+import { appStore } from "../../stores/appStore";
+import { useObserver } from "mobx-react-lite";
 import type { Group, Channel, GroupMember } from "../../types";
 
 export const groupQueryKeys = {
@@ -20,7 +21,7 @@ export const groupQueryKeys = {
 };
 
 export function useUserGroupsWithChannels() {
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = useObserver(() => appStore.currentUser);
 
   return useQuery({
     queryKey: groupQueryKeys.userGroupsWithChannels(currentUser?.id ?? null),
@@ -37,7 +38,7 @@ export function useUserGroupsWithChannels() {
 }
 
 export function useUserGroups() {
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = useObserver(() => appStore.currentUser);
 
   return useQuery({
     queryKey: groupQueryKeys.userGroups(currentUser?.id ?? null),
@@ -70,8 +71,8 @@ export function useGroupChannels(groupId: string | null) {
 
 export function useCreateGroup() {
   const queryClient = useQueryClient();
-  const currentUser = useAppStore((state) => state.currentUser);
-  const setGroups = useAppStore((state) => state.setGroups);
+  const currentUser = useObserver(() => appStore.currentUser);
+  const setGroups = appStore.setGroups;
 
   return useMutation({
     mutationFn: async ({
@@ -121,7 +122,7 @@ export function useCreateGroup() {
 
 export function useJoinGroup() {
   const queryClient = useQueryClient();
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = useObserver(() => appStore.currentUser);
 
   return useMutation({
     mutationFn: async (groupId: string) => {
@@ -142,7 +143,7 @@ export function useJoinGroup() {
 
 export function useUpdateGroup() {
   const queryClient = useQueryClient();
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = useObserver(() => appStore.currentUser);
 
   return useMutation({
     mutationFn: async ({
@@ -178,8 +179,8 @@ export function useUpdateGroup() {
 
 export function useUpdateGroupIcon() {
   const queryClient = useQueryClient();
-  const currentUser = useAppStore((state) => state.currentUser);
-  const setGroups = useAppStore((state) => state.setGroups);
+  const currentUser = useObserver(() => appStore.currentUser);
+  const setGroups = appStore.setGroups;
 
   return useMutation({
     mutationFn: async ({ groupId, iconUrl }: { groupId: string; iconUrl: string }) => {
@@ -210,8 +211,8 @@ export function useUpdateGroupIcon() {
 
 export function useCreateChannel() {
   const queryClient = useQueryClient();
-  const currentUser = useAppStore((state) => state.currentUser);
-  const setChannels = useAppStore((state) => state.setChannels);
+  const currentUser = useObserver(() => appStore.currentUser);
+  const setChannels = appStore.setChannels;
 
   return useMutation({
     mutationFn: async ({
@@ -268,7 +269,7 @@ export function useCreateChannel() {
 
 export function useUpdateChannel() {
   const queryClient = useQueryClient();
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = useObserver(() => appStore.currentUser);
 
   return useMutation({
     mutationFn: async ({
@@ -304,7 +305,7 @@ export function useUpdateChannel() {
 
 export function useDeleteChannel() {
   const queryClient = useQueryClient();
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = useObserver(() => appStore.currentUser);
 
   return useMutation({
     mutationFn: async ({ channelId }: { groupId: string; channelId: string }) => {
@@ -326,7 +327,7 @@ export function useDeleteChannel() {
 
 export function useLeaveGroup() {
   const queryClient = useQueryClient();
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = useObserver(() => appStore.currentUser);
 
   return useMutation({
     mutationFn: async (groupId: string) => {
@@ -365,7 +366,7 @@ export type JoinRequest = {
 };
 
 export function usePendingInvites() {
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = useObserver(() => appStore.currentUser);
 
   return useQuery({
     queryKey: groupQueryKeys.pendingInvites(currentUser?.id ?? null),
@@ -383,7 +384,7 @@ export function usePendingInvites() {
 
 export function useAcceptInvite() {
   const queryClient = useQueryClient();
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = useObserver(() => appStore.currentUser);
 
   return useMutation({
     mutationFn: async (inviteId: string) => {
@@ -406,7 +407,7 @@ export function useAcceptInvite() {
 
 export function useDeclineInvite() {
   const queryClient = useQueryClient();
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = useObserver(() => appStore.currentUser);
 
   return useMutation({
     mutationFn: async (inviteId: string) => {
@@ -482,7 +483,7 @@ export function useGroupMembers(groupId: string | null) {
 
 export function useSetMemberRole() {
   const queryClient = useQueryClient();
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = useObserver(() => appStore.currentUser);
 
   return useMutation({
     mutationFn: async ({ groupId, userId, role }: { groupId: string; userId: string; role: 'admin' | 'member' }) => {
@@ -500,7 +501,7 @@ export function useSetMemberRole() {
 
 export function useKickMember() {
   const queryClient = useQueryClient();
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = useObserver(() => appStore.currentUser);
 
   return useMutation({
     mutationFn: async ({ groupId, userId }: { groupId: string; userId: string }) => {
@@ -518,7 +519,7 @@ export function useKickMember() {
 }
 
 export function useRequestGroupAccess() {
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = useObserver(() => appStore.currentUser);
 
   return useMutation({
     mutationFn: async (groupId: string) => {
@@ -531,7 +532,7 @@ export function useRequestGroupAccess() {
 }
 
 export function useMyJoinRequest(groupId: string | undefined) {
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = useObserver(() => appStore.currentUser);
 
   return useQuery({
     queryKey: groupQueryKeys.myJoinRequest(groupId, currentUser?.id ?? null),
@@ -551,7 +552,7 @@ export function useMyJoinRequest(groupId: string | undefined) {
 }
 
 export function useSendGroupInvite() {
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = useObserver(() => appStore.currentUser);
 
   return useMutation({
     mutationFn: async ({ groupId, inviteeIdentifier }: { groupId: string; inviteeIdentifier: string }) => {
@@ -564,7 +565,7 @@ export function useSendGroupInvite() {
 }
 
 export function useGroupJoinRequests(groupId: string | null) {
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = useObserver(() => appStore.currentUser);
 
   return useQuery({
     queryKey: groupQueryKeys.joinRequests(groupId ?? ''),
@@ -582,7 +583,7 @@ export function useGroupJoinRequests(groupId: string | null) {
 
 export function useApproveJoinRequest() {
   const queryClient = useQueryClient();
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = useObserver(() => appStore.currentUser);
 
   return useMutation({
     mutationFn: async ({ requestId, groupId }: { requestId: string; groupId: string }) => {
@@ -601,7 +602,7 @@ export function useApproveJoinRequest() {
 
 export function useRejectJoinRequest() {
   const queryClient = useQueryClient();
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = useObserver(() => appStore.currentUser);
 
   return useMutation({
     mutationFn: async ({ requestId, groupId }: { requestId: string; groupId: string }) => {
@@ -619,7 +620,7 @@ export function useRejectJoinRequest() {
 }
 
 export function useAllPendingJoinRequests() {
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = useObserver(() => appStore.currentUser);
   const { data: groupsWithChannels } = useUserGroupsWithChannels();
 
   const adminGroupIds = useMemo(() => {

--- a/frontend/src/hooks/queries/useMessages.ts
+++ b/frontend/src/hooks/queries/useMessages.ts
@@ -1,7 +1,8 @@
 import { useEffect, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { invoke } from "../../bridge";
-import { useAppStore } from "../../stores/appStore";
+import { appStore } from "../../stores/appStore";
+import { useObserver } from "mobx-react-lite";
 import type { Message, DMConversation } from "../../types";
 
 // Per-conversation timestamp of the last background ingest. Used to debounce
@@ -147,7 +148,7 @@ type MessagesQueryResult = {
 };
 
 export function useMessages(channelId: string | null, conversationId: string | null) {
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = useObserver(() => appStore.currentUser);
   const queryClient = useQueryClient();
   const isChannel = !!channelId;
   const queryKey = isChannel
@@ -243,7 +244,7 @@ export function useConversationMessages(conversationId: string | null) {
 
 export function useSendMessage() {
   const queryClient = useQueryClient();
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = useObserver(() => appStore.currentUser);
 
   return useMutation({
     mutationFn: async ({
@@ -303,7 +304,7 @@ export function useSendMessage() {
 }
 
 export function useDMConversations() {
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = useObserver(() => appStore.currentUser);
 
   return useQuery({
     queryKey: messageQueryKeys.dmConversations(currentUser?.id ?? null),
@@ -332,7 +333,7 @@ export function useDMConversations() {
 }
 
 export function useLastMessage(channelId: string | null, conversationId: string | null) {
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = useObserver(() => appStore.currentUser);
   const isChannel = !!channelId;
   const queryKey = isChannel
     ? (["last-message", "channel", channelId] as const)
@@ -367,7 +368,7 @@ export function useLastMessage(channelId: string | null, conversationId: string 
 
 export function useLeaveDM() {
   const queryClient = useQueryClient();
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = useObserver(() => appStore.currentUser);
 
   return useMutation({
     mutationFn: async (conversationId: string): Promise<void> => {
@@ -389,7 +390,7 @@ export function useLeaveDM() {
 
 export function useCreateOrGetDMConversation() {
   const queryClient = useQueryClient();
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = useObserver(() => appStore.currentUser);
 
   return useMutation({
     mutationFn: async (identifier: string): Promise<{ id: string }> => {
@@ -419,7 +420,7 @@ export function useCreateOrGetDMConversation() {
 
 export function useDeleteMessage() {
   const queryClient = useQueryClient();
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = useObserver(() => appStore.currentUser);
 
   return useMutation({
     mutationFn: async ({ messageId }: { messageId: string }) => {
@@ -453,7 +454,7 @@ type EditMessageContext = {
 
 export function useEditMessage() {
   const queryClient = useQueryClient();
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = useObserver(() => appStore.currentUser);
 
   return useMutation<void, Error, EditMessageVars, EditMessageContext>({
     mutationFn: async ({ conversationId, messageId, newContent }) => {

--- a/frontend/src/hooks/queries/usePreferences.ts
+++ b/frontend/src/hooks/queries/usePreferences.ts
@@ -2,7 +2,8 @@ import { useCallback, useEffect } from "react";
 import { useQuery, useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { invoke } from "../../bridge";
 import { electron, hasElectron } from "../../bridge/runtime";
-import { useAppStore } from "../../stores/appStore";
+import { appStore } from "../../stores/appStore";
+import { useObserver } from "mobx-react-lite";
 import {
   applyAccentColor,
   applyBackgroundColor,
@@ -231,7 +232,7 @@ function scheduleSave(
 }
 
 export function usePreferences() {
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = useObserver(() => appStore.currentUser);
   const queryClient = useQueryClient();
 
   const query = useQuery({
@@ -350,7 +351,7 @@ export function applyDeviceFontSize(
  */
 export function useApplyPreferences(): void {
   const { query } = usePreferences();
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = useObserver(() => appStore.currentUser);
   const data = query.data;
   // Stringify the override map so the effect re-runs when any override
   // changes (a React Query refetch returns a new object reference, and we

--- a/frontend/src/hooks/queries/useUserProfile.ts
+++ b/frontend/src/hooks/queries/useUserProfile.ts
@@ -1,7 +1,8 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { invoke } from "../../bridge";
 import * as api from "../../services/api";
-import { useAppStore } from "../../stores/appStore";
+import { appStore } from "../../stores/appStore";
+import { useObserver } from "mobx-react-lite";
 import { messageQueryKeys } from "./useMessages";
 import { groupQueryKeys } from "./useGroups";
 
@@ -68,7 +69,7 @@ export const peerVerificationKeys = {
 /// sidebar / DM list and for the inline key-changed banner. Invalidated
 /// on the `KeyChanged` realtime event and after `set_contact_verified`.
 export function usePeerVerifications() {
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = useObserver(() => appStore.currentUser);
   return useQuery({
     queryKey: peerVerificationKeys.all,
     queryFn: async (): Promise<PeerVerificationEntry[]> => {
@@ -84,7 +85,7 @@ export const safetyQueryKeys = {
 };
 
 export function useSafetyNumber(peerUserId: string | null | undefined) {
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = useObserver(() => appStore.currentUser);
   return useQuery({
     queryKey: safetyQueryKeys.number(peerUserId ?? null),
     queryFn: async (): Promise<SafetyNumberInfo> => {
@@ -116,7 +117,7 @@ export function useSetContactVerified(peerUserId: string | null | undefined) {
 }
 
 export function useUserProfile() {
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = useObserver(() => appStore.currentUser);
 
   return useQuery({
     queryKey: userQueryKeys.profile(currentUser?.id ?? null),
@@ -148,8 +149,8 @@ export function useUserProfile() {
 
 export function useUpdateProfile() {
   const queryClient = useQueryClient();
-  const currentUser = useAppStore((state) => state.currentUser);
-  const setUsername = useAppStore((state) => state.setUsername);
+  const currentUser = useObserver(() => appStore.currentUser);
+  const setUsername = appStore.setUsername;
 
   return useMutation({
     mutationFn: async ({ username, preferredName, phone }: { username: string; preferredName?: string; phone?: string }) => {
@@ -182,7 +183,7 @@ export function useUpdateProfile() {
 
 export function useUserAvatar() {
   const { data: userProfile } = useUserProfile();
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = useObserver(() => appStore.currentUser);
 
   return useQuery({
     queryKey: ["user", "avatar", currentUser?.id, userProfile?.avatar_url],
@@ -219,8 +220,8 @@ export function useAvatarBlobUrl(avatarKey: string | null | undefined) {
 
 export function useUpdateAvatar() {
   const queryClient = useQueryClient();
-  const currentUser = useAppStore((state) => state.currentUser);
-  const setUserAvatarUrl = useAppStore((state) => state.setUserAvatarUrl);
+  const currentUser = useObserver(() => appStore.currentUser);
+  const setUserAvatarUrl = appStore.setUserAvatarUrl;
 
   return useMutation({
     mutationFn: async (avatarUrl: string) => {

--- a/frontend/src/hooks/useBadge.ts
+++ b/frontend/src/hooks/useBadge.ts
@@ -1,7 +1,8 @@
 import { useEffect } from 'react';
 import { getCurrentWindow, Image, type PollisImage } from '../bridge';
 import { electron, hasElectron } from '../bridge/runtime';
-import { useAppStore } from '../stores/appStore';
+import { appStore } from '../stores/appStore';
+import { useObserver } from 'mobx-react-lite';
 import { useTauriReady } from './useTauriReady';
 import { isMac, isWindows } from '../utils/platform';
 
@@ -42,7 +43,7 @@ async function getWindowsNotifIcon(): Promise<PollisImage> {
  */
 export function useBadge() {
   const { isReady } = useTauriReady();
-  const unreadCounts = useAppStore((s) => s.unreadCounts);
+  const unreadCounts = useObserver(() => appStore.unreadCounts);
 
   const total = Object.values(unreadCounts).reduce((sum, n) => sum + n, 0);
 

--- a/frontend/src/hooks/useLiveKitRealtime.ts
+++ b/frontend/src/hooks/useLiveKitRealtime.ts
@@ -6,16 +6,17 @@ import {
   requestPermission,
 } from '../bridge';
 import { useQueryClient } from '@tanstack/react-query';
-import { useAppStore } from '../stores/appStore';
+import { useObserver } from 'mobx-react-lite';
+import { appStore } from '../stores/appStore';
 import { useTauriReady } from './useTauriReady';
 import { messageQueryKeys, useDMConversations, markIngested } from './queries/useMessages';
 import { usePreferences } from './queries/usePreferences';
 import { groupQueryKeys, useUserGroupsWithChannels } from './queries/useGroups';
 import { notify, setNotifyPrefs, loadDeviceCallRingtone } from '../utils/notify';
-import { useTypingStore, typingRoomKey } from '../stores/typingStore';
-import { usePresenceStore } from '../stores/presenceStore';
-import { useKeyChangeStore } from '../stores/keyChangeStore';
-import { useRosterChangeStore, type RosterBanner } from '../stores/rosterChangeStore';
+import { typingStore, typingRoomKey } from '../stores/typingStore';
+import { presenceStore } from '../stores/presenceStore';
+import { keyChangeStore } from '../stores/keyChangeStore';
+import { rosterChangeStore, type RosterBanner } from '../stores/rosterChangeStore';
 import { peerVerificationKeys } from './queries/useUserProfile';
 
 // Mirrors the RealtimeEvent enum in pollis-core/src/realtime.rs.
@@ -142,11 +143,13 @@ type RealtimeEvent =
 export function useLiveKitRealtime() {
   const { isReady: isTauriReady } = useTauriReady();
   const queryClient = useQueryClient();
-  const {
-    selectedChannelId,
-    selectedConversationId,
-    currentUser,
-  } = useAppStore();
+  const { selectedChannelId, selectedConversationId, currentUser } = useObserver(
+    () => ({
+      selectedChannelId: appStore.selectedChannelId,
+      selectedConversationId: appStore.selectedConversationId,
+      currentUser: appStore.currentUser,
+    }),
+  );
 
   const { query: prefsQuery } = usePreferences();
   const { data: groupsWithChannels } = useUserGroupsWithChannels();
@@ -215,8 +218,8 @@ export function useLiveKitRealtime() {
 
   // Track the voice room the user is currently connected to so we only play
   // join/leave cues for rooms they can actually hear.
-  const activeVoiceChannelId = useAppStore((s) =>
-    s.voiceState.kind === 'idle' ? null : s.voiceState.channelId,
+  const activeVoiceChannelId = useObserver(() =>
+    appStore.voiceState.kind === 'idle' ? null : appStore.voiceState.channelId,
   );
   const activeVoiceChannelIdRef = useRef<string | null>(activeVoiceChannelId);
   useEffect(() => { activeVoiceChannelIdRef.current = activeVoiceChannelId; }, [activeVoiceChannelId]);
@@ -393,7 +396,7 @@ export function useLiveKitRealtime() {
         queryClientRef.current.invalidateQueries({ queryKey: ['voice-participants'] });
         // Wipe stale presence for the reconnected room — Rust will re-emit
         // a fresh participant snapshot right after.
-        usePresenceStore.getState().resetRoom(event.room_id);
+        presenceStore.resetRoom(event.room_id);
         // Catch up on welcomes that may have arrived during the outage so
         // new-group invites apply without waiting for the user to open a
         // channel from one of those groups.
@@ -421,7 +424,7 @@ export function useLiveKitRealtime() {
       }
 
       if (event.type === 'call_invite') {
-        useAppStore.getState().setIncomingCall({
+        appStore.setIncomingCall({
           callId: event.call_id,
           roomName: event.room_name,
           callerId: event.caller_id,
@@ -437,7 +440,7 @@ export function useLiveKitRealtime() {
       }
 
       if (event.type === 'call_canceled') {
-        const store = useAppStore.getState();
+        const store = appStore;
         // Callee receives this when the caller hangs up before pickup —
         // dismiss the ring UI immediately.
         const incoming = store.incomingCall;
@@ -455,9 +458,7 @@ export function useLiveKitRealtime() {
       }
 
       if (event.type === 'presence_changed') {
-        usePresenceStore
-          .getState()
-          .setPresent(event.user_id, event.room_id, event.present);
+        presenceStore.setPresent(event.user_id, event.room_id, event.present);
         return;
       }
 
@@ -514,7 +515,7 @@ export function useLiveKitRealtime() {
             payload: { kind: "device_removed", user_id, device_id },
           });
         }
-        useRosterChangeStore.getState().push(event.conversation_id, banners);
+        rosterChangeStore.push(event.conversation_id, banners);
         // Refresh the member list so the sidebar / member roster picks
         // up the change without waiting for the next periodic refetch.
         queryClientRef.current.invalidateQueries({
@@ -526,9 +527,7 @@ export function useLiveKitRealtime() {
       if (event.type === 'key_changed') {
         // Signal-style "safety number changed" — surface inline so the
         // user re-verifies out-of-band. Advisory; sends are unaffected.
-        useKeyChangeStore
-          .getState()
-          .flagChanged(event.peer_user_id, event.peer_identity_version);
+        keyChangeStore.flagChanged(event.peer_user_id, event.peer_identity_version);
         // Refresh the shield-badge query so DM/contact lists drop the
         // verified badge for this peer immediately, and the open profile
         // recomputes its "Changed — re-verify" state.
@@ -552,11 +551,9 @@ export function useLiveKitRealtime() {
           return;
         }
         if (event.is_typing) {
-          useTypingStore
-            .getState()
-            .setTyping(roomKey, event.user_id, event.username ?? event.user_id);
+          typingStore.setTyping(roomKey, event.user_id, event.username ?? event.user_id);
         } else {
-          useTypingStore.getState().clearTyping(roomKey, event.user_id);
+          typingStore.clearTyping(roomKey, event.user_id);
         }
         return;
       }
@@ -581,7 +578,7 @@ export function useLiveKitRealtime() {
             return invoke('logout', { deleteData: false })
               .catch(() => {})
               .then(() => {
-                useAppStore.getState().logout();
+                appStore.logout();
               });
           })
           // Offline / transient error — never sign out on a blip.

--- a/frontend/src/hooks/useTypingPublisher.ts
+++ b/frontend/src/hooks/useTypingPublisher.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef } from "react";
 import { invoke } from "../bridge";
-import { useAppStore } from "../stores/appStore";
+import { appStore } from "../stores/appStore";
+import { useObserver } from "mobx-react-lite";
 import { TYPING_REFRESH_MS } from "../stores/typingStore";
 
 /**
@@ -20,7 +21,7 @@ export function useTypingPublisher(args: {
   conversationId: string | null;
 }) {
   const { roomId, channelId, conversationId } = args;
-  const currentUser = useAppStore((s) => s.currentUser);
+  const currentUser = useObserver(() => appStore.currentUser);
 
   // We avoid hammering publish_typing on every keystroke by tracking the
   // last-sent timestamp and only re-emitting once the throttle window has

--- a/frontend/src/hooks/useTypingState.ts
+++ b/frontend/src/hooks/useTypingState.ts
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
-import { useTypingStore, TYPING_TTL_MS, typingRoomKey } from "../stores/typingStore";
+import { useObserver } from "mobx-react-lite";
+import { typingStore, TYPING_TTL_MS, typingRoomKey } from "../stores/typingStore";
 
 /**
  * Returns the list of usernames currently typing in the named room, sorted
@@ -14,8 +15,8 @@ export function useTypingState(args: {
   const { channelId, conversationId } = args;
   const roomKey = typingRoomKey(channelId, conversationId);
 
-  const room = useTypingStore((s) => (roomKey ? s.byRoom[roomKey] : undefined));
-  const pruneExpired = useTypingStore((s) => s.pruneExpired);
+  const room = useObserver(() => (roomKey ? typingStore.byRoom[roomKey] : undefined));
+  const pruneExpired = typingStore.pruneExpired;
 
   // Drive the prune on a coarse interval — finer than TTL but cheap. The
   // store no-ops when nothing actually expired.

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,7 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import "./index.css";
 import App from "./App";
 import { ErrorBoundary } from "./components/ErrorBoundary";
-import { useAppStore } from "./stores/appStore";
+import { appStore } from "./stores/appStore";
 
 // Tag <html> with the platform so CSS can opt out of features the OS
 // handles natively (e.g. corner rounding on macOS — the NSWindow
@@ -19,9 +19,10 @@ const platformTag = /Mac OS X/.test(ua)
       : "unknown";
 document.documentElement.dataset.platform = platformTag;
 
-// Expose Zustand store for Playwright tests so page.evaluate() can set state
+// Expose the MobX store singleton for Playwright tests so page.evaluate() can
+// read and mutate state (e.g. __pollisStore.setSelectedGroupId(...)).
 if (import.meta.env.VITE_PLAYWRIGHT === 'true') {
-  (window as any).__pollisStore = useAppStore;
+  (window as any).__pollisStore = appStore;
 }
 
 const container = document.getElementById("root");

--- a/frontend/src/pages/Call.tsx
+++ b/frontend/src/pages/Call.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect } from "react";
 import { useNavigate, useParams } from "@tanstack/react-router";
 import { PhoneOff } from "lucide-react";
+import { observer } from "mobx-react-lite";
 import { invoke } from "../bridge";
-import { useAppStore } from "../stores/appStore";
+import { appStore } from "../stores/appStore";
 import { VoiceChannelView } from "../components/Voice/VoiceChannelView";
 import { voiceSession } from "../voice";
 
@@ -31,16 +32,15 @@ const RINGING_TIMEOUT_MS = 30_000;
 const DEFER_CANCEL_MS = 200;
 const pendingCancels = new Map<string, ReturnType<typeof setTimeout>>();
 
-export const CallPage: React.FC = () => {
+export const CallPage: React.FC = observer(() => {
   const navigate = useNavigate();
   const { callId } = useParams({ from: "/call/$callId" });
   const roomName = `call-${callId}`;
-  const activeVoiceChannelId = useAppStore((s) =>
-    s.voiceState.kind === 'idle' ? null : s.voiceState.channelId,
-  );
-  const voiceParticipants = useAppStore((s) => s.voiceParticipants);
-  const outgoingCall = useAppStore((s) => s.outgoingCall);
-  const setOutgoingCall = useAppStore((s) => s.setOutgoingCall);
+  const activeVoiceChannelId =
+    appStore.voiceState.kind === 'idle' ? null : appStore.voiceState.channelId;
+  const voiceParticipants = appStore.voiceParticipants;
+  const outgoingCall = appStore.outgoingCall;
+  const setOutgoingCall = appStore.setOutgoingCall;
 
   // Bounce-back guard. Three cases:
   //   1. Voice is our room → stay.
@@ -64,7 +64,7 @@ export const CallPage: React.FC = () => {
       return;
     }
     const timer = setTimeout(() => {
-      const cur = useAppStore.getState().voiceState;
+      const cur = appStore.voiceState;
       const curChannel = cur.kind === 'idle' ? null : cur.channelId;
       if (curChannel !== roomName) {
         navigate({ to: "/dms" });
@@ -115,10 +115,10 @@ export const CallPage: React.FC = () => {
     return () => {
       const timer = setTimeout(() => {
         pendingCancels.delete(callId);
-        const pending = useAppStore.getState().outgoingCall;
+        const pending = appStore.outgoingCall;
         if (pending && pending.callId === callId) {
           const calleeId = pending.calleeId;
-          useAppStore.getState().setOutgoingCall(null);
+          appStore.setOutgoingCall(null);
           invoke("cancel_call", { otherUserId: calleeId, callId }).catch(() => {});
         }
       }, DEFER_CANCEL_MS);
@@ -167,4 +167,4 @@ export const CallPage: React.FC = () => {
       </div>
     </div>
   );
-};
+});

--- a/frontend/src/pages/Channel.tsx
+++ b/frontend/src/pages/Channel.tsx
@@ -3,22 +3,23 @@ import { useNavigate, useParams } from "@tanstack/react-router";
 import { Pencil, Trash2 } from "lucide-react";
 import { MainContent } from "../components/Layout/MainContent";
 import { useUserGroupsWithChannels } from "../hooks/queries/useGroups";
-import { useAppStore } from "../stores/appStore";
+import { appStore } from "../stores/appStore";
+import { observer } from "mobx-react-lite";
 
-export const ChannelPage: React.FC = () => {
+export const ChannelPage: React.FC = observer(() => {
   const navigate = useNavigate();
   const { groupId, channelId } = useParams({ from: "/groups/$groupId/channels/$channelId" });
-  const setSelectedChannelId = useAppStore((s) => s.setSelectedChannelId);
-  const setSelectedGroupId = useAppStore((s) => s.setSelectedGroupId);
-  const markRead = useAppStore((s) => s.markRead);
-  const pendingDeleteChannelId = useAppStore((s) => s.pendingDeleteChannelId);
-  const setPendingDeleteChannelId = useAppStore((s) => s.setPendingDeleteChannelId);
+  const setSelectedChannelId = appStore.setSelectedChannelId;
+  const setSelectedGroupId = appStore.setSelectedGroupId;
+  const markRead = appStore.markRead;
+  const pendingDeleteChannelId = appStore.pendingDeleteChannelId;
+  const setPendingDeleteChannelId = appStore.setPendingDeleteChannelId;
 
   useEffect(() => {
     // selectedGroupId drives the LiveKit room id used by the typing
     // publisher; without it, this client's typing events never go out.
     // setSelectedGroupId also nulls channelId, so set the group first.
-    if (useAppStore.getState().selectedGroupId !== groupId) {
+    if (appStore.selectedGroupId !== groupId) {
       setSelectedGroupId(groupId);
     }
     setSelectedChannelId(channelId);
@@ -77,4 +78,4 @@ export const ChannelPage: React.FC = () => {
       </div>
     </div>
   );
-};
+});

--- a/frontend/src/pages/CreateChannel.tsx
+++ b/frontend/src/pages/CreateChannel.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
-import { useAppStore } from "../stores/appStore";
+import { appStore } from "../stores/appStore";
+import { observer } from "mobx-react-lite";
 import { invoke } from "../bridge";
 import { useQueryClient } from "@tanstack/react-query";
 import { deriveSlug } from "../utils/urlRouting";
@@ -13,8 +14,8 @@ interface CreateChannelProps {
   onSuccess?: (channelId: string, channelType: "text" | "voice") => void;
 }
 
-export const CreateChannel: React.FC<CreateChannelProps> = ({ onSuccess }) => {
-  const { selectedGroupId, currentUser, addChannel, channels, groups, setSelectedChannelId } = useAppStore();
+export const CreateChannel: React.FC<CreateChannelProps> = observer(({ onSuccess }) => {
+  const { selectedGroupId, currentUser, addChannel, channels, groups, setSelectedChannelId } = appStore;
   const queryClient = useQueryClient();
   const [name, setName] = useState("");
   const [slug, setSlug] = useState("");
@@ -188,4 +189,4 @@ export const CreateChannel: React.FC<CreateChannelProps> = ({ onSuccess }) => {
       </div>
     </div>
   );
-};
+});

--- a/frontend/src/pages/CreateChannelPage.tsx
+++ b/frontend/src/pages/CreateChannelPage.tsx
@@ -1,13 +1,14 @@
 import React from "react";
 import { useNavigate, useParams } from "@tanstack/react-router";
 import { PageShell } from "../components/Layout/PageShell";
-import { useAppStore } from "../stores/appStore";
+import { appStore } from "../stores/appStore";
+import { observer } from "mobx-react-lite";
 import { CreateChannel } from "./CreateChannel";
 
-export const CreateChannelPage: React.FC = () => {
+export const CreateChannelPage: React.FC = observer(() => {
   const navigate = useNavigate();
   const { groupId } = useParams({ from: "/groups/$groupId/channels/new" });
-  const { setSelectedChannelId } = useAppStore();
+  const { setSelectedChannelId } = appStore;
 
   return (
     <PageShell title="New Channel" scrollable>
@@ -23,4 +24,4 @@ export const CreateChannelPage: React.FC = () => {
       />
     </PageShell>
   );
-};
+});

--- a/frontend/src/pages/CreateGroup.tsx
+++ b/frontend/src/pages/CreateGroup.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
-import { useAppStore } from "../stores/appStore";
+import { appStore } from "../stores/appStore";
+import { observer } from "mobx-react-lite";
 import { invoke } from "../bridge";
 import { useQueryClient } from "@tanstack/react-query";
 import { deriveSlug } from "../utils/urlRouting";
@@ -13,8 +14,8 @@ interface CreateGroupProps {
   onSuccess?: (groupId: string) => void;
 }
 
-export const CreateGroup: React.FC<CreateGroupProps> = ({ onSuccess }) => {
-  const { currentUser, addGroup, setSelectedGroupId } = useAppStore();
+export const CreateGroup: React.FC<CreateGroupProps> = observer(({ onSuccess }) => {
+  const { currentUser, addGroup, setSelectedGroupId } = appStore;
   const queryClient = useQueryClient();
   const [name, setName] = useState("");
   const [slug, setSlug] = useState("");
@@ -166,4 +167,4 @@ export const CreateGroup: React.FC<CreateGroupProps> = ({ onSuccess }) => {
       </div>
     </div>
   );
-};
+});

--- a/frontend/src/pages/DM.tsx
+++ b/frontend/src/pages/DM.tsx
@@ -5,7 +5,8 @@ import { MainContent } from "../components/Layout/MainContent";
 import type { PendingDmRequest } from "../components/Layout/MainContent";
 import { useDMConversations } from "../hooks/queries/useMessages";
 import { useDMRequests } from "../hooks/queries";
-import { useAppStore } from "../stores/appStore";
+import { appStore } from "../stores/appStore";
+import { observer } from "mobx-react-lite";
 import { usePresenceStatus } from "../stores/presenceStore";
 import { invoke } from "../bridge";
 import { voiceSession } from "../voice";
@@ -15,14 +16,14 @@ import { warmVoiceChannel } from "../utils/voiceWarmup";
 type RawDmMember = { user_id: string; username?: string; accepted_at?: string | null };
 type RawDmChannel = { id: string; members: RawDmMember[] };
 
-export const DMPage: React.FC = () => {
+export const DMPage: React.FC = observer(() => {
   const navigate = useNavigate();
   const { conversationId } = useParams({ from: "/dms/$conversationId" });
-  const setSelectedConversationId = useAppStore((s) => s.setSelectedConversationId);
-  const markRead = useAppStore((s) => s.markRead);
-  const currentUser = useAppStore((s) => s.currentUser);
-  const setOutgoingCall = useAppStore((s) => s.setOutgoingCall);
-  const outgoingCall = useAppStore((s) => s.outgoingCall);
+  const setSelectedConversationId = appStore.setSelectedConversationId;
+  const markRead = appStore.markRead;
+  const currentUser = appStore.currentUser;
+  const setOutgoingCall = appStore.setOutgoingCall;
+  const outgoingCall = appStore.outgoingCall;
 
   const [otherUserId, setOtherUserId] = React.useState<string | null>(null);
   const [memberCount, setMemberCount] = React.useState<number>(0);
@@ -232,4 +233,4 @@ export const DMPage: React.FC = () => {
       </div>
     </div>
   );
-};
+});

--- a/frontend/src/pages/DMSettings.tsx
+++ b/frontend/src/pages/DMSettings.tsx
@@ -1,14 +1,15 @@
 import React from "react";
 import { useNavigate, useParams } from "@tanstack/react-router";
-import { useAppStore } from "../stores/appStore";
+import { appStore } from "../stores/appStore";
+import { observer } from "mobx-react-lite";
 import { useLeaveDM } from "../hooks/queries/useMessages";
 import { Button } from "../components/ui/Button";
 import { PageShell } from "../components/Layout/PageShell";
 
-export const DMSettingsPage: React.FC = () => {
+export const DMSettingsPage: React.FC = observer(() => {
   const navigate = useNavigate();
   const { conversationId } = useParams({ from: "/dms/$conversationId/settings" });
-  const { setSelectedConversationId } = useAppStore();
+  const { setSelectedConversationId } = appStore;
   const leaveDMMutation = useLeaveDM();
 
   return (
@@ -49,4 +50,4 @@ export const DMSettingsPage: React.FC = () => {
       </div>
     </PageShell>
   );
-};
+});

--- a/frontend/src/pages/DMs.tsx
+++ b/frontend/src/pages/DMs.tsx
@@ -2,16 +2,17 @@ import React, { useMemo } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { ArrowLeft, Inbox, Ban, Plus, ShieldCheck, ShieldAlert } from "lucide-react";
 import { TerminalMenu, type TerminalMenuItem } from "../components/ui/TerminalMenu";
-import { useAppStore } from "../stores/appStore";
+import { appStore } from "../stores/appStore";
+import { observer } from "mobx-react-lite";
 import { useDMConversations } from "../hooks/queries/useMessages";
 import { useDMRequests } from "../hooks/queries";
 import { usePeerVerifications } from "../hooks/queries/useUserProfile";
 import { LastMessagePreview } from "../components/Message/LastMessagePreview";
 import { PresenceAvatar } from "../components/ui/PresenceAvatar";
 
-export const DMsPage: React.FC = () => {
+export const DMsPage: React.FC = observer(() => {
   const navigate = useNavigate();
-  const { setSelectedConversationId, markRead, unreadCounts } = useAppStore();
+  const { setSelectedConversationId, markRead, unreadCounts } = appStore;
 
   const { data: conversations = [] } = useDMConversations();
   const { data: requests = [] } = useDMRequests();
@@ -121,4 +122,4 @@ export const DMsPage: React.FC = () => {
       onEsc={() => navigate({ to: "/" })}
     />
   );
-};
+});

--- a/frontend/src/pages/Group.tsx
+++ b/frontend/src/pages/Group.tsx
@@ -2,16 +2,17 @@ import React, { useMemo } from "react";
 import { useNavigate, useParams } from "@tanstack/react-router";
 import { ArrowLeft, Hash, Plus, Volume2, Users, UserPlus, Inbox, LogOut, Pencil } from "lucide-react";
 import { TerminalMenu, type TerminalMenuItem } from "../components/ui/TerminalMenu";
-import { useAppStore } from "../stores/appStore";
+import { appStore } from "../stores/appStore";
+import { observer } from "mobx-react-lite";
 import { useUserGroupsWithChannels, useGroupJoinRequests } from "../hooks/queries/useGroups";
 import { LastMessagePreview } from "../components/Message/LastMessagePreview";
 import { useVoiceRoomCounts } from "../hooks/queries/useVoiceParticipants";
 import { warmVoiceChannel } from "../utils/voiceWarmup";
 
-export const GroupPage: React.FC = () => {
+export const GroupPage: React.FC = observer(() => {
   const navigate = useNavigate();
   const { groupId } = useParams({ from: "/groups/$groupId" });
-  const { setSelectedGroupId, setSelectedChannelId, markRead, unreadCounts } = useAppStore();
+  const { setSelectedGroupId, setSelectedChannelId, markRead, unreadCounts } = appStore;
 
   const { data: groupsWithChannels, isLoading } = useUserGroupsWithChannels();
   const group = groupsWithChannels?.find((g) => g.id === groupId);
@@ -166,4 +167,4 @@ export const GroupPage: React.FC = () => {
       onEsc={() => navigate({ to: "/groups" })}
     />
   );
-};
+});

--- a/frontend/src/pages/Groups.tsx
+++ b/frontend/src/pages/Groups.tsx
@@ -2,12 +2,13 @@ import React, { useMemo } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { ArrowLeft, Users, Plus, Search } from "lucide-react";
 import { TerminalMenu, type TerminalMenuItem } from "../components/ui/TerminalMenu";
-import { useAppStore } from "../stores/appStore";
+import { appStore } from "../stores/appStore";
+import { observer } from "mobx-react-lite";
 import { useUserGroupsWithChannels, useAllPendingJoinRequests } from "../hooks/queries/useGroups";
 
-export const GroupsPage: React.FC = () => {
+export const GroupsPage: React.FC = observer(() => {
   const navigate = useNavigate();
-  const { setSelectedGroupId, unreadCounts } = useAppStore();
+  const { setSelectedGroupId, unreadCounts } = appStore;
 
   const { data: groupsWithChannels, isLoading: groupsLoading, error: groupsError } = useUserGroupsWithChannels();
   const { data: allJoinRequests = [] } = useAllPendingJoinRequests();
@@ -94,4 +95,4 @@ export const GroupsPage: React.FC = () => {
       onEsc={() => navigate({ to: "/" })}
     />
   );
-};
+});

--- a/frontend/src/pages/LeaveGroup.tsx
+++ b/frontend/src/pages/LeaveGroup.tsx
@@ -1,14 +1,15 @@
 import React from "react";
 import { useNavigate, useParams } from "@tanstack/react-router";
-import { useAppStore } from "../stores/appStore";
+import { appStore } from "../stores/appStore";
+import { observer } from "mobx-react-lite";
 import { useLeaveGroup, useUserGroupsWithChannels } from "../hooks/queries/useGroups";
 import { Button } from "../components/ui/Button";
 import { PageShell } from "../components/Layout/PageShell";
 
-export const LeaveGroupPage: React.FC = () => {
+export const LeaveGroupPage: React.FC = observer(() => {
   const navigate = useNavigate();
   const { groupId } = useParams({ from: "/groups/$groupId/leave" });
-  const { setSelectedGroupId, setSelectedChannelId } = useAppStore();
+  const { setSelectedGroupId, setSelectedChannelId } = appStore;
   const leaveGroupMutation = useLeaveGroup();
 
   const { data: groupsWithChannels, isLoading } = useUserGroupsWithChannels();
@@ -62,4 +63,4 @@ export const LeaveGroupPage: React.FC = () => {
       </div>
     </PageShell>
   );
-};
+});

--- a/frontend/src/pages/Members.tsx
+++ b/frontend/src/pages/Members.tsx
@@ -1,7 +1,8 @@
 import React, { useMemo } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { ShieldCheck, ShieldAlert } from "lucide-react";
-import { useAppStore } from "../stores/appStore";
+import { appStore } from "../stores/appStore";
+import { observer } from "mobx-react-lite";
 import { useGroupMembers, useSetMemberRole } from "../hooks/queries/useGroups";
 import { usePeerVerifications } from "../hooks/queries/useUserProfile";
 import { Switch } from "../components/ui/Switch";
@@ -13,9 +14,9 @@ interface MembersProps {
   isAdmin: boolean;
 }
 
-export const Members: React.FC<MembersProps> = ({ groupId, isAdmin }) => {
+export const Members: React.FC<MembersProps> = observer(({ groupId, isAdmin }) => {
   const navigate = useNavigate();
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = appStore.currentUser;
   const { data: members = [], isLoading } = useGroupMembers(groupId);
   const setRoleMutation = useSetMemberRole();
   const { data: peerVerifications = [] } = usePeerVerifications();
@@ -130,4 +131,4 @@ export const Members: React.FC<MembersProps> = ({ groupId, isAdmin }) => {
       }}
     />
   );
-};
+});

--- a/frontend/src/pages/Preferences.tsx
+++ b/frontend/src/pages/Preferences.tsx
@@ -14,7 +14,8 @@ import {
 import { RangeSlider } from "../components/ui/RangeSlider";
 import { Switch } from "../components/ui/Switch";
 import { Button } from "../components/ui/Button";
-import { useAppStore } from "../stores/appStore";
+import { appStore } from "../stores/appStore";
+import { observer } from "mobx-react-lite";
 import { loadDeviceCallRingtone, saveDeviceCallRingtone } from "../utils/notify";
 import { electron, hasElectron } from "../bridge/runtime";
 import { isMac } from "../utils/platform";
@@ -28,9 +29,9 @@ function isValidHex(val: string): boolean {
   return /^#[0-9a-fA-F]{6}$/.test(val);
 }
 
-export const Preferences: React.FC = () => {
+export const Preferences: React.FC = observer(() => {
   const navigate = useNavigate();
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = appStore.currentUser;
   const toggleSidebarLabel = useShortcutLabel("app.toggleSidebar");
   const [hue, setHue] = useState<number>(38);
   const [saturation, setSaturation] = useState<number>(90);
@@ -536,4 +537,4 @@ export const Preferences: React.FC = () => {
       </div>
     </div>
   );
-};
+});

--- a/frontend/src/pages/RenameChannel.tsx
+++ b/frontend/src/pages/RenameChannel.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
-import { useAppStore } from "../stores/appStore";
+import { appStore } from "../stores/appStore";
+import { observer } from "mobx-react-lite";
 import { useUpdateChannel, useUserGroupsWithChannels } from "../hooks/queries/useGroups";
 import { TextInput } from "../components/ui/TextInput";
 import { TextArea } from "../components/ui/TextArea";
@@ -11,8 +12,8 @@ interface RenameChannelProps {
   onSuccess?: () => void;
 }
 
-export const RenameChannel: React.FC<RenameChannelProps> = ({ groupId, channelId, onSuccess }) => {
-  const { currentUser } = useAppStore();
+export const RenameChannel: React.FC<RenameChannelProps> = observer(({ groupId, channelId, onSuccess }) => {
+  const { currentUser } = appStore;
   const { data: groupsWithChannels } = useUserGroupsWithChannels();
   const updateChannel = useUpdateChannel();
 
@@ -135,4 +136,4 @@ export const RenameChannel: React.FC<RenameChannelProps> = ({ groupId, channelId
       </div>
     </div>
   );
-};
+});

--- a/frontend/src/pages/RenameGroup.tsx
+++ b/frontend/src/pages/RenameGroup.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
-import { useAppStore } from "../stores/appStore";
+import { appStore } from "../stores/appStore";
+import { observer } from "mobx-react-lite";
 import { useUpdateGroup, useUserGroupsWithChannels } from "../hooks/queries/useGroups";
 import { TextInput } from "../components/ui/TextInput";
 import { TextArea } from "../components/ui/TextArea";
@@ -10,8 +11,8 @@ interface RenameGroupProps {
   onSuccess?: () => void;
 }
 
-export const RenameGroup: React.FC<RenameGroupProps> = ({ groupId, onSuccess }) => {
-  const { currentUser } = useAppStore();
+export const RenameGroup: React.FC<RenameGroupProps> = observer(({ groupId, onSuccess }) => {
+  const { currentUser } = appStore;
   const { data: groupsWithChannels } = useUserGroupsWithChannels();
   const updateGroup = useUpdateGroup();
 
@@ -132,4 +133,4 @@ export const RenameGroup: React.FC<RenameGroupProps> = ({ groupId, onSuccess }) 
       </div>
     </div>
   );
-};
+});

--- a/frontend/src/pages/Requests.tsx
+++ b/frontend/src/pages/Requests.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useNavigate } from "@tanstack/react-router";
-import { useAppStore } from "../stores/appStore";
+import { appStore } from "../stores/appStore";
+import { observer } from "mobx-react-lite";
 import {
   useDMRequests,
   useAcceptDMRequest,
@@ -28,9 +29,9 @@ const RequestPreview: React.FC<{ dmChannelId: string }> = ({ dmChannelId }) => {
   return <ScrambleText text={text} placeholderLength={28} typeSpeed={25} />;
 };
 
-export const Requests: React.FC = () => {
+export const Requests: React.FC = observer(() => {
   const navigate = useNavigate();
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = appStore.currentUser;
   const { data: requests = [], isLoading } = useDMRequests();
   const acceptMutation = useAcceptDMRequest();
   const blockMutation = useBlockUser();
@@ -125,4 +126,4 @@ export const Requests: React.FC = () => {
       />
     </div>
   );
-};
+});

--- a/frontend/src/pages/Root.tsx
+++ b/frontend/src/pages/Root.tsx
@@ -3,13 +3,14 @@ import { useNavigate, useRouter } from "@tanstack/react-router";
 import { exit } from "../bridge";
 import { Users, MessageCircle, Mail, UserPlus, LogOut, Power } from "lucide-react";
 import { TerminalMenu, type TerminalMenuItem } from "../components/ui/TerminalMenu";
-import { useAppStore } from "../stores/appStore";
+import { appStore } from "../stores/appStore";
+import { observer } from "mobx-react-lite";
 import { usePendingInvites, useAllPendingJoinRequests } from "../hooks/queries/useGroups";
 import { useDMConversations } from "../hooks/queries/useMessages";
 import type { RouterContext } from "../types/router";
 
-export const RootPage: React.FC = () => {
-  const { unreadCounts } = useAppStore();
+export const RootPage: React.FC = observer(() => {
+  const { unreadCounts } = appStore;
   const navigate = useNavigate();
   const router = useRouter();
   const { onLogout } = router.options.context as RouterContext;
@@ -78,4 +79,4 @@ export const RootPage: React.FC = () => {
   ];
 
   return <TerminalMenu items={items} />;
-};
+});

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -2,11 +2,12 @@ import React from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { PageShell } from "../components/Layout/PageShell";
 import { SearchView } from "../components/Search/SearchView";
-import { useAppStore } from "../stores/appStore";
+import { appStore } from "../stores/appStore";
+import { observer } from "mobx-react-lite";
 
-export const SearchPage: React.FC = () => {
+export const SearchPage: React.FC = observer(() => {
   const navigate = useNavigate();
-  const { setSelectedConversationId } = useAppStore();
+  const { setSelectedConversationId } = appStore;
 
   return (
     <PageShell title="Search">
@@ -18,4 +19,4 @@ export const SearchPage: React.FC = () => {
       />
     </PageShell>
   );
-};
+});

--- a/frontend/src/pages/SearchGroup.tsx
+++ b/frontend/src/pages/SearchGroup.tsx
@@ -2,16 +2,17 @@ import React, { useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { invoke } from "../bridge";
 import { useQueryClient } from "@tanstack/react-query";
-import { useAppStore } from "../stores/appStore";
+import { appStore } from "../stores/appStore";
+import { observer } from "mobx-react-lite";
 import { useRequestGroupAccess, useMyJoinRequest, useUserGroupsWithChannels, groupQueryKeys } from "../hooks/queries";
 import { deriveSlug } from "../utils/urlRouting";
 import { TextInput } from "../components/ui/TextInput";
 import { Button } from "../components/ui/Button";
 import { Card } from "../components/ui/Card";
 
-export const SearchGroup: React.FC = () => {
+export const SearchGroup: React.FC = observer(() => {
   const navigate = useNavigate();
-  const currentUser = useAppStore((state) => state.currentUser);
+  const currentUser = appStore.currentUser;
   const queryClient = useQueryClient();
   const { data: userGroups } = useUserGroupsWithChannels();
   const [slug, setSlug] = useState("");
@@ -160,4 +161,4 @@ export const SearchGroup: React.FC = () => {
       </div>
     </div>
   );
-};
+});

--- a/frontend/src/pages/SecurityPage.tsx
+++ b/frontend/src/pages/SecurityPage.tsx
@@ -4,7 +4,8 @@ import { PageShell } from "../components/Layout/PageShell";
 import { Button } from "../components/ui/Button";
 import { TextInput } from "../components/ui/TextInput";
 import { NavigableList } from "../components/ui/NavigableList";
-import { useAppStore } from "../stores/appStore";
+import { appStore } from "../stores/appStore";
+import { observer } from "mobx-react-lite";
 import type { RouterContext } from "../types/router";
 import * as api from "../services/api";
 
@@ -69,11 +70,11 @@ const sectionHeaderStyle: React.CSSProperties = {
   borderColor: "var(--c-border)",
 };
 
-export const SecurityPage: React.FC = () => {
+export const SecurityPage: React.FC = observer(() => {
   const navigate = useNavigate();
   const router = useRouter();
   const { onDeleteAccount } = router.options.context as RouterContext;
-  const { currentUser } = useAppStore();
+  const { currentUser } = appStore;
   const [events, setEvents] = useState<api.SecurityEvent[] | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -162,7 +163,7 @@ export const SecurityPage: React.FC = () => {
       await api.deleteAccount(currentUser.id);
       // Clear local state immediately so the user is logged out even if the
       // callback chain from the router context is broken.
-      useAppStore.getState().logout();
+      appStore.logout();
       if (onDeleteAccount) {
         onDeleteAccount();
       } else {
@@ -393,4 +394,4 @@ export const SecurityPage: React.FC = () => {
       </div>
     </PageShell>
   );
-};
+});

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
 import { Upload, User } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
-import { useAppStore } from "../stores/appStore";
+import { appStore } from "../stores/appStore";
+import { observer } from "mobx-react-lite";
 import { uploadAvatar } from "../services/r2-upload";
 import { resizeImage } from "../utils/imageProcessing";
 import { useUserProfile, useUpdateProfile, useUpdateAvatar, useUserAvatar, userQueryKeys } from "../hooks/queries";
@@ -9,8 +10,8 @@ import { TextInput } from "../components/ui/TextInput";
 import { Button } from "../components/ui/Button";
 import { convertFileSrc, invoke } from "../bridge";
 
-export const Settings: React.FC = () => {
-  const { currentUser } = useAppStore();
+export const Settings: React.FC = observer(() => {
+  const { currentUser } = appStore;
 
   const { data: userData, isLoading } = useUserProfile();
   const { data: avatarDownloadUrl } = useUserAvatar();
@@ -489,4 +490,4 @@ export const Settings: React.FC = () => {
       </div>
     </div>
   );
-};
+});

--- a/frontend/src/pages/SettingsHub.tsx
+++ b/frontend/src/pages/SettingsHub.tsx
@@ -5,11 +5,12 @@ import { PageShell } from "../components/Layout/PageShell";
 import { PresenceAvatar } from "../components/ui/PresenceAvatar";
 import { TerminalMenu, type TerminalMenuItem } from "../components/ui/TerminalMenu";
 import { useUserProfile } from "../hooks/queries";
-import { useAppStore } from "../stores/appStore";
+import { appStore } from "../stores/appStore";
+import { observer } from "mobx-react-lite";
 
-export const SettingsHubPage: React.FC = () => {
+export const SettingsHubPage: React.FC = observer(() => {
   const navigate = useNavigate();
-  const currentUser = useAppStore((s) => s.currentUser);
+  const currentUser = appStore.currentUser;
   const { data: profile } = useUserProfile();
 
   const headlineName =
@@ -100,4 +101,4 @@ export const SettingsHubPage: React.FC = () => {
       </div>
     </PageShell>
   );
-};
+});

--- a/frontend/src/pages/StartDM.tsx
+++ b/frontend/src/pages/StartDM.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
-import { useAppStore } from "../stores/appStore";
+import { appStore } from "../stores/appStore";
+import { observer } from "mobx-react-lite";
 import { useCreateOrGetDMConversation } from "../hooks/queries";
 import { TextInput } from "../components/ui/TextInput";
 import { Button } from "../components/ui/Button";
@@ -8,11 +9,9 @@ interface StartDMProps {
   onSuccess?: (conversationId: string) => void;
 }
 
-export const StartDM: React.FC<StartDMProps> = ({ onSuccess }) => {
-  const currentUser = useAppStore((state) => state.currentUser);
-  const setSelectedConversationId = useAppStore(
-    (state) => state.setSelectedConversationId
-  );
+export const StartDM: React.FC<StartDMProps> = observer(({ onSuccess }) => {
+  const currentUser = appStore.currentUser;
+  const setSelectedConversationId = appStore.setSelectedConversationId;
   const [identifier, setIdentifier] = useState("");
   const [error, setError] = useState<string | null>(null);
 
@@ -86,4 +85,4 @@ export const StartDM: React.FC<StartDMProps> = ({ onSuccess }) => {
       </div>
     </div>
   );
-};
+});

--- a/frontend/src/pages/StartDMPage.tsx
+++ b/frontend/src/pages/StartDMPage.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { PageShell } from "../components/Layout/PageShell";
-import { useAppStore } from "../stores/appStore";
+import { appStore } from "../stores/appStore";
+import { observer } from "mobx-react-lite";
 import { StartDM } from "./StartDM";
 
-export const StartDMPage: React.FC = () => {
+export const StartDMPage: React.FC = observer(() => {
   const navigate = useNavigate();
-  const { setSelectedConversationId } = useAppStore();
+  const { setSelectedConversationId } = appStore;
 
   return (
     <PageShell title="New Message">
@@ -18,4 +19,4 @@ export const StartDMPage: React.FC = () => {
       />
     </PageShell>
   );
-};
+});

--- a/frontend/src/pages/UpdatePage.tsx
+++ b/frontend/src/pages/UpdatePage.tsx
@@ -6,15 +6,16 @@ import {
 } from "../bridge";
 import { PageShell } from "../components/Layout/PageShell";
 import { Button } from "../components/ui/Button";
-import { useAppStore } from "../stores/appStore";
+import { appStore } from "../stores/appStore";
+import { observer } from "mobx-react-lite";
 import type { ManagedInstallInfo } from "../types";
 
 type Status = "checking" | "available" | "none" | "error" | "managed";
 
-export const UpdatePage: React.FC = () => {
-  const setUpdateRequired = useAppStore((s) => s.setUpdateRequired);
-  const cachedAvailable = useAppStore((s) => s.availableUpdateVersion);
-  const setAvailableUpdateVersion = useAppStore((s) => s.setAvailableUpdateVersion);
+export const UpdatePage: React.FC = observer(() => {
+  const setUpdateRequired = appStore.setUpdateRequired;
+  const cachedAvailable = appStore.availableUpdateVersion;
+  const setAvailableUpdateVersion = appStore.setAvailableUpdateVersion;
 
   const [appVersion, setAppVersion] = useState<string>("");
   const [status, setStatus] = useState<Status>(cachedAvailable ? "available" : "checking");
@@ -217,4 +218,4 @@ export const UpdatePage: React.FC = () => {
       </div>
     </PageShell>
   );
-};
+});

--- a/frontend/src/pages/UserProfile.tsx
+++ b/frontend/src/pages/UserProfile.tsx
@@ -13,12 +13,13 @@ import {
 import { Button } from "../components/ui/Button";
 import { useBlockUser } from "../hooks/queries";
 import { useCreateOrGetDMConversation } from "../hooks/queries/useMessages";
-import { useAppStore } from "../stores/appStore";
+import { appStore } from "../stores/appStore";
+import { observer } from "mobx-react-lite";
 
-export const UserProfilePage: React.FC = () => {
+export const UserProfilePage: React.FC = observer(() => {
   const navigate = useNavigate();
   const { userId } = useParams({ from: "/user/$userId" });
-  const currentUser = useAppStore((s) => s.currentUser);
+  const currentUser = appStore.currentUser;
 
   const { data: profile, isLoading } = useOtherUserProfile(userId);
   const { data: safety } = useSafetyNumber(userId);
@@ -251,4 +252,4 @@ export const UserProfilePage: React.FC = () => {
       </div>
     </PageShell>
   );
-};
+});

--- a/frontend/src/pages/VoiceChannel.tsx
+++ b/frontend/src/pages/VoiceChannel.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useRef } from "react";
 import { useNavigate, useParams } from "@tanstack/react-router";
 import { ArrowLeft, Pencil, Trash2, Volume2, X } from "lucide-react";
-import { useAppStore } from "../stores/appStore";
+import { observer } from "mobx-react-lite";
+import { appStore } from "../stores/appStore";
 import { useDeleteChannel, useUserGroupsWithChannels } from "../hooks/queries/useGroups";
 import { VoiceChannelView } from "../components/Voice/VoiceChannelView";
 import { VoiceMemberTile } from "../components/Voice/VoiceMemberTile";
@@ -15,14 +16,14 @@ import { voiceSession } from "../voice";
 
 
 
-export const VoiceChannelPage: React.FC = () => {
+export const VoiceChannelPage: React.FC = observer(() => {
   const navigate = useNavigate();
   const { groupId, channelId } = useParams({ from: "/groups/$groupId/voice/$channelId" });
   const {
     voiceState,
     pendingDeleteChannelId,
     setPendingDeleteChannelId,
-  } = useAppStore();
+  } = appStore;
   const activeVoiceChannelId =
     voiceState.kind === 'idle' ? null : voiceState.channelId;
 
@@ -240,4 +241,4 @@ export const VoiceChannelPage: React.FC = () => {
       )}
     </div>
   );
-};
+});

--- a/frontend/src/screenshare/livekitView.ts
+++ b/frontend/src/screenshare/livekitView.ts
@@ -47,7 +47,8 @@ import { installAv1Stripper } from './sdpMunger';
 // load — before any livekit-client code constructs a PeerConnection. See
 // sdpMunger.ts for the full diagnosis.
 installAv1Stripper();
-import { useAppStore } from '../stores/appStore';
+import { autorun } from 'mobx';
+import { appStore } from '../stores/appStore';
 import { LOCAL_PREVIEW_KEY } from './screenShareSession';
 
 // ── Public types ─────────────────────────────────────────────────────────────
@@ -313,7 +314,7 @@ class LiveKitView {
     track.addEventListener('ended', () => {
       void this.unpublishScreenShare();
       // Notify the store so VoiceMemberTile flips back to the avatar.
-      useAppStore.getState().shareStopped();
+      appStore.shareStopped();
     });
     this.tracks.set(LOCAL_PREVIEW_KEY, track);
     const settings = track.getSettings();
@@ -551,7 +552,7 @@ class LiveKitView {
     // it's gone too — but call shareStopped() first to be explicit while
     // we're still in `joined`, in case the consumer flow handles
     // share-stopped and voice-left as distinct UI events.
-    useAppStore.getState().shareStopped();
+    appStore.shareStopped();
     if (room) {
       try {
         await room.disconnect();
@@ -680,7 +681,7 @@ class LiveKitView {
     this.snapshot = new Map(this.tracks);
     // Mirror remote keys into the store. Local preview is driven by the
     // existing `screenShareLocalActive` field — don't duplicate it here.
-    const store = useAppStore.getState();
+    const store = appStore;
     const desired: Record<
       string,
       { trackKey: string; width: number; height: number }
@@ -713,7 +714,7 @@ class LiveKitView {
       }
     }
     if (changed) {
-      useAppStore.setState({ screenShareRemotes: desired });
+      store.setScreenShareRemotes(desired);
     }
     for (const listener of this.listeners) {
       try {
@@ -741,7 +742,7 @@ if (typeof window !== 'undefined') {
     if (!hasElectron()) {
       return null;
     }
-    const s = useAppStore.getState();
+    const s = appStore;
     if (s.voiceState.kind !== 'joined') {
       return null;
     }
@@ -756,17 +757,10 @@ if (typeof window !== 'undefined') {
     };
   };
 
-  // Apply once at module load in case voice was already joined when this
-  // file is imported (it isn't, today, but the call is cheap and
-  // future-proofs against import-order churn).
-  livekitView.setIntent(computeIntent());
-
-  useAppStore.subscribe((state, prev) => {
-    if (
-      state.voiceState !== prev.voiceState ||
-      state.currentUser !== prev.currentUser
-    ) {
-      livekitView.setIntent(computeIntent());
-    }
+  // `autorun` applies once immediately (covering the case where voice was
+  // already joined when this file is imported) and re-runs whenever the voice
+  // state or current user that `computeIntent` reads changes.
+  autorun(() => {
+    livekitView.setIntent(computeIntent());
   });
 }

--- a/frontend/src/screenshare/screenShareSession.ts
+++ b/frontend/src/screenshare/screenShareSession.ts
@@ -13,7 +13,7 @@
 
 import { Channel, hasMediaDevices, invoke } from "../bridge";
 
-import { useAppStore } from "../stores/appStore";
+import { appStore } from "../stores/appStore";
 import { playSfx, SFX } from "../utils/sfx";
 
 /** Capturable display reported by `enumerate_screen_sources`.
@@ -378,7 +378,7 @@ class ScreenShareSession {
     // which silently captures the primary display and was the symptom
     // we just fixed. Fail loudly instead.
     if (!selection) {
-      const store = useAppStore.getState();
+      const store = appStore;
       const msg = "Screen share requires a picked source.";
       store.shareFailed(msg);
       throw new Error(msg);
@@ -387,7 +387,7 @@ class ScreenShareSession {
       `${selection.kind}:${selection.id}`,
     );
     if (!electronSourceId) {
-      const store = useAppStore.getState();
+      const store = appStore;
       const msg = "Screen share selection no longer available — re-open the picker.";
       store.shareFailed(msg);
       throw new Error(msg);
@@ -398,7 +398,7 @@ class ScreenShareSession {
     // ordinarily do this for us, but the dynamic import makes it
     // explicit and survives any future Vite config quirks.)
     const { livekitView } = await import("./livekitView");
-    const store = useAppStore.getState();
+    const store = appStore;
     store.shareStartStarting();
     let stream: MediaStream;
     try {
@@ -497,7 +497,7 @@ class ScreenShareSession {
     if (hasMediaDevices()) {
       const { livekitView } = await import("./livekitView");
       await livekitView.unpublishScreenShare();
-      const store = useAppStore.getState();
+      const store = appStore;
       store.shareStopped();
       playSfx(SFX.ping);
       return;
@@ -506,7 +506,7 @@ class ScreenShareSession {
   }
 
   private handleEvent(ev: ScreenShareEvent) {
-    const store = useAppStore.getState();
+    const store = appStore;
     switch (ev.type) {
       case "local_started":
         // Tauri path: backend signals the start after its capture helper

--- a/frontend/src/services/updatePoller.ts
+++ b/frontend/src/services/updatePoller.ts
@@ -1,5 +1,5 @@
 import { check as checkForUpdate } from "../bridge";
-import { useAppStore } from "../stores/appStore";
+import { appStore } from "../stores/appStore";
 
 // The update poller lives outside React on purpose: a singleton timer is
 // resilient to StrictMode double-mounts, route changes, and component
@@ -20,7 +20,7 @@ let started = false;
 async function runCheck(): Promise<void> {
   try {
     const update = await checkForUpdate();
-    const setAvailable = useAppStore.getState().setAvailableUpdateVersion;
+    const setAvailable = appStore.setAvailableUpdateVersion;
     setAvailable(update ? update.version : null);
   } catch (err) {
     // Network blips are expected; log once and move on. Don't clear an

--- a/frontend/src/stores/appStore.ts
+++ b/frontend/src/stores/appStore.ts
@@ -1,391 +1,391 @@
-import { create } from 'zustand';
+import { makeAutoObservable } from 'mobx';
 import type { AppState, User, Group, Channel, DMConversation, MessageQueueItem, VoiceParticipant } from '../types';
-import type { ShareState, VoiceState } from '../types/voice-state';
+import type { VoiceState } from '../types/voice-state';
 import type { SourceList } from '../screenshare/screenShareSession';
 
-interface AppStore extends AppState {
+type ScreenShareRemote = { trackKey: string; width: number; height: number };
+type EnrollmentApproval = { requestId: string; newDeviceId: string; verificationCode: string };
+type IncomingCall = { callId: string; roomName: string; callerId: string; callerUsername: string };
+type OutgoingCall = { callId: string; calleeId: string };
+type StatusBarAlert = { senderUsername: string; roomId: string };
+
+class AppStore implements AppState {
+  // ── Core / user ────────────────────────────────────────────────────────
+  currentUser: User | null = null;
   // User profile data from Turso
-  username: string | null;
-  userAvatarUrl: string | null;
+  username: string | null = null;
+  userAvatarUrl: string | null = null;
+
+  // ── Selected views ─────────────────────────────────────────────────────
+  selectedGroupId: string | null = null;
+  selectedChannelId: string | null = null;
+  selectedConversationId: string | null = null;
+
+  // ── Data (messages managed by React Query, not here) ───────────────────
+  groups: Group[] = [];
+  channels: Record<string, Channel[]> = {};
+  dmConversations: DMConversation[] = [];
+  messageQueue: MessageQueueItem[] = [];
+
+  // ── UI state ───────────────────────────────────────────────────────────
+  replyToMessageId: string | null = null;
+  showThreadId: string | null = null;
+  isLoading = false;
+  error: string | null = null;
 
   // Unread message counts keyed by conversation_id or channel_id
-  unreadCounts: Record<string, number>;
+  unreadCounts: Record<string, number> = {};
 
-  // Actions
-  setCurrentUser: (user: User | null) => void;
-  setUsername: (username: string | null) => void;
-  setUserAvatarUrl: (url: string | null) => void;
-  setSelectedGroupId: (groupId: string | null) => void;
-  setSelectedChannelId: (channelId: string | null) => void;
-  setSelectedConversationId: (conversationId: string | null) => void;
-  setGroups: (groups: Group[]) => void;
-  addGroup: (group: Group) => void;
-  setChannels: (groupId: string, channels: Channel[]) => void;
-  addChannel: (channel: Channel) => void;
-  setDMConversations: (conversations: DMConversation[]) => void;
-  addDMConversation: (conversation: DMConversation) => void;
-  setMessageQueue: (queue: MessageQueueItem[]) => void;
-  addToMessageQueue: (item: MessageQueueItem) => void;
-  updateMessageQueueItem: (id: string, updates: Partial<MessageQueueItem>) => void;
-  removeFromMessageQueue: (id: string) => void;
-  setReplyToMessageId: (messageId: string | null) => void;
-  setShowThreadId: (threadId: string | null) => void;
-  setLoading: (loading: boolean) => void;
-  setError: (error: string | null) => void;
-  // Clears the unread count for a conversation or channel
-  markRead: (id: string) => void;
-  // Increments the unread count for a conversation or channel by 1
-  incrementUnread: (id: string) => void;
   // Voice room + local screenshare state. Single source of truth — see
   // `frontend/src/types/voice-state.ts` for the union shape. Replaces the
   // previous bag of flags (`voicePhase`, `screenShareMode`,
   // `screenShareLocalActive`, `activeVoiceChannelId`,
   // `voiceCounterpartyUserId`, `voiceIsMuted`, `screenShareSources`,
   // `screenShareLocalDimensions`) that could contradict each other.
-  voiceState: VoiceState;
-
-  // Semantic transitions. Each one guards on the current state's `kind`
-  // and no-ops (with a console.warn) if the transition isn't allowed.
-  // Prefer these over setVoiceState() for everyday writes — they
-  // document the lifecycle and prevent skipping phases.
-  voiceStartJoining: (channelId: string, counterpartyUserId: string | null) => void;
-  voiceJoined: () => void;
-  voiceJoinFailed: (error: string) => void;
-  voiceStartLeaving: () => void;
-  voiceLeft: () => void;
-  voiceSetMicMuted: (muted: boolean) => void;
-
-  shareStartPicking: (sources: SourceList) => void;
-  shareCancelPicker: () => void;
-  shareStartStarting: () => void;
-  shareStarted: (trackId: string, dimensions: { width: number; height: number } | null) => void;
-  shareSetDimensions: (dimensions: { width: number; height: number } | null) => void;
-  shareFailed: (error: string) => void;
-  shareStopped: () => void;
+  voiceState: VoiceState = { kind: 'idle' };
 
   // Status bar alert — shown in bottom bar when a message arrives for a
   // channel/DM the user is not currently viewing. Cleared on navigation.
-  statusBarAlert: { senderUsername: string; roomId: string } | null;
-  setStatusBarAlert: (alert: { senderUsername: string; roomId: string } | null) => void;
+  statusBarAlert: StatusBarAlert | null = null;
+
   // Voice join failure — surfaced in the bottom bar when join_voice_channel
   // fails (e.g. the LiveKit server is unreachable). Cleared on dismiss or on
   // the next join attempt.
-  voiceError: string | null;
-  setVoiceError: (message: string | null) => void;
+  voiceError: string | null = null;
+
   // True when local participant's mic is actively picking up audio.
   // Derived from LiveKit speaker events; not part of the lifecycle union.
-  isLocalSpeaking: boolean;
-  setIsLocalSpeaking: (speaking: boolean) => void;
+  isLocalSpeaking = false;
+
   // Live voice channel participants — driven by LiveKit events.
   // Collection data, kept separate from the lifecycle union.
-  voiceParticipants: VoiceParticipant[];
-  voiceActiveSpeakerIds: string[];
-  setVoiceParticipants: (participants: VoiceParticipant[]) => void;
-  setVoiceActiveSpeakerIds: (ids: string[]) => void;
+  voiceParticipants: VoiceParticipant[] = [];
+  voiceActiveSpeakerIds: string[] = [];
+
   /** Active remote screenshares keyed by participant identity. */
-  screenShareRemotes: Record<string, { trackKey: string; width: number; height: number }>;
-  upsertScreenShareRemote: (identity: string, info: { trackKey: string; width: number; height: number }) => void;
-  removeScreenShareRemote: (trackKey: string) => void;
+  screenShareRemotes: Record<string, ScreenShareRemote> = {};
+
   /** Track key currently being viewed in the inline stream pane, if any. */
-  viewingScreenShareTrackKey: string | null;
-  setViewingScreenShareTrackKey: (k: string | null) => void;
+  viewingScreenShareTrackKey: string | null = null;
+
   // Pending enrollment approval prompt — set by `useLiveKitRealtime`
   // when an `EnrollmentRequested` event arrives from the user's inbox
   // room. Causes the UI to immediately take over with the approval
   // prompt regardless of which page the user is on. Cleared when the
   // user approves, rejects, or after the request expires.
-  pendingEnrollmentApproval:
-    | {
-        requestId: string;
-        newDeviceId: string;
-        verificationCode: string;
-      }
-    | null;
-  setPendingEnrollmentApproval: (
-    p: { requestId: string; newDeviceId: string; verificationCode: string } | null,
-  ) => void;
-  updateRequired: boolean;
-  setUpdateRequired: (v: boolean) => void;
+  pendingEnrollmentApproval: EnrollmentApproval | null = null;
+
+  updateRequired = false;
+
   // Latest version detected by the in-app poller while the user is signed in.
   // null = no update detected (or not yet checked); a string = the version
   // returned by the updater bridge's `check()`. Drives the discrete "Update
   // available" indicator in the bottom bar.
-  availableUpdateVersion: string | null;
-  setAvailableUpdateVersion: (v: string | null) => void;
+  availableUpdateVersion: string | null = null;
+
   // Channel id pending admin delete confirmation. When non-null and equal to
   // selectedChannelId, MainContent replaces the chat input with the
   // delete-channel confirm bar.
-  pendingDeleteChannelId: string | null;
-  setPendingDeleteChannelId: (channelId: string | null) => void;
+  pendingDeleteChannelId: string | null = null;
+
   // Incoming 1:1 call ringing this device. Set when a `call_invite` arrives
   // on the personal inbox; cleared on accept, decline, cancel, or logout.
   // Renders in the bottom status bar with priority over `statusBarAlert`.
-  incomingCall: {
-    callId: string;
-    roomName: string;
-    callerId: string;
-    callerUsername: string;
-  } | null;
-  setIncomingCall: (
-    call:
-      | { callId: string; roomName: string; callerId: string; callerUsername: string }
-      | null,
-  ) => void;
+  incomingCall: IncomingCall | null = null;
+
   // Outgoing 1:1 call this device initiated and is waiting on. Set in
   // `DM.tsx` when `start_call` returns, cleared once the callee actually
   // joins the LiveKit room (call answered) or once the caller hangs up
   // before pickup (in which case the Call page emits `cancel_call` to stop
   // the callee's ring). Holds just enough to address the cancel signal.
-  outgoingCall: {
-    callId: string;
-    calleeId: string;
-  } | null;
-  setOutgoingCall: (call: { callId: string; calleeId: string } | null) => void;
-  logout: () => void;
-}
+  outgoingCall: OutgoingCall | null = null;
 
-export const useAppStore = create<AppStore>((set) => ({
-  // Initial state
-  currentUser: null,
-  username: null,
-  userAvatarUrl: null,
-  selectedGroupId: null,
-  selectedChannelId: null,
-  selectedConversationId: null,
-  groups: [],
-  channels: {},
-  dmConversations: [],
-  messageQueue: [],
-  replyToMessageId: null,
-  showThreadId: null,
-  isLoading: false,
-  error: null,
-  unreadCounts: {},
-  voiceState: { kind: 'idle' },
-  statusBarAlert: null,
-  voiceError: null,
-  isLocalSpeaking: false,
-  voiceParticipants: [],
-  voiceActiveSpeakerIds: [],
-  screenShareRemotes: {},
-  viewingScreenShareTrackKey: null,
+  constructor() {
+    makeAutoObservable(this, {}, { autoBind: true });
+  }
 
-  // Actions
-  setCurrentUser: (user) => set({ currentUser: user }),
-  setUsername: (username) => set((state) => ({
-    username,
+  // ── Actions ────────────────────────────────────────────────────────────
+  setCurrentUser(user: User | null) {
+    this.currentUser = user;
+  }
+
+  setUsername(username: string | null) {
+    this.username = username;
     // Keep currentUser in sync so components reading currentUser.username
     // see the updated value without a page reload.
-    currentUser: state.currentUser
-      ? { ...state.currentUser, username: username ?? state.currentUser.username }
-      : null,
-  })),
-  setUserAvatarUrl: (url) => set({ userAvatarUrl: url }),
-  
-  setSelectedGroupId: (groupId) => set({ selectedGroupId: groupId, selectedChannelId: null }),
-  setSelectedChannelId: (channelId) => set({ selectedChannelId: channelId, selectedConversationId: null }),
-  setSelectedConversationId: (conversationId) => set({ selectedConversationId: conversationId, selectedChannelId: null }),
-  
-  setGroups: (groups) => set({ groups }),
-  addGroup: (group) => set((state) => ({ groups: [...state.groups, group] })),
-  
-  setChannels: (groupId, channels) => set((state) => ({
-    channels: { ...state.channels, [groupId]: channels }
-  })),
-  addChannel: (channel) => set((state) => ({
-    channels: {
-      ...state.channels,
-      [channel.group_id]: [...(state.channels[channel.group_id] || []), channel]
+    if (this.currentUser) {
+      this.currentUser = {
+        ...this.currentUser,
+        username: username ?? this.currentUser.username,
+      };
     }
-  })),
+  }
 
-  setDMConversations: (conversations) => set({ dmConversations: conversations }),
-  addDMConversation: (conversation) => set((state) => ({
-    dmConversations: [...state.dmConversations, conversation]
-  })),
-  
-  setMessageQueue: (queue) => set({ messageQueue: queue }),
-  addToMessageQueue: (item) => set((state) => ({
-    messageQueue: [...state.messageQueue, item]
-  })),
-  updateMessageQueueItem: (id, updates) => set((state) => ({
-    messageQueue: state.messageQueue.map((item) =>
-      item.id === id ? { ...item, ...updates } : item
-    )
-  })),
-  removeFromMessageQueue: (id) => set((state) => ({
-    messageQueue: state.messageQueue.filter((item) => item.id !== id)
-  })),
-  
-  setReplyToMessageId: (messageId) => set({ replyToMessageId: messageId }),
-  setShowThreadId: (threadId) => set({ showThreadId: threadId }),
-  
-  setLoading: (loading) => set({ isLoading: loading }),
-  setError: (error) => set({ error }),
+  setUserAvatarUrl(url: string | null) {
+    this.userAvatarUrl = url;
+  }
 
-  markRead: (id) => set((state) => {
-    const next = { ...state.unreadCounts };
+  setSelectedGroupId(groupId: string | null) {
+    this.selectedGroupId = groupId;
+    this.selectedChannelId = null;
+  }
+
+  setSelectedChannelId(channelId: string | null) {
+    this.selectedChannelId = channelId;
+    this.selectedConversationId = null;
+  }
+
+  setSelectedConversationId(conversationId: string | null) {
+    this.selectedConversationId = conversationId;
+    this.selectedChannelId = null;
+  }
+
+  setGroups(groups: Group[]) {
+    this.groups = groups;
+  }
+
+  addGroup(group: Group) {
+    this.groups = [...this.groups, group];
+  }
+
+  setChannels(groupId: string, channels: Channel[]) {
+    this.channels = { ...this.channels, [groupId]: channels };
+  }
+
+  addChannel(channel: Channel) {
+    this.channels = {
+      ...this.channels,
+      [channel.group_id]: [...(this.channels[channel.group_id] || []), channel],
+    };
+  }
+
+  setDMConversations(conversations: DMConversation[]) {
+    this.dmConversations = conversations;
+  }
+
+  addDMConversation(conversation: DMConversation) {
+    this.dmConversations = [...this.dmConversations, conversation];
+  }
+
+  setMessageQueue(queue: MessageQueueItem[]) {
+    this.messageQueue = queue;
+  }
+
+  addToMessageQueue(item: MessageQueueItem) {
+    this.messageQueue = [...this.messageQueue, item];
+  }
+
+  updateMessageQueueItem(id: string, updates: Partial<MessageQueueItem>) {
+    this.messageQueue = this.messageQueue.map((item) =>
+      item.id === id ? { ...item, ...updates } : item,
+    );
+  }
+
+  removeFromMessageQueue(id: string) {
+    this.messageQueue = this.messageQueue.filter((item) => item.id !== id);
+  }
+
+  setReplyToMessageId(messageId: string | null) {
+    this.replyToMessageId = messageId;
+  }
+
+  setShowThreadId(threadId: string | null) {
+    this.showThreadId = threadId;
+  }
+
+  setLoading(loading: boolean) {
+    this.isLoading = loading;
+  }
+
+  setError(error: string | null) {
+    this.error = error;
+  }
+
+  // Clears the unread count for a conversation or channel
+  markRead(id: string) {
+    if (!(id in this.unreadCounts)) {
+      return;
+    }
+    const next = { ...this.unreadCounts };
     delete next[id];
-    return { unreadCounts: next };
-  }),
+    this.unreadCounts = next;
+  }
 
-  incrementUnread: (id) => set((state) => ({
-    unreadCounts: {
-      ...state.unreadCounts,
-      [id]: (state.unreadCounts[id] ?? 0) + 1,
-    },
-  })),
+  // Increments the unread count for a conversation or channel by 1
+  incrementUnread(id: string) {
+    this.unreadCounts = {
+      ...this.unreadCounts,
+      [id]: (this.unreadCounts[id] ?? 0) + 1,
+    };
+  }
 
   // ── Voice + share transitions ──────────────────────────────────────────
   // Each transition guards on the current `voiceState.kind`. Bad
   // transitions are logged + dropped instead of mutating state — this is
   // the whole point of the union: contradictory state is unrepresentable.
-  voiceStartJoining: (channelId, counterpartyUserId) => set((state) => {
-    if (state.voiceState.kind !== 'idle') {
-      console.warn('[voiceState] voiceStartJoining ignored:', state.voiceState.kind);
-      return {};
+  voiceStartJoining(channelId: string, counterpartyUserId: string | null) {
+    if (this.voiceState.kind !== 'idle') {
+      console.warn('[voiceState] voiceStartJoining ignored:', this.voiceState.kind);
+      return;
     }
-    return {
-      voiceState: { kind: 'joining', channelId, counterpartyUserId },
-      voiceError: null,
+    this.voiceState = { kind: 'joining', channelId, counterpartyUserId };
+    this.voiceError = null;
+  }
+
+  voiceJoined() {
+    if (this.voiceState.kind !== 'joining') {
+      console.warn('[voiceState] voiceJoined ignored:', this.voiceState.kind);
+      return;
+    }
+    const { channelId, counterpartyUserId } = this.voiceState;
+    this.voiceState = {
+      kind: 'joined',
+      channelId,
+      counterpartyUserId,
+      micMuted: false,
+      share: { kind: 'idle' },
     };
-  }),
-  voiceJoined: () => set((state) => {
-    if (state.voiceState.kind !== 'joining') {
-      console.warn('[voiceState] voiceJoined ignored:', state.voiceState.kind);
-      return {};
+  }
+
+  voiceJoinFailed(error: string) {
+    if (this.voiceState.kind !== 'joining') {
+      console.warn('[voiceState] voiceJoinFailed ignored:', this.voiceState.kind);
+      return;
     }
-    const { channelId, counterpartyUserId } = state.voiceState;
-    return {
-      voiceState: {
-        kind: 'joined',
-        channelId,
-        counterpartyUserId,
-        micMuted: false,
-        share: { kind: 'idle' },
-      },
-    };
-  }),
-  voiceJoinFailed: (error) => set((state) => {
-    if (state.voiceState.kind !== 'joining') {
-      console.warn('[voiceState] voiceJoinFailed ignored:', state.voiceState.kind);
-      return {};
-    }
-    return { voiceState: { kind: 'idle' }, voiceError: error };
-  }),
-  voiceStartLeaving: () => set((state) => {
+    this.voiceState = { kind: 'idle' };
+    this.voiceError = error;
+  }
+
+  voiceStartLeaving() {
     // Tolerate from joining or joined; the user can hit "leave" while we
     // were still connecting.
-    if (state.voiceState.kind !== 'joining' && state.voiceState.kind !== 'joined') {
-      console.warn('[voiceState] voiceStartLeaving ignored:', state.voiceState.kind);
-      return {};
+    if (this.voiceState.kind !== 'joining' && this.voiceState.kind !== 'joined') {
+      console.warn('[voiceState] voiceStartLeaving ignored:', this.voiceState.kind);
+      return;
     }
-    return { voiceState: { kind: 'leaving', channelId: state.voiceState.channelId } };
-  }),
-  voiceLeft: () => set(() => ({
+    this.voiceState = { kind: 'leaving', channelId: this.voiceState.channelId };
+  }
+
+  voiceLeft() {
     // Unconditional reset — clears share state along the way since the
     // union guarantees share can't outlive the joined parent.
-    voiceState: { kind: 'idle' },
-  })),
-  voiceSetMicMuted: (muted) => set((state) => {
-    if (state.voiceState.kind !== 'joined') {
-      return {};
-    }
-    return { voiceState: { ...state.voiceState, micMuted: muted } };
-  }),
+    this.voiceState = { kind: 'idle' };
+  }
 
-  shareStartPicking: (sources) => set((state) => {
-    if (state.voiceState.kind !== 'joined' || state.voiceState.share.kind !== 'idle') {
-      console.warn('[voiceState] shareStartPicking ignored:', state.voiceState.kind, 'share=', state.voiceState.kind === 'joined' ? state.voiceState.share.kind : 'n/a');
-      return {};
+  voiceSetMicMuted(muted: boolean) {
+    if (this.voiceState.kind !== 'joined') {
+      return;
     }
-    return {
-      voiceState: { ...state.voiceState, share: { kind: 'picking', sources } },
-    };
-  }),
-  shareCancelPicker: () => set((state) => {
-    if (state.voiceState.kind !== 'joined' || state.voiceState.share.kind !== 'picking') {
-      return {};
+    this.voiceState = { ...this.voiceState, micMuted: muted };
+  }
+
+  shareStartPicking(sources: SourceList) {
+    if (this.voiceState.kind !== 'joined' || this.voiceState.share.kind !== 'idle') {
+      console.warn('[voiceState] shareStartPicking ignored:', this.voiceState.kind, 'share=', this.voiceState.kind === 'joined' ? this.voiceState.share.kind : 'n/a');
+      return;
     }
-    return { voiceState: { ...state.voiceState, share: { kind: 'idle' } } };
-  }),
-  shareStartStarting: () => set((state) => {
-    if (state.voiceState.kind !== 'joined') {
-      console.warn('[voiceState] shareStartStarting ignored:', state.voiceState.kind);
-      return {};
+    this.voiceState = { ...this.voiceState, share: { kind: 'picking', sources } };
+  }
+
+  shareCancelPicker() {
+    if (this.voiceState.kind !== 'joined' || this.voiceState.share.kind !== 'picking') {
+      return;
+    }
+    this.voiceState = { ...this.voiceState, share: { kind: 'idle' } };
+  }
+
+  shareStartStarting() {
+    if (this.voiceState.kind !== 'joined') {
+      console.warn('[voiceState] shareStartStarting ignored:', this.voiceState.kind);
+      return;
     }
     // From idle (Linux portal path) or picking (macOS in-app picker).
-    if (state.voiceState.share.kind !== 'idle' && state.voiceState.share.kind !== 'picking') {
-      console.warn('[voiceState] shareStartStarting ignored, share=', state.voiceState.share.kind);
-      return {};
+    if (this.voiceState.share.kind !== 'idle' && this.voiceState.share.kind !== 'picking') {
+      console.warn('[voiceState] shareStartStarting ignored, share=', this.voiceState.share.kind);
+      return;
     }
-    return {
-      voiceState: {
-        ...state.voiceState,
-        share: { kind: 'starting', startedAt: performance.now() },
-      },
+    this.voiceState = {
+      ...this.voiceState,
+      share: { kind: 'starting', startedAt: performance.now() },
     };
-  }),
-  shareStarted: (trackId, dimensions) => set((state) => {
-    if (state.voiceState.kind !== 'joined' || state.voiceState.share.kind !== 'starting') {
-      console.warn('[voiceState] shareStarted ignored:', state.voiceState.kind, state.voiceState.kind === 'joined' ? state.voiceState.share.kind : 'n/a');
-      return {};
+  }
+
+  shareStarted(trackId: string, dimensions: { width: number; height: number } | null) {
+    if (this.voiceState.kind !== 'joined' || this.voiceState.share.kind !== 'starting') {
+      console.warn('[voiceState] shareStarted ignored:', this.voiceState.kind, this.voiceState.kind === 'joined' ? this.voiceState.share.kind : 'n/a');
+      return;
     }
-    return {
-      voiceState: {
-        ...state.voiceState,
-        share: { kind: 'active', trackId, dimensions },
-      },
+    this.voiceState = {
+      ...this.voiceState,
+      share: { kind: 'active', trackId, dimensions },
     };
-  }),
-  shareSetDimensions: (dimensions) => set((state) => {
-    if (state.voiceState.kind !== 'joined' || state.voiceState.share.kind !== 'active') {
-      return {};
+  }
+
+  shareSetDimensions(dimensions: { width: number; height: number } | null) {
+    if (this.voiceState.kind !== 'joined' || this.voiceState.share.kind !== 'active') {
+      return;
     }
-    return {
-      voiceState: {
-        ...state.voiceState,
-        share: { ...state.voiceState.share, dimensions },
-      },
+    this.voiceState = {
+      ...this.voiceState,
+      share: { ...this.voiceState.share, dimensions },
     };
-  }),
-  shareFailed: (error) => set((state) => {
-    if (state.voiceState.kind !== 'joined') {
-      console.warn('[voiceState] shareFailed ignored, voice=', state.voiceState.kind);
-      return {};
+  }
+
+  shareFailed(error: string) {
+    if (this.voiceState.kind !== 'joined') {
+      console.warn('[voiceState] shareFailed ignored, voice=', this.voiceState.kind);
+      return;
     }
-    return {
-      voiceState: {
-        ...state.voiceState,
-        share: { kind: 'failed', error },
-      },
+    this.voiceState = {
+      ...this.voiceState,
+      share: { kind: 'failed', error },
     };
-  }),
-  shareStopped: () => set((state) => {
+  }
+
+  shareStopped() {
     // Unconditional reset of share — safe to call from any share state
     // (active, failed, starting, picking). The reset-on-leave path also
     // calls voiceLeft which clears share via the union structure.
-    if (state.voiceState.kind !== 'joined') {
-      return {};
+    if (this.voiceState.kind !== 'joined') {
+      return;
     }
-    return {
-      voiceState: { ...state.voiceState, share: { kind: 'idle' } },
-    };
-  }),
+    this.voiceState = { ...this.voiceState, share: { kind: 'idle' } };
+  }
 
-  setStatusBarAlert: (alert) => set({ statusBarAlert: alert }),
-  setVoiceError: (message) => set({ voiceError: message }),
-  setIsLocalSpeaking: (speaking) => set({ isLocalSpeaking: speaking }),
+  setStatusBarAlert(alert: StatusBarAlert | null) {
+    this.statusBarAlert = alert;
+  }
 
-  setVoiceParticipants: (participants) => set({ voiceParticipants: participants }),
-  setVoiceActiveSpeakerIds: (ids) => set({ voiceActiveSpeakerIds: ids }),
-  upsertScreenShareRemote: (identity, info) => set((state) => ({
-    screenShareRemotes: { ...state.screenShareRemotes, [identity]: info },
-  })),
-  removeScreenShareRemote: (trackKey) => set((state) => {
-    const next: typeof state.screenShareRemotes = {};
-    let viewing = state.viewingScreenShareTrackKey;
-    for (const [id, info] of Object.entries(state.screenShareRemotes)) {
+  setVoiceError(message: string | null) {
+    this.voiceError = message;
+  }
+
+  setIsLocalSpeaking(speaking: boolean) {
+    this.isLocalSpeaking = speaking;
+  }
+
+  setVoiceParticipants(participants: VoiceParticipant[]) {
+    this.voiceParticipants = participants;
+  }
+
+  setVoiceActiveSpeakerIds(ids: string[]) {
+    this.voiceActiveSpeakerIds = ids;
+  }
+
+  /** Replace the whole remote-screenshare map wholesale. Used by the LiveKit
+   *  view client's `emit()` mirror, which computes the desired set in one go. */
+  setScreenShareRemotes(remotes: Record<string, ScreenShareRemote>) {
+    this.screenShareRemotes = remotes;
+  }
+
+  upsertScreenShareRemote(identity: string, info: ScreenShareRemote) {
+    this.screenShareRemotes = { ...this.screenShareRemotes, [identity]: info };
+  }
+
+  removeScreenShareRemote(trackKey: string) {
+    const next: Record<string, ScreenShareRemote> = {};
+    let viewing = this.viewingScreenShareTrackKey;
+    for (const [id, info] of Object.entries(this.screenShareRemotes)) {
       if (info.trackKey !== trackKey) {
         next[id] = info;
       }
@@ -393,59 +393,67 @@ export const useAppStore = create<AppStore>((set) => ({
     if (viewing === trackKey) {
       viewing = null;
     }
-    return {
-      screenShareRemotes: next,
-      viewingScreenShareTrackKey: viewing,
-    };
-  }),
-  setViewingScreenShareTrackKey: (k) => set({ viewingScreenShareTrackKey: k }),
+    this.screenShareRemotes = next;
+    this.viewingScreenShareTrackKey = viewing;
+  }
 
-  pendingEnrollmentApproval: null,
-  setPendingEnrollmentApproval: (p) => set({ pendingEnrollmentApproval: p }),
+  setViewingScreenShareTrackKey(k: string | null) {
+    this.viewingScreenShareTrackKey = k;
+  }
 
-  updateRequired: false,
-  setUpdateRequired: (v) => set({ updateRequired: v }),
+  setPendingEnrollmentApproval(p: EnrollmentApproval | null) {
+    this.pendingEnrollmentApproval = p;
+  }
 
-  availableUpdateVersion: null,
-  setAvailableUpdateVersion: (v) => set({ availableUpdateVersion: v }),
+  setUpdateRequired(v: boolean) {
+    this.updateRequired = v;
+  }
 
-  pendingDeleteChannelId: null,
-  setPendingDeleteChannelId: (channelId) => set({ pendingDeleteChannelId: channelId }),
+  setAvailableUpdateVersion(v: string | null) {
+    this.availableUpdateVersion = v;
+  }
 
-  incomingCall: null,
-  setIncomingCall: (call) => set({ incomingCall: call }),
+  setPendingDeleteChannelId(channelId: string | null) {
+    this.pendingDeleteChannelId = channelId;
+  }
 
-  outgoingCall: null,
-  setOutgoingCall: (call) => set({ outgoingCall: call }),
+  setIncomingCall(call: IncomingCall | null) {
+    this.incomingCall = call;
+  }
 
-  logout: () => set({
-    currentUser: null,
-    username: null,
-    userAvatarUrl: null,
-    selectedGroupId: null,
-    selectedChannelId: null,
-    selectedConversationId: null,
-    groups: [],
-    channels: {},
-    dmConversations: [],
-    messageQueue: [],
-    replyToMessageId: null,
-    showThreadId: null,
-    isLoading: false,
-    error: null,
-    unreadCounts: {},
-    voiceState: { kind: 'idle' },
-    statusBarAlert: null,
-    voiceError: null,
-    isLocalSpeaking: false,
-    voiceParticipants: [],
-    voiceActiveSpeakerIds: [],
-    screenShareRemotes: {},
-    viewingScreenShareTrackKey: null,
-    pendingEnrollmentApproval: null,
-    pendingDeleteChannelId: null,
-    incomingCall: null,
-    outgoingCall: null,
-  }),
-}));
+  setOutgoingCall(call: OutgoingCall | null) {
+    this.outgoingCall = call;
+  }
 
+  logout() {
+    this.currentUser = null;
+    this.username = null;
+    this.userAvatarUrl = null;
+    this.selectedGroupId = null;
+    this.selectedChannelId = null;
+    this.selectedConversationId = null;
+    this.groups = [];
+    this.channels = {};
+    this.dmConversations = [];
+    this.messageQueue = [];
+    this.replyToMessageId = null;
+    this.showThreadId = null;
+    this.isLoading = false;
+    this.error = null;
+    this.unreadCounts = {};
+    this.voiceState = { kind: 'idle' };
+    this.statusBarAlert = null;
+    this.voiceError = null;
+    this.isLocalSpeaking = false;
+    this.voiceParticipants = [];
+    this.voiceActiveSpeakerIds = [];
+    this.screenShareRemotes = {};
+    this.viewingScreenShareTrackKey = null;
+    this.pendingEnrollmentApproval = null;
+    this.pendingDeleteChannelId = null;
+    this.incomingCall = null;
+    this.outgoingCall = null;
+  }
+}
+
+export const appStore = new AppStore();

--- a/frontend/src/stores/dropTargetStore.ts
+++ b/frontend/src/stores/dropTargetStore.ts
@@ -1,4 +1,4 @@
-import { create } from "zustand";
+import { makeAutoObservable } from "mobx";
 
 // Tracks whether a file-drop target (a mounted ChatInput) currently exists, so
 // the global drag-over overlay in AppShell only appears on views that can
@@ -9,20 +9,29 @@ import { create } from "zustand";
 // Ref-counted rather than a plain boolean so transient double-mounts (React
 // StrictMode) and any future layout with more than one input don't clear the
 // flag prematurely.
-interface DropTargetStore {
-  count: number;
-  register: () => void;
-  unregister: () => void;
+class DropTargetStore {
+  count = 0;
+
+  constructor() {
+    makeAutoObservable(this, {}, { autoBind: true });
+  }
+
+  register() {
+    this.count += 1;
+  }
+
+  unregister() {
+    this.count = Math.max(0, this.count - 1);
+  }
+
+  get active(): boolean {
+    return this.count > 0;
+  }
 }
 
-export const useDropTargetStore = create<DropTargetStore>((set) => ({
-  count: 0,
-  register: () => set((s) => ({ count: s.count + 1 })),
-  unregister: () => set((s) => ({ count: Math.max(0, s.count - 1) })),
-}));
+export const dropTargetStore = new DropTargetStore();
 
 // Read the current value outside React (e.g. inside the AppShell drag-event
 // callback, which is registered once and would otherwise close over a stale
 // value).
-export const isDropTargetActive = (): boolean =>
-  useDropTargetStore.getState().count > 0;
+export const isDropTargetActive = (): boolean => dropTargetStore.active;

--- a/frontend/src/stores/keyChangeStore.ts
+++ b/frontend/src/stores/keyChangeStore.ts
@@ -1,4 +1,4 @@
-import { create } from "zustand";
+import { makeAutoObservable } from "mobx";
 
 /// Per-peer "their identity key just changed" signal. Pushed by the
 /// `key_changed` realtime event the backend emits whenever
@@ -10,38 +10,43 @@ import { create } from "zustand";
 /// to re-verify out-of-band. Acknowledging the banner only dismisses it
 /// from the UI — the verified flag in the local DB stays cleared until
 /// the user explicitly re-verifies on the profile page.
-interface KeyChangeStore {
+interface KeyChangeFlag {
+  peerIdentityVersion: number;
+  observedAt: number;
+}
+
+class KeyChangeStore {
   // peerUserId → version observed at the time of the change. We key by
   // peerUserId (not conversation_id) because the same peer may be in
   // several DMs and the warning is per-identity, not per-conversation.
-  flagged: Record<string, { peerIdentityVersion: number; observedAt: number }>;
-  flagChanged: (peerUserId: string, peerIdentityVersion: number) => void;
-  acknowledge: (peerUserId: string) => void;
-  clearAll: () => void;
+  flagged: Record<string, KeyChangeFlag> = {};
+
+  constructor() {
+    makeAutoObservable(this, {}, { autoBind: true });
+  }
+
+  flagChanged(peerUserId: string, peerIdentityVersion: number) {
+    this.flagged = {
+      ...this.flagged,
+      [peerUserId]: {
+        peerIdentityVersion,
+        observedAt: Date.now(),
+      },
+    };
+  }
+
+  acknowledge(peerUserId: string) {
+    if (!(peerUserId in this.flagged)) {
+      return;
+    }
+    const next = { ...this.flagged };
+    delete next[peerUserId];
+    this.flagged = next;
+  }
+
+  clearAll() {
+    this.flagged = {};
+  }
 }
 
-export const useKeyChangeStore = create<KeyChangeStore>((set) => ({
-  flagged: {},
-  flagChanged: (peerUserId, peerIdentityVersion) => {
-    set((state) => ({
-      flagged: {
-        ...state.flagged,
-        [peerUserId]: {
-          peerIdentityVersion,
-          observedAt: Date.now(),
-        },
-      },
-    }));
-  },
-  acknowledge: (peerUserId) => {
-    set((state) => {
-      if (!(peerUserId in state.flagged)) {
-        return state;
-      }
-      const next = { ...state.flagged };
-      delete next[peerUserId];
-      return { flagged: next };
-    });
-  },
-  clearAll: () => set({ flagged: {} }),
-}));
+export const keyChangeStore = new KeyChangeStore();

--- a/frontend/src/stores/presenceStore.ts
+++ b/frontend/src/stores/presenceStore.ts
@@ -1,4 +1,4 @@
-import { create } from "zustand";
+import { makeAutoObservable } from "mobx";
 
 // Presence is inferred from LiveKit room participation: a user is online as
 // long as at least one room they share with us shows them as connected. The
@@ -7,64 +7,71 @@ import { create } from "zustand";
 
 export type PresenceStatus = "online" | "offline";
 
-interface PresenceStore {
+class PresenceStore {
   // user_id → Set<room_id>
-  byUser: Record<string, Set<string>>;
-  setPresent: (userId: string, roomId: string, present: boolean) => void;
+  byUser: Record<string, Set<string>> = {};
+
+  constructor() {
+    // `isOnline` is excluded from auto-annotation (left a plain method, not an
+    // `action`). Actions run in an untracked context, so if `isOnline` were an
+    // action its `byUser` reads would not be tracked by the observing
+    // component and presence wouldn't update live. As a plain method its reads
+    // are tracked by the enclosing observer's render.
+    makeAutoObservable(this, { isOnline: false }, { autoBind: true });
+  }
+
+  setPresent(userId: string, roomId: string, present: boolean) {
+    const existing = this.byUser[userId];
+    const nextSet = new Set(existing ?? []);
+    if (present) {
+      nextSet.add(roomId);
+    } else {
+      nextSet.delete(roomId);
+    }
+    const byUser = { ...this.byUser };
+    if (nextSet.size === 0) {
+      delete byUser[userId];
+    } else {
+      byUser[userId] = nextSet;
+    }
+    this.byUser = byUser;
+  }
+
   // Drop every record for the named room — used on `realtime_reconnected`
   // before re-emitting the new participant snapshot.
-  resetRoom: (roomId: string) => void;
+  resetRoom(roomId: string) {
+    let changed = false;
+    const byUser: Record<string, Set<string>> = {};
+    for (const [userId, rooms] of Object.entries(this.byUser)) {
+      if (!rooms.has(roomId)) {
+        byUser[userId] = rooms;
+        continue;
+      }
+      const next = new Set(rooms);
+      next.delete(roomId);
+      if (next.size > 0) {
+        byUser[userId] = next;
+      }
+      changed = true;
+    }
+    if (changed) {
+      this.byUser = byUser;
+    }
+  }
+
+  isOnline(userId: string | null | undefined): boolean {
+    return userId ? (this.byUser[userId]?.size ?? 0) > 0 : false;
+  }
 }
 
-export const usePresenceStore = create<PresenceStore>((set) => ({
-  byUser: {},
-  setPresent: (userId, roomId, present) => {
-    set((state) => {
-      const existing = state.byUser[userId];
-      const nextSet = new Set(existing ?? []);
-      if (present) {
-        nextSet.add(roomId);
-      } else {
-        nextSet.delete(roomId);
-      }
-      const byUser = { ...state.byUser };
-      if (nextSet.size === 0) {
-        delete byUser[userId];
-      } else {
-        byUser[userId] = nextSet;
-      }
-      return { byUser };
-    });
-  },
-  resetRoom: (roomId) => {
-    set((state) => {
-      let changed = false;
-      const byUser: Record<string, Set<string>> = {};
-      for (const [userId, rooms] of Object.entries(state.byUser)) {
-        if (!rooms.has(roomId)) {
-          byUser[userId] = rooms;
-          continue;
-        }
-        const next = new Set(rooms);
-        next.delete(roomId);
-        if (next.size > 0) {
-          byUser[userId] = next;
-        }
-        changed = true;
-      }
-      return changed ? { byUser } : state;
-    });
-  },
-}));
+export const presenceStore = new PresenceStore();
 
 /**
- * Lightweight selector — returns "online" if we currently see this user in
+ * Lightweight derivation — returns "online" if we currently see this user in
  * any shared room, otherwise "offline". Designed to be called from the
- * components that render avatars (DM list, search panel, profile page).
+ * components that render avatars (DM list, search panel, profile page). The
+ * caller must be wrapped in `observer()` for the value to stay live.
  */
 export function usePresenceStatus(userId: string | null | undefined): PresenceStatus {
-  const present = usePresenceStore((s) =>
-    userId ? (s.byUser[userId]?.size ?? 0) > 0 : false,
-  );
-  return present ? "online" : "offline";
+  return presenceStore.isOnline(userId) ? "online" : "offline";
 }

--- a/frontend/src/stores/rosterChangeStore.ts
+++ b/frontend/src/stores/rosterChangeStore.ts
@@ -1,4 +1,4 @@
-import { create } from "zustand";
+import { makeAutoObservable } from "mobx";
 
 // Per-conversation queue of roster-change banners (member joined, member
 // left, device added, device removed). Pushed by the `roster_changed`
@@ -31,49 +31,47 @@ export interface RosterBanner extends Record<string, unknown> {
   payload: RosterBannerKind;
 }
 
-interface RosterChangeStore {
-  /** conversation_id → list of banners, oldest first. */
-  byConversation: Record<string, RosterBanner[]>;
-  push: (conversation_id: string, banners: RosterBanner[]) => void;
-  clearConversation: (conversation_id: string) => void;
-  clearAll: () => void;
-}
-
 // Cap per-conversation history so a noisy reconcile loop can't pin
 // arbitrary memory. 200 is well above any realistic single-session
 // roster churn; older banners drop off the front.
 const MAX_PER_CONVERSATION = 200;
 
-export const useRosterChangeStore = create<RosterChangeStore>((set) => ({
-  byConversation: {},
-  push: (conversation_id, banners) => {
+class RosterChangeStore {
+  /** conversation_id → list of banners, oldest first. */
+  byConversation: Record<string, RosterBanner[]> = {};
+
+  constructor() {
+    makeAutoObservable(this, {}, { autoBind: true });
+  }
+
+  push(conversation_id: string, banners: RosterBanner[]) {
     if (banners.length === 0) {
       return;
     }
-    set((state) => {
-      const existing = state.byConversation[conversation_id] ?? [];
-      const next = [...existing, ...banners];
-      const trimmed =
-        next.length > MAX_PER_CONVERSATION
-          ? next.slice(next.length - MAX_PER_CONVERSATION)
-          : next;
-      return {
-        byConversation: {
-          ...state.byConversation,
-          [conversation_id]: trimmed,
-        },
-      };
-    });
-  },
-  clearConversation: (conversation_id) => {
-    set((state) => {
-      if (!(conversation_id in state.byConversation)) {
-        return state;
-      }
-      const next = { ...state.byConversation };
-      delete next[conversation_id];
-      return { byConversation: next };
-    });
-  },
-  clearAll: () => set({ byConversation: {} }),
-}));
+    const existing = this.byConversation[conversation_id] ?? [];
+    const next = [...existing, ...banners];
+    const trimmed =
+      next.length > MAX_PER_CONVERSATION
+        ? next.slice(next.length - MAX_PER_CONVERSATION)
+        : next;
+    this.byConversation = {
+      ...this.byConversation,
+      [conversation_id]: trimmed,
+    };
+  }
+
+  clearConversation(conversation_id: string) {
+    if (!(conversation_id in this.byConversation)) {
+      return;
+    }
+    const next = { ...this.byConversation };
+    delete next[conversation_id];
+    this.byConversation = next;
+  }
+
+  clearAll() {
+    this.byConversation = {};
+  }
+}
+
+export const rosterChangeStore = new RosterChangeStore();

--- a/frontend/src/stores/typingStore.ts
+++ b/frontend/src/stores/typingStore.ts
@@ -1,4 +1,4 @@
-import { create } from "zustand";
+import { makeAutoObservable } from "mobx";
 
 // Receiver-side TTL: a typing entry that hasn't been refreshed within this
 // many ms ages out, even without an explicit `is_typing: false`. Covers the
@@ -16,67 +16,65 @@ interface TypingEntry {
   expiresAt: number;
 }
 
-interface TypingStore {
+class TypingStore {
   // roomKey → userId → entry. Two-level map so typing in one channel doesn't
   // leak into another and lookups stay O(1).
-  byRoom: Record<string, Record<string, TypingEntry>>;
-  setTyping: (roomKey: TypingRoomKey, userId: string, username: string) => void;
-  clearTyping: (roomKey: TypingRoomKey, userId: string) => void;
+  byRoom: Record<string, Record<string, TypingEntry>> = {};
+
+  constructor() {
+    makeAutoObservable(this, {}, { autoBind: true });
+  }
+
+  setTyping(roomKey: TypingRoomKey, userId: string, username: string) {
+    const room = { ...(this.byRoom[roomKey] ?? {}) };
+    room[userId] = { username, expiresAt: Date.now() + TYPING_TTL_MS };
+    this.byRoom = { ...this.byRoom, [roomKey]: room };
+  }
+
+  clearTyping(roomKey: TypingRoomKey, userId: string) {
+    const room = this.byRoom[roomKey];
+    if (!room || !(userId in room)) {
+      return;
+    }
+    const next = { ...room };
+    delete next[userId];
+    const byRoom = { ...this.byRoom };
+    if (Object.keys(next).length === 0) {
+      delete byRoom[roomKey];
+    } else {
+      byRoom[roomKey] = next;
+    }
+    this.byRoom = byRoom;
+  }
+
   // Drop expired entries; called from a polling effect so the UI re-renders
   // when a typing indicator times out without an explicit clear.
-  pruneExpired: () => void;
-}
-
-export const useTypingStore = create<TypingStore>((set) => ({
-  byRoom: {},
-  setTyping: (roomKey, userId, username) => {
-    set((state) => {
-      const room = { ...(state.byRoom[roomKey] ?? {}) };
-      room[userId] = { username, expiresAt: Date.now() + TYPING_TTL_MS };
-      return { byRoom: { ...state.byRoom, [roomKey]: room } };
-    });
-  },
-  clearTyping: (roomKey, userId) => {
-    set((state) => {
-      const room = state.byRoom[roomKey];
-      if (!room || !(userId in room)) {
-        return state;
-      }
-      const next = { ...room };
-      delete next[userId];
-      const byRoom = { ...state.byRoom };
-      if (Object.keys(next).length === 0) {
-        delete byRoom[roomKey];
-      } else {
-        byRoom[roomKey] = next;
-      }
-      return { byRoom };
-    });
-  },
-  pruneExpired: () => {
-    set((state) => {
-      const now = Date.now();
-      let changed = false;
-      const byRoom: Record<string, Record<string, TypingEntry>> = {};
-      for (const [roomKey, room] of Object.entries(state.byRoom)) {
-        const live: Record<string, TypingEntry> = {};
-        for (const [userId, entry] of Object.entries(room)) {
-          if (entry.expiresAt > now) {
-            live[userId] = entry;
-          } else {
-            changed = true;
-          }
-        }
-        if (Object.keys(live).length > 0) {
-          byRoom[roomKey] = live;
-        } else if (Object.keys(room).length > 0) {
+  pruneExpired() {
+    const now = Date.now();
+    let changed = false;
+    const byRoom: Record<string, Record<string, TypingEntry>> = {};
+    for (const [roomKey, room] of Object.entries(this.byRoom)) {
+      const live: Record<string, TypingEntry> = {};
+      for (const [userId, entry] of Object.entries(room)) {
+        if (entry.expiresAt > now) {
+          live[userId] = entry;
+        } else {
           changed = true;
         }
       }
-      return changed ? { byRoom } : state;
-    });
-  },
-}));
+      if (Object.keys(live).length > 0) {
+        byRoom[roomKey] = live;
+      } else if (Object.keys(room).length > 0) {
+        changed = true;
+      }
+    }
+    if (changed) {
+      this.byRoom = byRoom;
+    }
+  }
+}
+
+export const typingStore = new TypingStore();
 
 export function typingRoomKey(
   channelId: string | null | undefined,

--- a/frontend/src/utils/notify.ts
+++ b/frontend/src/utils/notify.ts
@@ -1,6 +1,6 @@
 import { sendNotification } from '../bridge';
 import { playSfx } from './sfx';
-import { useAppStore } from '../stores/appStore';
+import { appStore } from '../stores/appStore';
 
 export type Category =
   | 'direct_message'
@@ -148,18 +148,18 @@ export function notify(category: Category, payload: NotifyPayload = {}): void {
   }
 
   if (config.badge && payload.roomId) {
-    useAppStore.getState().incrementUnread(payload.roomId);
+    appStore.incrementUnread(payload.roomId);
   }
 
   if (config.alert && payload.roomId && payload.senderUsername) {
-    useAppStore.getState().setStatusBarAlert({
+    appStore.setStatusBarAlert({
       senderUsername: payload.senderUsername,
       roomId: payload.roomId,
     });
   }
 
   if (config.overlay && payload.enrollment) {
-    useAppStore.getState().setPendingEnrollmentApproval(payload.enrollment);
+    appStore.setPendingEnrollmentApproval(payload.enrollment);
   }
 
   if (config.cooldownMs !== undefined && fired) {

--- a/frontend/src/utils/voiceWarmup.ts
+++ b/frontend/src/utils/voiceWarmup.ts
@@ -1,5 +1,5 @@
 import { invoke } from "../bridge";
-import { useAppStore } from "../stores/appStore";
+import { appStore } from "../stores/appStore";
 
 // Issue #176: pre-warm DNS / TLS / token mint to LiveKit on user "intent"
 // (hover, route entry) so the actual `join_voice_channel` only pays the
@@ -25,7 +25,7 @@ export function warmVoiceChannel(channelId: string | null | undefined): void {
   if (!channelId) {
     return;
   }
-  const { currentUser } = useAppStore.getState();
+  const { currentUser } = appStore;
   if (!currentUser) {
     return;
   }

--- a/frontend/src/voice/VoiceSessionManager.ts
+++ b/frontend/src/voice/VoiceSessionManager.ts
@@ -1,6 +1,7 @@
 import { Channel, invoke } from '../bridge';
 
-import { useAppStore } from '../stores/appStore';
+import { reaction } from 'mobx';
+import { appStore } from '../stores/appStore';
 import type { VoiceParticipant, VoiceConnectionQuality } from '../types';
 import type { ApmConfig, PreferencesData } from '../hooks/queries/usePreferences';
 import { preferencesToApmConfig } from '../hooks/queries/usePreferences';
@@ -347,7 +348,7 @@ class VoiceSessionManager {
   }
 
   private guardsPass(): boolean {
-    const store = useAppStore.getState();
+    const store = appStore;
     if (!store.currentUser) {
       return false;
     }
@@ -355,7 +356,7 @@ class VoiceSessionManager {
   }
 
   private async executeJoin(target: VoiceIntent): Promise<boolean> {
-    const store = useAppStore.getState();
+    const store = appStore;
     const user = store.currentUser;
     if (!user) {
       return false;
@@ -762,7 +763,7 @@ export const voiceSession = new VoiceSessionManager();
  */
 voiceSession.subscribe(() => {
   const s = voiceSession.getSnapshot();
-  const store = useAppStore.getState();
+  const store = appStore;
   const v = store.voiceState;
 
   // Lifecycle transitions — drive the union via semantic methods. The
@@ -803,7 +804,7 @@ voiceSession.subscribe(() => {
         store.voiceJoined();
       }
       // Mic-mute mirror.
-      const after = useAppStore.getState().voiceState;
+      const after = appStore.voiceState;
       if (after.kind === 'joined' && after.micMuted !== s.isMuted) {
         store.voiceSetMicMuted(s.isMuted);
       }
@@ -817,28 +818,30 @@ voiceSession.subscribe(() => {
     }
   }
 
-  // Collection / derived fields stay as direct sets.
+  // Collection / derived fields stay as direct sets through store actions.
   if (store.voiceParticipants !== s.participants) {
-    useAppStore.setState({ voiceParticipants: s.participants });
+    store.setVoiceParticipants(s.participants);
   }
   if (store.voiceActiveSpeakerIds !== s.activeSpeakerIds) {
-    useAppStore.setState({ voiceActiveSpeakerIds: s.activeSpeakerIds });
+    store.setVoiceActiveSpeakerIds(s.activeSpeakerIds);
   }
   if (store.isLocalSpeaking !== s.isLocalSpeaking) {
-    useAppStore.setState({ isLocalSpeaking: s.isLocalSpeaking });
+    store.setIsLocalSpeaking(s.isLocalSpeaking);
   }
   // Join errors mirror through the store's separate voiceError field;
   // the union's idle state doesn't carry the error itself.
   if (store.voiceError !== s.error) {
-    useAppStore.setState({ voiceError: s.error });
+    store.setVoiceError(s.error);
   }
 });
 
 // React to currentUser changes by re-running reconciliation.
 // Logging out should tear down any active voice session without each caller
-// having to remember to.
-useAppStore.subscribe((state, prev) => {
-  if (state.currentUser !== prev.currentUser) {
+// having to remember to. `reaction` fires only when currentUser actually
+// changes, so the previous explicit `!==` guard is implicit.
+reaction(
+  () => appStore.currentUser,
+  () => {
     voiceSession.refresh();
-  }
-});
+  },
+);

--- a/frontend/src/voice/trayVoiceBridge.ts
+++ b/frontend/src/voice/trayVoiceBridge.ts
@@ -1,5 +1,6 @@
+import { autorun } from "mobx";
 import { electron, hasElectron } from "../bridge/runtime";
-import { useAppStore } from "../stores/appStore";
+import { appStore } from "../stores/appStore";
 import { voiceSession } from "./VoiceSessionManager";
 
 interface BridgeHandle {
@@ -26,7 +27,7 @@ export function installTrayVoiceBridge(): BridgeHandle {
   const api = electron();
 
   const pushState = (): void => {
-    const vs = useAppStore.getState().voiceState;
+    const vs = appStore.voiceState;
     const inCall = vs.kind === "joined";
     const muted = inCall ? vs.micMuted : false;
     void api.traySetVoiceState(inCall, muted).catch((err) => {
@@ -34,11 +35,10 @@ export function installTrayVoiceBridge(): BridgeHandle {
     });
   };
 
-  // Push initial state, then on every store change. The selector returns a
-  // fresh object reference on every set; we re-derive inCall+muted inside
-  // pushState so subscription churn doesn't matter for correctness.
-  pushState();
-  const unsubStore = useAppStore.subscribe(pushState);
+  // `autorun` pushes once immediately and re-runs whenever the voice state it
+  // reads changes. We re-derive inCall+muted inside pushState each run so
+  // reactivity churn doesn't matter for correctness.
+  const unsubStore = autorun(pushState);
 
   const unsubToggle = api.trayOnRequestToggleMute(() => {
     void voiceSession.toggleMute();

--- a/frontend/src/voice/voiceBridge.ts
+++ b/frontend/src/voice/voiceBridge.ts
@@ -2,7 +2,7 @@ import type { QueryClient } from '@tanstack/react-query';
 import { invoke } from '../bridge';
 
 import { notify } from '../utils/notify';
-import { useAppStore } from '../stores/appStore';
+import { appStore } from '../stores/appStore';
 import { voiceSession, type JoinedEvent, type LeftEvent } from './VoiceSessionManager';
 
 interface VoiceBridgeOptions {
@@ -83,10 +83,10 @@ export function installVoiceBridge(opts: VoiceBridgeOptions): BridgeHandle {
     // If this client initiated a 1:1 call and the callee never picked up
     // (outgoingCall still set when we leave the matching room), notify the
     // callee to stop ringing. Mirrors the decline path in AppShell.
-    const outgoing = useAppStore.getState().outgoingCall;
+    const outgoing = appStore.outgoingCall;
     if (outgoing && event.channelId === `call-${outgoing.callId}`) {
       const { callId, calleeId } = outgoing;
-      useAppStore.getState().setOutgoingCall(null);
+      appStore.setOutgoingCall(null);
       invoke('cancel_call', { otherUserId: calleeId, callId }).catch(() => {});
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,12 @@ importers:
       lucide-react:
         specifier: ^0.344.0
         version: 0.344.0(react@19.2.5)
+      mobx:
+        specifier: ^6.16.0
+        version: 6.16.0
+      mobx-react-lite:
+        specifier: ^4.1.1
+        version: 4.1.1(mobx@6.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       qrcode.react:
         specifier: ^4.2.0
         version: 4.2.0(react@19.2.5)
@@ -2064,6 +2070,22 @@ packages:
   mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
     hasBin: true
+
+  mobx-react-lite@4.1.1:
+    resolution: {integrity: sha512-iUxiMpsvNraCKXU+yPotsOncNNmyeS2B5DKL+TL6Tar/xm+wwNJAubJmtRSeAoYawdZqwv8Z/+5nPRHeQxTiXg==}
+    peerDependencies:
+      mobx: ^6.9.0
+      react: ^16.8.0 || ^17 || ^18 || ^19
+      react-dom: '*'
+      react-native: '*'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
+
+  mobx@6.16.0:
+    resolution: {integrity: sha512-qFIcwox4Mc4xRUVBGm0mt2uXmm4zCnfpwBRVkm59Y7zDei498NmpyKvEDsjCR3OYPbnQCKyhV6mLDs0vt2hBxA==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -4715,6 +4737,16 @@ snapshots:
   mkdirp@0.5.6:
     dependencies:
       minimist: 1.2.8
+
+  mobx-react-lite@4.1.1(mobx@6.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      mobx: 6.16.0
+      react: 19.2.5
+      use-sync-external-store: 1.6.0(react@19.2.5)
+    optionalDependencies:
+      react-dom: 19.2.5(react@19.2.5)
+
+  mobx@6.16.0: {}
 
   ms@2.1.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,9 +130,6 @@ importers:
       react-dom:
         specifier: ^19.2.4
         version: 19.2.5(react@19.2.5)
-      zustand:
-        specifier: ^4.5.0
-        version: 4.5.7(@types/react@19.2.14)(react@19.2.5)
     devDependencies:
       '@types/react':
         specifier: ^19.1.10
@@ -2786,21 +2783,6 @@ packages:
   youch@4.1.0-beta.10:
     resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
 
-  zustand@4.5.7:
-    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
-    engines: {node: '>=12.7.0'}
-    peerDependencies:
-      '@types/react': '>=16.8'
-      immer: '>=9.0.6'
-      react: '>=16.8'
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      immer:
-        optional: true
-      react:
-        optional: true
-
 snapshots:
 
   7zip-bin@5.2.0: {}
@@ -5425,10 +5407,3 @@ snapshots:
       '@speed-highlight/core': 1.2.15
       cookie: 1.1.1
       youch-core: 0.3.3
-
-  zustand@4.5.7(@types/react@19.2.14)(react@19.2.5):
-    dependencies:
-      use-sync-external-store: 1.6.0(react@19.2.5)
-    optionalDependencies:
-      '@types/react': 19.2.14
-      react: 19.2.5


### PR DESCRIPTION
Closes #365.

Replaces the Zustand store layer with MobX class singletons. React Query stays the source of truth for remote data; the framework-agnostic managers stay plain TS and write through into the stores.

## What changed
- **Stores** (`frontend/src/stores/`): all six (`appStore`, `typingStore`, `presenceStore`, `keyChangeStore`, `rosterChangeStore`, `dropTargetStore`) are now MobX class singletons — `makeAutoObservable(this, {}, { autoBind: true })`. Same field/method names and immutable-update logic.
- **Consumers** (~50 components/pages): wrapped in `observer()`; selectors/`getState()`/bare destructures replaced with direct singleton reads.
- **Non-React managers** (`VoiceSessionManager`, `trayVoiceBridge`, `livekitView`, `screenShareSession`, `voiceBridge`, `updatePoller`, `notify`, `voiceWarmup`): read singletons directly; `.subscribe((state, prev) => …)` → `autorun`/`reaction`; `setState({...})` → store actions.
- **Shared hooks** (React Query hooks, `useBadge`, `useTypingState`, `useTypingPublisher`, `useLiveKitRealtime`): use `useObserver(() => store.x)` so they stay reactive without forcing every transitive consumer to be an `observer`.
- Dropped the `zustand` dependency; docs (CLAUDE.md, ARCHITECTURE.md, wiki) updated.

## Two correctness traps caught
- **Actions run untracked in MobX.** `presenceStore.isOnline()` would've been auto-wrapped as an action, silently killing presence reactivity. Excluded it from action-wrapping.
- **`PresenceAvatar`** used only the unchanged `usePresenceStatus` helper, so it wasn't in the hook-name sweep — but it reads the observable and needed `observer()`.

## Notes
- `ChatInput` is a `forwardRef`, so it's `observer(React.forwardRef(...))`.
- No `useEffect`/`useMemo` were removed: an audit found no selector-churn scaffolding to delete. The remaining memos/effects are compute-caching over React Query data and genuine side-effects. The reactivity win landed structurally — 25 components that read the whole store (re-rendering on *any* mutation under Zustand) now track only the fields they touch via `observer`.

## Verification
- `tsc --noEmit` clean
- `vite build` succeeds