### PR TITLE
feat(mls): route commit submission through the Delivery Service when configured

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,12 @@ LIVEKIT_URL=wss://your-livekit-domain.example.com
 LIVEKIT_API_KEY=your_api_key
 LIVEKIT_API_SECRET=your_api_secret
 
+# Delivery Service (optional). When set, MLS commit submission routes through
+# the DS, which serializes commits per conversation (race-free, gap-free).
+# Leave unset to write commits directly to Turso (the default / self-host path).
+# Prod desktop builds use https://api.pollis.com; dev uses https://api-dev.pollis.com.
+# POLLIS_DELIVERY_URL=https://api.pollis.com
+
 # Dev bypass: set this to skip email sends during local development.
 # The OTP step still appears but you can enter this fixed code instead.
 # DEV_OTP=000000

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -64,6 +64,7 @@ jobs:
           echo "LIVEKIT_URL=${{ secrets.LIVEKIT_URL }}" >> $GITHUB_ENV
           echo "LIVEKIT_API_KEY=${{ secrets.LIVEKIT_API_KEY }}" >> $GITHUB_ENV
           echo "LIVEKIT_API_SECRET=${{ secrets.LIVEKIT_API_SECRET }}" >> $GITHUB_ENV
+          echo "POLLIS_DELIVERY_URL=${{ secrets.POLLIS_DELIVERY_URL }}" >> $GITHUB_ENV
           echo "CLOUDFLARE_ACCOUNT_ID=${{ secrets.CLOUDFLARE_ACCOUNT_ID }}" >> $GITHUB_ENV
 
       # webrtc-audio-processing-sys (vendored): meson + ninja drive the C++
@@ -145,6 +146,7 @@ jobs:
           echo "LIVEKIT_URL=${{ secrets.LIVEKIT_URL }}" >> $GITHUB_ENV
           echo "LIVEKIT_API_KEY=${{ secrets.LIVEKIT_API_KEY }}" >> $GITHUB_ENV
           echo "LIVEKIT_API_SECRET=${{ secrets.LIVEKIT_API_SECRET }}" >> $GITHUB_ENV
+          echo "POLLIS_DELIVERY_URL=${{ secrets.POLLIS_DELIVERY_URL }}" >> $GITHUB_ENV
           echo "CLOUDFLARE_ACCOUNT_ID=${{ secrets.CLOUDFLARE_ACCOUNT_ID }}" >> $GITHUB_ENV
 
       - name: Install dependencies
@@ -358,6 +360,7 @@ jobs:
           echo "LIVEKIT_URL=${{ secrets.LIVEKIT_URL }}" >> $GITHUB_ENV
           echo "LIVEKIT_API_KEY=${{ secrets.LIVEKIT_API_KEY }}" >> $GITHUB_ENV
           echo "LIVEKIT_API_SECRET=${{ secrets.LIVEKIT_API_SECRET }}" >> $GITHUB_ENV
+          echo "POLLIS_DELIVERY_URL=${{ secrets.POLLIS_DELIVERY_URL }}" >> $GITHUB_ENV
           echo "CLOUDFLARE_ACCOUNT_ID=${{ secrets.CLOUDFLARE_ACCOUNT_ID }}" >> $GITHUB_ENV
 
       - name: Install dependencies

--- a/pollis-core/src/bridge.rs
+++ b/pollis-core/src/bridge.rs
@@ -126,6 +126,9 @@ struct InitConfig {
     livekit_api_secret: String,
     #[serde(default)]
     resend_api_key: String,
+    /// Optional Delivery Service base URL. Absent → direct Turso writes.
+    #[serde(default)]
+    pollis_delivery_url: Option<String>,
 }
 
 /// Initialize the process-global `AppState`. Safe to call multiple times —
@@ -156,6 +159,7 @@ async fn init_pollis_inner(config_json: String) -> Result<(), BridgeError> {
                 livekit_api_key: parsed.livekit_api_key,
                 livekit_api_secret: parsed.livekit_api_secret,
                 resend_api_key: parsed.resend_api_key,
+                pollis_delivery_url: parsed.pollis_delivery_url.filter(|s| !s.is_empty()),
             };
             let state = AppState::new(config).await?;
             Ok::<Arc<AppState>, BridgeError>(Arc::new(state))

--- a/pollis-core/src/commands/mls/delivery.rs
+++ b/pollis-core/src/commands/mls/delivery.rs
@@ -1,10 +1,11 @@
 //! Client seam for submitting MLS commits to the log.
 //!
-//! Two paths, one decision:
-//! - **Direct** (default, when `POLLIS_DELIVERY_URL` is unset): the client
+//! Two paths, one decision, keyed on `config.pollis_delivery_url`
+//! (compile-time-baked from `POLLIS_DELIVERY_URL`, or runtime env in dev):
+//! - **Direct** (default, when it's `None`): the client
 //!   writes the commit straight to `mls_commit_log` — byte-for-byte the prior
 //!   behavior. Used in tests and until the Delivery Service is deployed.
