### PR TITLE
ci(livekit): manual deploy buttons for LiveKit + nginx + website (#410, #406)

### DIFF
--- a/.github/workflows/livekit-deploy.yml
+++ b/.github/workflows/livekit-deploy.yml
@@ -1,0 +1,135 @@
+# Manual deploy of the LiveKit + nginx ingress stack to the VPS.
+#
+# Unlike the Delivery Service (built in CI, rolled by Watchtower — see
+# delivery-deploy-*.yml / #407), LiveKit and nginx run UPSTREAM images with
+# mounted config. Their deployable is config files, which Watchtower can't carry
+# and can't bootstrap a fresh box — so this uses Option B: SSH + `docker compose`
+# (#410). One-click from the Actions tab; the workflow SSHes to the box, syncs
+# the canonical `livekit/` config, renders the LiveKit keys from secrets, and
+# brings the stack up.
+#
+# Manual only — no push/tag trigger. See #406 (deploy-button pattern), #410.
+name: Deploy LiveKit + nginx
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Target environment
+        type: choice
+        options: [prod, dev]
+        default: prod
+      ref:
+        description: Git ref to deploy (branch, tag, or SHA)
+        required: false
+        default: main
+
+permissions:
+  contents: read
+
+# One deploy per environment at a time; never cancel an in-flight deploy.
+concurrency:
+  group: livekit-deploy-${{ inputs.environment }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    # GitHub Environment: optional manual-approval gate + audit trail, matching
+    # the delivery deploys. Create `livekit-prod` (and `livekit-dev` if used).
+    environment: livekit-${{ inputs.environment }}
+    env:
+      VPS_HOST: ${{ vars.VPS_HOST }}
+      VPS_USER: ${{ vars.VPS_USER }}
+      # Path to the canonical config dir on the box (bind-mount source).
+      REMOTE_DIR: /root/livekit
+    steps:
+      - name: Checkout ${{ inputs.ref }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Preflight — required secrets/vars present
+        run: |
+          set -euo pipefail
+          missing=()
+          [ -n "${VPS_HOST}" ] || missing+=("vars.VPS_HOST")
+          [ -n "${VPS_USER}" ] || missing+=("vars.VPS_USER")
+          [ -n "${{ secrets.VPS_SSH_KEY }}" ] || missing+=("secrets.VPS_SSH_KEY")
+          [ -n "${{ secrets.LIVEKIT_API_KEY }}" ] || missing+=("secrets.LIVEKIT_API_KEY")
+          [ -n "${{ secrets.LIVEKIT_API_SECRET }}" ] || missing+=("secrets.LIVEKIT_API_SECRET")
+          if [ "${#missing[@]}" -ne 0 ]; then
+            printf '::error::Missing required config: %s\n' "${missing[*]}"
+            exit 1
+          fi
+
+      - name: Render LiveKit keys into livekit.yml
+        env:
+          LIVEKIT_API_KEY: ${{ secrets.LIVEKIT_API_KEY }}
+          LIVEKIT_API_SECRET: ${{ secrets.LIVEKIT_API_SECRET }}
+        run: |
+          set -euo pipefail
+          # The committed livekit.yml has no `keys:` block by design; append it
+          # here so the secret only ever lives on the runner + the box, never git.
+          {
+            printf '\nkeys:\n'
+            printf '  %s: %s\n' "${LIVEKIT_API_KEY}" "${LIVEKIT_API_SECRET}"
+          } >> livekit/livekit.yml
+
+      - name: Set up SSH
+        run: |
+          set -euo pipefail
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "${{ secrets.VPS_SSH_KEY }}" > ~/.ssh/id_deploy
+          chmod 600 ~/.ssh/id_deploy
+          ssh-keyscan -H "${VPS_HOST}" >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Sync config to the box (staging dir)
+        run: |
+          set -euo pipefail
+          SSH="ssh -i ~/.ssh/id_deploy"
+          $SSH "${VPS_USER}@${VPS_HOST}" "mkdir -p ${REMOTE_DIR}/.staging"
+          scp -i ~/.ssh/id_deploy \
+            livekit/nginx.conf livekit/livekit.yml livekit/docker-compose.yml \
+            "${VPS_USER}@${VPS_HOST}:${REMOTE_DIR}/.staging/"
+
+      - name: Apply config + bring the stack up
+        run: |
+          set -euo pipefail
+          ssh -i ~/.ssh/id_deploy "${VPS_USER}@${VPS_HOST}" REMOTE_DIR="${REMOTE_DIR}" 'bash -seuo pipefail' <<'REMOTE'
+            cd "${REMOTE_DIR}"
+            # Apply bind-mounted files IN PLACE (cat >, not mv): nginx.conf and
+            # livekit.yml are bind-mounted by inode into the running containers
+            # (#405), so a rename would leave the container reading the old inode.
+            cat .staging/nginx.conf      > nginx.conf
+            cat .staging/livekit.yml     > livekit.yml
+            # The compose file is read by the CLI, not bind-mounted — plain copy.
+            cp .staging/docker-compose.yml docker-compose.yml
+            rm -rf .staging
+
+            # Pull pinned images + (re)create only what changed. NOT --remove-orphans:
+            # delivery/delivery-dev/watchtower are standalone (owned by #407) and
+            # must survive a LiveKit deploy.
+            docker compose -f docker-compose.yml up -d
+
+            # nginx.conf may have changed without the service def changing (bind
+            # mount, content-only) — validate then reload to pick it up gracefully.
+            docker compose exec -T nginx nginx -t
+            docker compose exec -T nginx nginx -s reload
+
+            # livekit reads its config only at start — restart to apply livekit.yml.
+            docker compose restart livekit
+
+            docker compose ps
+          REMOTE
+
+      - name: Validate — LiveKit up + delivery routing intact
+        run: |
+          set -euo pipefail
+          # LiveKit answers GET / with "OK".
+          echo "rtc.pollis.com:"
+          curl -fsS --max-time 20 https://rtc.pollis.com ; echo
+          # Regression check: the shared nginx still routes the delivery service
+          # after a LiveKit deploy (api.pollis.com -> delivery:8788).
+          echo "api.pollis.com/health:"
+          curl -fsS --max-time 20 https://api.pollis.com/health ; echo

--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -1,20 +1,25 @@
 # Manual deploy of the static marketing site (website/) to Cloudflare Pages.
 #
 # Moves the website off auto-on-merge onto the deploy-button pattern (#406):
-# `main` stays always-deployable, publishing is a deliberate manual act. Disable
-# the Cloudflare Pages git auto-deploy in the CF dashboard so this is the only
-# path that ships the site.
+# `main` stays always-deployable, publishing is a deliberate manual act.
+#
+# The Pages project (`pollis`) is GIT-CONNECTED (root dir `website/`, production
+# branch `main`), so deployments are git builds — not wrangler direct uploads
+# (which Cloudflare rejects on a git-connected project). The manual trigger is
+# therefore a Pages **Deploy Hook**: a POST kicks a build of the connected
+# production branch, same pipeline as before, just on-demand.
 #
 # Manual only — no push/tag trigger. See #406.
+#
+# One-time setup in the Cloudflare dashboard (Pages → pollis → Settings):
+#   1. Branch control → Automatic deployments → OFF (so merges to main no longer
+#      auto-deploy; this workflow becomes the only path that ships the site).
+#   2. Deploy Hooks → create one for branch `main`; store its URL as the GitHub
+#      secret `CF_PAGES_DEPLOY_HOOK` (the URL embeds the project + a token).
 name: Deploy Website
 
 on:
   workflow_dispatch:
-    inputs:
-      ref:
-        description: Git ref to deploy (branch, tag, or SHA)
-        required: false
-        default: main
 
 permissions:
   contents: read
@@ -29,28 +34,18 @@ jobs:
     # Optional manual-approval gate + audit trail, matching the other deploys.
     environment: website-prod
     steps:
-      - name: Checkout ${{ inputs.ref }}
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.ref }}
-
-      - name: Preflight — required config present
+      - name: Preflight — deploy hook configured
         run: |
           set -euo pipefail
-          missing=()
-          [ -n "${{ secrets.CLOUDFLARE_API_TOKEN }}" ] || missing+=("secrets.CLOUDFLARE_API_TOKEN")
-          [ -n "${{ secrets.CLOUDFLARE_ACCOUNT_ID }}" ] || missing+=("secrets.CLOUDFLARE_ACCOUNT_ID")
-          [ -n "${{ vars.CF_PAGES_PROJECT }}" ] || missing+=("vars.CF_PAGES_PROJECT")
-          if [ "${#missing[@]}" -ne 0 ]; then
-            printf '::error::Missing required config: %s\n' "${missing[*]}"
+          if [ -z "${{ secrets.CF_PAGES_DEPLOY_HOOK }}" ]; then
+            echo "::error::Missing required config: secrets.CF_PAGES_DEPLOY_HOOK"
             exit 1
           fi
 
-      # The static site is plain HTML/CSS/JS — no build step; publish website/ as-is.
-      - name: Publish website/ to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          # --branch=main marks this as a production deployment for the project.
-          command: pages deploy website --project-name=${{ vars.CF_PAGES_PROJECT }} --branch=main
+      # Kicks a git build of the connected production branch (main). The build
+      # runs async on Cloudflare — watch progress in the Pages dashboard, same as
+      # the delivery deploys poke Watchtower and return.
+      - name: Trigger Cloudflare Pages build
+        run: |
+          set -euo pipefail
+          curl -fsS -X POST "${{ secrets.CF_PAGES_DEPLOY_HOOK }}" ; echo

--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -1,0 +1,56 @@
+# Manual deploy of the static marketing site (website/) to Cloudflare Pages.
+#
+# Moves the website off auto-on-merge onto the deploy-button pattern (#406):
+# `main` stays always-deployable, publishing is a deliberate manual act. Disable
+# the Cloudflare Pages git auto-deploy in the CF dashboard so this is the only
+# path that ships the site.
+#
+# Manual only — no push/tag trigger. See #406.
+name: Deploy Website
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref to deploy (branch, tag, or SHA)
+        required: false
+        default: main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: website-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    # Optional manual-approval gate + audit trail, matching the other deploys.
+    environment: website-prod
+    steps:
+      - name: Checkout ${{ inputs.ref }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Preflight — required config present
+        run: |
+          set -euo pipefail
+          missing=()
+          [ -n "${{ secrets.CLOUDFLARE_API_TOKEN }}" ] || missing+=("secrets.CLOUDFLARE_API_TOKEN")
+          [ -n "${{ secrets.CLOUDFLARE_ACCOUNT_ID }}" ] || missing+=("secrets.CLOUDFLARE_ACCOUNT_ID")
+          [ -n "${{ vars.CF_PAGES_PROJECT }}" ] || missing+=("vars.CF_PAGES_PROJECT")
+          if [ "${#missing[@]}" -ne 0 ]; then
+            printf '::error::Missing required config: %s\n' "${missing[*]}"
+            exit 1
+          fi
+
+      # The static site is plain HTML/CSS/JS — no build step; publish website/ as-is.
+      - name: Publish website/ to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # --branch=main marks this as a production deployment for the project.
+          command: pages deploy website --project-name=${{ vars.CF_PAGES_PROJECT }} --branch=main

--- a/livekit/DEPLOY.md
+++ b/livekit/DEPLOY.md
@@ -1,147 +1,131 @@
-# LiveKit Server Deployment
+# LiveKit + nginx Deployment
+
+This directory holds the **canonical, deployable** config for the LiveKit media
+server and the shared nginx ingress on the Pollis VPS. `main` is the source of
+truth — **do not hand-edit on the box**; deploys go through a button.
+
+## Deploy (the button)
+
+**Actions tab → "Deploy LiveKit + nginx" → Run workflow** (`prod` default).
+
+`.github/workflows/livekit-deploy.yml` (#410) SSHes to the box, syncs this dir,
+renders the LiveKit keys from secrets, and runs `docker compose up -d` + a
+graceful nginx reload. No manual SSH. See "Workflow requirements" below.
 
 ## Stack
-- LiveKit server (Docker)
-- Nginx reverse proxy (Docker)
-- Let's Encrypt SSL (host certbot)
 
-## Directory Structure
+| Service | Image (pinned) | Managed by |
+|---------|----------------|------------|
+| `livekit` | `livekit/livekit-server:v1.10.0` | this compose |
+| `nginx` (shared ingress) | `nginx:1.29-alpine` | this compose |
+| `delivery` / `delivery-dev` | `ghcr.io/actuallydan/pollis-delivery:{prod,dev}` | **#407** (Watchtower) — standalone |
+| `watchtower` | `containrrr/watchtower` | **#407** — standalone |
+
+All five containers share the `livekit_default` docker network. nginx reaches
+the delivery/watchtower containers by network alias.
+
 ```
 livekit/
-  docker-compose.yml
-  livekit.yml
-  nginx.conf
-  README.md
+  docker-compose.yml   # livekit + nginx only (delivery/watchtower owned by #407)
+  livekit.yml          # non-secret; deploy appends the keys: block from secrets
+  nginx.conf           # full ingress: rtc, downpage (LiveKit) + api, api-dev, deploy (delivery)
+  DEPLOY.md
 ```
 
----
+### Ingress routing (nginx.conf)
 
-## Fresh Server Setup
+| Hostname | Upstream | Cert |
+|----------|----------|------|
+| `rtc.pollis.com` | `livekit:7880` | Let's Encrypt |
+| `downpage.xyz` | `livekit:7880` (legacy) | Let's Encrypt |
+| `api.pollis.com` | `delivery:8788` | Cloudflare Origin (`/etc/ssl/cloudflare/verify.pollis.com.*`) |
+| `api-dev.pollis.com` | `delivery-dev:8788` | Cloudflare Origin |
+| `deploy.pollis.com` | `watchtower:8080` | Cloudflare Origin |
 
-### 1. Install Docker
+> **Ordering dependency:** nginx resolves `proxy_pass` upstreams at config load,
+> so the `delivery`/`delivery-dev`/`watchtower` containers must be **up before
+> nginx starts or reloads** — otherwise nginx fails with "host not found in
+> upstream". On a fresh box, deploy the Delivery Service (#407) first. The deploy
+> workflow runs `nginx -t` before reloading to catch this.
+
+## Workflow requirements (one-time)
+
+- **Secrets:** `VPS_SSH_KEY` (deploy private key; add the pubkey to the box's
+  `authorized_keys`), `LIVEKIT_API_KEY`, `LIVEKIT_API_SECRET` (must match what
+  shipped clients use).
+- **Variables:** `VPS_HOST` (`31.97.140.76`), `VPS_USER` (`root`).
+- **GitHub Environment** `livekit-prod` (+ `livekit-dev` if used) for the
+  optional manual-approval gate.
+
+## Fresh-box provisioning (one-time, manual)
+
+The deploy workflow assumes the box already has Docker, the firewall, certs, and
+the host tunables in place. On a brand-new box:
+
+### 1. Docker + firewall
 ```bash
 curl -fsSL https://get.docker.com | sh
+ufw allow 80/tcp && ufw allow 443/tcp
+ufw allow 7881/tcp          # ICE TCP
+ufw allow 7882/udp          # ICE UDP
+ufw allow 5349/tcp          # TURNS (TURN over TLS, for VPNs)
+ufw allow 30000:30100/udp   # TURN relay media ports
+ufw reload
 ```
+Note: if the host (e.g. Hostinger) has a control-panel firewall, open the same
+ports there too — it overrides UFW.
 
-### 2. Open firewall ports
+### 2. Certs
+- **Let's Encrypt** (`rtc.pollis.com`, `downpage.xyz`) via host certbot:
+  ```bash
+  apt install certbot -y
+  certbot certonly --standalone -d rtc.pollis.com -d downpage.xyz
+  ```
+  Auto-renews via a systemd timer; nginx must reload to pick up renewals:
+  ```bash
+  # crontab -e
+  0 3 * * * certbot renew --quiet && docker compose -f /root/livekit/docker-compose.yml exec -T nginx nginx -s reload
+  ```
+- **Cloudflare Origin cert** for `api`/`api-dev`/`deploy.pollis.com` at
+  `/etc/ssl/cloudflare/verify.pollis.com.{pem,key}` (Cloudflare runs Full
+  (strict) in front of these).
+
+### 3. Host tunables (UDP receive buffer)
+LiveKit warns and drops packets under load if the OS UDP receive buffer is below
+5 MB. Apply once (already applied on the current box):
 ```bash
-sudo ufw allow 80/tcp
-sudo ufw allow 443/tcp
-sudo ufw allow 7881/tcp          # ICE TCP
-sudo ufw allow 7882/udp          # ICE UDP
-sudo ufw allow 5349/tcp          # TURNS (TURN over TLS, for VPN clients)
-sudo ufw allow 30000:30100/udp   # TURN relay media ports
-sudo ufw reload
+sysctl -w net.core.rmem_max=5000000
+sysctl -w net.core.rmem_default=5000000
+echo "net.core.rmem_max=5000000"     >> /etc/sysctl.conf
+echo "net.core.rmem_default=5000000" >> /etc/sysctl.conf
 ```
 
-Note: If your host (e.g. Hostinger) has a control panel firewall, open the same ports there too -- it overrides UFW.
+### 4. Delivery Service
+Stand up `delivery` / `delivery-dev` / `watchtower` (#407) so nginx's upstreams
+resolve, then hit the **Deploy LiveKit + nginx** button.
 
-### 3. Install certbot and generate SSL cert
-```bash
-sudo apt install certbot -y
-sudo certbot certonly --standalone -d yourdomain.com
-```
-
-Certbot installs a systemd timer that auto-renews the cert before it expires. Certs expire every 90 days.
-
-### 4. Clone or copy this directory onto the server
-```bash
-mkdir ~/livekit && cd ~/livekit
-# copy docker-compose.yml, livekit.yml, nginx.conf here
-```
-
-### 5. Edit livekit.yml
-Replace `your_api_key` and `your_api_secret` with your actual credentials:
-```bash
-vim livekit.yml
-```
-
-Generate a key/secret pair if you don't have one:
-```bash
-livekit-server generate-keys
-```
-
-### 6. Edit nginx.conf
-Replace both instances of `yourdomain.com` with your actual domain:
-```bash
-vim nginx.conf
-```
-
-### 7. Start the stack
-```bash
-docker compose up -d
-```
-
-### 8. Verify
-```bash
-docker compose ps
-curl https://yourdomain.com
-```
-
-Both containers should show as `Up` and the curl should return `OK`.
-
----
-
-## App Connection
+## App connection
 
 | Protocol | Endpoint |
 |----------|----------|
-| WebSocket (prod) | `wss://yourdomain.com` |
-| HTTP API | `https://yourdomain.com` |
+| WebSocket (prod) | `wss://rtc.pollis.com` |
+| HTTP API | `https://rtc.pollis.com` |
 
----
-
-## SSL Renewal
-
-Certbot renews automatically, but Nginx needs a restart to pick up the new cert:
+## Useful commands (on the box)
 
 ```bash
-sudo certbot renew
-docker compose restart nginx
+cd /root/livekit
+docker compose ps                 # status (livekit + nginx)
+docker compose logs -f livekit    # LiveKit logs
+docker compose exec nginx nginx -t            # validate ingress config
+docker compose exec nginx nginx -s reload     # graceful reload after a cert renew
+docker stats                      # live CPU/memory per container
 ```
 
-To automate this, add a cron job:
-```bash
-sudo crontab -e
-```
-```
-0 3 * * * certbot renew --quiet && docker compose -f /root/livekit/docker-compose.yml restart nginx
-```
+## Performance notes
 
----
-
-## Useful Commands
-
-```bash
-docker compose up -d          # start stack
-docker compose down           # stop stack
-docker compose restart        # restart all services
-docker compose ps             # status
-docker compose logs -f        # live logs
-docker compose logs livekit   # LiveKit logs only
-docker compose logs nginx     # Nginx logs only
-docker stats                  # live CPU/memory per container
-```
-
----
-
-## Performance Notes
-
-- Each participant media track consumes one UDP port from the 50000-50200 range
-- 200 ports handles ~20-30 concurrent users comfortably
-- To expand the range, edit the UDP ports in docker-compose.yml (note: large ranges cause slow Docker startup)
-- LiveKit exposes a Prometheus metrics endpoint at `/metrics` if you want to hook up monitoring later
-
-### UDP receive buffer
-
-LiveKit will warn at startup if the OS UDP receive buffer is below 5 MB (`UDP receive buffer is too small for a production set-up`). Under light load this doesn't matter, but at scale it causes packet drops and audio glitches. To fix:
-
-```bash
-# Apply immediately
-sudo sysctl -w net.core.rmem_max=5000000
-sudo sysctl -w net.core.rmem_default=5000000
-
-# Persist across reboots
-echo "net.core.rmem_max=5000000" | sudo tee -a /etc/sysctl.conf
-echo "net.core.rmem_default=5000000" | sudo tee -a /etc/sysctl.conf
-```
+- Each participant media track consumes one UDP port from the 30000–30100 range
+  (TURN relay); ~100 ports handles a healthy number of concurrent users.
+- LiveKit exposes Prometheus metrics at `/metrics` for future monitoring.
+- Expanding the UDP range means editing the port mapping in `docker-compose.yml`
+  *and* the firewall; large ranges slow Docker startup.

--- a/livekit/docker-compose.yml
+++ b/livekit/docker-compose.yml
@@ -1,25 +1,46 @@
+# LiveKit + nginx ingress stack for the Pollis VPS.
+#
+# Scope: this compose manages ONLY `livekit` and the shared `nginx` ingress.
+# The `delivery`, `delivery-dev`, and `watchtower` containers are deployed
+# independently by the Delivery Service workflows (#407, delivery-deploy-*.yml)
+# via Watchtower, and run as standalone containers on the same `livekit_default`
+# network. nginx reaches them by network alias (see nginx.conf api/api-dev/deploy
+# server blocks), so they must be up before nginx starts/reloads — nginx resolves
+# proxy_pass upstreams at config load and will refuse to start if one is missing.
+#
+# Images are pinned by digest (no `:latest`) so a deploy is reproducible; the
+# human-readable tag is cosmetic when an @sha256 digest is present. Bump these
+# deliberately when upgrading.
+#
+# Deploys go through .github/workflows/livekit-deploy.yml (manual button). Do not
+# hand-edit on the box — `main` carries the canonical config.
 services:
   livekit:
-    image: livekit/livekit-server:latest
+    image: livekit/livekit-server:v1.10.0@sha256:6ff9c33d21ae1b92b7f5a86bc55890a3e5b8ebe7b8a847349c5ee326e90ac965
     ports:
       - "7881:7881"             # ICE TCP candidates
       - "7882:7882/udp"         # ICE UDP (single-port mux)
       - "5349:5349"             # TURNS (TURN over TLS)
       - "30000-30100:30000-30100/udp"  # TURN relay media ports
     volumes:
+      # livekit.yml is rendered on the box with the `keys:` block appended from
+      # secrets by the deploy workflow — see livekit.yml's trailing note.
       - ./livekit.yml:/etc/livekit.yml
       - /etc/letsencrypt:/etc/letsencrypt:ro
     command: --config /etc/livekit.yml
     restart: unless-stopped
 
   nginx:
-    image: nginx:alpine
+    image: nginx:1.29-alpine@sha256:e7257f1ef28ba17cf7c248cb8ccf6f0c6e0228ab9c315c152f9c203cd34cf6d1
     ports:
       - "80:80"
       - "443:443"
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      # Let's Encrypt — rtc.pollis.com + downpage.xyz (LiveKit endpoints).
       - /etc/letsencrypt:/etc/letsencrypt:ro
+      # Cloudflare Origin cert — api / api-dev / deploy .pollis.com (delivery + watchtower).
+      - /etc/ssl/cloudflare:/etc/ssl/cloudflare:ro
     depends_on:
       - livekit
     restart: unless-stopped

--- a/livekit/livekit.yml
+++ b/livekit/livekit.yml
@@ -3,6 +3,7 @@ rtc:
   tcp_port: 7881
   udp_port: 7882
   use_external_ip: true
+  use_ice_lite: true
 
 # TURNS (TURN over TLS on port 5349) — handles VPNs that block UDP and
 # non-443 ports. relay_range_* are the UDP ports LiveKit allocates to
@@ -16,5 +17,11 @@ turn:
   relay_range_start: 30000
   relay_range_end: 30100
 
-keys:
-  your_api_key: your_api_secret
+# NOTE: the `keys:` block is intentionally NOT committed. The deploy workflow
+# (.github/workflows/livekit-deploy.yml) appends it on the box from the
+# LIVEKIT_API_KEY / LIVEKIT_API_SECRET GitHub secrets:
+#
+#   keys:
+#     <LIVEKIT_API_KEY>: <LIVEKIT_API_SECRET>
+#
+# A bare checkout of this file therefore carries no credentials by design.

--- a/livekit/nginx.conf
+++ b/livekit/nginx.conf
@@ -1,12 +1,19 @@
 events {}
 
 http {
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        "" close;
+    }
+
+    # HTTP -> HTTPS for all proxied/served names
     server {
         listen 80;
-        server_name rtc.pollis.com;
+        server_name rtc.pollis.com downpage.xyz api.pollis.com deploy.pollis.com api-dev.pollis.com;
         return 301 https://$host$request_uri;
     }
 
+    # LiveKit (canonical endpoint)
     server {
         listen 443 ssl;
         server_name rtc.pollis.com;
@@ -18,10 +25,86 @@ http {
             proxy_pass http://livekit:7880;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
+            proxy_set_header Connection $connection_upgrade;
             proxy_set_header Host $host;
             proxy_read_timeout 3600s;
             proxy_send_timeout 3600s;
+        }
+    }
+
+    # LiveKit legacy endpoint — kept for already-shipped clients during transition
+    server {
+        listen 443 ssl;
+        server_name downpage.xyz;
+
+        ssl_certificate /etc/letsencrypt/live/downpage.xyz/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/downpage.xyz/privkey.pem;
+
+        location / {
+            proxy_pass http://livekit:7880;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Host $host;
+            proxy_read_timeout 3600s;
+            proxy_send_timeout 3600s;
+        }
+    }
+
+    # Delivery Service — MLS commit log (Cloudflare-proxied, Full strict via CF Origin cert).
+    # The `delivery` upstream is the standalone Delivery Service container deployed
+    # by .github/workflows/delivery-deploy-prod.yml (#407), reachable here by its
+    # network alias on the shared `livekit_default` network. nginx is the shared
+    # ingress, so it can't be deployed independently of this routing.
+    server {
+        listen 443 ssl;
+        server_name api.pollis.com;
+
+        ssl_certificate /etc/ssl/cloudflare/verify.pollis.com.pem;
+        ssl_certificate_key /etc/ssl/cloudflare/verify.pollis.com.key;
+
+        location / {
+            proxy_pass http://delivery:8788;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_read_timeout 60s;
+        }
+    }
+
+    # Watchtower deploy trigger (token-gated; CI pokes this to roll the delivery
+    # containers — see delivery-deploy-{prod,dev}.yml / #407).
+    server {
+        listen 443 ssl;
+        server_name deploy.pollis.com;
+
+        ssl_certificate /etc/ssl/cloudflare/verify.pollis.com.pem;
+        ssl_certificate_key /etc/ssl/cloudflare/verify.pollis.com.key;
+
+        location / {
+            proxy_pass http://watchtower:8080;
+            proxy_set_header Host $host;
+            proxy_read_timeout 300s;
+            proxy_send_timeout 300s;
+        }
+    }
+
+    # Delivery Service (DEV) — the `delivery-dev` container (delivery-deploy-dev.yml).
+    server {
+        listen 443 ssl;
+        server_name api-dev.pollis.com;
+
+        ssl_certificate /etc/ssl/cloudflare/verify.pollis.com.pem;
+        ssl_certificate_key /etc/ssl/cloudflare/verify.pollis.com.key;
+
+        location / {
+            proxy_pass http://delivery-dev:8788;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_read_timeout 60s;
         }
     }
 }


### PR DESCRIPTION
Brings the **LiveKit + nginx ingress** stack under the deploy-button pattern (#410, Option B: SSH + compose) and moves the **website** deploy to manual (#406). Mirrors the delivery deploy buttons (#407/#408).

### Phase 0 — captured live VPS state
The committed `nginx.conf` only knew `rtc.pollis.com`; the live nginx also routes `api`/`api-dev`/`deploy.pollis.com` → the delivery/watchtower containers (Cloudflare origin cert). Reconciled to live so a deploy can't clobber delivery routing.

### Phase 1 — declarative config
- `nginx.conf`: full ingress (rtc + downpage LiveKit; api/api-dev/deploy delivery).
- `docker-compose.yml`: `livekit` + `nginx` only (delivery/watchtower stay owned by #407), images pinned by digest (`livekit-server:v1.10.0`, `nginx:1.29-alpine`), CF cert mount.
- `livekit.yml`: non-secret body; the `keys:` block is appended on the box from secrets at deploy — never committed.
- `DEPLOY.md`: rewritten for button deploys, ingress table, upstream-ordering caveat, certs, `rmem` tunables.

### Phase 2 — deploy buttons
- `.github/workflows/livekit-deploy.yml`: `workflow_dispatch` (env, ref) → SSH + `docker compose up -d`, in-place inode-safe config writes (#405), `nginx -t` → graceful reload, restart livekit, then validates `rtc.pollis.com` + `api.pollis.com/health` (delivery regression check).
- `.github/workflows/website-deploy.yml`: `workflow_dispatch` → POSTs a Cloudflare Pages **Deploy Hook**. The `pollis` Pages project is git-connected (rejects wrangler direct uploads), so the hook kicks a normal git build of the production branch.

### Required before first run
- **livekit:** secrets `VPS_SSH_KEY`, `LIVEKIT_API_KEY`, `LIVEKIT_API_SECRET`; vars `VPS_HOST`/`VPS_USER`; env `livekit-prod`.
- **website:** secret `CF_PAGES_DEPLOY_HOOK` ✅ set; CF dashboard auto-deploy disabled ✅; env `website-prod` (optional approval gate).

### Note on the livekit+nginx-only compose
nginx resolves `proxy_pass` upstreams at config load, so on a cold box the delivery containers (#407) must be up before nginx starts/reloads (documented in DEPLOY.md; `nginx -t` runs before reload to catch it).

Related: #406, #407, #408, #405.