### PR TITLE
feat(mls): route commit submission through the delivery seam (DS-ready)

### DIFF
--- a/pollis-core/src/commands/mls/delivery.rs
+++ b/pollis-core/src/commands/mls/delivery.rs
@@ -1,0 +1,125 @@
+//! Client seam for submitting MLS commits to the log.
+//!
+//! Two paths, one decision:
+//! - **Direct** (default, when `POLLIS_DELIVERY_URL` is unset): the client
+//!   writes the commit straight to `mls_commit_log` — byte-for-byte the prior
+//!   behavior. Used in tests and until the Delivery Service is deployed.
+//! - **Http** (when `POLLIS_DELIVERY_URL` is set): submission routes through the
+//!   deployed Delivery Service, which becomes the *sole writer* and serializes
+//!   commits per conversation authoritatively (race-free, gap-free, append-only
+//!   — see the `pollis-delivery` crate).
+//!
+//! Either way the caller gets the same [`SubmitResult`] and doesn't care which
+//! path ran — that's the whole point of the seam.
+//!
+//! Scope (this step): the **commit-log write only**. Welcomes / GroupInfo
+//! writes still go direct for now (they move behind the DS later), and the
+//! gap-preventing head check lives in the DS — the Direct path keeps the prior
+//! plain `ON CONFLICT` semantics so this change is behavior-identical.
+
+use std::sync::Arc;
+
+use crate::error::{Error, Result};
+use crate::state::AppState;
+
+pub enum SubmitResult {
+    /// Our commit won its epoch.
+    Committed,
+    /// Someone else committed this epoch first; the caller must converge on the
+    /// winner (roll back its local pending commit and re-process).
+    LostRace,
+}
+
+fn delivery_base_url() -> Option<String> {
+    std::env::var("POLLIS_DELIVERY_URL")
+        .ok()
+        .filter(|s| !s.is_empty())
+}
+
+/// Submit one commit at `epoch` for `conversation_id`. See the module docs.
+pub async fn submit_commit(
+    state: &Arc<AppState>,
+    conversation_id: &str,
+    epoch: i64,
+    sender_id: &str,
+    commit: &[u8],
+    added_user_id: Option<&str>,
+    added_device_ids: Option<&str>,
+) -> Result<SubmitResult> {
+    match delivery_base_url() {
+        Some(base) => {
+            http_submit(&base, conversation_id, epoch, sender_id, commit, added_user_id, added_device_ids).await
+        }
+        None => {
+            direct_submit(state, conversation_id, epoch, sender_id, commit, added_user_id, added_device_ids).await
+        }
+    }
+}
+
+async fn direct_submit(
+    state: &Arc<AppState>,
+    conversation_id: &str,
+    epoch: i64,
+    sender_id: &str,
+    commit: &[u8],
+    added_user_id: Option<&str>,
+    added_device_ids: Option<&str>,
+) -> Result<SubmitResult> {
+    let conn = state.remote_db.conn().await?;
+    let affected = conn
+        .execute(
+            "INSERT INTO mls_commit_log \
+             (conversation_id, epoch, sender_id, commit_data, added_user_id, added_device_ids) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6) \
+             ON CONFLICT(conversation_id, epoch) DO NOTHING",
+            libsql::params![
+                conversation_id.to_string(),
+                epoch,
+                sender_id.to_string(),
+                commit.to_vec(),
+                added_user_id.map(str::to_string),
+                added_device_ids.map(str::to_string),
+            ],
+        )
+        .await?;
+    Ok(if affected == 0 {
+        SubmitResult::LostRace
+    } else {
+        SubmitResult::Committed
+    })
+}
+
+async fn http_submit(
+    base_url: &str,
+    conversation_id: &str,
+    epoch: i64,
+    sender_id: &str,
+    commit: &[u8],
+    added_user_id: Option<&str>,
+    added_device_ids: Option<&str>,
+) -> Result<SubmitResult> {
+    use base64::Engine as _;
+    let body = serde_json::json!({
+        "conversation_id": conversation_id,
+        "based_on_epoch": epoch,
+        "sender_id": sender_id,
+        "commit": base64::engine::general_purpose::STANDARD.encode(commit),
+        "added_user_id": added_user_id,
+        "added_device_ids": added_device_ids,
+    });
+    let url = format!("{}/v1/commits", base_url.trim_end_matches('/'));
+    let resp = reqwest::Client::new()
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| Error::Other(anyhow::anyhow!("delivery submit: {e}")))?;
+    match resp.status() {
+        s if s.is_success() => Ok(SubmitResult::Committed),
+        reqwest::StatusCode::CONFLICT => Ok(SubmitResult::LostRace),
+        s => {
+            let txt = resp.text().await.unwrap_or_default();
+            Err(Error::Other(anyhow::anyhow!("delivery submit {s}: {txt}")))
+        }
+    }
+}

