### PR TITLE
ci(livekit): retry deploy validation instead of racing livekit boot

### DIFF
--- a/.github/workflows/livekit-deploy.yml
+++ b/.github/workflows/livekit-deploy.yml
@@ -126,10 +126,13 @@ jobs:
       - name: Validate — LiveKit up + delivery routing intact
         run: |
           set -euo pipefail
-          # LiveKit answers GET / with "OK".
+          # LiveKit answers GET / with "OK", but takes a couple seconds after a
+          # restart to discover its external IP (STUN) and bind :7880 — until
+          # then nginx returns 502. Retry transient errors instead of racing the
+          # boot, rather than failing the deploy on a not-yet-ready upstream.
           echo "rtc.pollis.com:"
-          curl -fsS --max-time 20 https://rtc.pollis.com ; echo
+          curl -fsS --retry 10 --retry-delay 3 --retry-all-errors --retry-connrefused --max-time 20 https://rtc.pollis.com ; echo
           # Regression check: the shared nginx still routes the delivery service
           # after a LiveKit deploy (api.pollis.com -> delivery:8788).
           echo "api.pollis.com/health:"
-          curl -fsS --max-time 20 https://api.pollis.com/health ; echo
+          curl -fsS --retry 5 --retry-delay 2 --retry-all-errors --max-time 20 https://api.pollis.com/health ; echo


### PR DESCRIPTION
First run of the LiveKit deploy button (run 28152350355) succeeded — config applied, containers recreated on the pinned images, `rtc.pollis.com` healthy — but the post-deploy validation curled livekit ~1s before it finished STUN external-IP discovery and bound :7880, so nginx returned 502 and the step false-failed.

Fix: the validation now retries transient errors (incl. 502 / connection-refused) instead of racing the boot. No behavior change to the deploy itself.