### PR TITLE
fix(transparency): distinct empty-log errors + decouple builder tenants

### DIFF
--- a/verifiable-log-builder/src/bin/builder.rs
+++ b/verifiable-log-builder/src/bin/builder.rs
@@ -145,13 +145,48 @@ async fn run_build(
     // Resolve the signing key BEFORE touching the DB so a missing key fails fast.
     let signing_key = keys::load_signing_key(signing_key_env, signing_key_file)?;
 
+    // The two tenants are INDEPENDENT: the commit log lives in the log DB and the
+    // account-key directory in the main DB, on separate Merkle trees. A transient
+    // empty commit log (e.g. right after Goal A's cutover) must NOT block the
+    // account-key bundle, and vice versa. So we read both first, then decide.
+
     // Commit-log tenant (frozen contract): read from the LOG DB with its token.
     let log_conn = source::connect_with_token(&log_db, &log_token).await?;
     let rows = source::read_commit_log(&log_conn).await?;
-    source::ensure_non_empty(&rows)?;
+    let commit_empty = rows.is_empty();
 
+    // Account-key tenant (separate tree, domain-separated STH) — only when asked.
+    // It stays in the MAIN DB (TURSO_AUTH_TOKEN), independent of the log DB.
+    let account_rows = if account_out.is_some() {
+        let conn = source::connect(&db).await?;
+        Some(source::read_account_key_log(&conn).await?)
+    } else {
+        None
+    };
+    // "Absent" (not requested) counts the same as "empty" for the all-empty check.
+    let account_empty = account_rows.as_ref().map_or(true, |r| r.is_empty());
+
+    // Only hard-fail when there is nothing to publish from EITHER tenant. With at
+    // least one non-empty source we go on to write a bundle for each — an empty
+    // source yields a valid empty/zero-length bundle (see below), never an abort.
+    if commit_empty && account_empty {
+        // The DB connected fine; the commit log is just empty. Surface that
+        // distinct condition (EmptyCommitLog), not the missing-source NoDbSource.
+        source::ensure_non_empty(&rows)?;
+    }
+
+    // Commit-log bundle. `build_bundle` over zero rows is well-defined — it emits
+    // a valid bundle with a single STH over tree size 0 and no entries — so we
+    // ALWAYS write `out`. That keeps the downstream `serve generate --bundle
+    // bundle.json` step working (the file always exists and parses) instead of
+    // crashing on a missing file when the commit log happens to be empty.
+    if commit_empty {
+        eprintln!(
+            "notice: commit log is empty (db connected OK) — writing an empty commit-log \
+             bundle so `serve generate` still runs; the account-key tree is built independently"
+        );
+    }
     let bundle = build_bundle(&rows, &signing_key, timestamp)?;
-
     let json = serde_json::to_string_pretty(&bundle)?;
     std::fs::write(&out, json)?;
 
@@ -164,13 +199,16 @@ async fn run_build(
         out.display()
     );
 
-    // Account-key tenant (separate tree, domain-separated STH) — only when asked.
-    // It stays in the MAIN DB (TURSO_AUTH_TOKEN), independent of the log DB.
-    if let Some(account_out) = account_out {
-        let conn = source::connect(&db).await?;
-        let account_rows = source::read_account_key_log(&conn).await?;
-        source::ensure_account_non_empty(&account_rows)?;
-
+    // Account-key bundle, written independently of the commit log's state. Like
+    // the commit bundle, a zero-row account log yields a valid empty bundle, so
+    // `serve generate --account-bundle ...` always has a file to read.
+    if let (Some(account_out), Some(account_rows)) = (account_out, account_rows) {
+        if account_rows.is_empty() {
+            eprintln!(
+                "notice: account-key log is empty (db connected OK) — writing an empty \
+                 account-key bundle"
+            );
+        }
         let account_bundle = build_account_bundle(&account_rows, &signing_key, account_timestamp)?;
         let account_json = serde_json::to_string_pretty(&account_bundle)?;
         std::fs::write(&account_out, account_json)?;

--- a/verifiable-log-builder/src/error.rs
+++ b/verifiable-log-builder/src/error.rs
@@ -27,6 +27,12 @@ pub enum BuilderError {
     #[error("no database source: pass --db <url-or-path> or set TURSO_DATABASE_URL")]
     NoDbSource,
 
+    #[error("commit log is empty: nothing to build a bundle from (db connected OK)")]
+    EmptyCommitLog,
+
+    #[error("account-key log is empty: nothing to build a bundle from (db connected OK)")]
+    EmptyAccountKeyLog,
+
     #[error(
         "no signing key: set env `{0}` to 32-byte hex, or pass --signing-key-file <path>. \
          Refusing to invent a key. Use `builder keygen` to mint a throwaway dev key."

--- a/verifiable-log-builder/src/source.rs
+++ b/verifiable-log-builder/src/source.rs
@@ -178,20 +178,24 @@ pub fn sha256_hex(bytes: &[u8]) -> String {
     hex::encode(digest)
 }
 
-/// Guard against an empty source: building a bundle over zero commits is almost
-/// always a misconfiguration (wrong DB / wrong table), so surface it.
+/// Guard against an empty commit-log source. An empty table is a distinct
+/// condition from a missing `--db` argument: the DB connected fine, it just has
+/// no commits yet (e.g. immediately after Goal A's cutover). So it returns
+/// [`BuilderError::EmptyCommitLog`], never [`BuilderError::NoDbSource`] — the
+/// latter is reserved for the genuine missing-source case in `builder.rs`.
 pub fn ensure_non_empty(rows: &[CommitRow]) -> Result<()> {
     if rows.is_empty() {
-        return Err(BuilderError::NoDbSource);
+        return Err(BuilderError::EmptyCommitLog);
     }
     Ok(())
 }
 
 /// Guard against an empty account-key source. Separate from [`ensure_non_empty`]
-/// so the two tenants can be checked independently.
+/// so the two tenants can be checked independently — an empty account-key log
+/// returns its own [`BuilderError::EmptyAccountKeyLog`].
 pub fn ensure_account_non_empty(rows: &[AccountKeyRow]) -> Result<()> {
     if rows.is_empty() {
-        return Err(BuilderError::NoDbSource);
+        return Err(BuilderError::EmptyAccountKeyLog);
     }
     Ok(())
 }

--- a/verifiable-log-builder/tests/account_build.rs
+++ b/verifiable-log-builder/tests/account_build.rs
@@ -13,7 +13,7 @@ use verifiable_log::{
 };
 use verifiable_log_builder::account_key::{AccountKeyInvariant, STH_CONTEXT, TENANT};
 use verifiable_log_builder::builder::Bundle;
-use verifiable_log_builder::{build_account_bundle, source};
+use verifiable_log_builder::{build_account_bundle, build_bundle, source};
 
 const TS: u64 = 1_700_000_000_000;
 const KEY: [u8; 32] = [9u8; 32];
@@ -206,6 +206,46 @@ async fn rebuild_is_byte_identical_for_a_reused_timestamp() {
     assert_ne!(
         first, moved,
         "a different timestamp must change the signed STH bytes"
+    );
+}
+
+/// The two tenants are independent: an empty commit log must not block the
+/// account-key bundle (and vice versa). This mirrors the builder's decoupled
+/// `run_build` — an empty commit source surfaces `EmptyCommitLog` and still
+/// yields a valid (empty) commit bundle, while the non-empty account log builds
+/// and verifies entirely on its own.
+#[tokio::test]
+async fn account_bundle_builds_when_commit_log_is_empty() {
+    // Commit log empty (e.g. right after Goal A's cutover).
+    let empty_commits: Vec<source::CommitRow> = Vec::new();
+    assert!(
+        matches!(
+            source::ensure_non_empty(&empty_commits).unwrap_err(),
+            verifiable_log_builder::BuilderError::EmptyCommitLog
+        ),
+        "an empty commit log must surface EmptyCommitLog"
+    );
+    // It still produces a valid bundle rather than aborting the whole run.
+    build_bundle(&empty_commits, &signing_key(), TS)
+        .expect("empty commit log must still build a valid bundle");
+
+    // The account-key log is non-empty and its bundle builds + verifies
+    // independently of the commit log's (empty) state.
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("accounts.db");
+    let rows = vec![
+        row(1, "u-alice", 1, &[0xa1; 32]),
+        row(2, "u-bob", 1, &[0xb1; 32]),
+    ];
+    seed_db(&db_path, &rows).await;
+
+    let conn = source::connect(db_path.to_str().unwrap()).await.unwrap();
+    let read = source::read_account_key_log(&conn).await.unwrap();
+    let bundle = build_account_bundle(&read, &signing_key(), TS).unwrap();
+    assert_eq!(bundle.entries.len(), 2);
+    assert!(
+        monitor_verify_account(&bundle),
+        "account bundle must verify even though the commit log is empty"
     );
 }
 

--- a/verifiable-log-builder/tests/build.rs
+++ b/verifiable-log-builder/tests/build.rs
@@ -254,6 +254,59 @@ async fn tampered_entry_fails_verification() {
     );
 }
 
+#[tokio::test]
+async fn empty_commit_log_yields_empty_commit_log_error_not_no_db_source() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("empty.db");
+    // A connectable DB with the right table but ZERO rows — the freshly-cut-over
+    // log DB case. The DB is fine; it is just empty.
+    seed_db(&db_path, &[]).await;
+
+    let conn = source::connect(db_path.to_str().unwrap()).await.unwrap();
+    let read = source::read_commit_log(&conn).await.unwrap();
+    assert!(read.is_empty());
+
+    let err = source::ensure_non_empty(&read).unwrap_err();
+    // It must be the empty-table signal, NOT the missing-`--db` signal.
+    assert!(
+        matches!(err, verifiable_log_builder::BuilderError::EmptyCommitLog),
+        "expected EmptyCommitLog, got: {err}"
+    );
+    let msg = err.to_string();
+    assert!(msg.contains("db connected OK"), "got: {msg}");
+    assert!(
+        !msg.contains("--db") && !msg.contains("TURSO_DATABASE_URL"),
+        "must not look like a missing-db-source error: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn empty_commit_log_still_builds_a_valid_bundle() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("empty.db");
+    seed_db(&db_path, &[]).await;
+
+    let conn = source::connect(db_path.to_str().unwrap()).await.unwrap();
+    let read = source::read_commit_log(&conn).await.unwrap();
+
+    // A zero-row commit log produces a valid empty bundle (one STH over tree
+    // size 0, no entries). This is what keeps `serve generate --bundle ...`
+    // working when the commit log happens to be empty: the file always exists
+    // and parses, rather than the builder aborting and leaving it missing.
+    let bundle = build_bundle(&read, &signing_key(), TS).unwrap();
+    assert_eq!(bundle.entries.len(), 0);
+    assert_eq!(bundle.inclusion.len(), 0);
+    assert_eq!(bundle.consistency.len(), 0);
+    assert_eq!(bundle.sths.len(), 1);
+    assert_eq!(bundle.sths[0].tree_size, 0);
+    assert!(monitor_verify(&bundle), "empty bundle must still verify");
+
+    // And it round-trips through the on-disk JSON shape `serve generate` reads.
+    let json = serde_json::to_string_pretty(&bundle).unwrap();
+    let reparsed: Bundle = serde_json::from_str(&json).unwrap();
+    assert!(monitor_verify(&reparsed));
+}
+
 #[test]
 fn keygen_output_roundtrips() {
     let g = keys::generate();


### PR DESCRIPTION
Two robustness fixes in `verifiable-log-builder` surfaced during the #420 prod cutover:

1. **Misleading empty-source error.** `ensure_non_empty`/`ensure_account_non_empty` reused `NoDbSource` ("no database source: pass --db…") when a table was merely empty — making a freshly cut-over (empty) log DB look like a connection/config bug. Added distinct `EmptyCommitLog` / `EmptyAccountKeyLog` variants.
2. **Coupled tenants.** An empty commit log aborted the whole run before the account-key bundle built, blocking account-key transparency republish even though that table is separate and non-empty. `run_build` now builds the two tenants independently; an empty commit log writes a valid empty bundle (so `serve generate` can't crash) and the account bundle still builds, and vice-versa. Both-non-empty path is byte-identical to before.

Tests added; `cargo test -p verifiable-log-builder -p verifiable-log-serve` green.