--- a/pollis-core/src/commands/mls/group_state.rs
+++ b/pollis-core/src/commands/mls/group_state.rs
@@ -281,26 +281,22 @@ async fn external_join_attempt(
     //    member already committed `stored_epoch`, the conflict makes this a
     //    no-op (0 rows) and we report a lost race — the branch we just built
     //    locally is doomed and the caller will discard it and retry.
-    let conn = state.remote_db.conn().await?;
-    let affected = conn
-        .execute(
-            "INSERT INTO mls_commit_log \
-             (conversation_id, epoch, sender_id, commit_data, added_user_id, added_device_ids) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6) \
-             ON CONFLICT(conversation_id, epoch) DO NOTHING",
-            libsql::params![
-                conversation_id,
-                stored_epoch,
-                user_id,
-                commit_bytes,
-                user_id,
-                device_id.clone()
-            ],
-        )
-        .await?;
-
-    if affected == 0 {
-        return Ok(ExternalJoinResult::LostRace);
+    // Submit through the delivery seam (Direct today, the Delivery Service once
+    // POLLIS_DELIVERY_URL is set). LostRace → another member committed this
+    // epoch first; discard our doomed local branch and retry.
+    match super::delivery::submit_commit(
+        state,
+        conversation_id,
+        stored_epoch,
+        user_id,
+        &commit_bytes,
+        Some(user_id),
+        Some(&device_id),
+    )
+    .await?
+    {
+        super::delivery::SubmitResult::LostRace => return Ok(ExternalJoinResult::LostRace),
+        super::delivery::SubmitResult::Committed => {}
     }
 
     // 4. Refresh the stored GroupInfo at the new epoch so any NEXT

--- a/pollis-core/src/commands/mls/mod.rs
+++ b/pollis-core/src/commands/mls/mod.rs
@@ -3,6 +3,7 @@
 //! (Tauri shims, sibling `commands::*` modules, integration tests) keeps
 //! resolving names at `pollis_core::commands::mls::*`.
 
+mod delivery;
 mod device;
 mod group_state;
 mod key_packages;

--- a/pollis-core/src/commands/mls/reconcile.rs
+++ b/pollis-core/src/commands/mls/reconcile.rs
@@ -588,34 +588,29 @@ pub async fn reconcile_group_mls_impl(
         // from being our only attempt. On failure, roll back the local
         // pending commit before returning.
         let remote_result: crate::error::Result<SubmitOutcome> = async {
-            let write_conn = state.remote_db.conn().await?;
-            // Claim this epoch via compare-and-swap. If another member already
-            // committed `epoch_before`, the conflict makes this a no-op (0
-            // rows) and we report a lost race instead of forking. We must NOT
-            // write the welcomes in that case — they'd point at a branch no one
-            // adopts.
-            let affected = write_conn
-                .execute(
-                    "INSERT INTO mls_commit_log \
-                     (conversation_id, epoch, sender_id, commit_data, added_user_id, added_device_ids) \
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6) \
-                     ON CONFLICT(conversation_id, epoch) DO NOTHING",
-                    libsql::params![
-                        conversation_id.clone(),
-                        outcome.epoch_before as i64,
-                        actor_user_id.clone(),
-                        data.commit_bytes,
-                        added_uid,
-                        added_dids
-                    ],
-                )
-                .await?;
-
-            if affected == 0 {
-                return Ok(SubmitOutcome::LostRace);
+            // Claim this epoch through the delivery seam (Direct today, the
+            // Delivery Service once POLLIS_DELIVERY_URL is set). LostRace →
+            // another member committed `epoch_before` first; report it (the
+            // caller rolls back the local pending commit) instead of forking.
+            // Welcomes are written ONLY on a win — they'd point at a doomed
+            // branch otherwise.
+            match super::delivery::submit_commit(
+                state,
+                &conversation_id,
+                outcome.epoch_before as i64,
+                &actor_user_id,
+                &data.commit_bytes,
+                added_uid.as_deref(),
+                added_dids.as_deref(),
+            )
+            .await?
+            {
+                super::delivery::SubmitResult::LostRace => return Ok(SubmitOutcome::LostRace),
+                super::delivery::SubmitResult::Committed => {}
             }
 
             if let Some(welcome_bytes) = data.welcome_bytes {
+                let write_conn = state.remote_db.conn().await?;
                 for (uid, did) in &outcome.added {
                     let welcome_id = Ulid::new().to_string();
                     write_conn.execute(


### PR DESCRIPTION
Second step of P1 (#397): both commit-submit sites (external-join + reconcile) now route through `mls::delivery::submit_commit` instead of inline `INSERT INTO mls_commit_log`.

- **Direct** (default): byte-for-byte the prior insert — behavior-identical, **29 flows green**.
- **Http** (`POLLIS_DELIVERY_URL` set): submission routes to the deployed Delivery Service (sole writer, server-side serialization).

Either way the caller gets `Committed`/`LostRace`. Host + iOS compile.

**Deliberate follow-ups** (each individually verified): the gap-preventing head check, welcomes/GroupInfo writes via the DS, fetch-via-DS, and the test-harness in-process DS. Refs #397.