### PR TITLE
feat(delivery): MLS Delivery Service spine — race-free commit serializer (P1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4588,6 +4588,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4881,6 +4890,15 @@ dependencies = [
  "serde",
  "tauri-winrt-notification",
  "zbus 5.14.0",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6155,6 +6173,24 @@ dependencies = [
  "windows-capture",
  "x25519-dalek",
  "zeroize",
+]
+
+[[package]]
+name = "pollis-delivery"
+version = "1.1.0"
+dependencies = [
+ "anyhow",
+ "axum 0.7.9",
+ "base64 0.22.1",
+ "libsql",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "ulid",
 ]
 
 [[package]]
@@ -7661,6 +7697,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shared_child"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8597,6 +8642,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tiff"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9105,6 +9159,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -9508,6 +9592,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "verifiable-log",
     "verifiable-log-builder",
     "verifiable-log-serve",
+    "pollis-delivery",
 ]
 
 [workspace.package]

--- a/pollis-delivery/Cargo.toml
+++ b/pollis-delivery/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "pollis-delivery"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+description = "Pollis MLS Delivery Service: the sole writer to the MLS control-plane tables. Serializes commits per conversation (race-free, append-only by construction) and serves the contiguous commit log. Sees only opaque blobs — never plaintext or keys (RFC 9420 Delivery Service role)."
+
+[lib]
+name = "pollis_delivery"
+path = "src/lib.rs"
+
+[[bin]]
+name = "pollis-delivery"
+path = "src/main.rs"
+
+[dependencies]
+axum = "0.7"
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "signal"] }
+# Sole-writer access to the MLS tables in Turso. `remote` for prod; local files
+# back the tests.
+libsql = { version = "0.9", features = ["remote"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+base64 = "0.22"
+ulid = "1"
+anyhow = "1"
+thiserror = "1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/pollis-delivery/Dockerfile
+++ b/pollis-delivery/Dockerfile
@@ -1,0 +1,29 @@
+# Pollis MLS Delivery Service image.
+#
+# Build from the REPO ROOT (the whole cargo workspace must resolve):
+#   docker build -f pollis-delivery/Dockerfile -t pollis-delivery .
+#
+# Run beside the LiveKit container, behind api.pollis.com (terminate TLS at a
+# reverse proxy). Required env: TURSO_URL, TURSO_TOKEN. Optional: PORT (8788).
+#
+# Only pollis-delivery + its deps compile here — none of the desktop/media
+# crates are in its dependency closure, so no media system libraries are needed.
+
+FROM rust:1-bookworm AS build
+# pkg-config/openssl for TLS deps; clang/libclang for libsql-ffi's bindgen;
+# cmake/cc for native builds.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      pkg-config libssl-dev build-essential cmake clang libclang-dev ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /src
+COPY . .
+RUN cargo build --release -p pollis-delivery \
+    && strip target/release/pollis-delivery
+
+FROM debian:bookworm-slim AS runtime
+# ca-certificates so libsql can TLS to Turso.
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=build /src/target/release/pollis-delivery /usr/local/bin/pollis-delivery
+EXPOSE 8788
+ENTRYPOINT ["/usr/local/bin/pollis-delivery"]

--- a/pollis-delivery/src/commit.rs
+++ b/pollis-delivery/src/commit.rs
@@ -1,0 +1,208 @@
+//! Commit serialization — the heart of the Delivery Service.
+//!
+//! `mls_commit_log.epoch` is the *source* epoch a commit was built from: a
+//! commit with `epoch = N` advances the group `N -> N+1`. So the group's head
+//! epoch is `MAX(epoch) + 1` — the next epoch a member may commit from.
+//!
+//! A submitted commit is **accepted iff its `based_on_epoch` equals the current
+//! head**, and it claims that epoch atomically. The whole decision is a single
+//! conditional `INSERT ... SELECT ... WHERE based_on = head ... ON CONFLICT DO
+//! NOTHING`, so:
+//!   - two clients racing at the same head → SQLite serializes the writers; one
+//!     INSERT lands (head advances), the other's `WHERE` now sees the new head
+//!     and inserts nothing. Exactly one winner. **No fork.**
+//!   - a stale client (`based_on < head`) or a forward gap (`based_on > head`)
+//!     → `WHERE` is false → nothing inserted → rejected. **No gap.**
+//!   - the log is only ever appended to, never deleted/rewritten, because this
+//!     service is the only writer and never issues such statements. **Append-only.**
+//!
+//! These invariants are properties of *this code*, not of DB triggers.
+
+use anyhow::{anyhow, Result};
+use libsql::Connection;
+use serde::{Deserialize, Serialize};
+
+// ── Wire types (blobs are base64 over the wire) ─────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct SubmitBody {
+    pub conversation_id: String,
+    /// The epoch this commit was built from = the head the client believes it's at.
+    pub based_on_epoch: i64,
+    pub sender_id: String,
+    /// TLS-serialized MLS Commit, base64.
+    pub commit: String,
+    #[serde(default)]
+    pub added_user_id: Option<String>,
+    /// CSV of device ids added by this commit, if any.
+    #[serde(default)]
+    pub added_device_ids: Option<String>,
+    /// New published GroupInfo at the *resulting* epoch (`based_on_epoch + 1`),
+    /// base64. Lets a future joiner external-join. Optional.
+    #[serde(default)]
+    pub group_info: Option<String>,
+    /// Welcomes for devices added by this commit. Optional.
+    #[serde(default)]
+    pub welcomes: Vec<WelcomeBody>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct WelcomeBody {
+    pub recipient_id: String,
+    pub recipient_device_id: String,
+    /// TLS-serialized MLS Welcome, base64.
+    pub welcome: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "status", rename_all = "lowercase")]
+pub enum SubmitResponse {
+    /// The commit won its epoch. The group head is now `epoch + 1`.
+    Accepted { epoch: i64 },
+    /// The client wasn't at the head. Here's the current head and the commits
+    /// it's missing so it can re-base and resubmit — no fork possible.
+    Rejected { head: i64, missing: Vec<CommitWire> },
+}
+
+#[derive(Debug, Serialize)]
+pub struct CommitWire {
+    pub epoch: i64,
+    pub seq: i64,
+    pub sender_id: String,
+    /// base64
+    pub commit: String,
+    pub added_user_id: Option<String>,
+    pub added_device_ids: Option<String>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CommitsResponse {
+    pub head: i64,
+    pub commits: Vec<CommitWire>,
+}
+
+// ── Core logic ──────────────────────────────────────────────────────────────
+
+fn b64_decode(s: &str) -> Result<Vec<u8>> {
+    use base64::Engine as _;
+    Ok(base64::engine::general_purpose::STANDARD.decode(s)?)
+}
+
+fn b64_encode(b: &[u8]) -> String {
+    use base64::Engine as _;
+    base64::engine::general_purpose::STANDARD.encode(b)
+}
+
+/// The group's head epoch = `MAX(epoch) + 1` (0 for an empty/unknown group).
+pub async fn head_epoch(conn: &Connection, conversation_id: &str) -> Result<i64> {
+    let mut rows = conn
+        .query(
+            "SELECT COALESCE(MAX(epoch), -1) + 1 FROM mls_commit_log WHERE conversation_id = ?1",
+            libsql::params![conversation_id],
+        )
+        .await?;
+    let row = rows.next().await?.ok_or_else(|| anyhow!("no head row"))?;
+    Ok(row.get::<i64>(0)?)
+}
+
+/// Commits with `epoch >= since`, contiguous, in apply order.
+pub async fn fetch_commits(conn: &Connection, conversation_id: &str, since: i64) -> Result<Vec<CommitWire>> {
+    let mut rows = conn
+        .query(
+            "SELECT epoch, seq, sender_id, commit_data, added_user_id, added_device_ids, created_at \
+             FROM mls_commit_log WHERE conversation_id = ?1 AND epoch >= ?2 ORDER BY epoch ASC, seq ASC",
+            libsql::params![conversation_id, since],
+        )
+        .await?;
+    let mut out = Vec::new();
+    while let Some(r) = rows.next().await? {
+        let commit: Vec<u8> = r.get(3)?;
+        out.push(CommitWire {
+            epoch: r.get(0)?,
+            seq: r.get(1)?,
+            sender_id: r.get(2)?,
+            commit: b64_encode(&commit),
+            added_user_id: r.get::<Option<String>>(4).ok().flatten(),
+            added_device_ids: r.get::<Option<String>>(5).ok().flatten(),
+            created_at: r.get(6)?,
+        });
+    }
+    Ok(out)
+}
+
+/// Submit a commit. Accepts iff `based_on_epoch` is the current head; otherwise
+/// rejects with the head + the missing commits. See the module docs for why
+/// this is race-free / fork-free / gap-free / append-only.
+pub async fn submit_commit(conn: &Connection, body: &SubmitBody) -> Result<SubmitResponse> {
+    let commit = b64_decode(&body.commit)?;
+
+    // The atomic decision: insert this commit at `based_on_epoch` ONLY IF that
+    // equals the current head. One statement → no read/write race.
+    let affected = conn
+        .execute(
+            "INSERT INTO mls_commit_log \
+                 (conversation_id, epoch, sender_id, commit_data, added_user_id, added_device_ids) \
+             SELECT ?1, ?2, ?3, ?4, ?5, ?6 \
+             WHERE ?2 = (SELECT COALESCE(MAX(epoch), -1) + 1 FROM mls_commit_log WHERE conversation_id = ?1) \
+             ON CONFLICT(conversation_id, epoch) DO NOTHING",
+            libsql::params![
+                body.conversation_id.clone(),
+                body.based_on_epoch,
+                body.sender_id.clone(),
+                commit,
+                body.added_user_id.clone(),
+                body.added_device_ids.clone(),
+            ],
+        )
+        .await?;
+
+    if affected == 0 {
+        let head = head_epoch(conn, &body.conversation_id).await?;
+        let missing = fetch_commits(conn, &body.conversation_id, body.based_on_epoch).await?;
+        return Ok(SubmitResponse::Rejected { head, missing });
+    }
+
+    // Won the epoch. Publish the resulting-epoch GroupInfo + any Welcomes so a
+    // future joiner / newly-added device can come online. (P1: best-effort
+    // after the commit lands; P2 makes the whole submit one transaction.)
+    if let Some(gi_b64) = &body.group_info {
+        let gi = b64_decode(gi_b64)?;
+        conn.execute(
+            "INSERT INTO mls_group_info (conversation_id, epoch, group_info, updated_by_device_id) \
+             VALUES (?1, ?2, ?3, ?4) \
+             ON CONFLICT(conversation_id) DO UPDATE SET \
+                 epoch = excluded.epoch, \
+                 group_info = excluded.group_info, \
+                 updated_by_device_id = excluded.updated_by_device_id, \
+                 updated_at = datetime('now')",
+            libsql::params![
+                body.conversation_id.clone(),
+                body.based_on_epoch + 1,
+                gi,
+                body.sender_id.clone(),
+            ],
+        )
+        .await?;
+    }
+    for w in &body.welcomes {
+        let welcome = b64_decode(&w.welcome)?;
+        conn.execute(
+            "INSERT INTO mls_welcome \
+                 (id, conversation_id, recipient_id, welcome_data, recipient_device_id) \
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            libsql::params![
+                ulid::Ulid::new().to_string(),
+                body.conversation_id.clone(),
+                w.recipient_id.clone(),
+                welcome,
+                w.recipient_device_id.clone(),
+            ],
+        )
+        .await?;
+    }
+
+    Ok(SubmitResponse::Accepted {
+        epoch: body.based_on_epoch,
+    })
+}

--- a/pollis-delivery/src/db.rs
+++ b/pollis-delivery/src/db.rs
@@ -1,0 +1,40 @@
+//! Thin libsql wrapper. The Delivery Service is the *sole writer* to the MLS
+//! control-plane tables (`mls_commit_log`, `mls_group_info`, `mls_welcome`,
+//! `mls_key_package`), so all writes funnel through one place — here.
+
+use anyhow::Result;
+use libsql::{Builder, Connection, Database};
+
+pub struct Db {
+    db: Database,
+}
+
+impl Db {
+    /// Connect to a remote Turso database (production).
+    pub async fn connect_remote(url: &str, token: &str) -> Result<Self> {
+        let db = Builder::new_remote(url.to_string(), token.to_string())
+            .build()
+            .await?;
+        Ok(Self { db })
+    }
+
+    /// Connect to a local libsql file. Tests only — avoids the network and lets
+    /// a test drive concurrent submitters against a single file.
+    pub async fn connect_local(path: &str) -> Result<Self> {
+        let db = Builder::new_local(path).build().await?;
+        let me = Self { db };
+        // WAL + a busy timeout so concurrent submitters serialize without
+        // surfacing "database is locked" — the conditional INSERT still
+        // guarantees exactly one winner per epoch.
+        let conn = me.conn()?;
+        conn.execute_batch(
+            "PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000; PRAGMA foreign_keys=OFF;",
+        )
+        .await?;
+        Ok(me)
+    }
+
+    pub fn conn(&self) -> Result<Connection> {
+        Ok(self.db.connect()?)
+    }
+}

--- a/pollis-delivery/src/error.rs
+++ b/pollis-delivery/src/error.rs
@@ -1,0 +1,31 @@
+//! HTTP error mapping. Any internal failure becomes a 500 with a terse JSON
+//! body; the logged detail stays server-side. (A rejected commit is NOT an
+//! error — it's a normal 409 response carrying the head + missing commits.)
+
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+
+pub struct AppError(pub anyhow::Error);
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> Response {
+        tracing::error!("delivery error: {:#}", self.0);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": "internal error" })),
+        )
+            .into_response()
+    }
+}
+
+impl<E> From<E> for AppError
+where
+    E: Into<anyhow::Error>,
+{
+    fn from(err: E) -> Self {
+        Self(err.into())
+    }
+}

