### PR TITLE
ci(delivery): manual deploy workflows for prod + dev Delivery Service

### DIFF
--- a/.github/workflows/delivery-deploy-dev.yml
+++ b/.github/workflows/delivery-deploy-dev.yml
@@ -1,0 +1,57 @@
+# Manual deploy of the Delivery Service to DEV.
+# Same shape as the prod workflow but builds/pushes :dev and recreates the
+# `delivery-dev` container on the VPS. Manual only — no push/tag trigger.
+# See issue #406 (deploy-button pattern) and #405 (dev DS instance).
+name: Deploy Delivery (dev)
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref to build (branch, tag, or SHA)
+        required: false
+        default: main
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: delivery-deploy-dev
+  cancel-in-progress: false
+
+env:
+  IMAGE: ghcr.io/actuallydan/pollis-delivery:dev
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: delivery-dev
+    steps:
+      - name: Checkout ${{ inputs.ref }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push ${{ env.IMAGE }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: pollis-delivery/Dockerfile
+          push: true
+          tags: ${{ env.IMAGE }}
+          cache-from: type=gha,scope=pollis-delivery
+          cache-to: type=gha,scope=pollis-delivery,mode=max
+
+      - name: Trigger Watchtower (recreate dev container)
+        run: |
+          curl -fsS -G "${{ vars.WATCHTOWER_URL }}/v1/update" \
+            --data-urlencode "image=${IMAGE}" \
+            -H "Authorization: Bearer ${{ secrets.WATCHTOWER_TOKEN }}"

--- a/.github/workflows/delivery-deploy-prod.yml
+++ b/.github/workflows/delivery-deploy-prod.yml
@@ -1,0 +1,60 @@
+# Manual deploy of the Delivery Service to PROD.
+# Builds the pollis-delivery image on GitHub runners (off the VPS — no LiveKit
+# CPU contention), pushes it to GHCR as :prod, then pokes the token-gated
+# Watchtower endpoint on the VPS, which pulls the new digest and recreates the
+# `delivery` container in place (env/network/restart-policy preserved).
+#
+# Manual only — no push/tag trigger. See issue #406 (deploy-button pattern).
+name: Deploy Delivery (prod)
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref to build (branch, tag, or SHA)
+        required: false
+        default: main
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: delivery-deploy-prod
+  cancel-in-progress: false
+
+env:
+  IMAGE: ghcr.io/actuallydan/pollis-delivery:prod
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: delivery-prod
+    steps:
+      - name: Checkout ${{ inputs.ref }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push ${{ env.IMAGE }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: pollis-delivery/Dockerfile
+          push: true
+          tags: ${{ env.IMAGE }}
+          cache-from: type=gha,scope=pollis-delivery
+          cache-to: type=gha,scope=pollis-delivery,mode=max
+
+      - name: Trigger Watchtower (recreate prod container)
+        run: |
+          curl -fsS -G "${{ vars.WATCHTOWER_URL }}/v1/update" \
+            --data-urlencode "image=${IMAGE}" \
+            -H "Authorization: Bearer ${{ secrets.WATCHTOWER_TOKEN }}"


### PR DESCRIPTION
Two manual (`workflow_dispatch`) workflows to deploy the `pollis-delivery` Delivery Service — one per environment, no push/tag triggers.

Each: checkout `ref` (default `main`) → build `pollis-delivery/Dockerfile` on GitHub runners → push to GHCR (`:prod` / `:dev`) → poke the token-gated Watchtower endpoint on the VPS, which pulls the new digest and recreates the container in place.

**Why off-box build + Watchtower trigger:** build never contends with LiveKit for CPU; no inbound SSH or VPS credentials in CI — the box pulls. Trigger token's blast radius is "redeploy whatever's already in GHCR" (can't inject images; that needs GHCR write, which only CI has).

### Requires before first run (follow-up, not in this PR)
- GHCR package `pollis-delivery` set **public** (repo is public) so the VPS pulls credential-free.
- Repo **variable** `WATCHTOWER_URL` (e.g. `https://deploy.pollis.com`) and **secret** `WATCHTOWER_TOKEN`.
- GitHub **Environments** `delivery-prod` / `delivery-dev` (optional manual-approval gate on prod).
- VPS bootstrap: Watchtower (`--http-api-update`, docker.sock, `livekit_default`) behind a token-gated nginx route; prod `delivery` recreated from the GHCR image; dev `delivery-dev` stood up (#405).

Related: #406 (deploy-button pattern), #405 (dev DS instance).