### PR TITLE
docs: correct wiki + whitepaper to reflect Tauri runtime (not Electron)

### DIFF
--- a/.codesight/wiki/capture-split.md
+++ b/.codesight/wiki/capture-split.md
@@ -162,9 +162,7 @@ helper, never killing the host app.
 
 ### Packaging
 
-The helper sidecar packaging story is in transition: the legacy `src-tauri/` build pipeline ships a working sidecar today, while the active Electron pipeline's strategy (extraResource via electron-builder, or fold-in to `pollis-node`) is still being decided. Both paths are documented here so the helper can be wired into the Electron build without re-discovering the constraints.
-
-**Legacy Tauri shell (still produces a runnable helper):**
+The helper sidecar ships through the Tauri build pipeline:
 - `src-tauri/tauri.macos.conf.json`: `externalBin`
   `binaries/pollis-capture-macos`, Developer-ID signed, **same team
   9JF7WWYMU2**.
@@ -175,9 +173,6 @@ The helper sidecar packaging story is in transition: the legacy `src-tauri/` bui
   reused on the app job (ubuntu-22.04). No shell script wrapper — runs
   uniformly for `cargo check`, `tauri dev`, and `tauri build` on macOS
   and Linux. Windows is skipped (WGC is in-process).
-
-**Electron shell (active path; helper packaging is a TODO in `electron/build/electron-builder.yml`):**
-- The decision pending in the config TODO is whether to ship the helper as an `extraResources` entry next to `pollis-node`, embed it inside `pollis-node`, or drop the separate binary entirely if `pollis-node` performs the capture itself. Until that lands, screenshare under the Electron build will not have a packaged helper.
 
 ### Picker UX
 
@@ -209,12 +204,17 @@ Linux helpers never send `MSG_SOURCES` and never read `MSG_SELECT`.
 The same opcodes are reserved in the proto crate so both helpers
 share one wire format definition.
 
-## Electron publish-path codec policy
+## Browser publish-path codec policy
 
-Under Electron, capture + encode + publish all happen in Chromium
-(`screenShareSession.ts` → `livekitView.publishScreenShare`), bypassing
-the Rust helper pipeline above. The codec is chosen **per-machine at
-publish time** by `frontend/src/screenshare/codecPolicy.ts`:
+When the host WebView exposes WebRTC (`hasWebRTC()` in
+`frontend/src/bridge/runtime.ts` — historically the Electron Chromium
+renderer, and any Chromium-based WebView2), capture + encode + publish
+all happen in the WebView (`screenShareSession.ts` →
+`livekitView.publishScreenShare`), bypassing the Rust helper pipeline
+above. Under Tauri's WebKitGTK (Linux) there is no WebRTC, so the Rust
+helper path is used instead. On the browser path the codec is chosen
+**per-machine at publish time** by
+`frontend/src/screenshare/codecPolicy.ts`:
 
 - **Hardware H.264 when present.** `pickScreenShareCodec()` scans
   `RTCRtpSender.getCapabilities('video')` for an H.264 entry whose
@@ -286,8 +286,6 @@ overrides the auto-detection for A/B testing. See issue #364.
 - `frontend/src/screenshare/screenShareSession.ts` —
   `local_unsupported` event + distinct error message.
 - `src-tauri/tauri.linux.conf.json`, `src-tauri/tauri.macos.conf.json`
-  — sidecar packaging in the legacy Tauri build.
+  — sidecar packaging in the Tauri build.
 - `src-tauri/build.rs` — auto-builds + stages the per-OS helper sidecar
-  during the legacy Tauri shell's cargo build.
-- `electron/build/electron-builder.yml` — active build config; helper
-  packaging strategy is the open TODO described in "Packaging" above.
+  during the Tauri shell's cargo build.

--- a/.codesight/wiki/commands.md
+++ b/.codesight/wiki/commands.md
@@ -1,8 +1,8 @@
 # Backend Commands
 