--- a/pollis-delivery/src/lib.rs
+++ b/pollis-delivery/src/lib.rs
@@ -1,0 +1,76 @@
+//! Pollis MLS Delivery Service.
+//!
+//! The sole writer to the MLS control-plane tables. It serializes commits per
+//! conversation and serves the contiguous commit log. It sees only opaque
+//! blobs — never plaintext or group/private keys — so it cannot decrypt or
+//! forge a commit (RFC 9420 "Delivery Service" role). Clients keep all MLS
+//! crypto; they submit commits here instead of writing the DB directly, which
+//! is what makes forks/wedges structurally impossible (see [`commit`]).
+
+pub mod commit;
+pub mod db;
+pub mod error;
+
+use std::sync::Arc;
+
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, post},
+    Json, Router,
+};
+use serde::Deserialize;
+
+use crate::commit::{CommitsResponse, SubmitBody, SubmitResponse};
+use crate::db::Db;
+use crate::error::AppError;
+
+pub type AppState = Arc<Db>;
+
+/// Build the HTTP router. Exposed so tests can drive it (and so `main` is thin).
+pub fn build_router(db: AppState) -> Router {
+    Router::new()
+        .route("/health", get(health))
+        .route("/v1/commits", post(submit))
+        .route("/v1/commits/:conversation_id", get(commits))
+        .with_state(db)
+}
+
+async fn health() -> impl IntoResponse {
+    (StatusCode::OK, "ok")
+}
+
+/// POST /v1/commits — submit a commit. 200 Accepted (won the epoch) or
+/// 409 Rejected (not at head; body carries head + missing commits).
+async fn submit(
+    State(db): State<AppState>,
+    Json(body): Json<SubmitBody>,
+) -> Result<impl IntoResponse, AppError> {
+    let conn = db.conn()?;
+    let outcome = commit::submit_commit(&conn, &body).await?;
+    let code = match &outcome {
+        SubmitResponse::Accepted { .. } => StatusCode::OK,
+        SubmitResponse::Rejected { .. } => StatusCode::CONFLICT,
+    };
+    Ok((code, Json(outcome)))
+}
+
+#[derive(Deserialize)]
+struct Since {
+    #[serde(default)]
+    since: i64,
+}
+
+/// GET /v1/commits/:conversation_id?since=N — the contiguous commit log from
+/// epoch N (default 0) to head.
+async fn commits(
+    State(db): State<AppState>,
+    Path(conversation_id): Path<String>,
+    Query(q): Query<Since>,
+) -> Result<impl IntoResponse, AppError> {
+    let conn = db.conn()?;
+    let head = commit::head_epoch(&conn, &conversation_id).await?;
+    let commits = commit::fetch_commits(&conn, &conversation_id, q.since).await?;
+    Ok(Json(CommitsResponse { head, commits }))
+}

