### PR TITLE
ci(delivery): fix buildx gha cache (setup-buildx-action)

### DIFF
--- a/.github/workflows/delivery-deploy-dev.yml
+++ b/.github/workflows/delivery-deploy-dev.yml
@@ -40,6 +40,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # docker-container driver — required for the gha cache backend below
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push ${{ env.IMAGE }}
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/delivery-deploy-prod.yml
+++ b/.github/workflows/delivery-deploy-prod.yml
@@ -43,6 +43,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # docker-container driver — required for the gha cache backend below
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push ${{ env.IMAGE }}
         uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
First prod run failed: `Cache export is not supported for the docker driver`. The default runner buildx builder uses the `docker` driver, which can't export `type=gha` cache. Add `docker/setup-buildx-action@v3` (docker-container driver) to both delivery deploy workflows.

https://claude.ai/code/session_01RsZ8WRmw7GrT4B5vxRgDLy