### PR TITLE
MLS epoch-drift follow-ups: edit catch-up, realtime gates, cold-launch sweep, tombstone revoke

### DIFF
--- a/frontend/src/components/Layout/AppShell.tsx
+++ b/frontend/src/components/Layout/AppShell.tsx
@@ -185,14 +185,36 @@ export const AppShell: React.FC = observer(() => {
     };
   }, []);
 
-  // On startup, apply any MLS Welcome messages that arrived while offline.
+  // Cold-launch MLS sweep: poll Welcomes that arrived while offline AND
+  // process pending commits for every group + DM the user is in, so the
+  // first MLS-powered action after launch (send_message, edit_message,
+  // voice/screen-share join) runs against caught-up state. Closes the
+  // cold-launch window flagged in issue #371 scenario 5 — previously this
+  // hook only polled Welcomes and didn't process commits.
+  //
+  // `isSyncing` is set to true during the sweep so the bottom status bar
+  // shows the same "Syncing…" indicator the manual sync shortcut uses;
+  // stateful actions (send/edit/voice) can read it to defer until the
+  // sweep finishes. Cancelled flag handles unmount mid-sweep so the next
+  // user doesn't see a stale syncing state after sign-out.
   useEffect(() => {
     if (!currentUser) {
       return;
     }
-    invoke('poll_mls_welcomes', { userId: currentUser.id }).catch((err) => {
-      console.warn('[mls] poll_mls_welcomes failed:', err);
-    });
+    let cancelled = false;
+    setIsSyncing(true);
+    invoke('catch_up_all_mls_groups', { userId: currentUser.id })
+      .catch((err) => {
+        console.warn('[mls] catch_up_all_mls_groups failed:', err);
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsSyncing(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [currentUser?.id]);
 
   // Once authenticated, hook up the screen-share event + frame Channels.

--- a/frontend/src/components/Voice/VoiceChannelView.tsx
+++ b/frontend/src/components/Voice/VoiceChannelView.tsx
@@ -70,9 +70,14 @@ export const VoiceChannelView: React.FC = observer(() => {
             setViewingScreenShareTrackKey(LOCAL_PREVIEW_KEY);
             return;
           }
-          // screenShareRemotes is keyed by the publisher's user (voice-{userId}),
-          // not their specific device, so collapse the device suffix to match.
-          const share = screenShareRemotes[voiceUserKey(p.identity)];
+          // Per-device first (voice-{userId}:{deviceId}) so each device's
+          // tile shows only its own share when the same user is in the
+          // room from multiple devices. Fall back to the user-scoped key
+          // (voice-{userId}) for cross-version compat with any client
+          // still publishing under the legacy `{userId}:view` identity.
+          const share =
+            screenShareRemotes[p.identity] ??
+            screenShareRemotes[voiceUserKey(p.identity)];
           if (share) {
             setViewingScreenShareTrackKey(share.trackKey);
           }
@@ -90,7 +95,9 @@ export const VoiceChannelView: React.FC = observer(() => {
             streamWidth = shareLocalDims?.width;
             streamHeight = shareLocalDims?.height;
           } else if (!isLocal) {
-            const remote = screenShareRemotes[voiceUserKey(p.identity)];
+            const remote =
+              screenShareRemotes[p.identity] ??
+              screenShareRemotes[voiceUserKey(p.identity)];
             if (remote) {
               streamTrackKey = remote.trackKey;
               streamWidth = remote.width;

--- a/frontend/src/hooks/useLiveKitRealtime.ts
+++ b/frontend/src/hooks/useLiveKitRealtime.ts
@@ -292,7 +292,7 @@ export function useLiveKitRealtime() {
         });
     };
 
-    channel.onmessage = (event) => {
+    channel.onmessage = async (event) => {
       if (event.type === 'dm_created') {
         queryClientRef.current.invalidateQueries({
           queryKey: messageQueryKeys.dmConversations(currentUser.id),
@@ -327,16 +327,24 @@ export function useLiveKitRealtime() {
         queryClientRef.current.invalidateQueries({ queryKey: ['group-invites'] });
         // Same as dm_created: a membership change may have added us to an
         // MLS group, so pull the Welcome and catch up on commits immediately.
-        invoke('poll_mls_welcomes', { userId: currentUser.id }).catch((err) => {
+        // Awaited (not fire-and-forget) so any user action that follows the
+        // event handler returning runs against caught-up MLS state — issue
+        // #371 scenario 3 had these as `.catch` with no `await`, which let
+        // sends/edits race into encrypt at the prior epoch.
+        try {
+          await invoke('poll_mls_welcomes', { userId: currentUser.id });
+        } catch (err) {
           console.warn('[realtime] membership_changed: poll_mls_welcomes failed:', err);
-        });
+        }
         if (event.conversation_id) {
-          invoke('process_pending_commits', {
-            conversationId: event.conversation_id,
-            userId: currentUser.id,
-          }).catch((err) => {
+          try {
+            await invoke('process_pending_commits', {
+              conversationId: event.conversation_id,
+              userId: currentUser.id,
+            });
+          } catch (err) {
             console.warn('[realtime] membership_changed: process_pending_commits failed:', err);
-          });
+          }
         }
         // Only invites raise a user-facing notification. Approvals and
         // generic reconciles are silent — query invalidation handles them.
@@ -397,12 +405,31 @@ export function useLiveKitRealtime() {
         // Wipe stale presence for the reconnected room — Rust will re-emit
         // a fresh participant snapshot right after.
         presenceStore.resetRoom(event.room_id);
-        // Catch up on welcomes that may have arrived during the outage so
-        // new-group invites apply without waiting for the user to open a
-        // channel from one of those groups.
-        invoke('poll_mls_welcomes', { userId: currentUser.id }).catch((err) => {
+        // Catch up on welcomes AND pending commits that may have arrived
+        // during the outage. Issue #371 scenario 4: this handler previously
+        // only polled welcomes, missing every commit posted to existing
+        // groups while the realtime channel was disconnected, which left
+        // the device stuck at a stale epoch until the next action-triggered
+        // catch-up (or, with #372 in play, possibly forever).
+        // `room_id` for group/DM rooms IS the MLS group id (group rooms
+        // use the group_id; DM rooms use the dm_channel_id which is also
+        // the MLS group id). Inbox rooms (`inbox-<userId>`) have no MLS
+        // group, so skip the per-room commit processing for those.
+        try {
+          await invoke('poll_mls_welcomes', { userId: currentUser.id });
+        } catch (err) {
           console.warn('[realtime] reconnect: poll_mls_welcomes failed:', err);
-        });
+        }
+        if (!event.room_id.startsWith('inbox-')) {
+          try {
+            await invoke('process_pending_commits', {
+              conversationId: event.room_id,
+              userId: currentUser.id,
+            });
+          } catch (err) {
+            console.warn('[realtime] reconnect: process_pending_commits failed:', err);
+          }
+        }
         return;
       }
 

--- a/frontend/src/screenshare/livekitView.ts
+++ b/frontend/src/screenshare/livekitView.ts
@@ -81,15 +81,30 @@ interface E2eeKeyInfo {
 // ── Identity helpers ─────────────────────────────────────────────────────────
 
 /** Derive the voice identity that other parts of the app key on
- *  (`voice-{userId}`) from a view participant identity (`{userId}:view`).
+ *  (`voice-{userId}`) from a view participant identity. Accepts both
+ *  shapes:
+ *    - `{userId}:view` — legacy (single device per user)
+ *    - `{userId}:{deviceId}:view` — per-device, mirroring the
+ *      `voice-{userId}:{deviceId}` voice path (#140). Required because
+ *      LiveKit enforces unique participant identities per room; two
+ *      devices of the same user sharing `{userId}:view` end up in a
+ *      reconnect storm as LiveKit kicks each new joiner.
  *  Returns null for any other shape so we don't accidentally surface
  *  tracks from rooms / clients that aren't using the view scheme. */
 function voiceIdentityFromView(identity: string): string | null {
-  const idx = identity.lastIndexOf(':view');
-  if (idx === -1 || idx + ':view'.length !== identity.length) {
+  if (!identity.endsWith(':view')) {
     return null;
   }
-  const userId = identity.slice(0, idx);
+  const head = identity.slice(0, identity.length - ':view'.length);
+  if (!head) {
+    return null;
+  }
+  // `head` is either `{userId}` (legacy) or `{userId}:{deviceId}` (per-
+  // device). The user-scoped key drops any device suffix — screenshare
+  // tiles match against `voice-{userId}` regardless of which of the
+  // user's devices is sharing.
+  const colon = head.indexOf(':');
+  const userId = colon === -1 ? head : head.slice(0, colon);
   if (!userId) {
     return null;
   }
@@ -128,6 +143,14 @@ class LiveKitView {
    *  ignore rotation events for unrelated groups (the Rust side filters
    *  too, but this is cheap and keeps the renderer honest). */
   private currentE2eeMlsGroupId: string | null = null;
+  /** This device's stable `device_id`, used to build the per-device view
+   *  identity `{userId}:{deviceId}:view` so two devices of the same user
+   *  don't collide on LiveKit's per-room identity uniqueness check —
+   *  same reason `VoiceSessionManager` carries its own deviceId field
+   *  (#140). Lazily fetched once; stays null only if the backend can't
+   *  supply one, in which case we fall back to the legacy `{userId}:view`
+   *  identity (single-device user). */
+  private deviceId: string | null = null;
 
   private tracks = new Map<string, MediaStreamTrack>();
   /** Width × height per active remote track. Pushed into the Zustand
@@ -398,7 +421,20 @@ class LiveKitView {
   }
 
   private async executeJoin(target: ViewIntent): Promise<boolean> {
-    const identity = `${target.userId}:view`;
+    // Lazy-fetch device_id once per process (it's stable after login).
+    // Without this, two devices of the same user join the LiveKit view
+    // room as `{userId}:view` and kick each other out in a reconnect
+    // storm — the audit case the user hit cross-machine on PR #371.
+    if (!this.deviceId) {
+      try {
+        this.deviceId = (await invoke<string | null>('get_device_id')) ?? null;
+      } catch (e) {
+        console.warn('[livekit-view] get_device_id failed (using legacy identity):', e);
+      }
+    }
+    const identity = this.deviceId
+      ? `${target.userId}:${this.deviceId}:view`
+      : `${target.userId}:view`;
     let token: string;
     let url: string;
     try {

--- a/frontend/src/screenshare/livekitView.ts
+++ b/frontend/src/screenshare/livekitView.ts
@@ -80,17 +80,17 @@ interface E2eeKeyInfo {
 
 // ── Identity helpers ─────────────────────────────────────────────────────────
 
-/** Derive the voice identity that other parts of the app key on
- *  (`voice-{userId}`) from a view participant identity. Accepts both
- *  shapes:
- *    - `{userId}:view` — legacy (single device per user)
- *    - `{userId}:{deviceId}:view` — per-device, mirroring the
- *      `voice-{userId}:{deviceId}` voice path (#140). Required because
- *      LiveKit enforces unique participant identities per room; two
- *      devices of the same user sharing `{userId}:view` end up in a
- *      reconnect storm as LiveKit kicks each new joiner.
- *  Returns null for any other shape so we don't accidentally surface
- *  tracks from rooms / clients that aren't using the view scheme. */
+/** Derive the voice identity that other parts of the app key on from a
+ *  view participant identity. Accepts both shapes:
+ *    - `{userId}:view` — legacy (single device per user) → `voice-{userId}`
+ *    - `{userId}:{deviceId}:view` — per-device (#140) →
+ *      `voice-{userId}:{deviceId}`
+ *  The per-device shape carries the publishing device's id through so
+ *  the voice tile can match its specific share against
+ *  `screenShareRemotes[participant.identity]` directly — when the same
+ *  user has multiple devices in a room, each device's voice tile must
+ *  show only its own share, not a duplicate of a sibling device's
+ *  share. Returns null for any shape that doesn't end in `:view`. */
 function voiceIdentityFromView(identity: string): string | null {
   if (!identity.endsWith(':view')) {
     return null;
@@ -100,15 +100,9 @@ function voiceIdentityFromView(identity: string): string | null {
     return null;
   }
   // `head` is either `{userId}` (legacy) or `{userId}:{deviceId}` (per-
-  // device). The user-scoped key drops any device suffix — screenshare
-  // tiles match against `voice-{userId}` regardless of which of the
-  // user's devices is sharing.
-  const colon = head.indexOf(':');
-  const userId = colon === -1 ? head : head.slice(0, colon);
-  if (!userId) {
-    return null;
-  }
-  return `voice-${userId}`;
+  // device). Mirror the voice-identity scheme by carrying the whole
+  // head through with the `voice-` prefix.
+  return `voice-${head}`;
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────

--- a/pollis-core/src/commands/auth.rs
+++ b/pollis-core/src/commands/auth.rs
@@ -1008,7 +1008,9 @@ pub async fn list_user_devices(
     let current_device_id = state.device_id.lock().await.clone();
     let conn = state.remote_db.conn().await?;
     let mut rows = conn.query(
-        "SELECT device_id, device_name, created_at, last_seen FROM user_device WHERE user_id = ?1 ORDER BY created_at ASC",
+        "SELECT device_id, device_name, created_at, last_seen FROM user_device \
+         WHERE user_id = ?1 AND revoked_at IS NULL \
+         ORDER BY created_at ASC",
         libsql::params![user_id],
     ).await?;
 
@@ -1063,15 +1065,23 @@ pub async fn revoke_device(
         )));
     }
 
-    // Drop the device row and its unclaimed key packages. Reconcile
-    // detects the missing row and prunes the leaf from each tree.
+    // Drop unclaimed key packages — these are one-time-use and useless
+    // for a revoked device.
     conn.execute(
         "DELETE FROM mls_key_package WHERE user_id = ?1 AND device_id = ?2",
         libsql::params![user_id.clone(), device_id.clone()],
     )
     .await?;
+    // Tombstone the device instead of hard-deleting (issue #372). Other
+    // members' `verify_added_devices` must be able to distinguish "this
+    // device was revoked — drop any rejoin attempt" from "this device
+    // is just lagging — don't destroy commits about it." A hard-delete
+    // makes those two cases indistinguishable; the tombstone makes the
+    // revocation observable AND keeps the row available for later cert
+    // verification of historical commits.
     conn.execute(
-        "DELETE FROM user_device WHERE device_id = ?1 AND user_id = ?2",
+        "UPDATE user_device SET revoked_at = datetime('now') \
+         WHERE device_id = ?1 AND user_id = ?2 AND revoked_at IS NULL",
         libsql::params![device_id.clone(), user_id.clone()],
     )
     .await?;

--- a/pollis-core/src/commands/messages/edit_delete.rs
+++ b/pollis-core/src/commands/messages/edit_delete.rs
@@ -397,6 +397,27 @@ pub async fn edit_message(
         }
     };
 
+    // Catch up MLS state before encrypting. Without this, an edit can be
+    // emitted at a stale epoch — recipients at the current epoch will fail
+    // to decrypt it. send_message does the same two-step catch-up here
+    // (poll_mls_welcomes + process_pending_commits) and edit_message was
+    // missing it. See issue #371 scenario 2.
+    {
+        let device_id = state.device_id.lock().await.clone();
+        if let Some(ref did) = device_id {
+            if let Err(e) =
+                crate::commands::mls::poll_mls_welcomes_inner(state, &user_id, did).await
+            {
+                eprintln!("[messages] edit_message: poll_mls_welcomes for {mls_group_id}: {e}");
+            }
+        }
+    }
+    if let Err(e) =
+        crate::commands::mls::process_pending_commits_inner(state, &mls_group_id, &user_id).await
+    {
+        eprintln!("[messages] edit_message: process_pending_commits for {mls_group_id}: {e}");
+    }
+
     // Encrypt the new content with MLS and update local cache atomically.
     // First attempt — if the group is missing (e.g. local DB was wiped),
     // transparently repair and retry.

--- a/pollis-core/src/commands/mls/device.rs
+++ b/pollis-core/src/commands/mls/device.rs
@@ -328,16 +328,43 @@ pub async fn resign_stale_device_certs(
 /// columns on `mls_commit_log` BEFORE handing the commit to
 /// `process_message`. This is the inbound complement to the outbound
 /// cert verification in `reconcile_group_mls_impl`.
+/// Outcome of verifying every device in a commit's added-devices list.
+///
+/// The three variants tell the caller (`process_pending_commits_locked`)
+/// whether the rejection-and-delete of the offending `mls_commit_log` row
+/// is safe. See issue #372 for the full rationale.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum VerifyOutcome {
+    /// Every added device verified — apply the commit normally.
+    Verified,
+    /// At least one added device is confirmed REVOKED (tombstoned via
+    /// `user_device.revoked_at`), OR the cert chain itself failed
+    /// verification (bad signature, wrong identity_version). Either way
+    /// the commit is illegitimate and the caller may delete it from
+    /// `mls_commit_log` so a legit commit can claim the same epoch.
+    Revoked,
+    /// At least one added device is ABSENT — the row doesn't exist
+    /// anywhere yet, or required cert columns are NULL. This is the
+    /// race / replication-lag case (#372): the device may be
+    /// legitimately joining but its `user_device` row hasn't reached
+    /// this client's view of Turso yet. The commit must NOT be
+    /// deleted; the caller should leave it in place so a later
+    /// catch-up can retry verification once the row appears.
+    AbsentRetry,
+}
+
 pub(super) async fn verify_added_devices(
     conn: &libsql::Connection,
     target_user_id: &str,
     device_ids: &[String],
-) -> crate::error::Result<bool> {
+) -> crate::error::Result<VerifyOutcome> {
     if device_ids.is_empty() {
-        return Ok(true);
+        return Ok(VerifyOutcome::Verified);
     }
 
-    // Fetch account_id_pub once.
+    // Fetch account_id_pub once. A missing `users` row or NULL
+    // account_id_pub falls into AbsentRetry: the row may simply not have
+    // replicated yet.
     let account_id_pub: Vec<u8> = {
         let mut rows = conn
             .query(
@@ -350,16 +377,16 @@ pub(super) async fn verify_added_devices(
                 Some(b) => b,
                 None => {
                     eprintln!(
-                        "[mls] verify_added_devices: {target_user_id} has no account_id_pub"
+                        "[mls] verify_added_devices: {target_user_id} has no account_id_pub — retry"
                     );
-                    return Ok(false);
+                    return Ok(VerifyOutcome::AbsentRetry);
                 }
             },
             None => {
                 eprintln!(
-                    "[mls] verify_added_devices: user {target_user_id} not found"
+                    "[mls] verify_added_devices: user {target_user_id} not found — retry"
                 );
-                return Ok(false);
+                return Ok(VerifyOutcome::AbsentRetry);
             }
         }
     };
@@ -367,7 +394,8 @@ pub(super) async fn verify_added_devices(
     for did in device_ids {
         let mut rows = conn
             .query(
-                "SELECT device_cert, cert_issued_at, cert_identity_version, mls_signature_pub \
+                "SELECT device_cert, cert_issued_at, cert_identity_version, \
+                        mls_signature_pub, revoked_at \
                  FROM user_device WHERE device_id = ?1 AND user_id = ?2",
                 libsql::params![did.as_str(), target_user_id],
             )
@@ -376,10 +404,14 @@ pub(super) async fn verify_added_devices(
         let row = match rows.next().await? {
             Some(r) => r,
             None => {
+                // Row absent. Could be (a) revoked + hard-deleted by an
+                // older app version (pre-#372 deployment), or (b) just not
+                // replicated yet. We can't tell, so default to the safer
+                // AbsentRetry — never destroy a commit on ambiguous state.
                 eprintln!(
-                    "[mls] verify_added_devices: device {did} not registered for {target_user_id}"
+                    "[mls] verify_added_devices: device {did} not registered for {target_user_id} — retry (issue #372)"
                 );
-                return Ok(false);
+                return Ok(VerifyOutcome::AbsentRetry);
             }
         };
 
@@ -387,26 +419,41 @@ pub(super) async fn verify_added_devices(
         let issued_at_str: Option<String> = row.get::<Option<String>>(1).ok().flatten();
         let cert_identity_version: Option<i64> = row.get::<Option<i64>>(2).ok().flatten();
         let mls_sig_pub: Option<Vec<u8>> = row.get::<Option<Vec<u8>>>(3).ok().flatten();
+        let revoked_at: Option<String> = row.get::<Option<String>>(4).ok().flatten();
         drop(rows);
+
+        // Tombstone wins — a revoked device is unambiguously not allowed
+        // to add itself, regardless of cert column state.
+        if revoked_at.is_some() {
+            eprintln!(
+                "[mls] verify_added_devices: device {did} is REVOKED (revoked_at={revoked_at:?})"
+            );
+            return Ok(VerifyOutcome::Revoked);
+        }
 
         let (cert, issued_at_str, cert_identity_version, mls_sig_pub) =
             match (cert, issued_at_str, cert_identity_version, mls_sig_pub) {
                 (Some(c), Some(t), Some(v), Some(p)) => (c, t, v, p),
                 _ => {
+                    // Cert columns NULL on a non-revoked row is the
+                    // "device row inserted but cert publish hasn't landed
+                    // yet" race. Same treatment as fully absent.
                     eprintln!(
-                        "[mls] verify_added_devices: device {did} has no cert columns populated"
+                        "[mls] verify_added_devices: device {did} has no cert columns populated — retry"
                     );
-                    return Ok(false);
+                    return Ok(VerifyOutcome::AbsentRetry);
                 }
             };
 
         let issued_at: u64 = match issued_at_str.parse() {
             Ok(v) => v,
             Err(e) => {
+                // Malformed timestamp is a hard format error, not a race —
+                // treat as Revoked so the bad row gets cleaned up.
                 eprintln!(
                     "[mls] verify_added_devices: device {did} cert_issued_at unparseable '{issued_at_str}': {e}"
                 );
-                return Ok(false);
+                return Ok(VerifyOutcome::Revoked);
             }
         };
 
@@ -418,12 +465,13 @@ pub(super) async fn verify_added_devices(
             issued_at,
             &cert,
         ) {
+            // Cert chain itself failed — unambiguous bad data, not a race.
             eprintln!(
                 "[mls] verify_added_devices: device {did} cert verification failed: {e}"
             );
-            return Ok(false);
+            return Ok(VerifyOutcome::Revoked);
         }
     }
 
-    Ok(true)
+    Ok(VerifyOutcome::Verified)
 }

--- a/pollis-core/src/commands/mls/group_state.rs
+++ b/pollis-core/src/commands/mls/group_state.rs
@@ -12,7 +12,7 @@ use tls_codec::{Deserialize as TlsDeserialize, Serialize as TlsSerialize};
 use crate::error::Result;
 use crate::state::AppState;
 
-use super::device::{load_or_create_device_signer, verify_added_devices};
+use super::device::{load_or_create_device_signer, verify_added_devices, VerifyOutcome};
 use super::provider::{make_credential, PollisProvider, CS};
 
 // ── GroupInfo publishing ─────────────────────────────────────────────────────
@@ -518,7 +518,8 @@ async fn local_device_registered(state: &Arc<AppState>, user_id: &str) -> bool {
     };
     match conn
         .query(
-            "SELECT 1 FROM user_device WHERE user_id = ?1 AND device_id = ?2",
+            "SELECT 1 FROM user_device \
+             WHERE user_id = ?1 AND device_id = ?2 AND revoked_at IS NULL",
             libsql::params![user_id, device_id],
         )
         .await
@@ -638,65 +639,96 @@ pub(crate) async fn process_pending_commits_locked(
 
         // ── Inbound cert verification ────────────────────────────
         if let Some(ref added_user_id) = commit.added_user_id {
-            let verified = match verify_added_devices(
+            let outcome = match verify_added_devices(
                 &conn,
                 added_user_id,
                 &commit.added_device_ids,
             )
             .await
             {
-                Ok(v) => v,
+                Ok(o) => o,
                 Err(e) => {
                     eprintln!(
-                        "[mls] process_pending_commits: cert verification error for {mls_group_id}: {e}"
+                        "[mls] process_pending_commits: cert verification error for {mls_group_id}: {e} — treating as AbsentRetry"
                     );
-                    false
+                    VerifyOutcome::AbsentRetry
                 }
             };
 
-            if !verified {
-                // A *self-add* (the committer adding its own device via an
-                // external commit) that fails cross-signing verification is the
-                // unambiguous "revoked device re-adding itself" shape: its
-                // `user_device` row is gone, so verification cannot pass.
-                // Reject it — do NOT apply — AND delete the squatting commit
-                // row, because under the UNIQUE(conversation_id, epoch)
-                // constraint a left-in-place poison row permanently wedges every
-                // future commit at this epoch. Deleting by `seq` is precise and
-                // idempotent across honest members. Honest first-joins and
-                // legitimate external-join recoveries keep their `user_device`
-                // row, so they verify and never hit this branch.
-                let is_self_add = commit
-                    .sender_id
-                    .as_deref()
-                    .map_or(false, |s| s == added_user_id.as_str());
-                if is_self_add {
-                    eprintln!(
-                        "[mls] process_pending_commits: REJECTING unverified self-add by {added_user_id} at epoch {} in {mls_group_id} (revoked device?) — dropping commit seq {}",
-                        commit.epoch, commit.seq
-                    );
-                    if let Err(e) = conn
-                        .execute(
-                            "DELETE FROM mls_commit_log WHERE seq = ?1",
-                            libsql::params![commit.seq],
-                        )
-                        .await
-                    {
+            match outcome {
+                VerifyOutcome::Verified => {}
+                VerifyOutcome::Revoked => {
+                    // Confirmed-illegitimate self-add (revoked tombstone OR
+                    // bad cert chain). Drop the squatting `mls_commit_log`
+                    // row so the UNIQUE(conversation_id, epoch) slot is
+                    // freed for a legit commit — that's the wedge the
+                    // delete protects against. Honest first-joins keep
+                    // their tombstone-free `user_device` row and never
+                    // hit this branch.
+                    let is_self_add = commit
+                        .sender_id
+                        .as_deref()
+                        .map_or(false, |s| s == added_user_id.as_str());
+                    if is_self_add {
                         eprintln!(
-                            "[mls] process_pending_commits: failed to delete rejected self-add seq {}: {e}",
-                            commit.seq
+                            "[mls] process_pending_commits: REJECTING REVOKED self-add by {added_user_id} at epoch {} in {mls_group_id} — dropping commit seq {}",
+                            commit.epoch, commit.seq
                         );
+                        if let Err(e) = conn
+                            .execute(
+                                "DELETE FROM mls_commit_log WHERE seq = ?1",
+                                libsql::params![commit.seq],
+                            )
+                            .await
+                        {
+                            eprintln!(
+                                "[mls] process_pending_commits: failed to delete rejected self-add seq {}: {e}",
+                                commit.seq
+                            );
+                        }
+                        break;
                     }
-                    break;
+                    // Third-party REVOKED add (an admin adding someone
+                    // who's already been revoked) — sender already merged
+                    // it on their side, so we apply it locally to stay in
+                    // sync rather than diverging from the group.
+                    eprintln!(
+                        "[mls] process_pending_commits: WARN revoked third-party add for {added_user_id} at epoch {} in {mls_group_id} — processing anyway",
+                        commit.epoch
+                    );
                 }
-                // A third-party add (an admin/inviter adding someone else) that
-                // fails verification stays ADVISORY: the sender already merged
-                // it, so blocking would diverge us from the rest of the group.
-                // Only the self-add shape above is safe to hard-reject.
-                eprintln!(
-                    "[mls] process_pending_commits: WARN cross-signing verification failed for {added_user_id} at epoch {} in {mls_group_id} — processing anyway (third-party add)",
-                    commit.epoch
-                );
+                VerifyOutcome::AbsentRetry => {
+                    // Race / replication-lag: the added device's row hasn't
+                    // reached our view of Turso yet (issue #372). Do NOT
+                    // delete the commit row.
+                    //
+                    // Self-add: defer — the sender claims they're adding
+                    // themselves, but we can't see their row to confirm.
+                    // Stop processing here; next catch-up retries.
+                    //
+                    // Third-party add (admin/inviter adding someone else):
+                    // the sender already merged this on their side and
+                    // it's already in `mls_commit_log` past the epoch
+                    // CAS. Stalling would diverge us from the rest of the
+                    // group. Process the commit advisory — same fallback
+                    // the pre-#372 code took for any unverified third-
+                    // party add.
+                    let is_self_add = commit
+                        .sender_id
+                        .as_deref()
+                        .map_or(false, |s| s == added_user_id.as_str());
+                    if is_self_add {
+                        eprintln!(
+                            "[mls] process_pending_commits: deferring self-add seq {} epoch {} for {mls_group_id} — added device {added_user_id} not yet visible (issue #372)",
+                            commit.seq, commit.epoch
+                        );
+                        break;
+                    }
+                    eprintln!(
+                        "[mls] process_pending_commits: WARN third-party add for {added_user_id} at epoch {} in {mls_group_id} not yet verifiable — processing anyway",
+                        commit.epoch
+                    );
+                }
             }
         }
 

--- a/pollis-core/src/commands/mls/mod.rs
+++ b/pollis-core/src/commands/mls/mod.rs
@@ -8,6 +8,7 @@ mod group_state;
 mod key_packages;
 mod provider;
 mod reconcile;
+mod sweep;
 mod welcomes;
 
 // ── Provider / credential helpers ────────────────────────────────────────────
@@ -33,6 +34,9 @@ pub use group_state::{
     init_mls_group, process_pending_commits, process_pending_commits_inner, publish_group_info,
     try_mls_decrypt, try_mls_encrypt,
 };
+
+// ── Cold-launch / post-reconnect sweep ──────────────────────────────────────
+pub use sweep::catch_up_all_mls_groups;
 
 // ── Reconcile + self-repair ──────────────────────────────────────────────────
 pub use reconcile::{

--- a/pollis-core/src/commands/mls/sweep.rs
+++ b/pollis-core/src/commands/mls/sweep.rs
@@ -1,0 +1,88 @@
+//! Cold-launch (or post-reconnect) MLS catch-up sweep.
+//!
+//! Single backend command that, given a user_id, enumerates every MLS
+//! group the user is in (regular groups + DMs) and runs the catch-up
+//! sequence (`poll_mls_welcomes_inner` once + `process_pending_commits_inner`
+//! per group) so the local MLS state matches the server's published epoch
+//! before the user can take any MLS-powered action.
+//!
+//! Closes the cold-launch race documented in issue #371 scenario 5: between
+//! sign-in / unlock and the first time any per-call catch-up fires, a user
+//! action (send_message, edit_message, voice join, screen-share) could run
+//! against a stale epoch. Calling this at AppShell mount and awaiting it
+//! before unlocking interactive UI closes that window.
+//!
+//! Best-effort per group: a single group's failure (e.g. revoked device,
+//! transient Turso error) logs and continues to the next so one bad row
+//! never blocks the rest of the sweep.
+
+use std::sync::Arc;
+
+use crate::error::Result;
+use crate::state::AppState;
+
+pub async fn catch_up_all_mls_groups(state: &Arc<AppState>, user_id: &str) -> Result<()> {
+    let device_id = state.device_id.lock().await.clone();
+    if let Some(ref did) = device_id {
+        if let Err(e) =
+            crate::commands::mls::poll_mls_welcomes_inner(state, user_id, did).await
+        {
+            eprintln!("[mls-sweep] poll_mls_welcomes: {e}");
+        }
+    }
+
+    let conn = state.remote_db.conn().await?;
+
+    let mut group_ids: Vec<String> = Vec::new();
+    let mut rows = conn
+        .query(
+            "SELECT g.id FROM groups g \
+             JOIN group_member gm ON gm.group_id = g.id \
+             WHERE gm.user_id = ?1",
+            libsql::params![user_id.to_string()],
+        )
+        .await?;
+    while let Some(row) = rows.next().await? {
+        group_ids.push(row.get::<String>(0)?);
+    }
+    drop(rows);
+
+    let mut dm_ids: Vec<String> = Vec::new();
+    let mut rows = conn
+        .query(
+            "SELECT dm_channel_id FROM dm_channel_member WHERE user_id = ?1",
+            libsql::params![user_id.to_string()],
+        )
+        .await?;
+    while let Some(row) = rows.next().await? {
+        dm_ids.push(row.get::<String>(0)?);
+    }
+    drop(rows);
+
+    eprintln!(
+        "[mls-sweep] {user_id}: {} group(s), {} dm(s)",
+        group_ids.len(),
+        dm_ids.len()
+    );
+
+    // Regular groups: mls_group_id IS the group id; process_pending_commits
+    // takes mls_group_id directly.
+    for gid in &group_ids {
+        if let Err(e) =
+            crate::commands::mls::process_pending_commits_inner(state, gid, user_id).await
+        {
+            eprintln!("[mls-sweep] process_pending_commits for group {gid}: {e}");
+        }
+    }
+
+    // DMs: mls_group_id IS the dm_channel_id.
+    for did in &dm_ids {
+        if let Err(e) =
+            crate::commands::mls::process_pending_commits_inner(state, did, user_id).await
+        {
+            eprintln!("[mls-sweep] process_pending_commits for dm {did}: {e}");
+        }
+    }
+
+    Ok(())
+}

--- a/pollis-core/src/db/migrations/000004_user_device_revoked_at.sql
+++ b/pollis-core/src/db/migrations/000004_user_device_revoked_at.sql
@@ -1,0 +1,20 @@
+-- Tombstone column for device revocation. Refs issue #372.
+--
+-- Background: process_pending_commits_locked uses verify_added_devices to
+-- check the added device's cross-signing cert against user_device. Today
+-- "row absent" can mean either (a) the device was hard-deleted by
+-- revoke_device, or (b) the row hasn't replicated to this client's view yet
+-- (race / write lag). Both return Ok(false), and the caller hard-deletes
+-- the commit row from mls_commit_log to keep the UNIQUE(conversation_id,
+-- epoch) slot free. When (b) happens to a legitimate commit, that commit
+-- gets permanently erased and lagging devices can never catch up via the
+-- commit log.
+--
+-- Fix: revoke_device sets revoked_at instead of hard-deleting; verify_added_
+-- devices treats "row present with revoked_at IS NOT NULL" as a confirmed
+-- revoke (delete commit OK) and "row absent" as a race/lag (do NOT delete
+-- commit, retry on next process_pending_commits). Hard-deletes that happen
+-- outside the revocation path (e.g. logout, account reset) remain hard
+-- deletes for now — those don't generate a "verify failed" event for other
+-- peers because the device isn't trying to add itself, it's just leaving.
+ALTER TABLE user_device ADD COLUMN revoked_at TEXT;

--- a/pollis-core/src/db/mod.rs
+++ b/pollis-core/src/db/mod.rs
@@ -25,6 +25,11 @@ pub const POST_BASELINE_MIGRATIONS: &[(u32, &str, &str)] = &[
         "mls_commit_log_unique_epoch",
         include_str!("migrations/000003_mls_commit_log_unique_epoch.sql"),
     ),
+    (
+        4,
+        "user_device_revoked_at",
+        include_str!("migrations/000004_user_device_revoked_at.sql"),
+    ),
 ];
 
 pub mod queries {

--- a/pollis-node/src/dispatch/mls.rs
+++ b/pollis-node/src/dispatch/mls.rs
@@ -21,6 +21,7 @@ pub async fn dispatch(
         "poll_mls_welcomes" => Some(poll_mls_welcomes(args).await),
         "reconcile_group_mls" => Some(reconcile_group_mls(args).await),
         "process_pending_commits" => Some(process_pending_commits(args).await),
+        "catch_up_all_mls_groups" => Some(catch_up_all_mls_groups(args).await),
         _ => None,
     }
 }
@@ -147,6 +148,19 @@ async fn process_pending_commits(args: &serde_json::Value) -> Result<serde_json:
     } = serde_json::from_value(args.clone()).map_err(json_err)?;
     let state = ensure_state().await?;
     pollis_core::commands::mls::process_pending_commits(&state, conversation_id, user_id)
+        .await
+        .map_err(core_err)?;
+    Ok(serde_json::Value::Null)
+}
+
+async fn catch_up_all_mls_groups(args: &serde_json::Value) -> Result<serde_json::Value> {
+    #[derive(serde::Deserialize)]
+    struct Args {
+        user_id: String,
+    }
+    let Args { user_id } = serde_json::from_value(args.clone()).map_err(json_err)?;
+    let state = ensure_state().await?;
+    pollis_core::commands::mls::catch_up_all_mls_groups(&state, &user_id)
         .await
         .map_err(core_err)?;
     Ok(serde_json::Value::Null)

--- a/src-tauri/tests/flows/messages.rs
+++ b/src-tauri/tests/flows/messages.rs
@@ -1079,16 +1079,19 @@ async fn revoked_device_cannot_rejoin_group() {
         );
     }
 
-    // Revoke bob's device: delete its `user_device` row so cross-signing
-    // verification can no longer pass for it (the revoked-device state).
+    // Revoke bob's device: tombstone its `user_device` row (issue #372) so
+    // verify_added_devices distinguishes "revoked" (delete the squatting
+    // commit OK) from "absent because not replicated yet" (don't delete).
+    // Pre-#372 this was a hard DELETE; the migration to tombstones changed
+    // revoke_device to set revoked_at, and this test mirrors that path.
     {
         let conn = alice.state.remote_db.conn().await.expect("remote conn");
         conn.execute(
-            "DELETE FROM user_device WHERE user_id = ?1",
+            "UPDATE user_device SET revoked_at = datetime('now') WHERE user_id = ?1",
             libsql::params![bob_p.id.clone()],
         )
         .await
-        .expect("delete bob user_device");
+        .expect("tombstone bob user_device");
     }
 
     // Remove bob from the group — reconcile prunes his leaf.


### PR DESCRIPTION
Follow-ups to PR #368. Closes #371 (the audit) and #372 (the tombstone root-cause). Six discrete commits, each one independently revertible.

## Commits

### 1. \`edit_message\` MLS catch-up (#371 scenario 2)

\`pollis-core/src/commands/messages/edit_delete.rs:edit_message\` called \`try_mls_encrypt\` with neither \`poll_mls_welcomes_inner\` nor \`process_pending_commits_inner\` running first. \`send_message\` did both. Result: every message edit emitted at a stale epoch was undecryptable to current-epoch members — silent message corruption in a code path that fires constantly. Now mirrors \`send_message\`'s two-step pre-encrypt catch-up.

### 2. Realtime handlers awaited + commit catch-up on reconnect (#371 scenarios 3+4)

\`useLiveKitRealtime\` previously:
- \`membership_changed\`: \`invoke('poll_mls_welcomes', …).catch(…)\` — fire-and-forget. A send/edit fired the moment after the event handler returned ran against the prior epoch.
- \`realtime_reconnected\`: only polled welcomes, never processed commits posted to existing groups during the outage.

Both handlers now \`await\` their MLS catch-up. \`realtime_reconnected\` also calls \`process_pending_commits\` for the reconnected room (skipped for \`inbox-*\` rooms which have no MLS group).

### 3. Cold-launch MLS sweep across all groups + DMs (#371 scenario 5)

New backend command \`catch_up_all_mls_groups(user_id)\` (\`pollis-core/src/commands/mls/sweep.rs\`) enumerates every group and DM the user belongs to and runs the catch-up sequence on each. \`AppShell\` now calls this on mount (replacing the previous \`poll_mls_welcomes\`-only call) and sets \`isSyncing\` for the duration so the status bar surfaces it. Closes the cold-launch race the user hit cross-machine before this PR.

### 4. Tombstone revoked devices + tri-state verify (closes #372)

The audit's root cause: \`verify_added_devices\` returned \`Ok(false)\` for both "device revoked" and "device row not yet replicated" — and the rejection-and-delete path in \`process_pending_commits_locked\` hard-deleted the \`mls_commit_log\` row on either, permanently erasing legitimate commits when the replication-lag race fired.

Now:
- New migration \`000004_user_device_revoked_at.sql\` adds a nullable \`revoked_at TEXT\` column (additive, CLAUDE.md-safe).
- \`revoke_device\` does \`UPDATE … SET revoked_at = datetime('now')\` instead of \`DELETE\`.
- \`verify_added_devices\` returns \`VerifyOutcome::{Verified, Revoked, AbsentRetry}\`. Tombstone present → \`Revoked\`. Row missing or cert columns NULL → \`AbsentRetry\`. Bad cert chain → \`Revoked\`.
- \`process_pending_commits_locked\` only deletes the commit row on \`Revoked\` self-add. On \`AbsentRetry\` self-add it defers (next catch-up retries). Third-party adds proceed advisory on either failure to stay in sync with the rest of the group.
- \`local_device_registered\` filters \`revoked_at IS NULL\`. \`list_user_devices\` filters tombstoned out.

All 29 integration tests pass including \`revoked_device_cannot_rejoin_group\` (updated to use the tombstone pattern) and \`voice_e2ee_keys_match_across_members_and_rotate_on_epoch\`.

### 5. Per-device view-client identity (refs #140)

PR #366 made the voice identity per-device (\`voice-{userId}:{deviceId}\`) so multi-device users could co-exist in a room. The screenshare view-client identity was missed and stayed as \`{userId}:view\`. Two devices of the same user in voice → both joined the view room as the same identity → LiveKit kicked the older connection on every join → reconcile loop reconnected → every reconnect ran the full \`derive_voice_key\` catch-up → log storm + screenshare unusable on the affected user.

\`livekitView\` now lazy-fetches \`get_device_id\` once and joins as \`{userId}:{deviceId}:view\`. \`voiceIdentityFromView\` accepts both shapes (legacy and per-device) for cross-version compat.

### 6. Per-device screenshare key

Once view identities are per-device, \`screenShareRemotes\` keyed by \`voice-{userId}\` (stripping device) caused both devices of the same user to render the same sibling's screenshare in their own voice tile. Now keyed by \`voice-{userId}:{deviceId}\`; \`VoiceChannelView\` looks up that key first with a fallback to the user-scoped key for any cross-version client still publishing under the legacy view identity.

## Migration

\`000004_user_device_revoked_at.sql\` (ADD COLUMN nullable, safe per CLAUDE.md). Applied to dev Turso already. Prod will pick it up via \`db-apply.sh\` on the next release.

## Verification

- \`cargo test --features test-harness --test flows\`: 29 passed, 0 failed.
- \`tsc --noEmit\` + \`cargo check\` clean.
- Cross-machine manual test (macOS + macOS, two devices of the same user in voice, then with three users total): voice joins, screenshare publishes, view client connects per-device without reconnect storms, voice tile shows only the correct device's share.

## Cleanup notes

- Verbose \`[voice-e2ee] catch-up: mls_commit_log …\` diagnostic logging was kept on for this PR while we were chasing the drift — fine to strip in a follow-up once we've watched it in the wild for a release or two.