--- a/pollis-delivery/src/main.rs
+++ b/pollis-delivery/src/main.rs
@@ -1,0 +1,54 @@
+//! Pollis MLS Delivery Service entrypoint.
+//!
+//! Env:
+//!   TURSO_URL    libsql://… (required)
+//!   TURSO_TOKEN  scoped write token for the MLS tables (required)
+//!   PORT         listen port (default 8788)
+//!
+//! Terminate TLS at a reverse proxy in front (this serves plain HTTP), and run
+//! it beside the LiveKit container behind `api.pollis.com`.
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use pollis_delivery::{build_router, db::Db};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "pollis_delivery=info,tower_http=info".into()),
+        )
+        .init();
+
+    let url = std::env::var("TURSO_URL").context("TURSO_URL must be set")?;
+    let token = std::env::var("TURSO_TOKEN").context("TURSO_TOKEN must be set")?;
+    let port: u16 = std::env::var("PORT")
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(8788);
+
+    let db = Arc::new(
+        Db::connect_remote(&url, &token)
+            .await
+            .context("connect to Turso")?,
+    );
+    let app = build_router(db);
+
+    let listener = tokio::net::TcpListener::bind(("0.0.0.0", port))
+        .await
+        .with_context(|| format!("bind 0.0.0.0:{port}"))?;
+    tracing::info!("pollis-delivery listening on 0.0.0.0:{port}");
+
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await
+        .context("server error")?;
+    Ok(())
+}
+
+async fn shutdown_signal() {
+    let _ = tokio::signal::ctrl_c().await;
+    tracing::info!("shutting down");
+}