-All backend calls from the frontend use `invoke("command_name", { args })` (imported from `frontend/src/bridge`, which routes to `window.electronAPI.invoke` under Electron). The active dispatch happens in `pollis-node/src/dispatch/`: a one-line match arm per command forwards the JSON-shaped call from the Electron main process into `pollis-core/src/commands/`. The implementations live in `pollis-core` so a CLI / TUI / mobile binding (uniffi) can call them without any shell-runtime dependency. Edit `pollis-core`, not the shims.
+All backend calls from the frontend use `invoke("command_name", { args })` (imported from `frontend/src/bridge`, which routes to Tauri's `invoke`). Dispatch happens in `src-tauri/src/commands/`: a thin `#[tauri::command]` shim per command — registered in `src-tauri/src/lib.rs`'s `invoke_handler!` — forwards the JSON-shaped call into `pollis-core/src/commands/`. The implementations live in `pollis-core` so a CLI / TUI / mobile binding (uniffi) can call them without any shell-runtime dependency. Edit `pollis-core`, not the shims.
 
-The path in each section header below points at the implementation in `pollis-core`. The `pollis-node` dispatch arm with the same module name re-exports the types and forwards each command verbatim. Legacy `#[tauri::command]` shims under `src-tauri/src/commands/` exist for rollback but are not the active path.
+The path in each section header below points at the implementation in `pollis-core`. The `#[tauri::command]` shim under `src-tauri/src/commands/` with the same module name re-exports the types and forwards each command verbatim.
 
 ## auth (`commands/auth.rs`)
 - `initialize_identity(user_id)` — ensure MLS credentials + KPs, poll welcomes. Requires the local DB to be open (post-`set_pin` / `unlock`).

--- a/.codesight/wiki/index.md
+++ b/.codesight/wiki/index.md
@@ -23,10 +23,9 @@ Start here. Navigate to the article you need.
 | Layer | Tech | Location |
 |-------|------|----------|
 | Frontend | React, TypeScript, Vite, TailwindCSS | `frontend/src/` |
-| Desktop shell | Electron 33 (main + preload + renderer) | `electron/src/` |
+| Desktop shell | Tauri 2 (Rust host + system WebView renderer) | `src-tauri/src/` |
 | Backend (logic) | Rust workspace crate `pollis-core` | `pollis-core/src/` |
-| Backend (host binding) | Rust napi-rs binding `pollis-node` loaded by the Electron main process | `pollis-node/src/` |
-| Backend (legacy shell, rollback only) | Rust, Tauri 2 — `#[tauri::command]` shims, plugins, lifecycle | `src-tauri/src/` |
+| Backend (host binding) | Tauri host — `#[tauri::command]` shims, plugins, `invoke_handler!`, lifecycle | `src-tauri/src/` |
 | Remote DB | Turso (libSQL) | `pollis-core/src/db/migrations/000000_baseline.sql` + `000*.sql` |
 | Local DB | SQLite (rusqlite) | `pollis-core/src/db/local_schema.sql` |
 | Encryption | OpenMLS (RFC 9420) | `pollis-core/src/commands/mls.rs` |

--- a/.codesight/wiki/libraries.md
+++ b/.codesight/wiki/libraries.md
@@ -30,6 +30,6 @@
 - `frontend/src/utils/fileIcon.ts` — getFileIcon
 
 ---
-**Note:** This only covers frontend libraries. The Rust backend lives in `pollis-core/src/commands/`, loaded into the Electron main process via `pollis-node` (napi-rs); see [commands.md](./commands.md). Legacy `#[tauri::command]` shims under `src-tauri/src/commands/` are preserved as a rollback path.
+**Note:** This only covers frontend libraries. The Rust backend lives in `pollis-core/src/commands/`, exposed to the renderer by the Tauri host via the `#[tauri::command]` shims under `src-tauri/src/commands/`; see [commands.md](./commands.md).
 
 _Back to [index.md](./index.md)_

--- a/.codesight/wiki/notifications.md
+++ b/.codesight/wiki/notifications.md
@@ -31,7 +31,7 @@ RealtimeEvent (Rust → JS Channel)         Local action (e.g. self voice join)
                           (Rust)   (Rust)   (MobX)    (MobX)    (MobX)
 ```
 
-There is **no parallel dispatcher in Rust**. All decisions happen in JS. Rust is just the transport for LiveKit events (pushed through `pollis-node`'s Rust → Node `ThreadsafeFunction`, forwarded by the Electron main process via `webContents.send("channel:<id>", payload)` to the renderer's `channelOn` subscriber) and the executor for sound (`play_sfx` rodio command). OS notifications fire through the bridge — the renderer calls `window.electronAPI.notify({ title, body, icon })`, which the main process implements via Electron's native `Notification` API.
+There is **no parallel dispatcher in Rust**. All decisions happen in JS. Rust is just the transport for LiveKit events (pushed through the `EventSink`/`ChannelSink` over a `tauri::ipc::Channel` to the renderer's `channelOn` subscriber) and the executor for sound (`play_sfx` rodio command). OS notifications fire through the bridge — the renderer calls `sendNotification({ title, body, icon })`, which routes to `tauri-plugin-notification`.
 
 ## The category table
 
@@ -56,7 +56,7 @@ const CATEGORIES: Record<Category, CategoryConfig> = {
 | Field | What it does | Pref gate | Notes |
 |---|---|---|---|
 | `sound` | Plays a sfx (`'ping'`/`'join'`/`'leave'`) via the `play_sfx` Rust command | `allow_sound_effects` | Cooldownable |
-| `osNotif` | Fires an OS notification banner via the bridge's `sendNotification` (→ `window.electronAPI.notify`) | `allow_desktop_notifications` + OS permission | Cooldownable |
+| `osNotif` | Fires an OS notification banner via the bridge's `sendNotification` (→ `tauri-plugin-notification`) | `allow_desktop_notifications` + OS permission | Cooldownable |
 | `badge` | Increments the per-room unread count (`useAppStore.incrementUnread`) | none | Drives dock/taskbar badge via `useBadge` |
 | `alert` | Sets the blinking status-bar alert (`useAppStore.setStatusBarAlert`) | none | Cleared on navigation |
 | `overlay` | Sets `pendingEnrollmentApproval` so the UI takes over | none | Used only by enrollment |
@@ -100,7 +100,7 @@ if (event.kind === 'invite') {
 `useLiveKitRealtime.ts` owns the React-side state and pushes it into `notify.ts` via `setNotifyPrefs(...)`. The effect re-runs whenever `allow_sound_effects` or `allow_desktop_notifications` changes:
 
 1. Read current prefs from `usePreferences()`.
-2. Call the bridge's `isPermissionGranted` (→ `window.electronAPI.notificationsPermissionGranted`) — if not granted *and* the user has notifications enabled, request permission via `requestPermission`.
+2. Call the bridge's `isPermissionGranted` (→ `tauri-plugin-notification`) — if not granted *and* the user has notifications enabled, request permission via `requestPermission`.
 3. Push `{ allowSound, allowOsNotif, osPermissionGranted }` into the dispatcher.
 
 Result: toggling notifications "on" in Preferences → granting the OS prompt → next event uses the new state, no restart needed.

--- a/.codesight/wiki/overview.md
+++ b/.codesight/wiki/overview.md
@@ -2,29 +2,27 @@
 
 ## Stack
 
-**Electron 33** desktop app: React/TypeScript renderer + Node main process + a native Rust addon (`pollis-node`) loaded into the main process via `require('pollis-node')`. The renderer reaches the Rust backend through the preload bridge `window.electronAPI`.
+**Tauri 2** desktop app: a React/TypeScript renderer running in the OS WebView (WebKitGTK on Linux, WKWebView on macOS, WebView2 on Windows), with the Rust backend compiled into the Tauri host process. The renderer reaches the backend through the shell-agnostic bridge `frontend/src/bridge`, which routes to Tauri's `invoke`.
 
-- **No backend server.** The Rust core (loaded into the Electron main process by `pollis-node`) connects directly to Turso (1 network hop). All business logic runs in the main process; the renderer invokes commands via `window.electronAPI.invoke(cmd, args)`.
-- **Media stays in Rust.** Voice and screenshare run inside `pollis-core` via the `livekit` + `libwebrtc` crates, not in the renderer. Two reasons: (a) cross-platform parity — the same Rust pipeline is consumed by mobile through uniffi bindings; (b) predictable allocation — multi-MB media buffers passed through V8's heap produce visible GC stutter, while Rust's manual allocation does not. The renderer's Chromium does have WebRTC available, but JS-based media APIs are reserved for small UI previews, not capture/publish/render.
+- **No backend server.** The Rust core (compiled into the Tauri host process) connects directly to Turso (1 network hop). All business logic runs in `pollis-core`; the renderer invokes commands via `invoke(cmd, args)` through the bridge.
+- **Media stays in Rust.** Voice and screenshare run inside `pollis-core` via the `livekit` + `libwebrtc` crates, not in the renderer. Two reasons: (a) cross-platform parity — the same Rust pipeline is consumed by mobile through uniffi bindings; (b) predictable allocation — multi-MB media buffers passed through a JS heap produce visible GC stutter, while Rust's manual allocation does not. This also sidesteps WebKitGTK's lack of WebRTC on Linux — the Rust path is the only one that works on every target.
 
 ## Data Flow
 
 ```
 React component
   → invoke("command_name", { args })            // from frontend/src/bridge
-    → window.electronAPI.invoke(...)            // preload (electron/src/preload.ts)
-      → ipcRenderer.invoke("invoke", cmd, args)
-        → ipcMain.handle("invoke", ...)         // main (electron/src/main.ts)
-          → pollis-node dispatch                // pollis-node/src/dispatch/*.rs
-            → pollis_core::commands::*          // pollis-core/src/commands/*.rs
-              → Turso (remote, metadata) or SQLite (local, secrets)
-            ← Result<T>
+    → @tauri-apps/api/core invoke(...)          // bridge routes to Tauri
+      → #[tauri::command] shim                   // src-tauri/src/commands/*.rs
+        → pollis_core::commands::*              // pollis-core/src/commands/*.rs
+          → Turso (remote, metadata) or SQLite (local, secrets)
         ← Result<T>
+      ← Result<T>
     ← Result<T>
   ← React Query cache
 ```
 
-The dispatch layer in `pollis-node/src/dispatch/<module>.rs` is mechanical — one match arm per command, deserialising the JSON args and calling the corresponding `pollis_core::commands::…` function. Real logic lives in the `pollis-core` workspace crate so other front-ends — a CLI, a TUI, mobile via uniffi — can consume it without any shell-runtime dependency. Legacy `#[tauri::command]` shims under `src-tauri/src/commands/` are preserved for rollback.
+The `#[tauri::command]` shims in `src-tauri/src/commands/<module>.rs` are mechanical — each is registered in `src-tauri/src/lib.rs`'s `invoke_handler!` and forwards the JSON-shaped call to the corresponding `pollis_core::commands::…` function. Real logic lives in the `pollis-core` workspace crate so other front-ends — a CLI, a TUI, mobile via uniffi — can consume it without any shell-runtime dependency. **Edit `pollis-core`, not the shims.**
 
 **React Query** is the source of truth for remote data. **MobX** holds only UI state (current user ref, transient session data).
 
@@ -59,17 +57,7 @@ pollis-core/src/
   signal/            # MLS storage backend
   lib.rs             # uniffi exports for mobile bindings
 
-pollis-node/src/
-  lib.rs             # napi-rs addon entry; loads .env.development; ThreadsafeFunction registration
-  state.rs           # Per-process AppState shared with pollis-core
-  events.rs          # Rust → Node event channel plumbing
-  dispatch/          # invoke dispatch — one arm per command module (active path)
-
-electron/src/
-  main.ts            # Electron main process — loads pollis-node, registers ipcMain handlers, owns BrowserWindow + auto-updater
-  preload.ts         # Exposes window.electronAPI to the renderer
-
-src-tauri/src/       # Legacy Tauri shell (retained for rollback; not the active path)
+src-tauri/src/       # Tauri desktop host — the shipping shell
   commands/          # Thin #[tauri::command] shims forwarding to pollis_core
   sink.rs            # ChannelSink adapter (Tauri's ipc::Channel → EventSink)
   test_harness.rs    # Multi-client integration harness (feature = "test-harness")
@@ -77,7 +65,7 @@ src-tauri/src/       # Legacy Tauri shell (retained for rollback; not the active
   main.rs            # Binary entry
 
 frontend/src/
-  bridge/            # Runtime-host bridge — invoke/Channel/window/dialog/fs/shell/app/updater route through window.electronAPI; legacy Tauri fallback retained
+  bridge/            # Runtime-host bridge — invoke/Channel/window/dialog/fs/shell/app/updater route through Tauri's invoke
   components/        # React components (Auth/, Layout/, Message/, ui/, Voice/, ...)
   hooks/queries/     # React Query hooks (useGroups, useMessages, usePreferences, ...)
   pages/             # Route pages
@@ -98,12 +86,12 @@ website/             # Static marketing site (Cloudflare Pages, not part of the 
 
 ## Security Model
 
-**Trusted:** User's device, local database, the signed Electron app binary (main process + preload + `pollis-node`/`pollis-core` addon) at the installed version, OS keystore.
+**Trusted:** User's device, local database, the signed Tauri application binary (Tauri host + WebView renderer + `pollis-core`) at the installed version, OS keystore.
 **Untrusted:** Network, Turso, server operators.
 
 ## Realtime
 
-LiveKit rooms carry realtime events (new_message, membership_changed, voice_joined, etc.). The Rust event loop in `livekit.rs` receives data events, dispatches them through `pollis-node`'s Rust → Node `ThreadsafeFunction`; the Electron main process forwards each envelope via `webContents.send("channel:<id>", payload)`; the renderer subscribes through `window.electronAPI.channelOn(id, handler)`. MLS operations (process commits, poll welcomes) fire as needed.
+LiveKit rooms carry realtime events (new_message, membership_changed, voice_joined, etc.). The Rust event loop in `livekit.rs` receives data events and pushes them through the `EventSink` trait; `src-tauri/src/sink.rs`'s `ChannelSink` wraps a `tauri::ipc::Channel<E>` so the event rides Tauri's IPC channel to the renderer, which subscribes through the bridge's `channelOn(id, handler)`. MLS operations (process commits, poll welcomes) fire as needed.
 
 Events are a **convenience for speed**, not a correctness requirement. All MLS state is also read from the DB on every message send/receive, so offline devices catch up when they next interact.
 

--- a/.codesight/wiki/pin-design.md
+++ b/.codesight/wiki/pin-design.md
@@ -231,7 +231,7 @@ Critically: the Turso-side account is untouched. Other devices for the same user
 
 ## New and changed commands
 
-Dispatched in `pollis-node/src/dispatch/pin.rs` (the active path), with a parallel `#[tauri::command]` shim retained under `src-tauri/src/commands/pin.rs` for rollback. The real implementation is in `pollis-core/src/commands/pin.rs` (alongside `auth.rs` and `account_identity.rs` in the same crate).
+Dispatched by the `#[tauri::command]` shim under `src-tauri/src/commands/pin.rs` (registered in `src-tauri/src/lib.rs`'s `invoke_handler!`). The real implementation is in `pollis-core/src/commands/pin.rs` (alongside `auth.rs` and `account_identity.rs` in the same crate).
 
 - `set_pin(old_pin: Option<String>, new_pin: String) -> Result<()>`
   - Initial set and change. See lifecycle above.

--- a/.codesight/wiki/testing.md
+++ b/.codesight/wiki/testing.md
@@ -5,7 +5,7 @@ Pollis has two tiers of automated tests:
 1. **Unit tests** (in-crate `#[cfg(test)]` modules) — pure logic, in-memory rusqlite schemas, no I/O.
 2. **Integration harness** (`src-tauri/tests/flows.rs`) — drives the real `pollis-core` commands end-to-end against a disposable test Turso database. This document covers the harness.
 
-> The harness is built on top of Tauri's test machinery (`tauri::test::get_ipc_response` + `MockRuntime`) because the underlying command logic lives in `pollis-core` and is reachable through either dispatcher. The shipping shell is Electron, but the harness drives the same commands through a headless Tauri runtime as a convenient test fixture — no separate Electron-side harness is needed because `pollis-core` is the unit under test in both cases.
+> The harness is built on top of Tauri's test machinery (`tauri::test::get_ipc_response` + `MockRuntime`). Tauri is the shipping shell, so the harness drives the real command logic through the same dispatch path the app uses, headlessly — `pollis-core` is the unit under test, reached through the `#[tauri::command]` shims exactly as at runtime.
 
 ## Integration harness — goals
 

--- a/.codesight/wiki/windows-signing.md
+++ b/.codesight/wiki/windows-signing.md
@@ -1,6 +1,6 @@
 # Windows Code Signing — Azure Trusted Signing
 
-Pollis signs Windows `.exe` artifacts (inner binary + NSIS installer) using **Azure Trusted Signing**. Signing runs on the `windows-latest` GitHub Actions runner via `electron-builder`'s `signtoolOptions.sign` hook (`electron/build/sign.js`), which wraps `signtool.exe` with Azure's `/dlib` + `/dmdf` integration. The private key lives in Azure's HSM — no PFX, no hardware token.
+Pollis signs the Windows NSIS installer using **Azure Trusted Signing**. Signing runs on the `windows-latest` GitHub Actions runner inside **Tauri's bundler**: the release workflow injects a `bundle.windows.signCommand` into `src-tauri/tauri.conf.json` that points `signtool.exe` at Azure's Code Signing dlib (`signtool sign … /dlib Azure.CodeSigning.Dlib.dll /dmdf <metadata.json> %1`), then `pnpm build:tauri:windows` invokes it on the bundled artifact. The private key lives in Azure's HSM — no PFX, no hardware token.
 
 > Note: in earlier names of the service this was called "Azure Artifact Signing". The Azure resources below still appear under that namespace in the `az` CLI surface (`az artifact-signing …`) even though Microsoft markets the service as Trusted Signing today.
 
@@ -100,7 +100,7 @@ Steps 2 and 4 are **portal-only** — no CLI path exists. Everything else is scr
      --scope "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.CodeSigning/codeSigningAccounts/<account>/certificateProfiles/pollis-public"
    ```
 
-8. **Update Doppler** with the six secrets from the table above. The CI workflow (`.github/workflows/electron-release.yml`) picks them up automatically; `electron-builder`'s sign hook reads them at signing time and passes them into the Azure dlib.
+8. **Update Doppler** with the six secrets from the table above. The release workflow (`.github/workflows/desktop-release.yml`) picks them up automatically: it writes the signing metadata JSON, injects the `signtool` `signCommand` into `tauri.conf.json`, and Tauri's bundler invokes signtool at bundle time — which hands the metadata to the Azure dlib (authenticated via `DefaultAzureCredential` from `AZURE_TENANT_ID/CLIENT_ID/CLIENT_SECRET`).
 
 ## Migrating to an organization tenant
 

--- a/docs/security-whitepaper.md
+++ b/docs/security-whitepaper.md
@@ -14,7 +14,7 @@
 |---|---|
 | The user's device | Network (any path between the device and any remote service) |
 | The OS keystore (Keychain / Secret Service / Credential Manager) | Turso (libSQL) — the remote relational database |
-| The Electron application binary (renderer + preload + Rust sidecar `pollis-node`) at the version the user installed | Cloudflare R2 — object storage for attachments |
+| The signed Tauri application binary (Tauri host + WebView renderer + `pollis-core`) at the version the user installed | Cloudflare R2 — object storage for attachments |
 | The local SQLCipher database file | LiveKit — SFU and signalling for voice and realtime events |
 | The user-held Secret Key (printed once, expected to be stored offline) | Resend — outbound email transit for OTPs |
 | The user-held PIN (in the user's head) | Anyone with read access to a copy of `accounts.json` or the keystore who does not also have the PIN |
@@ -337,7 +337,7 @@ This is the same shape as MEGA's "Convergent Encrypted" layer (without its block
 
 R2 is reached over HTTPS with **AWS SigV4** (`sigv4_headers`): canonical request → string-to-sign → date-region-service-derived signing key (HMAC-SHA256) → signature in the `Authorization` header. The `R2_ACCESS_KEY_ID` and `R2_SECRET_KEY` are baked into the binary, like `TURSO_TOKEN`. Same shared-credential trust model (§8.1).
 
-The `upload_media` command reads files from disk by path inside the Rust sidecar, not over Electron IPC, so arbitrary-size attachments do not hit IPC framing limits.
+The `upload_media` command reads files from disk by path inside `pollis-core` (in the Tauri host process), rather than marshalling bytes across the `invoke` IPC boundary, so arbitrary-size attachments do not hit IPC framing limits.
 
 ### 9.4 Avatars and group icons
 
@@ -382,7 +382,7 @@ The MLS group used is the same group that protects the channel's text messages (
 
 ### 10.3 Audio pipeline (defensive context)
 
-Mic capture: `cpal` in 10 ms i16 mono frames → optional RNNoise (`nnnoiseless`) → WebRTC AudioProcessing module (AGC2 + NS + HPF + AEC, via `webrtc-audio-processing`) → LiveKit `NativeAudioSource.capture_frame` → SRTP. The entire pipeline runs in the Rust sidecar; audio never enters the renderer. This is a deliberate architecture choice (cross-platform parity with mobile, and predictable allocation that avoids V8 GC pressure on multi-MB media buffers), enforced by the surrounding code and described in `CLAUDE.md`.
+Mic capture: `cpal` in 10 ms i16 mono frames → optional RNNoise (`nnnoiseless`) → WebRTC AudioProcessing module (AGC2 + NS + HPF + AEC, via `webrtc-audio-processing`) → LiveKit `NativeAudioSource.capture_frame` → SRTP. The entire pipeline runs in the Rust core (the Tauri host process); audio never enters the renderer. This is a deliberate architecture choice (cross-platform parity with mobile, and predictable allocation that avoids JS-heap GC pressure on multi-MB media buffers), enforced by the surrounding code and described in `CLAUDE.md`.
 
 ### 10.4 Signalling channel
 


### PR DESCRIPTION
The runtime reverted to Tauri (#386/#389), but `.codesight/wiki/` and the security whitepaper still described **Electron** as the active shell (`window.electronAPI`, `pollis-node` dispatch, `ThreadsafeFunction`/`webContents.send`, electron-builder signing, `electron-release.yml`), with `src-tauri` mislabeled 'legacy rollback'. Corrected to the actual Tauri architecture:

- **Dispatch:** `invoke` → `#[tauri::command]` shim (`src-tauri/src/commands`, registered in `invoke_handler!`) → `pollis-core`.
- **Events:** `EventSink`/`ChannelSink` over `tauri::ipc::Channel` → bridge `channelOn` (no ThreadsafeFunction/webContents).
- **Notifications:** `tauri-plugin-notification`.
- **Windows signing:** `desktop-release.yml` injects a `bundle.windows.signCommand` into `tauri.conf.json` (signtool + Azure CodeSigning dlib), signed by Tauri's bundler — not electron-builder's hook.
- **Screenshare (capture-split):** reframed the real WebRTC-vs-Rust-helper split — the browser publish path is gated by `hasWebRTC()` (WebKitGTK on Linux has none → Rust helper); the helper ships via the Tauri build.
- **Whitepaper trust model + media path:** Tauri host + WebView + `pollis-core` (not Electron binary + preload + `pollis-node` sidecar).

Scope: wiki + whitepaper only. Left as-is: the untracked `electron/`+`pollis-node/` rollback refs, historical `electron-migration*.md`, and the `frontend/src/bridge/*` dual-runtime code.