-//! - **Http** (when `POLLIS_DELIVERY_URL` is set): submission routes through the
+//! - **Http** (when it's `Some(url)`): submission routes through the
 //!   deployed Delivery Service, which becomes the *sole writer* and serializes
 //!   commits per conversation authoritatively (race-free, gap-free, append-only
 //!   — see the `pollis-delivery` crate).
@@ -30,12 +31,6 @@ pub enum SubmitResult {
     LostRace,
 }
 
-fn delivery_base_url() -> Option<String> {
-    std::env::var("POLLIS_DELIVERY_URL")
-        .ok()
-        .filter(|s| !s.is_empty())
-}
-
 /// Submit one commit at `epoch` for `conversation_id`. See the module docs.
 pub async fn submit_commit(
     state: &Arc<AppState>,
@@ -46,9 +41,9 @@ pub async fn submit_commit(
     added_user_id: Option<&str>,
     added_device_ids: Option<&str>,
 ) -> Result<SubmitResult> {
-    match delivery_base_url() {
+    match state.config.pollis_delivery_url.as_deref() {
         Some(base) => {
-            http_submit(&base, conversation_id, epoch, sender_id, commit, added_user_id, added_device_ids).await
+            http_submit(base, conversation_id, epoch, sender_id, commit, added_user_id, added_device_ids).await
         }
         None => {
             direct_submit(state, conversation_id, epoch, sender_id, commit, added_user_id, added_device_ids).await

--- a/pollis-core/src/config.rs
+++ b/pollis-core/src/config.rs
@@ -13,6 +13,10 @@ pub struct Config {
     pub livekit_api_key: String,
     pub livekit_api_secret: String,
     pub resend_api_key: String,
+    /// Delivery Service base URL (e.g. `https://api.pollis.com`). When set, MLS
+    /// commit submission routes through the DS (serialized, race/gap-free);
+    /// when `None`, commits write direct to Turso. See `commands::mls::delivery`.
+    pub pollis_delivery_url: Option<String>,
 }
 
 impl Config {
@@ -44,6 +48,11 @@ impl Config {
                 .map(|s| s.to_string())
                 .or_else(|| std::env::var("LIVEKIT_API_SECRET").ok())
                 .unwrap_or_default(),
+            // Optional: absent → direct Turso writes; present → route through the DS.
+            pollis_delivery_url: option_env!("POLLIS_DELIVERY_URL")
+                .map(|s| s.to_string())
+                .or_else(|| std::env::var("POLLIS_DELIVERY_URL").ok())
+                .filter(|s| !s.is_empty()),
         })
     }
 }
@@ -85,6 +94,8 @@ impl Config {
             livekit_api_key: String::new(),
             livekit_api_secret: String::new(),
             resend_api_key: String::new(),
+            // Integration tests exercise the direct write path.
+            pollis_delivery_url: None,
         })
     }
 }


### PR DESCRIPTION
Flips the desktop app's MLS **commit submission** onto the deployed Delivery Service (api.pollis.com), which serializes commits per conversation (race-free, gap-free). The seam already existed in `commands::mls::delivery`; this makes it actually reachable in packaged builds.

### What changed
- **`config.rs`** — `POLLIS_DELIVERY_URL` now flows through `Config` (`Option<String>`), baked at compile time via `option_env!` like `TURSO_URL`/`LIVEKIT_URL`, with a runtime-env fallback for dev. Previously it was read only via `std::env::var()` at runtime — which **never** resolves in a packaged release (no `.env` is loaded), so the switch could never actually flip in prod.
- **`delivery.rs`** — `submit_commit` reads `state.config.pollis_delivery_url` instead of the raw env.
- **`bridge.rs`** — mobile init config carries the optional field (absent → direct path).
- **`desktop-release.yml`** — injects `POLLIS_DELIVERY_URL` into the three build jobs.
- **`.env.example`** — documents the var.

### Safe to merge before the cutover
`None`/empty → **direct Turso writes** (the prior default). Until the `POLLIS_DELIVERY_URL` secret is set, prod release builds get an empty value → filtered to `None` → unchanged behavior. Integration tests use `Config::for_test()` → `None` → direct path, so the suite is unaffected.

### To actually flip prod (deliberate, later)
Set the `POLLIS_DELIVERY_URL` secret to `https://api.pollis.com`, then cut a desktop release. Local dev is already pointed at `https://api-dev.pollis.com` (gitignored `.env.development`).

Compiles clean (`pollis-core` + the `pollis` Tauri crate). Related: #406 (deploy-button pattern).