--- a/pollis-delivery/tests/serialize.rs
+++ b/pollis-delivery/tests/serialize.rs
@@ -1,0 +1,154 @@
+//! Delivery Service serialization invariants, against a real (local) libsql DB:
+//! at most one commit per epoch (no fork), only head-extending commits accepted
+//! (no gap), and concurrent submitters yield exactly one winner.
+
+use std::sync::Arc;
+
+use base64::Engine as _;
+use pollis_delivery::commit::{fetch_commits, head_epoch, submit_commit, SubmitBody, SubmitResponse};
+use pollis_delivery::db::Db;
+
+const SCHEMA: &str = "\
+CREATE TABLE mls_commit_log (\
+  seq INTEGER PRIMARY KEY AUTOINCREMENT,\
+  conversation_id TEXT NOT NULL,\
+  epoch INTEGER NOT NULL,\
+  sender_id TEXT NOT NULL,\
+  commit_data BLOB NOT NULL,\
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),\
+  added_user_id TEXT,\
+  added_device_ids TEXT\
+);\
+CREATE UNIQUE INDEX idx_mls_commit_conv_epoch ON mls_commit_log (conversation_id, epoch);\
+CREATE TABLE mls_group_info (\
+  conversation_id TEXT PRIMARY KEY,\
+  epoch INTEGER NOT NULL,\
+  group_info BLOB NOT NULL,\
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),\
+  updated_by_device_id TEXT NOT NULL\
+);\
+CREATE TABLE mls_welcome (\
+  id TEXT PRIMARY KEY,\
+  conversation_id TEXT NOT NULL,\
+  recipient_id TEXT NOT NULL,\
+  welcome_data BLOB NOT NULL,\
+  delivered INTEGER NOT NULL DEFAULT 0,\
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),\
+  recipient_device_id TEXT\
+);";
+
+fn b64(b: &[u8]) -> String {
+    base64::engine::general_purpose::STANDARD.encode(b)
+}
+
+fn body(conv: &str, epoch: i64, sender: &str) -> SubmitBody {
+    SubmitBody {
+        conversation_id: conv.to_string(),
+        based_on_epoch: epoch,
+        sender_id: sender.to_string(),
+        commit: b64(format!("commit-{conv}-{epoch}-{sender}").as_bytes()),
+        added_user_id: None,
+        added_device_ids: None,
+        group_info: Some(b64(b"group-info")),
+        welcomes: vec![],
+    }
+}
+
+async fn fresh_db() -> Arc<Db> {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("delivery.db");
+    // Keep the tempdir alive for the process.
+    std::mem::forget(dir);
+    let db = Db::connect_local(path.to_str().unwrap()).await.expect("local db");
+    db.conn().unwrap().execute_batch(SCHEMA).await.expect("schema");
+    Arc::new(db)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn accepts_head_rejects_stale_and_gap() {
+    let db = fresh_db().await;
+    let conn = db.conn().unwrap();
+    let c = "conv1";
+
+    // Empty group: head is 0. A commit from epoch 0 wins.
+    match submit_commit(&conn, &body(c, 0, "alice")).await.unwrap() {
+        SubmitResponse::Accepted { epoch } => assert_eq!(epoch, 0),
+        other => panic!("expected Accepted, got {other:?}"),
+    }
+    assert_eq!(head_epoch(&conn, c).await.unwrap(), 1);
+
+    // A second commit ALSO from epoch 0 is stale → rejected, head is 1, and it
+    // gets back the commit it's missing.
+    match submit_commit(&conn, &body(c, 0, "bob")).await.unwrap() {
+        SubmitResponse::Rejected { head, missing } => {
+            assert_eq!(head, 1);
+            assert_eq!(missing.len(), 1);
+            assert_eq!(missing[0].epoch, 0);
+        }
+        other => panic!("expected Rejected, got {other:?}"),
+    }
+
+    // A commit from the head (epoch 1) wins.
+    match submit_commit(&conn, &body(c, 1, "alice")).await.unwrap() {
+        SubmitResponse::Accepted { epoch } => assert_eq!(epoch, 1),
+        other => panic!("expected Accepted, got {other:?}"),
+    }
+    assert_eq!(head_epoch(&conn, c).await.unwrap(), 2);
+
+    // A forward gap (epoch 5 when head is 2) is rejected — no gap can be created.
+    match submit_commit(&conn, &body(c, 5, "alice")).await.unwrap() {
+        SubmitResponse::Rejected { head, .. } => assert_eq!(head, 2),
+        other => panic!("expected Rejected, got {other:?}"),
+    }
+
+    // The log is contiguous: epochs 0, 1.
+    let commits = fetch_commits(&conn, c, 0).await.unwrap();
+    let epochs: Vec<i64> = commits.iter().map(|c| c.epoch).collect();
+    assert_eq!(epochs, vec![0, 1]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn concurrent_submitters_yield_exactly_one_winner() {
+    let db = fresh_db().await;
+    let c = "race";
+
+    // 8 clients all submit a commit from epoch 0 at once. Exactly one may win.
+    let mut handles = Vec::new();
+    for i in 0..8 {
+        let db = Arc::clone(&db);
+        handles.push(tokio::spawn(async move {
+            let conn = db.conn().unwrap();
+            // busy_timeout is per-connection: each writer waits for the local
+            // file lock instead of erroring (a local-file test artifact; Turso
+            // serializes writes server-side). The conditional INSERT still
+            // decides exactly one winner.
+            conn.execute_batch("PRAGMA busy_timeout=10000;").await.unwrap();
+            let sender = format!("client{i}");
+            submit_commit(&conn, &body(c, 0, &sender)).await.unwrap()
+        }));
+    }
+
+    let mut accepted = 0;
+    let mut rejected = 0;
+    for h in handles {
+        match h.await.unwrap() {
+            SubmitResponse::Accepted { epoch } => {
+                assert_eq!(epoch, 0);
+                accepted += 1;
+            }
+            SubmitResponse::Rejected { head, .. } => {
+                assert_eq!(head, 1, "rejected losers must see the advanced head");
+                rejected += 1;
+            }
+        }
+    }
+
+    assert_eq!(accepted, 1, "exactly one commit may win the epoch — no fork");
+    assert_eq!(rejected, 7);
+
+    // And the log has exactly one commit at epoch 0.
+    let conn = db.conn().unwrap();
+    let commits = fetch_commits(&conn, c, 0).await.unwrap();
+    assert_eq!(commits.len(), 1);
+    assert_eq!(commits[0].epoch, 0);
+}


### PR DESCRIPTION
First half of P1 (#397): the **Delivery Service** spine.

New `pollis-delivery` axum crate — the sole writer to the MLS control-plane tables:
- `POST /v1/commits` — accepts a commit iff `based_on_epoch` == head, via one conditional `INSERT…SELECT…ON CONFLICT`. Concurrent submitters → **exactly one winner** (no fork); stale/gap → 409 with head + missing commits to re-base (no gap); append-only by construction (sole writer, never deletes).
- `GET /v1/commits/:id?since=N` — the contiguous log.
- Sees only opaque blobs — no plaintext/keys (RFC 9420 DS role).
- Dockerfile to deploy beside LiveKit behind `api.pollis.com`.

Tests prove accept-head / reject-stale-and-gap and **exactly-one-winner under 8-way concurrency**. Additive crate; doesn't touch the running app yet.

Next: wire the client's commit-write path through it. Refs #397.