### PR TITLE
Voice stage redesign + live per-source audio meter, bar-height unification, styling-system cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,3 +287,17 @@ checkStatus(); // Verify with backend
 // Verify with backend
 checkStatus();
 ```
+
+### Styling: Tailwind-first, token-backed
+
+Design tokens are CSS custom properties in `frontend/src/index.css` (`--c-*` colors, `--bar-h`, `--font-size-base`) — the single source of truth, themeable and font-scalable. They are surfaced as semantic Tailwind utilities in `tailwind.config.js`: `bg-bg`, `bg-surface[-raised|-high]`, `text-fg`/`text-dim`/`text-muted`, `text-accent`/`bg-accent`, `border-line`/`border-line-strong`, `hover:bg-hover`, `h-bar`. **Use these utilities** — do not write `[var(--c-…)]` arbitrary classes or inline `style={{ color: 'var(--c-…)' }}` for tokens that have a utility. If a token is missing a utility, add it to the Tailwind theme rather than reaching around it.
+
+Three idioms, in priority order:
+
+1. **Static styling → Tailwind utilities.** The default. Colors, spacing, borders, layout. No inline `style` for static values.
+2. **Runtime-dynamic values → inline `style`.** Only for values a static class cannot express: measured dimensions, dynamically-injected CSS variables (e.g. the voice meter's `--eqN`), a computed gradient stop. This is the sanctioned escape hatch.
+3. **Complex / stateful / repeated selectors → a co-located component CSS file** (e.g. `voice-stage.css`, prefixed classes) or `@layer components`. For pseudo-elements, `nth-child`, `::-webkit-scrollbar`, keyframes, descendant selectors — things utilities express badly.
+
+**Sizes that should track the user's font setting must be in `rem`** (Tailwind's scale is rem-native, so utilities scale for free; `--bar-h` is rem). Use `px` only for things that intentionally should *not* scale (1px hairlines). Never a `px` arbitrary class (`h-[28px]`) for a scalable dimension — use `rem` (`h-[1.75rem]`) or a token. Do **not** reintroduce per-file `px→rem` helpers.
+
+Bundle size is not a factor here — Tailwind's JIT only emits used classes (CSS is a rounding error next to the JS bundle); choose for consistency, not perf.

--- a/frontend/src/components/Layout/PageShell.tsx
+++ b/frontend/src/components/Layout/PageShell.tsx
@@ -32,8 +32,9 @@ export const PageShell: React.FC<PageShellProps> = ({ title, children, scrollabl
   return (
     <div className="flex flex-col h-full">
       <div
-        className="flex items-center px-4 py-2 flex-shrink-0 text-xs font-mono"
+        className="flex items-center px-4 flex-shrink-0 text-xs font-mono"
         style={{
+          height: "var(--bar-h)",
           borderBottom: "1px solid var(--c-border)",
           color: "var(--c-text-muted)",
         }}

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -21,25 +21,25 @@ import { useVoiceRoomCounts } from "../../hooks/queries/useVoiceParticipants";
 import { usePeerVerifications } from "../../hooks/queries/useUserProfile";
 import { observer } from "mobx-react-lite";
 import { appStore } from "../../stores/appStore";
-import { usePresenceStatus, type PresenceStatus } from "../../stores/presenceStore";
+import { usePresenceStatus } from "../../stores/presenceStore";
 import { useShortcutLabel } from "../../keyboard";
 
-const SIDEBAR_WIDTH = 220;
 const COLLAPSED_GROUPS_KEY = "pollis.sidebar.collapsedGroups";
 
-// The sidebar chrome is sized in rem so it tracks the user's font-size
-// preference (`--font-size-base` on :root, which scales rem). Hardcoded px
-// would stay frozen while the rest of the app scales. Values are expressed
-// relative to the 15px default base; rem keeps them reactive to live
-// changes without needing a re-render.
-const BASE_FONT_PX = 15;
-const rem = (px: number): string => `${px / BASE_FONT_PX}rem`;
-// Shared lucide sizing: `size` seeds the SVG attribute, the rem width/height
-// override actually scales it with the font preference.
+// Sidebar chrome is sized in rem (via Tailwind's rem-based scale + a few
+// rem arbitrary values) so it tracks the user's font-size preference
+// (`--font-size-base` on :root). px would freeze while the app scales.
+// Shared lucide sizing: `size` seeds the SVG attribute; the rem `size-[…]`
+// class scales it with the font preference (CSS wins over the attribute).
 const iconProps = {
   size: 14,
-  style: { width: rem(14), height: rem(14), flexShrink: 0 },
+  className: "size-[0.933rem] shrink-0",
 } as const;
+
+// Per-depth left padding (10 + indent*16 px @ 15px base ⇒ rem, scalable).
+// indent is only ever 1 (group / dm / settings) or 2 (channel).
+const indentPadClass = (indent: number): string =>
+  indent >= 2 ? "pl-[2.8rem]" : "pl-[1.733rem]";
 
 interface SidebarProps {
   isOpen: boolean;
@@ -151,17 +151,9 @@ export const Sidebar: React.FC<SidebarProps> = observer(({ isOpen, onToggle }) =
   return (
     <aside
       data-testid="sidebar"
-      style={{
-        width: rem(SIDEBAR_WIDTH),
-        flexShrink: 0,
-        borderRight: "1px solid var(--c-border)",
-        background: "var(--c-surface)",
-        display: "flex",
-        flexDirection: "column",
-        fontFamily: "var(--font-mono, monospace)",
-      }}
+      className="flex w-[14.667rem] shrink-0 flex-col border-r border-line bg-surface font-mono"
     >
-      <div style={{ flex: 1, overflowY: "auto", overflowX: "hidden" }}>
+      <div className="flex-1 overflow-y-auto overflow-x-hidden">
         <SectionHeader
           label="groups"
           icon={<Users {...iconProps} />}
@@ -170,7 +162,7 @@ export const Sidebar: React.FC<SidebarProps> = observer(({ isOpen, onToggle }) =
           borderedBottom
         />
 
-        <ul style={{ margin: 0, padding: 0, listStyle: "none" }}>
+        <ul>
           {groupsWithChannels.map((group) => {
             const isCollapsed = collapsedGroups.has(group.id);
             const groupUnread = group.channels.reduce(
@@ -241,7 +233,7 @@ export const Sidebar: React.FC<SidebarProps> = observer(({ isOpen, onToggle }) =
           bordered
         />
 
-        <ul style={{ margin: 0, padding: 0, listStyle: "none" }}>
+        <ul>
           {dmConversations.map((c) => {
             const unread = unreadCounts[c.id] ?? 0;
             const verification = c.user2_id ? verificationByPeer.get(c.user2_id) : undefined;
@@ -253,7 +245,7 @@ export const Sidebar: React.FC<SidebarProps> = observer(({ isOpen, onToggle }) =
               <span
                 data-testid={`dm-verification-changed-${c.id}`}
                 title="Identity key changed — re-verify"
-                style={{ display: "inline-flex", color: "#f0b429", flexShrink: 0 }}
+                className="inline-flex shrink-0 text-[#f0b429]"
               >
                 <ShieldAlert {...iconProps} />
               </span>
@@ -261,7 +253,7 @@ export const Sidebar: React.FC<SidebarProps> = observer(({ isOpen, onToggle }) =
               <span
                 data-testid={`dm-verification-verified-${c.id}`}
                 title="Verified contact"
-                style={{ display: "inline-flex", color: "var(--c-accent)", flexShrink: 0 }}
+                className="inline-flex shrink-0 text-accent"
               >
                 <ShieldCheck {...iconProps} />
               </span>
@@ -306,34 +298,12 @@ export const Sidebar: React.FC<SidebarProps> = observer(({ isOpen, onToggle }) =
         onClick={onToggle}
         aria-label={`Close sidebar (${toggleSidebarLabel})`}
         title={`Close sidebar (${toggleSidebarLabel})`}
-        className="transition-colors text-[var(--c-text-muted)] hover:text-[var(--c-text)]"
-        style={{
-          flexShrink: 0,
-          display: "flex",
-          alignItems: "center",
-          gap: rem(8),
-          padding: `${rem(8)} ${rem(10)}`,
-          borderTop: "1px solid var(--c-border)",
-          background: "none",
-          fontFamily: "inherit",
-          fontSize: rem(13),
-          textAlign: "left",
-          cursor: "pointer",
-        }}
+        className="flex shrink-0 items-center gap-2 px-2.5 py-2 border-t border-line text-xs text-left cursor-pointer transition-colors text-muted hover:text-fg"
       >
-        <span style={{ flex: 1 }}>Close</span>
+        <span className="flex-1">Close</span>
         <kbd
           aria-hidden="true"
-          className="font-mono"
-          style={{
-            color: "inherit",
-            background: "var(--c-bg)",
-            padding: `${rem(1)} ${rem(5)}`,
-            borderRadius: 3,
-            border: "1px solid var(--c-border)",
-            fontSize: rem(11),
-            lineHeight: 1.2,
-          }}
+          className="font-mono bg-bg px-1.5 py-px rounded-[3px] border border-line text-2xs leading-[1.2]"
         >
           {toggleSidebarLabel}
         </kbd>
@@ -354,40 +324,30 @@ interface SectionHeaderProps {
   borderedBottom?: boolean;
 }
 
-const SectionHeader: React.FC<SectionHeaderProps> = ({ label, icon, isActive, onClick, badge, bordered, borderedBottom }) => (
-  <button
-    type="button"
-    onClick={onClick}
-    className="bg-[var(--c-surface)] hover:bg-[var(--c-hover)]"
-    style={{
-      width: "100%",
-      display: "flex",
-      alignItems: "center",
-      gap: rem(6),
-      padding: `${rem(8)} ${rem(10)} ${rem(8)}`,
-      marginTop: bordered ? rem(4) : 0,
-      border: "none",
-      borderTop: bordered ? "1px solid var(--c-border)" : "none",
-      borderBottom: bordered || borderedBottom ? "1px solid var(--c-border)" : "none",
-      color: isActive ? "var(--c-accent)" : "var(--c-text-muted)",
-      letterSpacing: "0.08em",
-      textTransform: "uppercase",
-      cursor: "pointer",
-      textAlign: "left",
-      transition: "background 75ms",
-      position: "sticky",
-      top: 0,
-      zIndex: 1,
-      height: "var(--bar-h)",
-    }}
-    data-testId={`sidebar-row-${label.toLowerCase().replace(/\s+/g, "-")}`}
-
-  >
-    {icon}
-    <span style={{ flex: "1 1 0%", lineHeight: "100%", fontSize: "0.8rem" }}>{label}</span>
-    {badge != null && <UnreadBadge count={badge} muted />}
-  </button>
-);
+const SectionHeader: React.FC<SectionHeaderProps> = ({ label, icon, isActive, onClick, badge, bordered, borderedBottom }) => {
+  const cls = [
+    "sticky top-0 z-[1] flex w-full h-bar items-center gap-1.5 px-2.5",
+    "uppercase tracking-[0.08em] text-left cursor-pointer",
+    "transition-colors duration-75 bg-surface hover:bg-hover",
+    isActive ? "text-accent" : "text-muted",
+    bordered ? "mt-1 border-t border-line" : "",
+    bordered || borderedBottom ? "border-b border-line" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cls}
+      data-testid={`sidebar-row-${label.toLowerCase().replace(/\s+/g, "-")}`}
+    >
+      {icon}
+      <span className="flex-1 leading-[100%] text-[0.8rem]">{label}</span>
+      {badge != null && <UnreadBadge count={badge} muted />}
+    </button>
+  );
+};
 
 interface RowChevron {
   isCollapsed: boolean;
@@ -412,14 +372,11 @@ const Row: React.FC<RowProps> = ({ indent, isActive, onClick, leading, chevron, 
   return (
     <div
       data-active={isActive ? "true" : "false"}
-      className={`transition-colors ${isActive ? "bg-[var(--c-hover)]" : "bg-transparent hover:bg-[var(--c-hover)]"}`}
-      style={{
-        display: "flex",
-        alignItems: "stretch",
-        width: "100%",
-        borderLeft: isActive ? "2px solid var(--c-accent)" : "2px solid transparent",
-        color: isActive ? "var(--c-accent)" : "var(--c-text)",
-      }}
+      className={`flex w-full items-stretch border-l-2 transition-colors ${
+        isActive
+          ? "bg-hover border-accent text-accent"
+          : "bg-transparent border-transparent text-fg hover:bg-hover"
+      }`}
     >
       {chevron && (
         <button
@@ -430,18 +387,7 @@ const Row: React.FC<RowProps> = ({ indent, isActive, onClick, leading, chevron, 
             chevron.onToggle();
           }}
           aria-label={chevron.ariaLabel}
-          style={{
-            background: "none",
-            border: "none",
-            padding: 0,
-            margin: 0,
-            paddingLeft: rem(10 + indent * 16),
-            paddingRight: 0,
-            display: "inline-flex",
-            alignItems: "center",
-            color: "inherit",
-            cursor: "pointer",
-          }}
+          className={`inline-flex items-center pr-0 cursor-pointer text-inherit ${indentPadClass(indent)}`}
         >
           {chevron.isCollapsed ? <ChevronRight {...iconProps} /> : <ChevronDown {...iconProps} />}
         </button>
@@ -449,38 +395,12 @@ const Row: React.FC<RowProps> = ({ indent, isActive, onClick, leading, chevron, 
       <button
         type="button"
         onClick={onClick}
-        style={{
-          flex: 1,
-          minWidth: 0,
-          display: "flex",
-          alignItems: "center",
-          gap: rem(6),
-          paddingTop: rem(2),
-          paddingBottom: rem(2),
-          paddingLeft: chevron ? rem(6) : rem(10 + indent * 16),
-          paddingRight: rem(10),
-          background: "none",
-          border: "none",
-          color: "inherit",
-          fontSize: rem(15),
-          fontFamily: "inherit",
-          cursor: "pointer",
-          textAlign: "left",
-          lineHeight: rem(24),
-        }}
-
+        className={`flex flex-1 min-w-0 items-center gap-1.5 py-0.5 pr-2.5 text-base text-left cursor-pointer text-inherit ${
+          chevron ? "pl-[0.4rem]" : indentPadClass(indent)
+        }`}
       >
         {leading}
-        <span
-          style={{
-            flex: 1,
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-            whiteSpace: "nowrap",
-          }}
-        >
-          {label}
-        </span>
+        <span className="flex-1 truncate">{label}</span>
         {trailing}
         {badge != null && <UnreadBadge count={badge} />}
       </button>
@@ -490,45 +410,26 @@ const Row: React.FC<RowProps> = ({ indent, isActive, onClick, leading, chevron, 
 
 const UnreadBadge: React.FC<{ count: number; muted?: boolean }> = ({ count, muted }) => (
   <span
-    style={{
-      fontSize: rem(11),
-      lineHeight: 1,
-      padding: `${rem(2)} ${rem(6)}`,
-      borderRadius: "0.25rem",
-      background: muted ? "var(--c-text-muted)" : "var(--c-accent)",
-      color: "var(--c-bg)",
-      flexShrink: 0,
-    }}
+    className={`shrink-0 rounded px-1.5 py-0.5 text-2xs leading-none text-bg ${
+      muted ? "bg-muted" : "bg-accent"
+    }`}
   >
     {count > 99 ? "99+" : count}
   </span>
 );
 
-// Standalone presence dot mirroring the styling on Avatar's overlay dot:
-// online uses the accent color, offline uses the bg color ringed in
-// accent-muted. Used in the sidebar DM list where there's no avatar behind
-// it to anchor the dot.
-const PRESENCE_COLORS: Record<PresenceStatus, string> = {
-  online: "var(--c-accent)",
-  offline: "var(--c-bg)",
-};
-
+// Standalone presence dot mirroring Avatar's overlay dot: online uses the
+// accent color, offline uses the bg color ringed in accent-muted. Used in
+// the sidebar DM list where there's no avatar behind it to anchor the dot.
 const PresenceDot: React.FC<{ userId: string | null }> = observer(({ userId }) => {
   const status = usePresenceStatus(userId);
   return (
     <span
       data-testid={userId ? `sidebar-presence-${userId}` : undefined}
       aria-label={`Presence: ${status}`}
-      style={{
-        display: "inline-block",
-        width: rem(8),
-        height: rem(8),
-        borderRadius: "50%",
-        background: PRESENCE_COLORS[status],
-        border: status === "offline" ? "1px solid var(--c-accent-muted)" : "1px solid var(--c-surface, var(--c-bg))",
-        boxSizing: "content-box",
-        flexShrink: 0,
-      }}
+      className={`inline-block size-2 rounded-full box-content shrink-0 border ${
+        status === "offline" ? "bg-bg border-accent-muted" : "bg-accent border-surface"
+      }`}
     />
   );
 });

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -370,7 +370,6 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({ label, icon, isActive, on
       borderTop: bordered ? "1px solid var(--c-border)" : "none",
       borderBottom: bordered || borderedBottom ? "1px solid var(--c-border)" : "none",
       color: isActive ? "var(--c-accent)" : "var(--c-text-muted)",
-      fontSize: rem(12),
       letterSpacing: "0.08em",
       textTransform: "uppercase",
       cursor: "pointer",
@@ -379,10 +378,13 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({ label, icon, isActive, on
       position: "sticky",
       top: 0,
       zIndex: 1,
+      height: "var(--bar-h)",
     }}
+    data-testId={`sidebar-row-${label.toLowerCase().replace(/\s+/g, "-")}`}
+
   >
     {icon}
-    <span style={{ flex: 1 }}>{label}</span>
+    <span style={{ flex: "1 1 0%", lineHeight: "100%", fontSize: "0.8rem" }}>{label}</span>
     {badge != null && <UnreadBadge count={badge} muted />}
   </button>
 );
@@ -466,6 +468,7 @@ const Row: React.FC<RowProps> = ({ indent, isActive, onClick, leading, chevron, 
           textAlign: "left",
           lineHeight: rem(24),
         }}
+
       >
         {leading}
         <span

--- a/frontend/src/components/Voice/ScreenShareViewer.tsx
+++ b/frontend/src/components/Voice/ScreenShareViewer.tsx
@@ -12,6 +12,7 @@ import { observer } from "mobx-react-lite";
 import { appStore } from "../../stores/appStore";
 import { RemoteVideoTile } from "./RemoteVideoTile";
 import { LOCAL_PREVIEW_KEY } from "../../screenshare/screenShareSession";
+import { useScreenShareStats } from "../../screenshare/useScreenShareStats";
 import { shareOf } from "../../types/voice-state";
 
 export const ScreenShareViewer: React.FC = observer(() => {
@@ -25,6 +26,9 @@ export const ScreenShareViewer: React.FC = observer(() => {
   const share = shareOf(voiceState);
   const screenShareLocalActive = share.kind === 'active';
   const screenShareLocalDimensions = share.kind === 'active' ? share.dimensions : null;
+  // Live frame stats for the viewed track (fps + dimensions). Keyed by the
+  // same track key the tile uses; inert when nothing is being viewed.
+  const stats = useScreenShareStats(viewingScreenShareTrackKey);
   if (!viewingScreenShareTrackKey) {
     return null;
   }
@@ -56,6 +60,11 @@ export const ScreenShareViewer: React.FC = observer(() => {
     width = info.width;
     height = info.height;
   }
+  // Prefer the live stats dimensions/fps; fall back to the static hints.
+  const liveW = stats.dimensions?.width ?? width;
+  const liveH = stats.dimensions?.height ?? height;
+  const resLabel = liveW && liveH ? `${liveW}×${liveH}` : "";
+  const fpsLabel = stats.fps > 0 ? `${stats.fps}fps` : "";
   const close = () => setViewingScreenShareTrackKey(null);
   return (
     <div
@@ -80,7 +89,8 @@ export const ScreenShareViewer: React.FC = observer(() => {
       >
         <span>
           watching {label}
-          {width && height ? ` — ${width}×${height}` : ""}
+          {resLabel ? ` — ${resLabel}` : ""}
+          {fpsLabel ? ` · ${fpsLabel}` : ""}
         </span>
         <button
           data-testid="screenshare-viewer-close"

--- a/frontend/src/components/Voice/VoiceBar.tsx
+++ b/frontend/src/components/Voice/VoiceBar.tsx
@@ -7,10 +7,7 @@ import { Volume2, Mic, MicOff, PhoneOff, SlidersHorizontal, Monitor, MonitorOff 
 import { PillButton } from "../ui/PillButton";
 import { voiceSession } from "../../voice";
 import { disambiguateVoiceNames } from "../../voice/disambiguateNames";
-import {
-  friendlyScreenShareError,
-  screenShareSession,
-} from "../../screenshare/screenShareSession";
+import { toggleScreenShare } from "../../screenshare/screenShareActions";
 import { shareOf } from "../../types/voice-state";
 
 interface VoiceBarProps {
@@ -104,50 +101,7 @@ export const VoiceBar: React.FC<VoiceBarProps> = observer(({ channelId, channelN
       <PillButton
         data-testid="voice-bar-screenshare-button"
         accent={shareInFlight ? "#ff6b6b" : "var(--c-accent)"}
-        onClick={() => {
-          if (shareActive) {
-            screenShareSession
-              .stop()
-              .catch((e) => console.error("[screenshare] stop", e));
-            return;
-          }
-          if (share.kind === "picking") {
-            // Button doubles as a cancel affordance while the picker is open.
-            screenShareSession
-              .cancelPicker()
-              .catch((e) => console.warn("[screenshare] cancel:", e))
-              .finally(() => {
-                appStore.shareCancelPicker();
-              });
-            return;
-          }
-          // Any other non-idle share state (e.g. 'starting' that wedged
-          // because publishTrack hung on a dead Wayland-portal track, or
-          // 'failed') — let the button recover by force-stopping.
-          // shareStopped() is safe from any joined-state.
-          if (shareInFlight) {
-            screenShareSession
-              .stop()
-              .catch((e) => console.warn("[screenshare] force-stop:", e));
-            return;
-          }
-          // Engage enumerate→pick→start. The backend returns an empty
-          // list on Linux/Windows; in that case we skip our picker and
-          // go straight to start() (system portal/WGC handles selection).
-          (async () => {
-            try {
-              const list = await screenShareSession.enumerate();
-              if (list.displays.length + list.windows.length === 0) {
-                await screenShareSession.start();
-                return;
-              }
-              appStore.shareStartPicking(list);
-            } catch (e) {
-              console.error("[screenshare] enumerate:", e);
-              appStore.shareFailed(friendlyScreenShareError(String(e)));
-            }
-          })();
-        }}
+        onClick={() => toggleScreenShare(share)}
         title={
           shareActive
             ? "Stop screen share"

--- a/frontend/src/components/Voice/stage/StageTile.tsx
+++ b/frontend/src/components/Voice/stage/StageTile.tsx
@@ -1,0 +1,262 @@
+// One participant on the voice stage. Flat amber-POSIX terminal tile:
+// name + live mic state (top-left), connection-quality bars (top-right),
+// a centered avatar with a live multi-band audio meter when audio-only, or
+// the screenshare feed (with LIVE + res·fps badges) when streaming.
+// Speaking flips the border to a solid accent — no glow. Motion is minimal
+// and informational: only the meter moves, driven by real per-source levels.
+//
+// The tile fills its parent (a NavigableGrid cell, a filmstrip cell, or
+// the spotlight main area), so callers own the sizing/position logic.
+//
+// Reuses the app's own building blocks: Avatar, RemoteVideoTile (the real
+// screenshare renderer), RemoteUserVolumeSlider (the persisted per-user
+// mixer volume), and useScreenShareStats. lucide icons throughout.
+
+import React, { useEffect, useRef } from "react";
+import { Mic, MicOff, Maximize, Pin } from "lucide-react";
+
+import type { VoiceConnectionQuality } from "../../../types";
+import { Avatar } from "../../ui/Avatar";
+import { LoadingSpinner } from "../../ui/LoaderSpinner";
+import { RemoteUserVolumeSlider } from "../RemoteUserVolumeSlider";
+import { RemoteVideoTile } from "../RemoteVideoTile";
+import { useScreenShareStats } from "../../../screenshare/useScreenShareStats";
+import { audioLevels, BAND_COUNT } from "../../../voice/audioLevels";
+
+// Live audio meter: BAND_COUNT bars whose heights track this source's
+// real per-band levels (pushed from Rust at ~20 Hz). Subscribes by
+// identity and writes CSS variables straight onto the bar container via a
+// ref — no React state, no re-render. Falls back to the static glyph
+// (CSS default heights) until/if levels arrive. Mounted only for in-call
+// audio-only tiles, so the subscription lifecycle matches the meter's.
+const LiveWaveform: React.FC<{ identity: string }> = ({ identity }) => {
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) {
+      return;
+    }
+    const apply = (bands: number[]) => {
+      for (let i = 0; i < BAND_COUNT; i++) {
+        // Floor at a small height so a silent bar still reads as a bar.
+        const pct = Math.max(8, Math.round((bands[i] ?? 0) * 100));
+        el.style.setProperty(`--eq${i}`, `${pct}%`);
+      }
+    };
+    const seed = audioLevels.get(identity);
+    if (seed) {
+      apply(seed);
+    }
+    return audioLevels.subscribe(identity, apply);
+  }, [identity]);
+
+  return (
+    <div className="vs-eq" ref={ref} aria-hidden="true">
+      {Array.from({ length: BAND_COUNT }, (_, i) => (
+        <i key={i} />
+      ))}
+    </div>
+  );
+};
+
+export type TileMode = "grid" | "film" | "big" | "preview";
+
+export interface StageParticipant {
+  identity: string;
+  name: string;
+  avatarKey: string | null;
+  isMuted: boolean;
+  isLocal: boolean;
+  isSpeaking: boolean;
+  connectionQuality?: VoiceConnectionQuality;
+  /** Track key + hint dimensions of this participant's active screen
+   *  share (local preview or remote). Undefined ⇒ audio-only layout. */
+  streamTrackKey?: string;
+  streamWidth?: number;
+  streamHeight?: number;
+  /** Local user only, while the voice session is still negotiating. */
+  isConnecting?: boolean;
+}
+
+interface Props {
+  participant: StageParticipant;
+  mode: TileMode;
+  /** Keyboard focus from the enclosing NavigableGrid — reveals the volume
+   *  strip and highlights the border, mirroring mouse hover. */
+  focused?: boolean;
+  /** Focus this streamer in the inline spotlight. */
+  onFocus?: (identity: string) => void;
+  /** Open the global fullscreen viewer for a track. */
+  onView?: (trackKey: string) => void;
+}
+
+// LiveKit quality → the design's 3-step signal scale.
+function signalClass(q: VoiceConnectionQuality | undefined): string {
+  switch (q) {
+    case "poor":
+    case "lost":
+      return "poor";
+    case "good":
+      return "fair";
+    default:
+      return "good";
+  }
+}
+
+export const StageTile: React.FC<Props> = ({
+  participant: p,
+  mode,
+  focused = false,
+  onFocus,
+  onView,
+}) => {
+  const big = mode === "big";
+  const preview = mode === "preview";
+
+  const hasFeed = p.streamTrackKey !== undefined;
+  // A streaming tile in the filmstrip is clickable to spotlight it; the
+  // big tile is already focused, the preview state isn't a live call.
+  const focusable = hasFeed && !big && !preview;
+
+  const stats = useScreenShareStats(p.streamTrackKey ?? null);
+  const statsLabel = (() => {
+    if (!hasFeed) {
+      return null;
+    }
+    const w = stats.dimensions?.width ?? p.streamWidth;
+    const h = stats.dimensions?.height ?? p.streamHeight;
+    if (!w || !h) {
+      return null;
+    }
+    const heightLabel = h % 90 === 0 && h <= 4320 ? `${h}p` : `${h}px`;
+    const fpsLabel = stats.fps > 0 ? `${stats.fps}fps` : "…";
+    return `${heightLabel} · ${fpsLabel}`;
+  })();
+
+  const cls = [
+    "vs-tile",
+    p.isSpeaking && "speaking",
+    focusable && "clickable",
+    focused && "focused",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div
+      className={cls}
+      data-testid={`voice-tile-${p.identity}`}
+      onClick={focusable ? () => onFocus?.(p.identity) : undefined}
+    >
+      <div className="vs-tile-stage">
+        {hasFeed ? (
+          <RemoteVideoTile
+            trackKey={p.streamTrackKey!}
+            initialWidth={p.streamWidth}
+            initialHeight={p.streamHeight}
+            preview={!big}
+          />
+        ) : (
+          <div className="vs-tile-center">
+            <Avatar
+              avatarKey={p.avatarKey}
+              size={big ? 92 : 60}
+              alt={p.name}
+              testId={`voice-tile-avatar-${p.identity}`}
+            />
+            {!preview && <LiveWaveform identity={p.identity} />}
+          </div>
+        )}
+      </div>
+
+      {/* top-left: name + mic state */}
+      <div className="vs-tl">
+        <span className={"vs-name" + (p.isLocal ? " host" : "")}>
+          {p.isMuted ? (
+            <span className="vs-ic danger"><MicOff size={13} /></span>
+          ) : (
+            <span className={"vs-ic" + (p.isSpeaking ? " accent" : "")}><Mic size={13} /></span>
+          )}
+          <span className="vs-nm" title={p.name}>{p.name}</span>
+        </span>
+      </div>
+
+      {/* top-right: connecting spinner (local) → connection signal */}
+      <div className="vs-tr">
+        {p.isConnecting ? (
+          <span
+            data-testid={`voice-tile-connecting-${p.identity}`}
+            className="flex items-center leading-none"
+            title="Connecting…"
+            aria-label="Connecting"
+          >
+            <LoadingSpinner size="sm" />
+          </span>
+        ) : (
+          <span
+            className="vs-tag vs-pad6"
+            data-testid={`voice-tile-quality-${p.identity}`}
+            title={`Connection: ${p.connectionQuality ?? "excellent"}`}
+          >
+            <span className={"vs-sig " + signalClass(p.connectionQuality)}>
+              <i /><i /><i /><i />
+            </span>
+          </span>
+        )}
+      </div>
+
+      {/* LIVE badge: only useful before you join — once you're in the
+          channel the stream itself makes it obvious who's streaming. */}
+      {hasFeed && preview && (
+        <div className="vs-bl"><span className="vs-tag live">LIVE</span></div>
+      )}
+
+      {/* res · fps badge stays on the in-call tiles. */}
+      {hasFeed && !preview && statsLabel && (
+        <div className="vs-br">
+          <span
+            className="vs-tag res"
+            data-testid={`voice-tile-stream-stats-${p.identity}`}
+          >
+            {statsLabel}
+          </span>
+        </div>
+      )}
+
+      {/* hover controls — streaming tiles in-call only */}
+      {hasFeed && !preview && (
+        <div className="vs-hover">
+          <button
+            className="vs-hbtn"
+            title="fullscreen"
+            aria-label="Open fullscreen"
+            onClick={(e) => { e.stopPropagation(); onView?.(p.streamTrackKey!); }}
+          >
+            <Maximize size={17} />
+          </button>
+          {focusable && (
+            <button
+              className="vs-hbtn"
+              title="spotlight"
+              aria-label="Spotlight this stream"
+              onClick={(e) => { e.stopPropagation(); onFocus?.(p.identity); }}
+            >
+              <Pin size={17} />
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* volume — remote only; persistent in preview, hover/focus in-call */}
+      {!p.isLocal && (
+        <div
+          className={"vs-vol" + (preview ? " always" : "")}
+          data-testid={`voice-tile-volume-${p.identity}`}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <RemoteUserVolumeSlider identity={p.identity} participantName={p.name} />
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/Voice/stage/VoiceStage.tsx
+++ b/frontend/src/components/Voice/stage/VoiceStage.tsx
@@ -1,0 +1,292 @@
+// VoiceStage — the main content area for a voice channel. Flat amber-POSIX
+// terminal aesthetic (minimal/informational motion only, no gradients, no
+// glow), ported from the design handoff and wired onto the app's live
+// voice state.
+//
+// Body states:
+//   - picking   (choosing a screenshare source): the in-app source picker
+//                takes over the body (no modal — CLAUDE.md rule).
+//   - preview   (not joined): a "who's here" roster (NavigableGrid, same
+//                sizing as before) with persistent per-user volume + a
+//                solid Join Voice CTA.
+//   - spotlight (joined, someone streaming): the focused screenshare fills
+//                the body with a clickable filmstrip below.
+//   - grid      (joined, no stream): a reflowing equal grid of tiles.
+//
+// Reads live data straight off appStore (MobX observer) rather than being a
+// pure controlled component — matches the rest of the voice UI. The only
+// internal state is which streamer is spotlit.
+
+import React, { useState } from "react";
+import { observer } from "mobx-react-lite";
+import { ArrowLeft, Volume2, Mic, MicOff, Monitor, MonitorOff, LogOut, Phone, SlidersHorizontal } from "lucide-react";
+
+import { appStore } from "../../../stores/appStore";
+import type { VoiceParticipant } from "../../../types";
+import { shareOf } from "../../../types/voice-state";
+import { LOCAL_PREVIEW_KEY } from "../../../screenshare/screenShareSession";
+import { toggleScreenShare } from "../../../screenshare/screenShareActions";
+import { disambiguateVoiceNames } from "../../../voice/disambiguateNames";
+import { voiceUserKey } from "../../../voice/identity";
+import { voiceSession } from "../../../voice";
+import { Button } from "../../ui/Button";
+import { NavigableGrid } from "../../ui/NavigableGrid";
+import { ScreenSharePicker } from "../ScreenSharePicker";
+import { StageTile, type StageParticipant } from "./StageTile";
+import "./voice-stage.css";
+
+interface VoiceStageProps {
+  channelName: string;
+  isInCall: boolean;
+  onJoin: () => void;
+  onLeave: () => void;
+  onBack: () => void;
+  onOpenSettings: () => void;
+  /** Roster shown in the not-joined preview state. */
+  observerParticipants: VoiceParticipant[];
+  /** Admin affordances (rename/delete) rendered in the header, right side. */
+  headerActions?: React.ReactNode;
+  /** When set, replaces the standard footer (e.g. the pending-delete bar). */
+  footer?: React.ReactNode;
+}
+
+export const VoiceStage: React.FC<VoiceStageProps> = observer(
+  ({
+    channelName,
+    isInCall,
+    onJoin,
+    onLeave,
+    onBack,
+    onOpenSettings,
+    observerParticipants,
+    headerActions,
+    footer,
+  }) => {
+    const {
+      voiceParticipants,
+      voiceActiveSpeakerIds,
+      voiceState,
+      screenShareRemotes,
+      setViewingScreenShareTrackKey,
+    } = appStore;
+
+    const share = shareOf(voiceState);
+    const shareActive = share.kind === "active";
+    const sharePicking = share.kind === "picking";
+    const shareInFlight = share.kind !== "idle";
+    const shareLocalDims = shareActive ? share.dimensions : null;
+    const isJoining = voiceState.kind === "joining";
+    const micMuted = voiceState.kind === "joined" ? voiceState.micMuted : false;
+
+    const [focusId, setFocusId] = useState<string | null>(null);
+
+    // Drop any fullscreen stream when leaving this view (the viewer is a
+    // global overlay in AppShell and would otherwise stay pinned).
+    React.useEffect(() => {
+      return () => setViewingScreenShareTrackKey(null);
+    }, [setViewingScreenShareTrackKey]);
+
+    const displayNames = disambiguateVoiceNames(voiceParticipants);
+
+    // Map a live VoiceParticipant onto the tile's view model, resolving
+    // whichever screenshare track (local preview or remote) it's publishing.
+    const resolve = (p: VoiceParticipant): StageParticipant => {
+      let streamTrackKey: string | undefined;
+      let streamWidth: number | undefined;
+      let streamHeight: number | undefined;
+      if (p.isLocal && shareActive) {
+        streamTrackKey = LOCAL_PREVIEW_KEY;
+        streamWidth = shareLocalDims?.width;
+        streamHeight = shareLocalDims?.height;
+      } else if (!p.isLocal) {
+        const remote =
+          screenShareRemotes[p.identity] ??
+          screenShareRemotes[voiceUserKey(p.identity)];
+        if (remote) {
+          streamTrackKey = remote.trackKey;
+          streamWidth = remote.width;
+          streamHeight = remote.height;
+        }
+      }
+      return {
+        identity: p.identity,
+        name: displayNames.get(p.identity) ?? p.name,
+        avatarKey: p.avatarKey ?? null,
+        isMuted: p.isMuted,
+        isLocal: p.isLocal,
+        isSpeaking: voiceActiveSpeakerIds.includes(p.identity) && !p.isMuted,
+        connectionQuality: p.connectionQuality,
+        streamTrackKey,
+        streamWidth,
+        streamHeight,
+        isConnecting: p.isLocal && isJoining,
+      };
+    };
+
+    const people = voiceParticipants.map(resolve);
+    const streamers = people.filter((p) => p.streamTrackKey !== undefined);
+    const spotlight = isInCall && streamers.length > 0;
+    const focused =
+      streamers.find((p) => p.identity === focusId) ?? streamers[0] ?? null;
+
+    const previewPeople: StageParticipant[] = observerParticipants.map((p) => ({
+      identity: p.identity,
+      name: p.name,
+      avatarKey: p.avatarKey ?? null,
+      isMuted: false,
+      isLocal: false,
+      isSpeaking: false,
+    }));
+
+    const onView = (trackKey: string) => setViewingScreenShareTrackKey(trackKey);
+
+    return (
+      <div className="vs-stage font-mono text-xs">
+        {/* ---------- header (compact, matches the rest of the app) ---------- */}
+        <div
+          className="flex items-center px-4 flex-shrink-0 h-[var(--bar-h)]"
+          style={{ borderBottom: "1px solid var(--c-border)", color: "var(--c-text-muted)" }}
+        >
+          <button
+            onClick={onBack}
+            aria-label="Back"
+            className="mr-3 inline-flex items-center gap-1 leading-none transition-colors text-[var(--c-text-muted)] hover:text-[var(--c-accent)]"
+          >
+            <ArrowLeft size={12} />
+          </button>
+          <span style={{ flex: 1, color: "var(--c-accent)" }} className="flex items-center gap-1.5">
+            <Volume2 size={12} />
+            {channelName}
+          </span>
+          {headerActions && <div className="flex items-center gap-2">{headerActions}</div>}
+        </div>
+
+        {/* ---------- body ---------- */}
+        <div className="vs-body">
+          {sharePicking ? (
+            <ScreenSharePicker />
+          ) : !isInCall ? (
+            <div className="vs-preview" data-testid="voice-channel-observers">
+              {previewPeople.length === 0 ? (
+                // Empty: label + CTA centered together as one group.
+                <div className="vs-preview-empty">
+                  <span className="vs-preview-empty-label">No one in this channel</span>
+                  <Button data-testid="voice-join-cta" variant="primary" onClick={onJoin}>
+                    Join Voice
+                  </Button>
+                </div>
+              ) : (
+                // Populated: roster, then the CTA pinned below the users.
+                <>
+                  <NavigableGrid<StageParticipant>
+                    items={previewPeople}
+                    getKey={(p) => p.identity}
+                    autoFocus={false}
+                    minCellWidth={180}
+                    maxCellWidth={240}
+                    renderCell={(p, { focused: f }) => (
+                      <StageTile participant={p} mode="preview" focused={f} onView={onView} />
+                    )}
+                  />
+                  <div className="vs-preview-cta">
+                    <Button data-testid="voice-join-cta" variant="primary" onClick={onJoin}>
+                      Join Voice
+                    </Button>
+                  </div>
+                </>
+              )}
+            </div>
+          ) : spotlight ? (
+            <div className="vs-spotlight" data-testid="voice-channel-view">
+              <div className="vs-spot-main">
+                {focused ? (
+                  <StageTile participant={focused} mode="big" onFocus={setFocusId} onView={onView} />
+                ) : (
+                  <div className="vs-tile vs-empty">no active stream</div>
+                )}
+              </div>
+              <div className="vs-film">
+                {people
+                  .filter((p) => !focused || p.identity !== focused.identity)
+                  .map((p) => (
+                    <div key={p.identity} className="vs-film-cell">
+                      <StageTile participant={p} mode="film" onFocus={setFocusId} onView={onView} />
+                    </div>
+                  ))}
+              </div>
+            </div>
+          ) : (
+            <NavigableGrid<StageParticipant>
+              items={people}
+              getKey={(p) => p.identity}
+              testId="voice-channel-view"
+              emptyLabel="Connecting…"
+              autoFocus={false}
+              minCellWidth={180}
+              maxCellWidth={240}
+              renderCell={(p, { focused: f }) => (
+                <StageTile participant={p} mode="grid" focused={f} onView={onView} />
+              )}
+            />
+          )}
+        </div>
+
+        {/* ---------- footer (fixed height) ---------- */}
+        {footer ? (
+          footer
+        ) : (
+          <div className="vs-foot">
+            <div className="vs-foot-side">
+              {isInCall ? (
+                <div className="vs-tray">
+                  <button
+                    className={"vs-tray-btn danger" + (micMuted ? " on" : "")}
+                    data-testid="voice-tray-mute"
+                    title={micMuted ? "Unmute" : "Mute"}
+                    aria-label={micMuted ? "Unmute microphone" : "Mute microphone"}
+                    onClick={() => voiceSession.toggleMute()}
+                  >
+                    {micMuted ? <MicOff size={15} /> : <Mic size={15} />}
+                  </button>
+                  <button
+                    className={"vs-tray-btn" + (shareActive ? " on" : "")}
+                    data-testid="voice-tray-screenshare"
+                    title={shareActive ? "Stop screen share" : shareInFlight ? "Cancel (recover)" : "Share screen"}
+                    aria-label={shareActive ? "Stop screen share" : "Share screen"}
+                    onClick={() => toggleScreenShare(share)}
+                  >
+                    {shareActive ? <MonitorOff size={15} /> : <Monitor size={15} />}
+                  </button>
+                  <div className="vs-tray-sep" />
+                  <button
+                    className="vs-tray-leave"
+                    data-testid="voice-tray-leave"
+                    title="Leave channel"
+                    aria-label="Leave voice channel"
+                    onClick={onLeave}
+                  >
+                    {/* Exit arrow points left (mirrored) — a "leave" gesture. */}
+                    <LogOut size={14} style={{ transform: "scaleX(-1)" }} /> Leave
+                  </button>
+                </div>
+              ) : (
+                <Button data-testid="voice-join-leave-button" variant="primary" size="sm" className="h-[1.75rem]" onClick={onJoin}>
+                  <Phone size={14} /> Join
+                </Button>
+              )}
+            </div>
+            <div className="vs-foot-side right">
+              <button
+                className="flex items-center gap-2 text-xs transition-colors text-[var(--c-text-muted)] hover:text-[var(--c-text)]"
+                data-testid="voice-settings-link"
+                onClick={onOpenSettings}
+              >
+                <SlidersHorizontal size={15} /> Voice Settings
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  },
+);

--- a/frontend/src/components/Voice/stage/voice-stage.css
+++ b/frontend/src/components/Voice/stage/voice-stage.css
@@ -1,0 +1,519 @@
+/* ============================================================
+   VoiceStage — flat amber-POSIX terminal styling.
+   Minimal motion (only when it carries information, e.g. the live audio
+   meter), no gradients, no glow, no frosted transparency.
+   Rounded corners + accent-with-opacity are the only liberties.
+
+   Ported from the design handoff but rewired onto the app's own
+   theme tokens (--c-*) so the stage tracks the user's accent/theme
+   instead of a hard-coded green. Only the red/amber status colors
+   are local constants (the app has no dedicated tokens for them).
+   ============================================================ */
+
+.vs-stage {
+   --vs-r: 10px;
+
+   --vs-bg: var(--c-bg);
+   --vs-panel: var(--c-surface);
+   --vs-panel-2: var(--c-surface-raised);
+   --vs-line: var(--c-border);
+   --vs-border: var(--c-border-active);
+
+   --vs-ink: var(--c-text);
+   --vs-ink-dim: var(--c-text-dim);
+   --vs-ink-faint: var(--c-text-muted);
+
+   --vs-red: hsl(0 70% 60%);
+   --vs-red-dim: hsl(0 70% 50% / 0.5);
+   --vs-amber: #f0c674;
+
+   /* Fixed footer height — keeps the tray row from shifting layout as it
+     swaps between the not-joined Join button and the in-call tray. */
+   --vs-foot-h: var(--bar-h);
+
+   flex: 1;
+   min-width: 0;
+   min-height: 0;
+   display: flex;
+   flex-direction: column;
+   background: var(--vs-bg);
+   color: var(--vs-ink);
+}
+
+/* Inherit the mono font + pointer cursor onto the stage's own bespoke
+   buttons WITHOUT clobbering the reused <Button> component's background /
+   border / color (which it sets via utility classes of equal specificity). */
+.vs-stage button {
+   font-family: inherit;
+   cursor: pointer;
+}
+
+/* ---------- body ---------- */
+.vs-body {
+   flex: 1 1 auto;
+   min-height: 0;
+   display: flex;
+   flex-direction: column;
+}
+
+/* spotlight mode */
+.vs-spotlight {
+   flex: 1;
+   min-height: 0;
+   display: flex;
+   flex-direction: column;
+   padding: 18px;
+   gap: 14px;
+}
+
+.vs-spot-main {
+   flex: 1 1 auto;
+   min-height: 0;
+   display: flex;
+}
+
+.vs-film {
+   flex: 0 0 auto;
+   display: flex;
+   gap: 12px;
+   overflow-x: auto;
+   padding: 2px;
+}
+
+.vs-film-cell {
+   flex: 0 0 208px;
+   width: 208px;
+   aspect-ratio: 16/10;
+}
+
+/* ---------- tile (flat outlined box) ----------
+   Width/height come from the parent (NavigableGrid cell, filmstrip cell,
+   or the spotlight main area). 2px border + 10px radius match the app's
+   existing card/Button treatment. */
+.vs-tile {
+   position: relative;
+   width: 100%;
+   height: 100%;
+   min-width: 0;
+   background: transparent;
+   border: 2px solid var(--vs-line);
+   border-radius: var(--vs-r);
+   overflow: hidden;
+   display: flex;
+   flex-direction: column;
+}
+
+.vs-tile.clickable {
+   cursor: pointer;
+}
+
+.vs-tile.clickable:hover {
+   border-color: var(--vs-border);
+}
+
+.vs-tile.focused {
+   border-color: var(--c-accent);
+}
+
+.vs-tile.speaking {
+   border-color: var(--c-accent);
+}
+
+/* solid border = speaking. no glow */
+.vs-empty {
+   display: grid;
+   place-items: center;
+   color: var(--vs-ink-faint);
+}
+
+.vs-tile-stage {
+   flex: 1 1 auto;
+   position: relative;
+   display: grid;
+   place-items: center;
+   min-height: 0;
+}
+
+.vs-tile-center {
+   display: flex;
+   flex-direction: column;
+   align-items: center;
+}
+
+.vs-mark {
+   color: var(--c-accent);
+}
+
+/* live audio meter — BAND_COUNT bars driven by per-source levels via the
+   --eqN custom properties (set on the element by LiveWaveform). Falls back
+   to a fixed "glyph" shape until levels arrive. Minimal, informational
+   motion only: a short height transition smooths the ~20Hz updates. */
+.vs-eq {
+   display: flex;
+   align-items: flex-end;
+   gap: 3px;
+   height: 16px;
+   margin-top: 11px;
+}
+
+.vs-eq i {
+   width: 3px;
+   border-radius: 1px;
+   background: var(--vs-ink-faint);
+   transition: height 80ms linear;
+}
+
+.vs-tile.speaking .vs-eq i {
+   background: var(--c-accent);
+}
+
+.vs-eq i:nth-child(1) {
+   height: var(--eq0, 45%);
+}
+
+.vs-eq i:nth-child(2) {
+   height: var(--eq1, 100%);
+}
+
+.vs-eq i:nth-child(3) {
+   height: var(--eq2, 60%);
+}
+
+/* corner overlays */
+.vs-tl {
+   position: absolute;
+   top: 8px;
+   left: 8px;
+   z-index: 3;
+   display: flex;
+   align-items: center;
+   gap: 6px;
+   max-width: calc(100% - 16px);
+}
+
+.vs-tr {
+   position: absolute;
+   top: 8px;
+   right: 8px;
+   z-index: 3;
+   display: flex;
+   align-items: center;
+   gap: 6px;
+}
+
+.vs-bl {
+   position: absolute;
+   bottom: 8px;
+   left: 8px;
+   z-index: 3;
+   display: flex;
+   align-items: center;
+   gap: 6px;
+}
+
+.vs-br {
+   position: absolute;
+   bottom: 8px;
+   right: 8px;
+   z-index: 3;
+   display: flex;
+   align-items: center;
+   gap: 6px;
+}
+
+.vs-name {
+   display: inline-flex;
+   align-items: center;
+   gap: 6px;
+   background: var(--vs-panel-2);
+   border: 1px solid var(--vs-line);
+   border-radius: 6px;
+   padding: 3px 8px;
+   font-size: 12px;
+   color: var(--vs-ink);
+   max-width: 100%;
+}
+
+.vs-nm {
+   overflow: hidden;
+   text-overflow: ellipsis;
+   white-space: nowrap;
+}
+
+.vs-name.host {
+   color: var(--c-accent);
+   border-color: var(--vs-border);
+}
+
+.vs-ic {
+   display: grid;
+   place-items: center;
+   color: var(--vs-ink-dim);
+   flex-shrink: 0;
+}
+
+.vs-ic.accent {
+   color: var(--c-accent);
+}
+
+.vs-ic.danger {
+   color: var(--vs-red);
+}
+
+.vs-tag {
+   display: inline-flex;
+   align-items: center;
+   gap: 5px;
+   background: var(--vs-panel-2);
+   border: 1px solid var(--vs-line);
+   border-radius: 6px;
+   padding: 3px 7px;
+   font-size: 11px;
+   color: var(--vs-ink-dim);
+   letter-spacing: .02em;
+}
+
+.vs-pad6 {
+   padding: 3px 6px;
+}
+
+.vs-tag.live {
+   color: var(--vs-red);
+   border-color: var(--vs-red-dim);
+   font-weight: 600;
+   letter-spacing: .08em;
+}
+
+.vs-tag.res {
+   font-variant-numeric: tabular-nums;
+}
+
+/* connection bars (static) */
+.vs-sig {
+   display: flex;
+   align-items: flex-end;
+   gap: 2px;
+   height: 13px;
+}
+
+.vs-sig i {
+   width: 3px;
+   background: var(--vs-ink-faint);
+   border-radius: 1px;
+}
+
+.vs-sig i:nth-child(1) {
+   height: 35%;
+}
+
+.vs-sig i:nth-child(2) {
+   height: 60%;
+}
+
+.vs-sig i:nth-child(3) {
+   height: 85%;
+}
+
+.vs-sig i:nth-child(4) {
+   height: 110%;
+}
+
+.vs-sig.good i {
+   background: var(--c-accent);
+}
+
+.vs-sig.fair i:nth-child(1),
+.vs-sig.fair i:nth-child(2),
+.vs-sig.fair i:nth-child(3) {
+   background: var(--vs-amber);
+}
+
+.vs-sig.poor i:nth-child(1),
+.vs-sig.poor i:nth-child(2) {
+   background: var(--vs-red);
+}
+
+/* hover controls — opaque, instant (no scrim, no fade). Mouse-hover only. */
+.vs-hover {
+   position: absolute;
+   inset: 0;
+   z-index: 4;
+   display: none;
+   align-items: center;
+   justify-content: center;
+   gap: 10px;
+}
+
+.vs-tile:hover .vs-hover {
+   display: flex;
+}
+
+.vs-hbtn {
+   width: 38px;
+   height: 38px;
+   border-radius: 8px;
+   display: grid;
+   place-items: center;
+   background: var(--vs-panel-2);
+   border: 1px solid var(--vs-line);
+   color: var(--vs-ink);
+}
+
+.vs-hbtn:hover {
+   border-color: var(--vs-border);
+   color: var(--c-accent);
+}
+
+/* volume — opaque; persistent in preview, hover/keyboard-focus in-call */
+.vs-vol {
+   position: absolute;
+   left: 8px;
+   right: 8px;
+   bottom: 8px;
+   z-index: 4;
+   display: none;
+   align-items: center;
+   gap: 8px;
+   background: var(--vs-panel-2);
+   border: 1px solid var(--vs-line);
+   border-radius: 7px;
+   padding: 6px 9px;
+}
+
+.vs-tile:hover .vs-vol,
+.vs-tile.focused .vs-vol {
+   display: flex;
+}
+
+.vs-vol.always {
+   display: flex;
+   position: static;
+}
+
+/* ---------- footer call tray (fixed height) ----------
+   Compact 2.5rem bar — controls are sized to fit it (no 44px tiles). */
+.vs-foot {
+   flex: 0 0 auto;
+   height: calc(var(--vs-foot-h) - 1px);
+   display: flex;
+   align-items: center;
+   gap: 12px;
+   padding: 0 12px;
+   border-top: 1px solid var(--c-border);
+
+}
+
+.vs-foot-side {
+   flex: 1 1 0;
+   display: flex;
+   align-items: center;
+   min-width: 0;
+}
+
+.vs-foot-side.right {
+   justify-content: flex-end;
+}
+
+.vs-tray {
+   display: flex;
+   align-items: center;
+   gap: 6px;
+}
+
+.vs-tray-btn {
+   width: 28px;
+   height: 28px;
+   border-radius: 6px;
+   display: grid;
+   place-items: center;
+   background: var(--vs-panel);
+   border: 1px solid var(--vs-line);
+   color: var(--vs-ink);
+}
+
+.vs-tray-btn:hover {
+   border-color: var(--vs-border);
+   color: var(--c-accent);
+}
+
+.vs-tray-btn.on {
+   background: var(--c-accent);
+   color: var(--c-bg);
+   border-color: var(--c-accent);
+}
+
+.vs-tray-btn.danger.on {
+   background: var(--vs-red);
+   color: var(--c-bg);
+   border-color: var(--vs-red);
+}
+
+.vs-tray-leave {
+   display: inline-flex;
+   align-items: center;
+   gap: 6px;
+   height: 28px;
+   padding: 0 10px;
+   border-radius: 6px;
+   background: var(--vs-panel);
+   border: 1px solid var(--vs-red-dim);
+   color: var(--vs-red);
+   font-size: 12px;
+   font-weight: 600;
+   letter-spacing: .04em;
+}
+
+.vs-tray-leave:hover {
+   background: hsl(0 70% 50% / 0.12);
+   border-color: var(--vs-red);
+}
+
+.vs-tray-sep {
+   width: 1px;
+   height: 18px;
+   background: var(--vs-line);
+   margin: 0 2px;
+}
+
+/* ---------- preview (not joined) ---------- */
+.vs-preview {
+   flex: 1 1 auto;
+   min-height: 0;
+   display: flex;
+   flex-direction: column;
+}
+
+/* Empty state: "No one in this channel" + Join Voice centered together. */
+.vs-preview-empty {
+   flex: 1 1 auto;
+   min-height: 0;
+   display: flex;
+   flex-direction: column;
+   align-items: center;
+   justify-content: center;
+   gap: 16px;
+}
+
+.vs-preview-empty-label {
+   font-size: 12px;
+   color: var(--vs-ink-dim);
+}
+
+.vs-preview-cta {
+   flex: 0 0 auto;
+   display: flex;
+   align-items: center;
+   justify-content: center;
+   padding: 16px;
+}
+
+/* scrollbars */
+.vs-film::-webkit-scrollbar {
+   width: 9px;
+   height: 9px;
+}
+
+.vs-film::-webkit-scrollbar-thumb {
+   background: var(--c-border);
+   border-radius: 5px;
+}

--- a/frontend/src/components/ui/TerminalMenu.tsx
+++ b/frontend/src/components/ui/TerminalMenu.tsx
@@ -157,8 +157,9 @@ export const TerminalMenu: React.FC<TerminalMenuProps> = ({
     >
       {/* Keyboard hints */}
       <div
-        className="flex items-center gap-1 px-4 py-2 text-xs font-mono flex-shrink-0"
+        className="flex items-center gap-1 px-4 text-xs font-mono flex-shrink-0"
         style={{
+          height: "var(--bar-h)",
           borderBottom: "1px solid var(--c-border)",
           color: "var(--c-text-muted)",
         }}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -21,6 +21,8 @@
     /* background lightness */
     --font-size-base: 15px;
     /* base font size — scales all rem units */
+    --bar-h: 2.5rem;
+    /* shared chrome bar height — sidebar section headers, voice stage header/footer */
 
     /* ── Surfaces (dark, hue-tinted) ──────────────────────────────── */
     --c-bg: hsl(var(--bg-h) var(--bg-s) var(--bg-l));

--- a/frontend/src/pages/Channel.tsx
+++ b/frontend/src/pages/Channel.tsx
@@ -45,8 +45,9 @@ export const ChannelPage: React.FC = observer(() => {
   return (
     <div className="flex flex-col h-full">
       <div
-        className="flex items-center px-4 py-[7px] flex-shrink-0 text-xs font-mono"
+        className="flex items-center px-4 flex-shrink-0 text-xs font-mono"
         style={{
+          height: "var(--bar-h)",
           borderBottom: "1px solid var(--c-border)",
           color: "var(--c-text-muted)",
         }}

--- a/frontend/src/pages/DM.tsx
+++ b/frontend/src/pages/DM.tsx
@@ -147,8 +147,9 @@ export const DMPage: React.FC = observer(() => {
   return (
     <div className="flex flex-col h-full">
       <div
-        className="flex items-center px-4 py-2 flex-shrink-0 text-xs font-mono"
+        className="flex items-center px-4 flex-shrink-0 text-xs font-mono"
         style={{
+          height: "var(--bar-h)",
           borderBottom: "1px solid var(--c-border)",
           color: "var(--c-text-muted)",
         }}

--- a/frontend/src/pages/VoiceChannel.tsx
+++ b/frontend/src/pages/VoiceChannel.tsx
@@ -1,15 +1,13 @@
 import React, { useEffect, useRef } from "react";
 import { useNavigate, useParams } from "@tanstack/react-router";
-import { ArrowLeft, Pencil, Trash2, Volume2, X } from "lucide-react";
+import { Pencil, Trash2, X } from "lucide-react";
 import { observer } from "mobx-react-lite";
 import { appStore } from "../stores/appStore";
 import { useDeleteChannel, useUserGroupsWithChannels } from "../hooks/queries/useGroups";
-import { VoiceChannelView } from "../components/Voice/VoiceChannelView";
-import { VoiceMemberTile } from "../components/Voice/VoiceMemberTile";
+import { VoiceStage } from "../components/Voice/stage/VoiceStage";
 import { useVoiceParticipants } from "../hooks/queries/useVoiceParticipants";
 import { usePreferences } from "../hooks/queries/usePreferences";
 import { Button } from "../components/ui/Button";
-import { NavigableGrid } from "../components/ui/NavigableGrid";
 import type { VoiceParticipant } from "../types";
 import { warmVoiceChannel } from "../utils/voiceWarmup";
 import { voiceSession } from "../voice";
@@ -93,152 +91,93 @@ export const VoiceChannelPage: React.FC = observer(() => {
   }, [preferences.query.data]);
 
 
-  return (
-    <div className="flex flex-col h-full font-mono text-xs">
-      {/* Header */}
-      <div
-        className="flex items-center px-4 py-2 flex-shrink-0"
-        style={{ borderBottom: "1px solid var(--c-border)", color: "var(--c-text-muted)" }}
-      >
+  // Admin rename/delete affordances live in the stage header, right of
+  // the pills and left of Join/Leave. Hidden while the delete bar is open.
+  const headerActions =
+    isAdmin && channel && !isPendingDelete ? (
+      <>
         <button
-          onClick={() => navigate({ to: "/groups/$groupId", params: { groupId } })}
-          className="mr-3 inline-flex items-center gap-1 leading-none transition-colors text-[var(--c-text-muted)] hover:text-[var(--c-accent)]"
+          data-testid="rename-channel-trigger"
+          onClick={() =>
+            navigate({
+              to: "/groups/$groupId/channels/$channelId/rename",
+              params: { groupId, channelId },
+            })
+          }
+          aria-label="Rename channel"
+          className="icon-btn-sm flex-shrink-0"
         >
-          <ArrowLeft size={12} />
+          <Pencil size={14} aria-hidden="true" />
         </button>
-        <span style={{ flex: 1, color: "var(--c-accent)" }} className="flex items-center gap-1.5">
-          <Volume2 size={12} />
-          {channelName}
-        </span>
-        {isAdmin && channel && !isPendingDelete && (
-          <div className="flex items-center gap-2">
-            <button
-              data-testid="rename-channel-trigger"
-              onClick={() => navigate({ to: "/groups/$groupId/channels/$channelId/rename", params: { groupId, channelId } })}
-              aria-label="Rename channel"
-              className="icon-btn-sm flex-shrink-0"
-            >
-              <Pencil size={14} aria-hidden="true" />
-            </button>
-            <button
-              data-testid="delete-channel-trigger"
-              onClick={() => setPendingDeleteChannelId(channelId)}
-              aria-label="Delete channel"
-              className="icon-btn-sm flex-shrink-0"
-            >
-              <Trash2 size={14} aria-hidden="true" />
-            </button>
-          </div>
-        )}
-      </div>
-
-      {/* Join / Leave button */}
-      <div className="px-4 pt-4 pb-4 flex-shrink-0">
-        <Button
-          data-testid="voice-join-leave-button"
-          variant={isInCall ? "danger" : "primary"}
-          autoFocus
-          onClick={() => isInCall ? voiceSession.leave() : voiceSession.setIntent({ channelId, groupId })}
+        <button
+          data-testid="delete-channel-trigger"
+          onClick={() => setPendingDeleteChannelId(channelId)}
+          aria-label="Delete channel"
+          className="icon-btn-sm flex-shrink-0"
         >
-          {isInCall ? "Leave" : "Join"}
+          <Trash2 size={14} aria-hidden="true" />
+        </button>
+      </>
+    ) : null;
+
+  // The pending-delete confirmation replaces the stage footer, following
+  // the established replace-the-bar pattern (no modal).
+  const deleteFooter = isPendingDelete ? (
+    <div data-testid="delete-channel-bar">
+      <div
+        className="flex items-center gap-2 px-4 py-1.5 flex-shrink-0"
+        style={{ borderTop: "1px solid var(--c-border)", background: "var(--c-surface)" }}
+      >
+        <span className="flex-1 text-2xs font-mono uppercase tracking-widest" style={{ color: "var(--c-text-muted)" }}>
+          delete channel
+        </span>
+        <button
+          data-testid="delete-channel-cancel"
+          onClick={() => setPendingDeleteChannelId(null)}
+          aria-label="Cancel delete"
+          className="icon-btn-sm flex-shrink-0"
+        >
+          <X size={20} aria-hidden="true" />
+        </button>
+      </div>
+      <div
+        className="flex items-center justify-between gap-4 px-4 pb-3 pt-2"
+        style={{ background: "var(--c-surface)" }}
+      >
+        <p className="text-xs font-mono" style={{ color: "var(--c-text-dim)" }}>
+          This voice channel and any in-call state will be permanently deleted. This cannot be undone.
+        </p>
+        <Button
+          data-testid="delete-channel-confirm"
+          variant="danger"
+          onClick={handleConfirmDelete}
+          isLoading={deleteChannelMutation.isPending}
+          loadingText="Deleting…"
+          autoFocus
+        >
+          Delete
         </Button>
       </div>
-
-      {/* Participant list. When the user is IN the call we show the live
-          VoiceChannelView (active speakers, screenshare streams,
-          connection quality). When they're a bystander we show the same
-          tile grid in an inert variant — no speaking indicators, no
-          stream rendering — so the layout is identical the moment they
-          hit Join. */}
-      {isInCall ? (
-        <VoiceChannelView />
-      ) : (
-        <div
-          className="flex-1 flex flex-col font-mono text-xs min-h-0"
-          style={{
-            borderTop: "1px solid var(--c-border)",
-            borderBottom: "1px solid var(--c-border)",
-          }}
-        >
-          <NavigableGrid<VoiceParticipant>
-            items={observerParticipants.map((p): VoiceParticipant => ({
-              identity: p.identity,
-              name: p.name,
-              avatarKey: p.avatar_url ?? null,
-              isMuted: false,
-              isLocal: false,
-            }))}
-            getKey={(p) => p.identity}
-            testId="voice-channel-observers"
-            emptyLabel="No one in this channel"
-            autoFocus={false}
-            minCellWidth={180}
-            maxCellWidth={240}
-            renderCell={(p, { focused }) => (
-              <VoiceMemberTile
-                identity={p.identity}
-                name={p.name}
-                avatarKey={p.avatarKey ?? null}
-                isMuted={false}
-                isLocal={false}
-                isSpeaking={false}
-                focused={focused}
-                // No stream props in the inert preview, so onView is
-                // never reachable — `isStreaming ? () => onView(...) : undefined`
-                // in VoiceMemberTile.tsx:192 short-circuits to undefined.
-                onView={() => {}}
-              />
-            )}
-          />
-        </div>
-      )}
-
-      {/* Voice settings link, replaced by the delete-confirm bar when an
-          admin has triggered channel deletion. */}
-      {isPendingDelete ? (
-        <div data-testid="delete-channel-bar">
-          <div
-            className="flex items-center gap-2 px-4 py-1.5 flex-shrink-0"
-            style={{ borderTop: "1px solid var(--c-border)", background: "var(--c-surface)" }}
-          >
-            <span className="flex-1 text-2xs font-mono uppercase tracking-widest" style={{ color: "var(--c-text-muted)" }}>
-              delete channel
-            </span>
-            <button
-              data-testid="delete-channel-cancel"
-              onClick={() => setPendingDeleteChannelId(null)}
-              aria-label="Cancel delete"
-              className="icon-btn-sm flex-shrink-0"
-            >
-              <X size={20} aria-hidden="true" />
-            </button>
-          </div>
-          <div
-            className="flex items-center justify-between gap-4 px-4 pb-3 pt-2"
-            style={{ background: "var(--c-surface)" }}
-          >
-            <p className="text-xs font-mono" style={{ color: "var(--c-text-dim)" }}>
-              This voice channel and any in-call state will be permanently deleted. This cannot be undone.
-            </p>
-            <Button
-              data-testid="delete-channel-confirm"
-              variant="danger"
-              onClick={handleConfirmDelete}
-              isLoading={deleteChannelMutation.isPending}
-              loadingText="Deleting…"
-              autoFocus
-            >
-              Delete
-            </Button>
-          </div>
-        </div>
-      ) : (
-        <div className="px-4 py-3 flex-shrink-0">
-          <Button variant="secondary" onClick={() => navigate({ to: "/voice-settings" })}>
-            Voice Settings
-          </Button>
-        </div>
-      )}
     </div>
+  ) : undefined;
+
+  return (
+    <VoiceStage
+      channelName={channelName}
+      isInCall={isInCall}
+      observerParticipants={observerParticipants.map((p): VoiceParticipant => ({
+        identity: p.identity,
+        name: p.name,
+        avatarKey: p.avatar_url ?? null,
+        isMuted: false,
+        isLocal: false,
+      }))}
+      onJoin={() => voiceSession.setIntent({ channelId, groupId })}
+      onLeave={() => voiceSession.leave()}
+      onBack={() => navigate({ to: "/groups/$groupId", params: { groupId } })}
+      onOpenSettings={() => navigate({ to: "/voice-settings" })}
+      headerActions={headerActions}
+      footer={deleteFooter}
+    />
   );
 });

--- a/frontend/src/screenshare/screenShareActions.ts
+++ b/frontend/src/screenshare/screenShareActions.ts
@@ -1,0 +1,66 @@
+// Shared screen-share toggle action. Drives the enumerate → pick → start
+// flow (and the stop / cancel / recover branches) from a single place so
+// the green VoiceBar and the in-call voice stage tray behave identically.
+//
+// On macOS we enumerate via SCShareableContent and route to our in-app
+// picker — the system picker (SCContentSharingPicker) has an upstream
+// crate bug that crashes on selection (#283). On Linux/Windows the helper
+// falls back to the system portal / WGC picker, signalled by an empty
+// source list from enumerate() — in that case we skip our picker and go
+// straight to start().
+
+import { appStore } from "../stores/appStore";
+import {
+  friendlyScreenShareError,
+  screenShareSession,
+} from "./screenShareSession";
+import type { ShareState } from "../types/voice-state";
+
+export function toggleScreenShare(share: ShareState): void {
+  // Already sharing → stop.
+  if (share.kind === "active") {
+    screenShareSession
+      .stop()
+      .catch((e) => console.error("[screenshare] stop", e));
+    return;
+  }
+
+  // Picker open → button doubles as a cancel affordance.
+  if (share.kind === "picking") {
+    screenShareSession
+      .cancelPicker()
+      .catch((e) => console.warn("[screenshare] cancel:", e))
+      .finally(() => {
+        appStore.shareCancelPicker();
+      });
+    return;
+  }
+
+  // Any other non-idle state (e.g. a 'starting' that wedged because
+  // publishTrack hung on a dead Wayland-portal track, or 'failed') —
+  // let the button recover by force-stopping. shareStopped() is safe
+  // from any joined-state.
+  if (share.kind !== "idle") {
+    screenShareSession
+      .stop()
+      .catch((e) => console.warn("[screenshare] force-stop:", e));
+    return;
+  }
+
+  // Engage enumerate → pick → start. The backend returns an empty list on
+  // Linux/Windows; in that case we skip our picker and go straight to
+  // start() (system portal/WGC handles selection).
+  (async () => {
+    try {
+      const list = await screenShareSession.enumerate();
+      if (list.displays.length + list.windows.length === 0) {
+        await screenShareSession.start();
+        return;
+      }
+      appStore.shareStartPicking(list);
+    } catch (e) {
+      console.error("[screenshare] enumerate:", e);
+      appStore.shareFailed(friendlyScreenShareError(String(e)));
+    }
+  })();
+}

--- a/frontend/src/voice/VoiceSessionManager.ts
+++ b/frontend/src/voice/VoiceSessionManager.ts
@@ -5,6 +5,7 @@ import { appStore } from '../stores/appStore';
 import type { VoiceParticipant, VoiceConnectionQuality } from '../types';
 import type { ApmConfig, PreferencesData } from '../hooks/queries/usePreferences';
 import { preferencesToApmConfig } from '../hooks/queries/usePreferences';
+import { audioLevels } from './audioLevels';
 
 const VOICE_DEVICES_KEY = 'pollis:voice-devices';
 
@@ -24,6 +25,7 @@ export type VoiceEvent =
   | { type: 'unmuted'; identity: string }
   | { type: 'speaking_started'; identity: string }
   | { type: 'speaking_stopped'; identity: string }
+  | { type: 'audio_bands'; identity: string; bands: number[] }
   | { type: 'connection_quality_changed'; identity: string; quality: VoiceConnectionQuality }
   | {
       type: 'voice_e2ee_key_rotated';
@@ -595,6 +597,7 @@ class VoiceSessionManager {
         break;
       }
       case 'participant_left': {
+        audioLevels.clear(event.identity);
         const participants = this.state.participants.filter((p) => p.identity !== event.identity);
         const wasSpeaker = this.state.activeSpeakerIds.includes(event.identity);
         const activeSpeakerIds = wasSpeaker
@@ -636,6 +639,13 @@ class VoiceSessionManager {
           isLocalSpeaking:
             event.identity === localIdentity ? false : this.state.isLocalSpeaking,
         });
+        break;
+      }
+      case 'audio_bands': {
+        // High-frequency cosmetic data — forward straight to the per-tile
+        // meter pub/sub, deliberately bypassing setState so it never
+        // triggers a React/MobX re-render. See `audioLevels.ts`.
+        audioLevels.push(event.identity, event.bands);
         break;
       }
       case 'connection_quality_changed': {

--- a/frontend/src/voice/audioLevels.ts
+++ b/frontend/src/voice/audioLevels.ts
@@ -1,0 +1,63 @@
+// Per-source multi-band audio levels, pushed from Rust at ~20 Hz via the
+// `audio_bands` voice event. Kept OUT of the MobX/React-Query state on
+// purpose: this is high-frequency cosmetic data (N participants × ~20 Hz)
+// and routing it through observable state would thrash every tile 20×/sec.
+//
+// Instead it's a tiny per-identity pub/sub. The participant tile's live
+// waveform subscribes and writes CSS variables straight onto its bar
+// element via a ref — so the meter animates with zero React re-renders.
+// Mirrors the `livekitView.onStats` / `useScreenShareStats` pattern.
+
+/** Band count — MUST match `levels::BAND_COUNT` in pollis-core. */
+export const BAND_COUNT = 3;
+
+type Listener = (bands: number[]) => void;
+
+class AudioLevels {
+  private listeners = new Map<string, Set<Listener>>();
+  private latest = new Map<string, number[]>();
+
+  subscribe(identity: string, cb: Listener): () => void {
+    let set = this.listeners.get(identity);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(identity, set);
+    }
+    set.add(cb);
+    return () => {
+      const s = this.listeners.get(identity);
+      if (!s) {
+        return;
+      }
+      s.delete(cb);
+      if (s.size === 0) {
+        this.listeners.delete(identity);
+      }
+    };
+  }
+
+  /** Latest snapshot for an identity, if one has arrived (for seeding a
+   *  freshly-mounted subscriber before the next push). */
+  get(identity: string): number[] | undefined {
+    return this.latest.get(identity);
+  }
+
+  /** Called from the voice event handler when an `audio_bands` event lands. */
+  push(identity: string, bands: number[]): void {
+    this.latest.set(identity, bands);
+    const set = this.listeners.get(identity);
+    if (!set) {
+      return;
+    }
+    for (const cb of set) {
+      cb(bands);
+    }
+  }
+
+  /** Drop a participant's cached level (e.g. when they leave). */
+  clear(identity: string): void {
+    this.latest.delete(identity);
+  }
+}
+
+export const audioLevels = new AudioLevels();

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -6,23 +6,41 @@ export default {
   ],
   theme: {
     extend: {
+      // Design tokens live as CSS custom properties in index.css (single
+      // source of truth — themeable + font-scalable). Surface them as
+      // semantic Tailwind utilities so call sites write `text-muted` /
+      // `border-line` / `h-bar` instead of `[var(--c-text-muted)]` or an
+      // inline style. See CLAUDE.md → "Styling" for the convention.
       colors: {
-        accent: {
-          DEFAULT: 'var(--c-accent)',
-          bright:  'var(--c-accent-bright)',
-          dim:     'var(--c-accent-dim)',
-          muted:   'var(--c-accent-muted)',
-          ghost:   'var(--c-hover)',
-          subtle:  'var(--c-active)',
-          border:  'var(--c-border)',
-          active:  'var(--c-border-active)',
-        },
+        bg: 'var(--c-bg)',
         surface: {
           DEFAULT: 'var(--c-surface)',
           raised:  'var(--c-surface-raised)',
           high:    'var(--c-surface-high)',
         },
-        bg: 'var(--c-bg)',
+        accent: {
+          DEFAULT: 'var(--c-accent)',
+          bright:  'var(--c-accent-bright)',
+          dim:     'var(--c-accent-dim)',
+          muted:   'var(--c-accent-muted)',
+        },
+        // Foreground / text roles → `text-fg` `text-dim` `text-muted`.
+        fg:    'var(--c-text)',
+        dim:   'var(--c-text-dim)',
+        muted: 'var(--c-text-muted)',
+        // Hairline borders / dividers → `border-line` `border-line-strong`,
+        // also `bg-line` for the rare hairline fill (e.g. tray separator).
+        line: {
+          DEFAULT: 'var(--c-border)',
+          strong:  'var(--c-border-active)',
+        },
+        // Hover overlay (accent @ low alpha) → `hover:bg-hover`.
+        hover: 'var(--c-hover)',
+      },
+      // `--bar-h` is the shared chrome-bar height (rem ⇒ font-scalable).
+      // Exposed via spacing so `h-bar` / `min-h-bar` / `py-bar` all work.
+      spacing: {
+        bar: 'var(--bar-h)',
       },
       fontFamily: {
         mono: ['"DM Mono"', 'ui-monospace', 'monospace'],

--- a/pollis-core/src/commands/voice/levels.rs
+++ b/pollis-core/src/commands/voice/levels.rs
@@ -1,0 +1,136 @@
+//! Per-source multi-band audio level analysis for the participant-tile
+//! "live waveform" meter. We already compute a per-frame peak for speaking
+//! detection (see `playback.rs` / `lifecycle.rs`) and throw it away; this
+//! turns the same PCM into a small bank of band envelopes so the UI can
+//! show a real, per-source meter instead of a static glyph.
+//!
+//! Deliberately cheap: a fixed bank of 2nd-order bandpass biquads (RBJ
+//! cookbook, constant 0 dB peak gain) with a peak-hold envelope follower.
+//! No FFT, no allocation in the hot path. For mono voice at 48 kHz this is
+//! a few million flops/sec across all bands — negligible next to the codec
+//! and APM. The result is decimated to ~20 Hz before it leaves Rust.
+
+use std::f32::consts::PI;
+
+/// Number of frequency bands. MUST stay in sync with the renderer
+/// (`frontend/src/voice/audioLevels.ts` `BAND_COUNT`). Voice energy is
+/// concentrated low/low-mid, so three wide bands capture it well — five
+/// narrow bands left the top two near-dead for normal speech.
+pub const BAND_COUNT: usize = 3;
+
+/// Band centers across the voice-relevant range (Hz): fundamentals/low
+/// formants, the main formant region, and consonant/sibilance energy.
+const CENTERS_HZ: [f32; BAND_COUNT] = [250.0, 800.0, 2000.0];
+
+/// Bandpass Q. Low Q = wide bands that integrate more energy → a meter
+/// that actually moves at conversational levels.
+const Q: f32 = 1.0;
+
+/// i16 band-envelope magnitude that maps to a full bar. Each bandpass only
+/// passes a slice of the signal, so per-band envelopes are a fraction of
+/// the full-band peak — this reference is set low (with a perceptual curve
+/// in `levels()`) so normal speech a foot from the mic fills the bars.
+const REF: f32 = 2000.0;
+
+/// Direct-Form-I biquad. Coefficients are pre-normalized by a0.
+struct Biquad {
+    b0: f32,
+    b1: f32,
+    b2: f32,
+    a1: f32,
+    a2: f32,
+    x1: f32,
+    x2: f32,
+    y1: f32,
+    y2: f32,
+}
+
+impl Biquad {
+    /// RBJ bandpass with constant 0 dB peak gain.
+    fn bandpass(sample_rate: u32, center_hz: f32, q: f32) -> Self {
+        let w0 = 2.0 * PI * center_hz / sample_rate as f32;
+        let (sin_w0, cos_w0) = w0.sin_cos();
+        let alpha = sin_w0 / (2.0 * q);
+
+        let b0 = alpha;
+        let b1 = 0.0;
+        let b2 = -alpha;
+        let a0 = 1.0 + alpha;
+        let a1 = -2.0 * cos_w0;
+        let a2 = 1.0 - alpha;
+
+        Self {
+            b0: b0 / a0,
+            b1: b1 / a0,
+            b2: b2 / a0,
+            a1: a1 / a0,
+            a2: a2 / a0,
+            x1: 0.0,
+            x2: 0.0,
+            y1: 0.0,
+            y2: 0.0,
+        }
+    }
+
+    #[inline]
+    fn process(&mut self, x: f32) -> f32 {
+        let y = self.b0 * x + self.b1 * self.x1 + self.b2 * self.x2
+            - self.a1 * self.y1
+            - self.a2 * self.y2;
+        self.x2 = self.x1;
+        self.x1 = x;
+        self.y2 = self.y1;
+        self.y1 = y;
+        y
+    }
+}
+
+/// A bank of bandpass filters + per-band peak-hold envelopes.
+pub struct BandAnalyzer {
+    bands: Vec<Biquad>,
+    env: [f32; BAND_COUNT],
+    /// Per-sample release coefficient (~60 ms decay).
+    decay: f32,
+}
+
+impl BandAnalyzer {
+    pub fn new(sample_rate: u32) -> Self {
+        let bands = CENTERS_HZ
+            .iter()
+            .map(|&c| Biquad::bandpass(sample_rate, c, Q))
+            .collect();
+        // exp(-1 / (fs * 0.06)) — ~60 ms to decay by 1/e.
+        let decay = (-1.0 / (sample_rate as f32 * 0.06)).exp();
+        Self {
+            bands,
+            env: [0.0; BAND_COUNT],
+            decay,
+        }
+    }
+
+    /// Feed one frame of mono i16 samples through the bank, updating the
+    /// per-band envelopes (instant attack, slow release).
+    pub fn process(&mut self, samples: &[i16]) {
+        for &s in samples {
+            let x = s as f32;
+            for i in 0..BAND_COUNT {
+                let mag = self.bands[i].process(x).abs();
+                if mag > self.env[i] {
+                    self.env[i] = mag;
+                } else {
+                    self.env[i] *= self.decay;
+                }
+            }
+        }
+    }
+
+    /// Current per-band levels, normalized to 0..1 with a perceptual
+    /// (sqrt) curve so quiet-but-audible speech reads as real movement
+    /// instead of a barely-lifted floor.
+    pub fn levels(&self) -> Vec<f32> {
+        self.env
+            .iter()
+            .map(|&e| (e / REF).clamp(0.0, 1.0).sqrt())
+            .collect()
+    }
+}

--- a/pollis-core/src/commands/voice/lifecycle.rs
+++ b/pollis-core/src/commands/voice/lifecycle.rs
@@ -27,6 +27,7 @@ use crate::{
 };
 
 use super::devices::get_device;
+use super::levels::BandAnalyzer;
 use super::playback::{ensure_playback, register_remote_track};
 use super::streams::start_mic_stream;
 use super::types::{
@@ -446,6 +447,13 @@ pub async fn join_voice_channel(
         let mut onset_frames: u32 = 0; // consecutive above-threshold frames; 2 required to (re)trigger
         let mut is_speaking = false;
 
+        // Live multi-band meter for our own tile. Sink cloned once so the
+        // per-frame emit never re-locks the shared VoiceState mutex. Emit
+        // every 5 chunks (~10 ms each) ⇒ ~20 Hz.
+        let bands_sink = voice_arc_frame.lock().await.channel.clone();
+        let mut analyzer = BandAnalyzer::new(mic_rate);
+        let mut bands_ctr: u32 = 0;
+
         while let Some((samples, rate)) = frame_rx.recv().await {
             buf.extend_from_slice(&samples);
             while buf.len() >= chunk_size {
@@ -495,6 +503,21 @@ pub async fn join_voice_channel(
                         } else {
                             let _ = ch.send(VoiceEvent::SpeakingStopped { identity: local_identity_for_speaking.clone() });
                         }
+                    }
+                }
+
+                // Live band meter on the post-APM signal (same source as
+                // the speaking indicator, so the meter matches what others
+                // hear). Decimated to ~20 Hz.
+                analyzer.process(&chunk);
+                bands_ctr += 1;
+                if bands_ctr >= 5 {
+                    bands_ctr = 0;
+                    if let Some(ch) = &bands_sink {
+                        let _ = ch.send(VoiceEvent::AudioBands {
+                            identity: local_identity_for_speaking.clone(),
+                            bands: analyzer.levels(),
+                        });
                     }
                 }
 

--- a/pollis-core/src/commands/voice/mod.rs
+++ b/pollis-core/src/commands/voice/mod.rs
@@ -4,6 +4,7 @@
 //! `voice_test.rs`) keeps resolving names at `pollis_core::commands::voice::*`.
 
 mod devices;
+mod levels;
 mod lifecycle;
 mod playback;
 mod streams;

--- a/pollis-core/src/commands/voice/playback.rs
+++ b/pollis-core/src/commands/voice/playback.rs
@@ -19,10 +19,14 @@ use crate::{
 };
 
 use super::devices::get_device;
+use super::levels::BandAnalyzer;
 use super::streams::start_speaker_stream;
 use super::types::{
     user_id_from_voice_identity, TrackBuffers, VoiceEvent, VoiceState, TRACK_BUFFER_CAP_SAMPLES,
 };
+
+/// Emit an AudioBands event every N drained frames (~10 ms each) ⇒ ~20 Hz.
+const BANDS_EMIT_EVERY: u32 = 5;
 
 // ── Mixer + per-track drain ───────────────────────────────────────────────
 
@@ -43,9 +47,29 @@ async fn run_drain_task(
     let mut speak_hold: u32 = 0;
     let mut is_speaking = false;
 
+    // Live multi-band meter. Clone the event sink once so the hot loop never
+    // has to re-lock the shared VoiceState mutex just to publish levels.
+    let event_sink = voice_arc.lock().await.channel.clone();
+    let mut analyzer = BandAnalyzer::new(sample_rate);
+    let mut bands_ctr: u32 = 0;
+
     eprintln!("[voice] remote drain task started for {track_key}");
     while let Some(frame) = audio_stream.next().await {
         let peak = frame.data.iter().map(|&s| s.abs()).max().unwrap_or(0);
+
+        // Feed the same PCM to the band analyzer and publish a decimated
+        // snapshot. Cheap, allocation-free until the (rare) emit.
+        analyzer.process(&frame.data);
+        bands_ctr += 1;
+        if bands_ctr >= BANDS_EMIT_EVERY {
+            bands_ctr = 0;
+            if let Some(ch) = &event_sink {
+                let _ = ch.send(VoiceEvent::AudioBands {
+                    identity: participant_identity.clone(),
+                    bands: analyzer.levels(),
+                });
+            }
+        }
 
         if peak > 1000 {
             onset_frames += 1;

--- a/pollis-core/src/commands/voice/types.rs
+++ b/pollis-core/src/commands/voice/types.rs
@@ -90,6 +90,11 @@ pub enum VoiceEvent {
     Unmuted { identity: String },
     SpeakingStarted { identity: String },
     SpeakingStopped { identity: String },
+    /// Per-source multi-band audio levels (one 0..1 value per band),
+    /// emitted ~20 Hz while in a call to drive the participant tile's live
+    /// meter. Best-effort and purely cosmetic — drop freely. Band count is
+    /// fixed (`levels::BAND_COUNT`); keep the renderer in sync.
+    AudioBands { identity: String, bands: Vec<f32> },
     /// LiveKit's per-participant categorical connection quality. The Rust
     /// SDK doesn't expose RTT in ms here — this is the only signal it
     /// surfaces — so the UI shows a lagging-dot rather than a number.


### PR DESCRIPTION
Redesigns the voice channel main content area (from the design handoff), adds a real per-source audio meter, unifies chrome-bar heights, and completes the Tailwind design-token system.

## Highlights
- **Voice stage redesign** — new `VoiceStage`/`StageTile` (header / preview / spotlight / grid + call tray), reusing `Button`, `Avatar`, `RemoteVideoTile`, `RemoteUserVolumeSlider`; lucide icons; app theme tokens. Restores the in-app screenshare source picker in-stage and extracts a shared `toggleScreenShare` helper (also used by `VoiceBar`).
- **Live per-source audio meter** — Rust biquad bandpass bank + envelope (`levels.rs`) emits a decimated `AudioBands` event (~20Hz) from the local and remote loops; a tiny per-tile pub/sub drives the tile bars via CSS vars, bypassing React/MobX. 3 voice-tuned bands.
- **Fullscreen viewer** — now shows resolution **and** fps.
- **Chrome-bar height** — single global `--bar-h` token applied to sidebar section headers, settings pages (`PageShell`), `TerminalMenu`, group/DM chat headers, and the voice stage header/footer.
- **Styling system** — completed the Tailwind design-token theme (`text-fg/dim/muted`, `border-line`, `bg-surface/accent`, `hover`, `h-bar`), replaced the bespoke `rem()` helper in `Sidebar` with token-backed utilities, and documented the Tailwind-first / rem-for-scalable convention in `CLAUDE.md`.

The styling-system cleanup chips at the frontend refactor backlog — relates to #306 (does not close it).

## Verification
- `cargo check` + `pnpm build:pollis-node:debug` clean; frontend `tsc` + `vite build` clean.
- Voice preview (empty + populated), sidebar (pixel-identical post-refactor), and settings headers verified via screenshots in the real Electron app.
- The live audio meter compiles end-to-end but needs a real LiveKit call to verify audibly — DSP gain may want a nudge after listening.