### PR TITLE
docs(website): describe the client as Tauri, not Electron

### DIFF
--- a/website/faq.html
+++ b/website/faq.html
@@ -177,7 +177,7 @@
             <p>A desktop messaging app with group channels and direct messages, like Slack, but your messages are encrypted on your device before they leave it. The people running Pollis can't read them.</p>
           </div>
           <div class="dev">
-            <p>Electron desktop client with a React UI and a Rust core for cryptography, MLS group state, and real-time media. The Rust core connects directly to a Turso/libSQL backend. Messages are end-to-end encrypted with MLS (RFC 9420) via <code>openmls</code>; the server only stores ciphertext envelopes plus routing metadata. No intermediate app server.</p>
+            <p>Tauri desktop client with a React UI and a Rust core for cryptography, MLS group state, and real-time media. The Rust core connects directly to a Turso/libSQL backend. Messages are end-to-end encrypted with MLS (RFC 9420) via <code>openmls</code>; the server only stores ciphertext envelopes plus routing metadata. No intermediate app server.</p>
           </div>
         </div>
       </div>

--- a/website/install.sh
+++ b/website/install.sh
@@ -100,8 +100,8 @@ install_macos() {
     info "Mounting disk image..."
     mount_line=$(hdiutil attach "$dmg_path" -nobrowse -noautoopen | grep "/Volumes/")
     # `hdiutil attach` outputs tab-separated columns, and the volume path is
-    # the last column. electron-builder titles the DMG volume "Pollis <ver>"
-    # — the embedded space breaks `awk '{print $NF}'` (it returns just the
+    # the last column. The DMG volume title can contain a space (e.g.
+    # "Pollis 1.2.0"), which breaks `awk '{print $NF}'` (it returns just the
     # last whitespace-token). Strip everything up to the first `/Volumes/`
     # so the entire path, spaces and all, comes through.
     mount_point=$(echo "$mount_line" | sed -E 's|.*(/Volumes/.*)|\1|')


### PR DESCRIPTION
Follow-up to #416 (the wiki/whitepaper Electron→Tauri pass), covering the two user-facing `website/` spots:

- **`faq.html`** — the dev FAQ called Pollis an *"Electron desktop client"*; now says Tauri.
- **`install.sh`** — the DMG-volume comment attributed the volume title to `electron-builder`; reworded to be runtime-neutral. **No logic change** — the parsing already strips to `/Volumes/` regardless of the volume name, and `Pollis.app` matches Tauri's `productName` (verified), so the macOS install path works as-is.