### PR TITLE
LiveKit→rtc.pollis.com + transparency verify.pollis.com live

### DIFF
--- a/.github/workflows/verifier-release.yml
+++ b/.github/workflows/verifier-release.yml
@@ -1,0 +1,105 @@
+name: Transparency Verifier CLI
+
+# Builds the standalone transparency-log verifier CLI (the `serve` binary's
+# `verify-remote` / `verify-group` subcommands) so security analysts can verify
+# https://verify.pollis.com themselves, from their own machine.
+#
+# Trigger:
+#   * Tag push `verifier-v*` (e.g. `git tag verifier-v0.1.0 && git push origin
+#     verifier-v0.1.0`) — builds every target AND publishes a GitHub Release
+#     with the binaries + SHA256SUMS attached.
+#   * workflow_dispatch — builds every target and uploads them as run artifacts
+#     (no Release), for testing the pipeline without cutting a tag.
+#
+# Tag prefix is `verifier-v*` so it never collides with the app's `v*` release
+# tags handled by electron-release.yml.
+
+on:
+  push:
+    tags:
+      - "verifier-v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: build ${{ matrix.asset }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            asset: pollis-verify-linux-x86_64
+          - os: macos-14
+            target: aarch64-apple-darwin
+            asset: pollis-verify-macos-arm64
+          - os: macos-13
+            target: x86_64-apple-darwin
+            asset: pollis-verify-macos-x86_64
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: verifier-${{ matrix.target }}
+
+      - name: Build verifier
+        run: cargo build --release --locked -p verifiable-log-serve --bin serve --target ${{ matrix.target }}
+
+      - name: Package binary + checksum
+        shell: bash
+        run: |
+          mkdir -p dist
+          cp "target/${{ matrix.target }}/release/serve" "dist/${{ matrix.asset }}"
+          cd dist
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "${{ matrix.asset }}" > "${{ matrix.asset }}.sha256"
+          else
+            shasum -a 256 "${{ matrix.asset }}" > "${{ matrix.asset }}.sha256"
+          fi
+
+      - name: Upload run artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset }}
+          path: dist/*
+
+      - name: Publish to GitHub Release (tag pushes only)
+        if: startsWith(github.ref, 'refs/tags/verifier-v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          body: |
+            ## Pollis transparency-log verifier
+
+            Independently verify the public transparency log at
+            **https://verify.pollis.com** — no trust in Pollis required beyond
+            the published Ed25519 public key.
+
+            **Pinned public key:**
+            `175ebfef98fc6b20c67c4cba9d4a36a4f85f05afa4e31f707e7d7e3c02227148`
+
+            ### Usage
+            ```bash
+            # verify the entire log (signatures, inclusion proofs, consistency)
+            ./pollis-verify-<platform> verify-remote https://verify.pollis.com
+
+            # verify one conversation's commit chain (use a conversation id, not a name)
+            ./pollis-verify-<platform> verify-group \
+              --base https://verify.pollis.com \
+              --group <CONVERSATION_ID>
+            ```
+            Exit code is non-zero if any check fails. Add `--json` to
+            `verify-group` for machine-readable output.
+
+            Verify the download against the matching `*.sha256` file.

--- a/.github/workflows/verifier-release.yml
+++ b/.github/workflows/verifier-release.yml
@@ -54,13 +54,13 @@ jobs:
           key: verifier-${{ matrix.target }}
 
       - name: Build verifier
-        run: cargo build --release --locked -p verifiable-log-serve --bin serve --target ${{ matrix.target }}
+        run: cargo build --release --locked -p verifiable-log-serve --bin pollis-verify --target ${{ matrix.target }}
 
       - name: Package binary + checksum
         shell: bash
         run: |
           mkdir -p dist
-          cp "target/${{ matrix.target }}/release/serve" "dist/${{ matrix.asset }}"
+          cp "target/${{ matrix.target }}/release/pollis-verify" "dist/${{ matrix.asset }}"
           cd dist
           if command -v sha256sum >/dev/null 2>&1; then
             sha256sum "${{ matrix.asset }}" > "${{ matrix.asset }}.sha256"
@@ -92,14 +92,12 @@ jobs:
             ### Usage
             ```bash
             # verify the entire log (signatures, inclusion proofs, consistency)
-            ./pollis-verify-<platform> verify-remote https://verify.pollis.com
+            ./pollis-verify-<platform> remote https://verify.pollis.com
 
             # verify one conversation's commit chain (use a conversation id, not a name)
-            ./pollis-verify-<platform> verify-group \
-              --base https://verify.pollis.com \
-              --group <CONVERSATION_ID>
+            ./pollis-verify-<platform> group https://verify.pollis.com <CONVERSATION_ID>
             ```
             Exit code is non-zero if any check fails. Add `--json` to
-            `verify-group` for machine-readable output.
+            `group` for machine-readable output.
 
             Verify the download against the matching `*.sha256` file.

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,9 @@ Thumbs.db
 
 # Generated files
 pkg/proto/gen/
+site/v1
+bundle.json
+fixture.json
 
 # Environment
 .env.production

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7035,6 +7035,7 @@ version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -9411,7 +9412,10 @@ dependencies = [
  "base64 0.22.1",
  "log",
  "once_cell",
+ "rustls 0.23.39",
+ "rustls-pki-types",
  "url",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]

--- a/livekit/livekit.yml
+++ b/livekit/livekit.yml
@@ -9,10 +9,10 @@ rtc:
 # actually relay media; they must be open in the firewall.
 turn:
   enabled: true
-  domain: downpage.xyz
+  domain: rtc.pollis.com
   tls_port: 5349
-  cert_file: /etc/letsencrypt/live/downpage.xyz/fullchain.pem
-  key_file: /etc/letsencrypt/live/downpage.xyz/privkey.pem
+  cert_file: /etc/letsencrypt/live/rtc.pollis.com/fullchain.pem
+  key_file: /etc/letsencrypt/live/rtc.pollis.com/privkey.pem
   relay_range_start: 30000
   relay_range_end: 30100
 

--- a/livekit/nginx.conf
+++ b/livekit/nginx.conf
@@ -3,16 +3,16 @@ events {}
 http {
     server {
         listen 80;
-        server_name downpage.xyz;
+        server_name rtc.pollis.com;
         return 301 https://$host$request_uri;
     }
 
     server {
         listen 443 ssl;
-        server_name downpage.xyz;
+        server_name rtc.pollis.com;
 
-        ssl_certificate /etc/letsencrypt/live/downpage.xyz/fullchain.pem;
-        ssl_certificate_key /etc/letsencrypt/live/downpage.xyz/privkey.pem;
+        ssl_certificate /etc/letsencrypt/live/rtc.pollis.com/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/rtc.pollis.com/privkey.pem;
 
         location / {
             proxy_pass http://livekit:7880;

--- a/verifiable-log-serve/Cargo.toml
+++ b/verifiable-log-serve/Cargo.toml
@@ -27,8 +27,10 @@ thiserror = "1"
 clap = { version = "4", features = ["derive"] }
 # Tiny blocking HTTP server for the local dev/demo host.
 tiny_http = "0.12"
-# Blocking HTTP client for the remote verifier. Loopback HTTP only — no TLS.
-ureq = { version = "2", default-features = false }
+# Blocking HTTP client for the remote verifier. The "tls" feature pulls in
+# rustls + webpki-roots so auditors can verify a live https:// URL (e.g.
+# https://verify.pollis.com), not just loopback http://.
+ureq = { version = "2", default-features = false, features = ["tls"] }
 # Live mode: hold the Ed25519 signing key and drive the async libSQL read.
 ed25519-dalek = "2.1"
 tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/verifiable-log-serve/Cargo.toml
+++ b/verifiable-log-serve/Cargo.toml
@@ -13,6 +13,11 @@ path = "src/lib.rs"
 name = "serve"
 path = "src/bin/serve.rs"
 
+# Verification-only CLI shipped to auditors (operator commands live in `serve`).
+[[bin]]
+name = "pollis-verify"
+path = "src/bin/pollis-verify.rs"
+
 [dependencies]
 # Slice 1: Merkle/STH/proof core and its verifiers — depended on, never reimplemented.
 verifiable-log = { path = "../verifiable-log" }

--- a/verifiable-log-serve/src/bin/pollis-verify.rs
+++ b/verifiable-log-serve/src/bin/pollis-verify.rs
@@ -1,0 +1,77 @@
+//! `pollis-verify` — independently verify the Pollis public transparency log.
+//!
+//! A verification-only CLI for auditors: it fetches the published artifacts over
+//! HTTP(S) and checks them, trusting only the pinned Ed25519 public key. It does
+//! not run, serve, or build anything — that's what the operator `serve` binary
+//! is for. Both subcommands exit non-zero if verification fails, so they slot
+//! into CI and scripts.
+
+use clap::{Parser, Subcommand};
+use std::process::ExitCode;
+use verifiable_log_serve::{group, remote, ServeError};
+
+#[derive(Parser)]
+#[command(
+    name = "pollis-verify",
+    about = "Independently verify the Pollis public transparency log.",
+    version
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Verify the whole log: every STH signature, all inclusion proofs, and
+    /// consistency between tree sizes. Trusts only the pinned public key.
+    Remote {
+        /// Base URL of the transparency log, e.g. https://verify.pollis.com
+        base_url: String,
+    },
+    /// Verify a single conversation's commit chain. Use a conversation id (an
+    /// MLS conversation id), not a workspace name. Exits non-zero if invalid.
+    Group {
+        /// Base URL of the transparency log, e.g. https://verify.pollis.com
+        base_url: String,
+        /// Conversation id to verify.
+        conversation_id: String,
+        /// Print the report as JSON instead of a human-readable summary.
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+fn run() -> Result<bool, ServeError> {
+    match Cli::parse().command {
+        Command::Remote { base_url } => {
+            let report = remote::verify_remote(&base_url)?;
+            report.print();
+            Ok(report.ok)
+        }
+        Command::Group {
+            base_url,
+            conversation_id,
+            json,
+        } => {
+            let report = group::verify_group(&base_url, &conversation_id)?;
+            if json {
+                println!("{}", serde_json::to_string_pretty(&report)?);
+            } else {
+                report.print();
+            }
+            Ok(report.chain_valid)
+        }
+    }
+}
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(true) => ExitCode::SUCCESS,
+        Ok(false) => ExitCode::FAILURE,
+        Err(e) => {
+            eprintln!("error: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/verifiable-log-serve/src/live.rs
+++ b/verifiable-log-serve/src/live.rs
@@ -186,7 +186,12 @@ impl LiveServer {
         let runtime = tokio::runtime::Runtime::new()
             .map_err(|e| ServeError::Config(format!("failed to start async runtime: {e}")))?;
 
-        let server = Server::http(("127.0.0.1", port))
+        // Bind host defaults to loopback for safe local/dev use. Set
+        // `VLOG_BIND_HOST=0.0.0.0` to listen on all interfaces — required when
+        // running inside a container behind a reverse proxy (Docker's
+        // port-forward and sibling containers cannot reach a loopback bind).
+        let host = std::env::var("VLOG_BIND_HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
+        let server = Server::http((host.as_str(), port))
             .map_err(|e| ServeError::Http(format!("bind failed: {e}")))?;
         let addr = server
             .server_addr()

--- a/website/transparency.html
+++ b/website/transparency.html
@@ -300,7 +300,7 @@
 
       <form class="kt-form" id="kt-form">
         <input class="kt-input" id="kt-group" type="text" autocomplete="off" spellcheck="false"
-          placeholder="conversation id / slug" aria-label="Conversation id" />
+          placeholder="conversation id" aria-label="Conversation id" />
         <button class="btn btn-primary" type="submit" id="kt-submit">Verify</button>
       </form>
 

--- a/website/transparency.js
+++ b/website/transparency.js
@@ -3,10 +3,10 @@
 // only fetches a server-computed verdict and visualizes it.
 
 // ── Configuration ──────────────────────────────────────────────────────────
-// Base URL of the backend verifier (the `serve` dev server's HTTP endpoint).
-// Defaults to the local dev server; in production this points at the deployed
-// verifier (e.g. https://transparency.pollis.com).
-const BACKEND_BASE = "http://127.0.0.1:8787";
+// Base URL of the backend verifier (the live read API / `serve` HTTP endpoint).
+// Production points at the deployed transparency verifier. For local dev against
+// a `serve`/`live` instance, change this to http://127.0.0.1:8787.
+const BACKEND_BASE = "https://verify.pollis.com";
 
 // ── DOM helpers ─────────────────────────────────────────────────────────────
 const form = document.getElementById("kt-form");


### PR DESCRIPTION
Migrates self-hosted LiveKit to rtc.pollis.com, brings the transparency read  API up at verify.pollis.com, fixes two server bugs (bind host, ureq TLS), points the  website explorer at prod, and ships a pollis-verify CLI release workflow for auditors.