### PR TITLE
Goal B: route all client writes through the Delivery Service (write-API server) (#419)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5980,6 +5980,7 @@ version = "1.1.0"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
+ "base64 0.22.1",
  "chrono",
  "cocoa",
  "dotenvy",

--- a/pollis-core/src/commands/account_identity.rs
+++ b/pollis-core/src/commands/account_identity.rs
@@ -220,6 +220,15 @@ pub async fn generate_account_identity(state: &Arc<AppState>, user_id: &str) -> 
     let wrap_key = derive_wrap_key(&secret_key_body, &salt);
     let wrapped = aes_gcm_encrypt(&wrap_key, &nonce, &private_bytes)?;
 
+    // BOOTSTRAP — stays DIRECT, NOT routed through the DS (#419 domains E+G).
+    // This is the version-1 account-identity establishment at signup. It runs
+    // inside `verify_otp` BEFORE `register_device` / `ensure_device_cert`, so no
+    // device signing key is enrolled yet (`user_device.mls_signature_pub` is
+    // NULL) and the local DB isn't even open — the device cannot produce a
+    // signature the DS would accept. It is single-device, single-shot, with no
+    // concurrency, so the `UNIQUE (user_id, identity_version)` index on
+    // `account_key_log` is a sufficient guard. Rotations (version ≥ 2) DO route
+    // through the CAS-guarded `/v1/account/rotate-identity` (see `reset_identity`).
     let conn = state.remote_db.conn().await?;
 
     conn.execute(
@@ -426,22 +435,16 @@ pub async fn reset_identity(state: &Arc<AppState>, user_id: &str) -> Result<Stri
     let wrap_key = derive_wrap_key(&secret_key_body, &salt);
     let wrapped = aes_gcm_encrypt(&wrap_key, &nonce, &private_bytes)?;
 
-    // 3. Atomically bump identity_version, overwrite users.account_id_pub,
-    //    and REPLACE the account_recovery row. We do this in three
-    //    statements because libsql doesn't expose a transaction
-    //    abstraction in our current setup; failure between statements
-    //    leaves a partial state that the next reset_identity call can
-    //    clean up.
+    // 3. Rotate the account identity. The `account_key_log` is an append-only,
+    //    transparency-backed log (#419 domains E+G): the version bump, the log
+    //    append, and the `account_recovery` rewrap MUST be one atomic,
+    //    CAS-guarded unit so two concurrent rotations can never fork the
+    //    published account-key transparency history. We read the current
+    //    version (the CAS expectation) and hand it to the Delivery Service —
+    //    the sole writer — which performs the conditional append in ONE
+    //    transaction (`pollis_delivery::account::apply_rotate_identity`).
     let conn = state.remote_db.conn().await?;
-    conn.execute(
-        "UPDATE users \
-         SET account_id_pub = ?1, identity_version = identity_version + 1 \
-         WHERE id = ?2",
-        libsql::params![public_bytes.to_vec(), user_id.to_string()],
-    )
-    .await?;
-
-    let new_version: i64 = {
+    let based_on_version: i64 = {
         let mut rows = conn
             .query(
                 "SELECT identity_version FROM users WHERE id = ?1",
@@ -458,35 +461,77 @@ pub async fn reset_identity(state: &Arc<AppState>, user_id: &str) -> Result<Stri
         }
     };
 
-    // Append the rotated key + new version to the account-key transparency
-    // history. Kept in lock-step with the users UPDATE above; `?` propagation
-    // means the INSERT can never silently fail while the rotation persists.
-    conn.execute(
-        "INSERT INTO account_key_log (user_id, account_id_pub, identity_version) \
-         VALUES (?1, ?2, ?3)",
-        libsql::params![user_id.to_string(), public_bytes.to_vec(), new_version],
-    )
-    .await?;
-
-    conn.execute(
-        "INSERT INTO account_recovery \
-         (user_id, identity_version, salt, nonce, wrapped_key, created_at, updated_at) \
-         VALUES (?1, ?2, ?3, ?4, ?5, datetime('now'), datetime('now')) \
-         ON CONFLICT(user_id) DO UPDATE SET \
-             identity_version = excluded.identity_version, \
-             salt = excluded.salt, \
-             nonce = excluded.nonce, \
-             wrapped_key = excluded.wrapped_key, \
-             updated_at = datetime('now')",
-        libsql::params![
-            user_id.to_string(),
-            new_version,
-            salt.to_vec(),
-            nonce.to_vec(),
-            wrapped
-        ],
-    )
-    .await?;
+    let new_version: i64 = match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            use base64::Engine as _;
+            let b64 = base64::engine::general_purpose::STANDARD;
+            let body = serde_json::json!({
+                "based_on_version": based_on_version,
+                "account_id_pub": b64.encode(public_bytes),
+                "salt": b64.encode(salt),
+                "nonce": b64.encode(nonce),
+                "wrapped_key": b64.encode(&wrapped),
+            });
+            let resp =
+                crate::commands::mls::ds_post(state, "/v1/account/rotate-identity", &body).await?;
+            let status = resp.status();
+            if status.as_u16() == 409 {
+                // A concurrent rotation already won this version. Refuse rather
+                // than forking the transparency log — caller must re-read + retry.
+                return Err(Error::Other(anyhow::anyhow!(
+                    "identity rotation lost a concurrent race (account_key_log CAS); retry"
+                )));
+            }
+            if !status.is_success() {
+                let txt = resp.text().await.unwrap_or_default();
+                return Err(Error::Other(anyhow::anyhow!(
+                    "DS rotate-identity {status}: {txt}"
+                )));
+            }
+            let v: serde_json::Value = resp
+                .json()
+                .await
+                .map_err(|e| Error::Other(anyhow::anyhow!("rotate-identity response: {e}")))?;
+            v["identity_version"].as_i64().unwrap_or(based_on_version + 1)
+        }
+        None => {
+            // Direct fallback (pre-cutover / no DS configured). Three statements;
+            // the same per-version uniqueness is enforced by the `UNIQUE
+            // (user_id, identity_version)` index on `account_key_log`.
+            let new_version = based_on_version + 1;
+            conn.execute(
+                "UPDATE users SET account_id_pub = ?1, identity_version = ?2 WHERE id = ?3",
+                libsql::params![public_bytes.to_vec(), new_version, user_id.to_string()],
+            )
+            .await?;
+            conn.execute(
+                "INSERT INTO account_key_log (user_id, account_id_pub, identity_version) \
+                 VALUES (?1, ?2, ?3)",
+                libsql::params![user_id.to_string(), public_bytes.to_vec(), new_version],
+            )
+            .await?;
+            conn.execute(
+                "INSERT INTO account_recovery \
+                 (user_id, identity_version, salt, nonce, wrapped_key, created_at, updated_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, datetime('now'), datetime('now')) \
+                 ON CONFLICT(user_id) DO UPDATE SET \
+                     identity_version = excluded.identity_version, \
+                     salt = excluded.salt, \
+                     nonce = excluded.nonce, \
+                     wrapped_key = excluded.wrapped_key, \
+                     updated_at = datetime('now')",
+                libsql::params![
+                    user_id.to_string(),
+                    new_version,
+                    salt.to_vec(),
+                    nonce.to_vec(),
+                    wrapped
+                ],
+            )
+            .await?;
+            new_version
+        }
+    };
 
     // 4. Install the new private key in AppState.unlock so the calling
     //    device is enrolled under the new identity. The bytes never
@@ -507,19 +552,33 @@ pub async fn reset_identity(state: &Arc<AppState>, user_id: &str) -> Result<Stri
         );
     }
 
-    // 6. Record the reset in the security log. Best-effort only.
-    let event_id = ulid::Ulid::new().to_string();
-    let _ = conn
-        .execute(
-            "INSERT INTO security_event (id, user_id, kind, device_id, metadata) \
-             VALUES (?1, ?2, 'identity_reset', NULL, ?3)",
-            libsql::params![
-                event_id,
-                user_id.to_string(),
-                format!("new_identity_version={new_version}")
-            ],
-        )
-        .await;
+    // 6. Record the reset in the security log. Best-effort only. Routed through
+    //    the DS (sole writer; #419 domains E+G) when configured, else direct.
+    let metadata = format!("new_identity_version={new_version}");
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            let body = serde_json::json!({
+                "kind": "identity_reset",
+                "device_id": serde_json::Value::Null,
+                "metadata": metadata,
+            });
+            if let Err(e) =
+                crate::commands::mls::ds_post_ok(state, "/v1/security-events", &body).await
+            {
+                eprintln!("[reset] DS security-event failed (non-fatal): {e}");
+            }
+        }
+        None => {
+            let event_id = ulid::Ulid::new().to_string();
+            let _ = conn
+                .execute(
+                    "INSERT INTO security_event (id, user_id, kind, device_id, metadata) \
+                     VALUES (?1, ?2, 'identity_reset', NULL, ?3)",
+                    libsql::params![event_id, user_id.to_string(), metadata],
+                )
+                .await;
+        }
+    }
 
     Ok(secret_key_display)
 }

--- a/pollis-core/src/commands/auth.rs
+++ b/pollis-core/src/commands/auth.rs
@@ -664,6 +664,13 @@ async fn register_device(state: &Arc<AppState>, user_id: &str) -> Result<String>
 
     // COALESCE preserves any existing device_name — fills it in only if NULL,
     // so a user-set rename (future feature) is never overwritten on reconnect.
+    //
+    // BOOTSTRAP — stays DIRECT, never routed through the DS (#419 domain D).
+    // This creates the device's `user_device` row with `mls_signature_pub` still
+    // NULL; the row is what a later `ensure_device_cert` populates to make the
+    // device DS-authenticatable. A brand-new device has no registered key for the
+    // DS to verify against, so its first registration cannot be signature-authed
+    // and writes Turso directly. See `pollis_delivery::devices` docs.
     let conn = state.remote_db.conn().await?;
     conn.execute(
         "INSERT INTO user_device (device_id, user_id, device_name) VALUES (?1, ?2, ?3) \

--- a/pollis-core/src/commands/auth.rs
+++ b/pollis-core/src/commands/auth.rs
@@ -741,6 +741,14 @@ pub async fn logout(state: &Arc<AppState>, delete_data: bool) -> Result<()> {
     if delete_data {
         if let Some(ref uid) = user_id {
             // Remove this device from the remote registry.
+            //
+            // BOOTSTRAP-CLASS — stays DIRECT, NOT routed through the DS (#419
+            // domains E+G). By the time this runs the local DB has already been
+            // unloaded and the in-memory session (`unlock`) cleared (above), and
+            // `state.device_id` has been taken — so there is no signing key
+            // available to authenticate a DS request. The device is logging
+            // itself out; a stale `user_device` row left behind on a network
+            // failure is harmless (it's tombstoned/overwritten on next login).
             if let Some(ref did) = device_id {
                 if let Ok(conn) = state.remote_db.conn().await {
                     let _ = conn.execute(
@@ -838,94 +846,107 @@ pub async fn delete_account(
     }
 
     // ── Phase 2: remote data cleanup ───────────────────────────────────
-
-    // Handle group ownership before removing memberships. For each group
-    // the user belongs to, check whether they're the sole member (delete
-    // the group) or the sole admin (promote another member first).
-    {
-        let mut group_rows = conn.query(
-            "SELECT group_id, role FROM group_member WHERE user_id = ?1",
-            libsql::params![user_id.clone()],
-        ).await?;
-
-        let mut memberships: Vec<(String, String)> = Vec::new();
-        while let Some(row) = group_rows.next().await? {
-            memberships.push((row.get(0)?, row.get(1)?));
+    //
+    // Route the entire remote wipe through the DS (#419 domains E+G) as ONE
+    // transaction when configured: the group-ownership handoff, the sent-envelope
+    // / key-package / membership deletes, and the final `users` delete all commit
+    // together or not at all — a half-deleted account is a corrupt state. The
+    // device is still fully enrolled here (the local DB is unloaded only in Phase
+    // 3 below), so it can sign the request.
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            let body = serde_json::json!({});
+            crate::commands::mls::ds_post_ok(state, "/v1/account/delete", &body).await?;
         }
-
-        for (gid, role) in &memberships {
-            // How many members does this group have?
-            let mut count_rows = conn.query(
-                "SELECT COUNT(*) FROM group_member WHERE group_id = ?1",
-                libsql::params![gid.clone()],
-            ).await?;
-            let member_count: i64 = if let Some(row) = count_rows.next().await? {
-                row.get(0)?
-            } else {
-                0
-            };
-
-            if member_count <= 1 {
-                // Sole member — delete the entire group (cascades channels, invites, etc.)
-                let _ = conn.execute(
-                    "DELETE FROM groups WHERE id = ?1",
-                    libsql::params![gid.clone()],
-                ).await;
-                eprintln!("[account] deleted empty group {gid}");
-            } else if role == "admin" {
-                // Check if there are other admins.
-                let mut admin_rows = conn.query(
-                    "SELECT COUNT(*) FROM group_member WHERE group_id = ?1 AND role = 'admin' AND user_id != ?2",
-                    libsql::params![gid.clone(), user_id.clone()],
+        None => {
+            // Direct fallback (pre-cutover / no DS). Handle group ownership
+            // before removing memberships.
+            {
+                let mut group_rows = conn.query(
+                    "SELECT group_id, role FROM group_member WHERE user_id = ?1",
+                    libsql::params![user_id.clone()],
                 ).await?;
-                let other_admins: i64 = if let Some(row) = admin_rows.next().await? {
-                    row.get(0)?
-                } else {
-                    0
-                };
 
-                if other_admins == 0 {
-                    // Sole admin — promote the first non-admin member.
-                    let mut candidate_rows = conn.query(
-                        "SELECT user_id FROM group_member WHERE group_id = ?1 AND user_id != ?2 LIMIT 1",
-                        libsql::params![gid.clone(), user_id.clone()],
+                let mut memberships: Vec<(String, String)> = Vec::new();
+                while let Some(row) = group_rows.next().await? {
+                    memberships.push((row.get(0)?, row.get(1)?));
+                }
+
+                for (gid, role) in &memberships {
+                    // How many members does this group have?
+                    let mut count_rows = conn.query(
+                        "SELECT COUNT(*) FROM group_member WHERE group_id = ?1",
+                        libsql::params![gid.clone()],
                     ).await?;
-                    if let Some(row) = candidate_rows.next().await? {
-                        let new_admin: String = row.get(0)?;
+                    let member_count: i64 = if let Some(row) = count_rows.next().await? {
+                        row.get(0)?
+                    } else {
+                        0
+                    };
+
+                    if member_count <= 1 {
+                        // Sole member — delete the entire group (cascades channels, invites, etc.)
                         let _ = conn.execute(
-                            "UPDATE group_member SET role = 'admin' WHERE group_id = ?1 AND user_id = ?2",
-                            libsql::params![gid.clone(), new_admin.clone()],
+                            "DELETE FROM groups WHERE id = ?1",
+                            libsql::params![gid.clone()],
                         ).await;
-                        eprintln!("[account] promoted {new_admin} to admin in group {gid}");
+                        eprintln!("[account] deleted empty group {gid}");
+                    } else if role == "admin" {
+                        // Check if there are other admins.
+                        let mut admin_rows = conn.query(
+                            "SELECT COUNT(*) FROM group_member WHERE group_id = ?1 AND role = 'admin' AND user_id != ?2",
+                            libsql::params![gid.clone(), user_id.clone()],
+                        ).await?;
+                        let other_admins: i64 = if let Some(row) = admin_rows.next().await? {
+                            row.get(0)?
+                        } else {
+                            0
+                        };
+
+                        if other_admins == 0 {
+                            // Sole admin — promote the first non-admin member.
+                            let mut candidate_rows = conn.query(
+                                "SELECT user_id FROM group_member WHERE group_id = ?1 AND user_id != ?2 LIMIT 1",
+                                libsql::params![gid.clone(), user_id.clone()],
+                            ).await?;
+                            if let Some(row) = candidate_rows.next().await? {
+                                let new_admin: String = row.get(0)?;
+                                let _ = conn.execute(
+                                    "UPDATE group_member SET role = 'admin' WHERE group_id = ?1 AND user_id = ?2",
+                                    libsql::params![gid.clone(), new_admin.clone()],
+                                ).await;
+                                eprintln!("[account] promoted {new_admin} to admin in group {gid}");
+                            }
+                        }
                     }
                 }
             }
+
+            // Remove encrypted message envelopes sent by this user
+            let _ = conn.execute(
+                "DELETE FROM message_envelope WHERE sender_id = ?1",
+                libsql::params![user_id.clone()],
+            ).await;
+
+            // Remove MLS key packages
+            let _ = conn.execute(
+                "DELETE FROM mls_key_package WHERE user_id = ?1",
+                libsql::params![user_id.clone()],
+            ).await;
+
+            // Remove group memberships (for groups that weren't deleted above)
+            let _ = conn.execute(
+                "DELETE FROM group_member WHERE user_id = ?1",
+                libsql::params![user_id.clone()],
+            ).await;
+
+            // Remove the user row itself (cascades to dm_channel_member, group_invite, etc.)
+            conn.execute(
+                "DELETE FROM users WHERE id = ?1",
+                libsql::params![user_id.clone()],
+            ).await?;
         }
     }
-
-    // Remove encrypted message envelopes sent by this user
-    let _ = conn.execute(
-        "DELETE FROM message_envelope WHERE sender_id = ?1",
-        libsql::params![user_id.clone()],
-    ).await;
-
-    // Remove MLS key packages
-    let _ = conn.execute(
-        "DELETE FROM mls_key_package WHERE user_id = ?1",
-        libsql::params![user_id.clone()],
-    ).await;
-
-    // Remove group memberships (for groups that weren't deleted above)
-    let _ = conn.execute(
-        "DELETE FROM group_member WHERE user_id = ?1",
-        libsql::params![user_id.clone()],
-    ).await;
-
-    // Remove the user row itself (cascades to dm_channel_member, group_invite, etc.)
-    conn.execute(
-        "DELETE FROM users WHERE id = ?1",
-        libsql::params![user_id.clone()],
-    ).await?;
 
     // ── Phase 3: local cleanup ─────────────────────────────────────────
 
@@ -1072,26 +1093,33 @@ pub async fn revoke_device(
         )));
     }
 
-    // Drop unclaimed key packages — these are one-time-use and useless
-    // for a revoked device.
-    conn.execute(
-        "DELETE FROM mls_key_package WHERE user_id = ?1 AND device_id = ?2",
-        libsql::params![user_id.clone(), device_id.clone()],
-    )
-    .await?;
-    // Tombstone the device instead of hard-deleting (issue #372). Other
-    // members' `verify_added_devices` must be able to distinguish "this
-    // device was revoked — drop any rejoin attempt" from "this device
-    // is just lagging — don't destroy commits about it." A hard-delete
-    // makes those two cases indistinguishable; the tombstone makes the
-    // revocation observable AND keeps the row available for later cert
-    // verification of historical commits.
-    conn.execute(
-        "UPDATE user_device SET revoked_at = datetime('now') \
-         WHERE device_id = ?1 AND user_id = ?2 AND revoked_at IS NULL",
-        libsql::params![device_id.clone(), user_id.clone()],
-    )
-    .await?;
+    // Drop the revoked device's unclaimed key packages (one-time-use, useless
+    // now) and tombstone its row (issue #372 — a tombstone, not a hard-delete,
+    // so other members' `verify_added_devices` can tell "revoked, drop rejoin"
+    // from "lagging, keep commits" and the row stays available for historical
+    // cert verification). Routed through the DS (#419 domains E+G) as one
+    // transaction when configured — the CURRENT device drives this and is fully
+    // enrolled, so it can sign; the DS binds both writes to the signer
+    // (`WHERE user_id = actor`).
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            let body = serde_json::json!({ "device_id": device_id });
+            crate::commands::mls::ds_post_ok(state, "/v1/devices/revoke", &body).await?;
+        }
+        None => {
+            conn.execute(
+                "DELETE FROM mls_key_package WHERE user_id = ?1 AND device_id = ?2",
+                libsql::params![user_id.clone(), device_id.clone()],
+            )
+            .await?;
+            conn.execute(
+                "UPDATE user_device SET revoked_at = datetime('now') \
+                 WHERE device_id = ?1 AND user_id = ?2 AND revoked_at IS NULL",
+                libsql::params![device_id.clone(), user_id.clone()],
+            )
+            .await?;
+        }
+    }
 
     // Collect every conversation the user belongs to (groups + DMs) so
     // we can reconcile each one as the calling device.

--- a/pollis-core/src/commands/blocks.rs
+++ b/pollis-core/src/commands/blocks.rs
@@ -45,31 +45,46 @@ pub async fn block_user(
         )));
     }
 
-    let conn = state.remote_db.conn().await?;
+    // DS seam: route the block write (insert block row + reset the blocker's
+    // accepted_at in shared DMs) through the Delivery Service when configured;
+    // else write Turso directly. Server-side authz binds the block to the
+    // authenticated user's own list and runs both writes in one transaction.
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            let body = serde_json::json!({
+                "blocker_id": blocker_id,
+                "blocked_id": blocked_id,
+            });
+            crate::commands::mls::ds_post_ok(state, "/v1/blocks/add", &body).await?;
+        }
+        None => {
+            let conn = state.remote_db.conn().await?;
 
-    // Insert the block row. PK conflict means the block already
-    // exists, which is fine — idempotent.
-    conn.execute(
-        "INSERT OR IGNORE INTO user_block (blocker_id, blocked_id)
-         VALUES (?1, ?2)",
-        libsql::params![blocker_id.clone(), blocked_id.clone()],
-    )
-    .await?;
+            // Insert the block row. PK conflict means the block already
+            // exists, which is fine — idempotent.
+            conn.execute(
+                "INSERT OR IGNORE INTO user_block (blocker_id, blocked_id)
+                 VALUES (?1, ?2)",
+                libsql::params![blocker_id.clone(), blocked_id.clone()],
+            )
+            .await?;
 
-    // Reset accepted_at to NULL for the blocker's membership in every
-    // DM channel shared with the blocked user. If the block is later
-    // released, the channel resurfaces as a request rather than in
-    // the regular DM list.
-    conn.execute(
-        "UPDATE dm_channel_member
-         SET accepted_at = NULL
-         WHERE user_id = ?1
-           AND dm_channel_id IN (
-             SELECT dm_channel_id FROM dm_channel_member WHERE user_id = ?2
-           )",
-        libsql::params![blocker_id, blocked_id],
-    )
-    .await?;
+            // Reset accepted_at to NULL for the blocker's membership in every
+            // DM channel shared with the blocked user. If the block is later
+            // released, the channel resurfaces as a request rather than in
+            // the regular DM list.
+            conn.execute(
+                "UPDATE dm_channel_member
+                 SET accepted_at = NULL
+                 WHERE user_id = ?1
+                   AND dm_channel_id IN (
+                     SELECT dm_channel_id FROM dm_channel_member WHERE user_id = ?2
+                   )",
+                libsql::params![blocker_id, blocked_id],
+            )
+            .await?;
+        }
+    }
 
     Ok(())
 }
@@ -79,13 +94,26 @@ pub async fn unblock_user(
     blocked_id: String,
     state: &Arc<AppState>,
 ) -> Result<()> {
-    let conn = state.remote_db.conn().await?;
+    // DS seam: route the unblock (delete block row) through the Delivery Service
+    // when configured; else write Turso directly.
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            let body = serde_json::json!({
+                "blocker_id": blocker_id,
+                "blocked_id": blocked_id,
+            });
+            crate::commands::mls::ds_post_ok(state, "/v1/blocks/remove", &body).await?;
+        }
+        None => {
+            let conn = state.remote_db.conn().await?;
 
-    conn.execute(
-        "DELETE FROM user_block WHERE blocker_id = ?1 AND blocked_id = ?2",
-        libsql::params![blocker_id, blocked_id],
-    )
-    .await?;
+            conn.execute(
+                "DELETE FROM user_block WHERE blocker_id = ?1 AND blocked_id = ?2",
+                libsql::params![blocker_id, blocked_id],
+            )
+            .await?;
+        }
+    }
 
     Ok(())
 }

--- a/pollis-core/src/commands/device_enrollment.rs
+++ b/pollis-core/src/commands/device_enrollment.rs
@@ -201,6 +201,13 @@ pub async fn start_device_enrollment(
     // Insert the request row. Server stores only the public ephemeral key
     // and the verification code — the private key stays in memory on this
     // device.
+    //
+    // BOOTSTRAP — stays DIRECT, NOT routed through the DS (#419 domains E+G).
+    // This runs on the NEW device, which is pre-enrollment: it has registered
+    // (`register_device`) but never ran `ensure_device_cert`, so its
+    // `user_device.mls_signature_pub` is still NULL and its local DB is closed —
+    // it cannot produce a signature the DS would accept. The enrollment APPROVAL
+    // / REJECTION (run on an already-enrolled sibling) DO route through the DS.
     let conn = state.remote_db.conn().await?;
     conn.execute(
         "INSERT INTO device_enrollment_request \
@@ -529,33 +536,59 @@ pub async fn approve_device_enrollment(
     //    handle cert publishing in its own process.
     let _ = (identity_version, new_device_id.clone());
 
-    // 5. Write the wrapped account key and flip status to 'approved'.
-    conn.execute(
-        "UPDATE device_enrollment_request \
-         SET wrapped_account_key = ?1, \
-             status = 'approved', \
-             approved_by_device_id = ?2 \
-         WHERE id = ?3",
-        libsql::params![wrapped, approver_device_id.clone(), request_id.clone()],
-    )
-    .await?;
+    // 5. Write the wrapped account key and flip status to 'approved'. Routed
+    //    through the DS (#419 domains E+G) — the approver is a fully-enrolled
+    //    sibling device, so it can sign. The DS binds the request to the signer
+    //    (`WHERE id = ? AND user_id = actor`), so a device can only approve
+    //    enrollments for its OWN account.
+    let metadata = format!("via=approval,approver={approver_device_id}");
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            use base64::Engine as _;
+            let b64 = base64::engine::general_purpose::STANDARD;
+            let body = serde_json::json!({
+                "request_id": request_id,
+                "wrapped_account_key": b64.encode(&wrapped),
+                "approved_by_device_id": approver_device_id,
+            });
+            crate::commands::mls::ds_post_ok(state, "/v1/enrollment/approve", &body).await?;
 
-    // 6. Record a security event.
-    let event_id = Ulid::new().to_string();
-    if let Err(e) = conn
-        .execute(
-            "INSERT INTO security_event (id, user_id, kind, device_id, metadata) \
-             VALUES (?1, ?2, 'device_enrolled', ?3, ?4)",
-            libsql::params![
-                event_id,
-                user_id.clone(),
-                new_device_id.clone(),
-                format!("via=approval,approver={approver_device_id}")
-            ],
-        )
-        .await
-    {
-        eprintln!("[enrollment] security_event insert failed (non-fatal): {e}");
+            // 6. Record a security event (best-effort).
+            let ev = serde_json::json!({
+                "kind": "device_enrolled",
+                "device_id": new_device_id,
+                "metadata": metadata,
+            });
+            if let Err(e) =
+                crate::commands::mls::ds_post_ok(state, "/v1/security-events", &ev).await
+            {
+                eprintln!("[enrollment] DS security-event failed (non-fatal): {e}");
+            }
+        }
+        None => {
+            conn.execute(
+                "UPDATE device_enrollment_request \
+                 SET wrapped_account_key = ?1, \
+                     status = 'approved', \
+                     approved_by_device_id = ?2 \
+                 WHERE id = ?3",
+                libsql::params![wrapped, approver_device_id.clone(), request_id.clone()],
+            )
+            .await?;
+
+            // 6. Record a security event.
+            let event_id = Ulid::new().to_string();
+            if let Err(e) = conn
+                .execute(
+                    "INSERT INTO security_event (id, user_id, kind, device_id, metadata) \
+                     VALUES (?1, ?2, 'device_enrolled', ?3, ?4)",
+                    libsql::params![event_id, user_id.clone(), new_device_id.clone(), metadata],
+                )
+                .await
+            {
+                eprintln!("[enrollment] security_event insert failed (non-fatal): {e}");
+            }
+        }
     }
 
     // 7. MLS group addition is deferred — the new device hasn't published
@@ -626,6 +659,13 @@ pub async fn recover_with_secret_key(
 
     // 4. Record a security event so the user can audit this in the
     //    Security settings page.
+    //
+    // BOOTSTRAP — stays DIRECT, NOT routed through the DS (#419 domains E+G).
+    // This runs pre-finalize: the account key was just unwrapped into
+    // `AppState.unlock`, but this device has NOT yet published its cross-signing
+    // cert (`finalize_enrollment` → `ensure_device_cert` runs after `set_pin`),
+    // so its `user_device.mls_signature_pub` isn't established and it cannot sign
+    // a DS request the gate would accept. Best-effort either way.
     let conn = state.remote_db.conn().await?;
     let device_id = state.device_id.lock().await.clone().unwrap_or_default();
     let _ = conn
@@ -697,97 +737,131 @@ pub async fn reset_identity_and_recover(
     {
         let current_device_id = state.device_id.lock().await.clone();
 
-        // Group membership cleanup (handle ownership first)
-        let mut group_rows = conn
-            .query(
-                "SELECT group_id, role FROM group_member WHERE user_id = ?1",
-                libsql::params![user_id.clone()],
-            )
-            .await?;
-        let mut memberships: Vec<(String, String)> = Vec::new();
-        while let Some(row) = group_rows.next().await? {
-            memberships.push((row.get(0)?, row.get(1)?));
-        }
-
-        for (gid, role) in &memberships {
-            let mut count_rows = conn
-                .query(
-                    "SELECT COUNT(*) FROM group_member WHERE group_id = ?1",
-                    libsql::params![gid.clone()],
-                )
-                .await?;
-            let member_count: i64 = if let Some(row) = count_rows.next().await? {
-                row.get(0)?
-            } else {
-                0
-            };
-
-            if member_count <= 1 {
-                // Sole member — delete the entire group
-                let _ = conn
-                    .execute(
-                        "DELETE FROM groups WHERE id = ?1",
-                        libsql::params![gid.clone()],
-                    )
-                    .await;
-                eprintln!("[reset] deleted empty group {gid}");
-            } else if role == "admin" {
-                // Sole admin — promote another member
-                let mut admin_rows = conn
+        // Main-DB membership + device cleanup. Route through the DS (#419
+        // domains E+G) as ONE transaction when configured: the group-ownership
+        // handoff, the group/DM membership + key-package deletes, and the
+        // other-device orphaning all commit together or not at all — a
+        // half-cleaned account is a corrupt state. The current device CAN sign
+        // here: it was enrolled before the reset, so its `mls_signature_pub`
+        // survives the account-key rotation (the local DB is wiped only below).
+        match state.config.pollis_delivery_url.as_deref() {
+            Some(_) => {
+                let body = serde_json::json!({ "current_device_id": current_device_id });
+                crate::commands::mls::ds_post_ok(state, "/v1/account/reset-recover", &body).await?;
+            }
+            None => {
+                // Direct fallback (pre-cutover / no DS). Group membership
+                // cleanup (handle ownership first).
+                let mut group_rows = conn
                     .query(
-                        "SELECT COUNT(*) FROM group_member WHERE group_id = ?1 AND role = 'admin' AND user_id != ?2",
-                        libsql::params![gid.clone(), user_id.clone()],
+                        "SELECT group_id, role FROM group_member WHERE user_id = ?1",
+                        libsql::params![user_id.clone()],
                     )
                     .await?;
-                let other_admins: i64 = if let Some(row) = admin_rows.next().await? {
-                    row.get(0)?
-                } else {
-                    0
-                };
-                if other_admins == 0 {
-                    let mut candidate_rows = conn
+                let mut memberships: Vec<(String, String)> = Vec::new();
+                while let Some(row) = group_rows.next().await? {
+                    memberships.push((row.get(0)?, row.get(1)?));
+                }
+
+                for (gid, role) in &memberships {
+                    let mut count_rows = conn
                         .query(
-                            "SELECT user_id FROM group_member WHERE group_id = ?1 AND user_id != ?2 LIMIT 1",
-                            libsql::params![gid.clone(), user_id.clone()],
+                            "SELECT COUNT(*) FROM group_member WHERE group_id = ?1",
+                            libsql::params![gid.clone()],
                         )
                         .await?;
-                    if let Some(row) = candidate_rows.next().await? {
-                        let new_admin: String = row.get(0)?;
+                    let member_count: i64 = if let Some(row) = count_rows.next().await? {
+                        row.get(0)?
+                    } else {
+                        0
+                    };
+
+                    if member_count <= 1 {
+                        // Sole member — delete the entire group
                         let _ = conn
                             .execute(
-                                "UPDATE group_member SET role = 'admin' WHERE group_id = ?1 AND user_id = ?2",
-                                libsql::params![gid.clone(), new_admin.clone()],
+                                "DELETE FROM groups WHERE id = ?1",
+                                libsql::params![gid.clone()],
                             )
                             .await;
-                        eprintln!("[reset] promoted {new_admin} to admin in group {gid}");
+                        eprintln!("[reset] deleted empty group {gid}");
+                    } else if role == "admin" {
+                        // Sole admin — promote another member
+                        let mut admin_rows = conn
+                            .query(
+                                "SELECT COUNT(*) FROM group_member WHERE group_id = ?1 AND role = 'admin' AND user_id != ?2",
+                                libsql::params![gid.clone(), user_id.clone()],
+                            )
+                            .await?;
+                        let other_admins: i64 = if let Some(row) = admin_rows.next().await? {
+                            row.get(0)?
+                        } else {
+                            0
+                        };
+                        if other_admins == 0 {
+                            let mut candidate_rows = conn
+                                .query(
+                                    "SELECT user_id FROM group_member WHERE group_id = ?1 AND user_id != ?2 LIMIT 1",
+                                    libsql::params![gid.clone(), user_id.clone()],
+                                )
+                                .await?;
+                            if let Some(row) = candidate_rows.next().await? {
+                                let new_admin: String = row.get(0)?;
+                                let _ = conn
+                                    .execute(
+                                        "UPDATE group_member SET role = 'admin' WHERE group_id = ?1 AND user_id = ?2",
+                                        libsql::params![gid.clone(), new_admin.clone()],
+                                    )
+                                    .await;
+                                eprintln!("[reset] promoted {new_admin} to admin in group {gid}");
+                            }
+                        }
                     }
+                }
+
+                // Delete group memberships
+                let _ = conn
+                    .execute(
+                        "DELETE FROM group_member WHERE user_id = ?1",
+                        libsql::params![user_id.clone()],
+                    )
+                    .await;
+
+                // Delete DM channel memberships
+                let _ = conn
+                    .execute(
+                        "DELETE FROM dm_channel_member WHERE user_id = ?1",
+                        libsql::params![user_id.clone()],
+                    )
+                    .await;
+
+                // Delete MLS key packages (old identity, no longer valid)
+                let _ = conn
+                    .execute(
+                        "DELETE FROM mls_key_package WHERE user_id = ?1",
+                        libsql::params![user_id.clone()],
+                    )
+                    .await;
+
+                // Delete other devices (orphaned by the identity rotation).
+                // Keep the current device row since ensure_device_cert uses UPDATE.
+                if let Some(ref dev_id) = current_device_id {
+                    let _ = conn
+                        .execute(
+                            "DELETE FROM user_device WHERE user_id = ?1 AND device_id != ?2",
+                            libsql::params![user_id.clone(), dev_id.clone()],
+                        )
+                        .await;
+                } else {
+                    let _ = conn
+                        .execute(
+                            "DELETE FROM user_device WHERE user_id = ?1",
+                            libsql::params![user_id.clone()],
+                        )
+                        .await;
                 }
             }
         }
-
-        // Delete group memberships
-        let _ = conn
-            .execute(
-                "DELETE FROM group_member WHERE user_id = ?1",
-                libsql::params![user_id.clone()],
-            )
-            .await;
-
-        // Delete DM channel memberships
-        let _ = conn
-            .execute(
-                "DELETE FROM dm_channel_member WHERE user_id = ?1",
-                libsql::params![user_id.clone()],
-            )
-            .await;
-
-        // Delete MLS key packages (old identity, no longer valid)
-        let _ = conn
-            .execute(
-                "DELETE FROM mls_key_package WHERE user_id = ?1",
-                libsql::params![user_id.clone()],
-            )
-            .await;
 
         // Delete pending MLS welcomes (W8 seam). Route through the Delivery
         // Service (sole writer of the log DB) when configured; else direct
@@ -819,23 +893,8 @@ pub async fn reset_identity_and_recover(
             }
         }
 
-        // Delete other devices (they're orphaned by the identity rotation).
-        // Keep the current device row since ensure_device_cert uses UPDATE.
-        if let Some(ref dev_id) = current_device_id {
-            let _ = conn
-                .execute(
-                    "DELETE FROM user_device WHERE user_id = ?1 AND device_id != ?2",
-                    libsql::params![user_id.clone(), dev_id.clone()],
-                )
-                .await;
-        } else {
-            let _ = conn
-                .execute(
-                    "DELETE FROM user_device WHERE user_id = ?1",
-                    libsql::params![user_id.clone()],
-                )
-                .await;
-        }
+        // (Other devices are orphaned as part of the membership/device cleanup
+        // above — via the DS reset-recover transaction, or the direct fallback.)
 
         // Wipe local DB (MLS group state, cached messages — all invalid now)
         state.unload_user_db().await;
@@ -930,22 +989,47 @@ pub async fn reject_device_enrollment(
     };
     drop(rows);
 
-    conn.execute(
-        "UPDATE device_enrollment_request \
-         SET status = 'rejected', approved_by_device_id = ?1 \
-         WHERE id = ?2",
-        libsql::params![approver_device_id, request_id],
-    )
-    .await?;
+    // Flip the request to 'rejected'. Routed through the DS (#419 domains E+G)
+    // when configured — the rejecting device is a fully-enrolled sibling, so it
+    // can sign; the DS binds the request to the signer (`WHERE id = ? AND
+    // user_id = actor`).
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            let body = serde_json::json!({
+                "request_id": request_id,
+                "approved_by_device_id": approver_device_id,
+            });
+            crate::commands::mls::ds_post_ok(state, "/v1/enrollment/reject", &body).await?;
 
-    let event_id = Ulid::new().to_string();
-    let _ = conn
-        .execute(
-            "INSERT INTO security_event (id, user_id, kind, device_id, metadata) \
-             VALUES (?1, ?2, 'device_rejected', ?3, NULL)",
-            libsql::params![event_id, user_id, new_device_id],
-        )
-        .await;
+            let ev = serde_json::json!({
+                "kind": "device_rejected",
+                "device_id": new_device_id,
+                "metadata": serde_json::Value::Null,
+            });
+            if let Err(e) = crate::commands::mls::ds_post_ok(state, "/v1/security-events", &ev).await
+            {
+                eprintln!("[enrollment] DS security-event (reject) failed (non-fatal): {e}");
+            }
+        }
+        None => {
+            conn.execute(
+                "UPDATE device_enrollment_request \
+                 SET status = 'rejected', approved_by_device_id = ?1 \
+                 WHERE id = ?2",
+                libsql::params![approver_device_id, request_id],
+            )
+            .await?;
+
+            let event_id = Ulid::new().to_string();
+            let _ = conn
+                .execute(
+                    "INSERT INTO security_event (id, user_id, kind, device_id, metadata) \
+                     VALUES (?1, ?2, 'device_rejected', ?3, NULL)",
+                    libsql::params![event_id, user_id, new_device_id],
+                )
+                .await;
+        }
+    }
 
     Ok(())
 }

--- a/pollis-core/src/commands/dm.rs
+++ b/pollis-core/src/commands/dm.rs
@@ -108,46 +108,66 @@ pub async fn create_dm_channel(
     let id = Ulid::new().to_string();
     let now = chrono::Utc::now().to_rfc3339();
 
-    conn.execute(
-        "INSERT INTO dm_channel (id, created_by, created_at) VALUES (?1, ?2, ?3)",
-        libsql::params![id.clone(), creator_id.clone(), now.clone()],
-    ).await?;
-
-    // Creator is auto-accepted (they initiated the conversation).
-    conn.execute(
-        "INSERT INTO dm_channel_member (dm_channel_id, user_id, added_by, added_at, accepted_at)
-         VALUES (?1, ?2, ?3, ?4, ?4)",
-        libsql::params![id.clone(), creator_id.clone(), creator_id.clone(), now.clone()],
-    ).await?;
-
-    // Every other member starts with accepted_at = NULL — the channel
-    // is a pending request until they accept it.
-    for member_id in &member_ids {
-        if member_id == &creator_id {
-            continue;
+    // DS seam: route the channel-creation writes (dm_channel + every membership
+    // row + per-member watermark seeds) through the Delivery Service when
+    // configured; else write Turso directly. The DS performs all writes in one
+    // transaction and re-checks the block relationships server-side; the block
+    // check above is the client-side fast-fail for the generic BLOCK_ERR.
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            let body = serde_json::json!({
+                "id": id,
+                "creator_id": creator_id,
+                "member_ids": member_ids,
+                "created_at": now,
+            });
+            crate::commands::mls::ds_post_ok(state, "/v1/dm/create", &body).await?;
         }
-        conn.execute(
-            "INSERT OR IGNORE INTO dm_channel_member (dm_channel_id, user_id, added_by, added_at, accepted_at)
-             VALUES (?1, ?2, ?3, ?4, NULL)",
-            libsql::params![id.clone(), member_id.clone(), creator_id.clone(), now.clone()],
-        ).await?;
+        None => {
+            conn.execute(
+                "INSERT INTO dm_channel (id, created_by, created_at) VALUES (?1, ?2, ?3)",
+                libsql::params![id.clone(), creator_id.clone(), now.clone()],
+            ).await?;
+
+            // Creator is auto-accepted (they initiated the conversation).
+            conn.execute(
+                "INSERT INTO dm_channel_member (dm_channel_id, user_id, added_by, added_at, accepted_at)
+                 VALUES (?1, ?2, ?3, ?4, ?4)",
+                libsql::params![id.clone(), creator_id.clone(), creator_id.clone(), now.clone()],
+            ).await?;
+
+            // Every other member starts with accepted_at = NULL — the channel
+            // is a pending request until they accept it.
+            for member_id in &member_ids {
+                if member_id == &creator_id {
+                    continue;
+                }
+                conn.execute(
+                    "INSERT OR IGNORE INTO dm_channel_member (dm_channel_id, user_id, added_by, added_at, accepted_at)
+                     VALUES (?1, ?2, ?3, ?4, NULL)",
+                    libsql::params![id.clone(), member_id.clone(), creator_id.clone(), now.clone()],
+                ).await?;
+            }
+
+            // Initialize watermark rows for every (member, device) pair so
+            // envelope cleanup isn't blocked by devices that didn't exist at
+            // channel creation (those are seeded by `register_device`).
+            for member_id in std::iter::once(&creator_id)
+                .chain(member_ids.iter().filter(|m| *m != &creator_id))
+            {
+                if let Err(e) = conn.execute(
+                    "INSERT OR IGNORE INTO conversation_watermark (conversation_id, user_id, device_id, last_fetched_at)
+                     SELECT ?1, ?2, ud.device_id, datetime('now')
+                     FROM user_device ud WHERE ud.user_id = ?2",
+                    libsql::params![id.clone(), member_id.clone()],
+                ).await {
+                    eprintln!("[watermark] create_dm_channel: watermark init failed for {member_id}: {e}");
+                }
+            }
+        }
     }
 
     let members = fetch_dm_members(&conn, &id).await?;
-
-    // Initialize watermark rows for every (member, device) pair so envelope
-    // cleanup isn't blocked by devices that didn't exist at channel creation
-    // (those are seeded by `register_device`).
-    for member in &members {
-        if let Err(e) = conn.execute(
-            "INSERT OR IGNORE INTO conversation_watermark (conversation_id, user_id, device_id, last_fetched_at)
-             SELECT ?1, ?2, ud.device_id, datetime('now')
-             FROM user_device ud WHERE ud.user_id = ?2",
-            libsql::params![id.clone(), member.user_id.clone()],
-        ).await {
-            eprintln!("[watermark] create_dm_channel: watermark init failed for {}: {e}", member.user_id);
-        }
-    }
 
     // Initialise the MLS group for this DM (creator becomes the sole member).
     // Reconcile then adds all members' devices (including creator's other devices).
@@ -295,20 +315,37 @@ pub async fn accept_dm_request(
     user_id: String,
     state: &Arc<AppState>,
 ) -> Result<()> {
-    let conn = state.remote_db.conn().await?;
     let now = chrono::Utc::now().to_rfc3339();
 
-    // Only flip accepted_at when it's currently NULL — idempotent
-    // and preserves the original acceptance time if the user
-    // clicks accept twice.
-    conn.execute(
-        "UPDATE dm_channel_member
-         SET accepted_at = ?3
-         WHERE dm_channel_id = ?1
-           AND user_id = ?2
-           AND accepted_at IS NULL",
-        libsql::params![dm_channel_id, user_id, now],
-    ).await?;
+    // DS seam: route the accept (flip the user's own accepted_at NULL → now)
+    // through the Delivery Service when configured; else write Turso directly.
+    // Server-side authz binds the accept to the authenticated recipient's own
+    // membership row.
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            let body = serde_json::json!({
+                "dm_channel_id": dm_channel_id,
+                "user_id": user_id,
+                "accepted_at": now,
+            });
+            crate::commands::mls::ds_post_ok(state, "/v1/dm/accept", &body).await?;
+        }
+        None => {
+            let conn = state.remote_db.conn().await?;
+
+            // Only flip accepted_at when it's currently NULL — idempotent
+            // and preserves the original acceptance time if the user
+            // clicks accept twice.
+            conn.execute(
+                "UPDATE dm_channel_member
+                 SET accepted_at = ?3
+                 WHERE dm_channel_id = ?1
+                   AND user_id = ?2
+                   AND accepted_at IS NULL",
+                libsql::params![dm_channel_id, user_id, now],
+            ).await?;
+        }
+    }
 
     Ok(())
 }

--- a/pollis-core/src/commands/dm.rs
+++ b/pollis-core/src/commands/dm.rs
@@ -378,24 +378,42 @@ pub async fn add_user_to_dm_channel(
     added_by: String,
     state: &Arc<AppState>,
 ) -> Result<()> {
-    let conn = state.remote_db.conn().await?;
-    let now = chrono::Utc::now().to_rfc3339();
+    // DS seam: route the membership INSERT + watermark seeds through the
+    // Delivery Service when configured; else write Turso directly. The DS
+    // performs both writes in one transaction and re-derives the actor's DM
+    // membership server-side (a non-member cannot add anyone).
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            let now = chrono::Utc::now().to_rfc3339();
+            let body = serde_json::json!({
+                "dm_channel_id": dm_channel_id,
+                "user_id": user_id,
+                "added_by": added_by,
+                "added_at": now,
+            });
+            crate::commands::mls::ds_post_ok(state, "/v1/dm/add", &body).await?;
+        }
+        None => {
+            let conn = state.remote_db.conn().await?;
+            let now = chrono::Utc::now().to_rfc3339();
 
-    conn.execute(
-        "INSERT OR IGNORE INTO dm_channel_member (dm_channel_id, user_id, added_by, added_at)
-         VALUES (?1, ?2, ?3, ?4)",
-        libsql::params![dm_channel_id.clone(), user_id.clone(), added_by.clone(), now],
-    ).await?;
+            conn.execute(
+                "INSERT OR IGNORE INTO dm_channel_member (dm_channel_id, user_id, added_by, added_at)
+                 VALUES (?1, ?2, ?3, ?4)",
+                libsql::params![dm_channel_id.clone(), user_id.clone(), added_by.clone(), now],
+            ).await?;
 
-    // Initialize watermark for every device of the new member so pre-join
-    // messages don't block envelope cleanup indefinitely.
-    if let Err(e) = conn.execute(
-        "INSERT OR IGNORE INTO conversation_watermark (conversation_id, user_id, device_id, last_fetched_at)
-         SELECT ?1, ?2, ud.device_id, datetime('now')
-         FROM user_device ud WHERE ud.user_id = ?2",
-        libsql::params![dm_channel_id.clone(), user_id.clone()],
-    ).await {
-        eprintln!("[watermark] add_user_to_dm_channel: watermark init failed: {e}");
+            // Initialize watermark for every device of the new member so pre-join
+            // messages don't block envelope cleanup indefinitely.
+            if let Err(e) = conn.execute(
+                "INSERT OR IGNORE INTO conversation_watermark (conversation_id, user_id, device_id, last_fetched_at)
+                 SELECT ?1, ?2, ud.device_id, datetime('now')
+                 FROM user_device ud WHERE ud.user_id = ?2",
+                libsql::params![dm_channel_id.clone(), user_id.clone()],
+            ).await {
+                eprintln!("[watermark] add_user_to_dm_channel: watermark init failed: {e}");
+            }
+        }
     }
 
     // Reconcile adds the new member's devices to the MLS tree.
@@ -414,30 +432,46 @@ pub async fn remove_user_from_dm_channel(
     requester_id: String,
     state: &Arc<AppState>,
 ) -> Result<()> {
-    let conn = state.remote_db.conn().await?;
+    // DS seam: route the membership DELETE through the Delivery Service when
+    // configured; else write Turso directly. The same authz rule (only the
+    // channel creator or the user themselves may remove a member) is enforced
+    // server-side on the DS path and inline here on the direct path.
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            let body = serde_json::json!({
+                "dm_channel_id": dm_channel_id,
+                "user_id": user_id,
+                "requester_id": requester_id,
+            });
+            crate::commands::mls::ds_post_ok(state, "/v1/dm/remove", &body).await?;
+        }
+        None => {
+            let conn = state.remote_db.conn().await?;
 
-    // Only the channel creator or the user themselves can remove
-    let mut rows = conn.query(
-        "SELECT created_by FROM dm_channel WHERE id = ?1",
-        libsql::params![dm_channel_id.clone()],
-    ).await?;
+            // Only the channel creator or the user themselves can remove
+            let mut rows = conn.query(
+                "SELECT created_by FROM dm_channel WHERE id = ?1",
+                libsql::params![dm_channel_id.clone()],
+            ).await?;
 
-    let creator_id: String = if let Some(row) = rows.next().await? {
-        row.get(0)?
-    } else {
-        return Err(Error::Other(anyhow::anyhow!("DM channel not found")));
-    };
+            let creator_id: String = if let Some(row) = rows.next().await? {
+                row.get(0)?
+            } else {
+                return Err(Error::Other(anyhow::anyhow!("DM channel not found")));
+            };
 
-    if requester_id != creator_id && requester_id != user_id {
-        return Err(Error::Other(anyhow::anyhow!(
-            "only the channel creator or the user themselves can remove a member"
-        )));
+            if requester_id != creator_id && requester_id != user_id {
+                return Err(Error::Other(anyhow::anyhow!(
+                    "only the channel creator or the user themselves can remove a member"
+                )));
+            }
+
+            conn.execute(
+                "DELETE FROM dm_channel_member WHERE dm_channel_id = ?1 AND user_id = ?2",
+                libsql::params![dm_channel_id.clone(), user_id],
+            ).await?;
+        }
     }
-
-    conn.execute(
-        "DELETE FROM dm_channel_member WHERE dm_channel_id = ?1 AND user_id = ?2",
-        libsql::params![dm_channel_id.clone(), user_id],
-    ).await?;
 
     // Reconcile removes the member's leaves from the MLS tree (was a security gap).
     if let Err(e) = crate::commands::mls::reconcile_group_mls_impl(
@@ -454,12 +488,45 @@ pub async fn leave_dm_channel(
     user_id: String,
     state: &Arc<AppState>,
 ) -> Result<()> {
-    let conn = state.remote_db.conn().await?;
+    // DS seam: route the membership DELETE and the empty-channel teardown
+    // (envelopes + dm_channel) through the Delivery Service when configured; else
+    // write Turso directly. The DS does the member-delete + count + conditional
+    // teardown in ONE transaction so a DM never lingers half-deleted; authz binds
+    // the leave to the actor's own membership.
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            let body = serde_json::json!({
+                "dm_channel_id": dm_channel_id,
+                "user_id": user_id,
+            });
+            crate::commands::mls::ds_post_ok(state, "/v1/dm/leave", &body).await?;
+        }
+        None => {
+            let conn = state.remote_db.conn().await?;
 
-    conn.execute(
-        "DELETE FROM dm_channel_member WHERE dm_channel_id = ?1 AND user_id = ?2",
-        libsql::params![dm_channel_id.clone(), user_id.clone()],
-    ).await?;
+            conn.execute(
+                "DELETE FROM dm_channel_member WHERE dm_channel_id = ?1 AND user_id = ?2",
+                libsql::params![dm_channel_id.clone(), user_id.clone()],
+            ).await?;
+
+            // If no members remain, clean up the channel and all associated data
+            let mut rows = conn.query(
+                "SELECT COUNT(*) FROM dm_channel_member WHERE dm_channel_id = ?1",
+                libsql::params![dm_channel_id.clone()],
+            ).await?;
+
+            let remaining: i64 = if let Some(row) = rows.next().await? {
+                row.get(0)?
+            } else {
+                0
+            };
+
+            if remaining == 0 {
+                conn.execute("DELETE FROM message_envelope WHERE conversation_id = ?1", libsql::params![dm_channel_id.clone()]).await?;
+                conn.execute("DELETE FROM dm_channel WHERE id = ?1", libsql::params![dm_channel_id.clone()]).await?;
+            }
+        }
+    }
 
     // Wipe local MLS state so the leaver can't decrypt future messages.
     match crate::commands::mls::forget_local_mls_group(state, &dm_channel_id).await {
@@ -474,23 +541,6 @@ pub async fn leave_dm_channel(
         serde_json::json!({"type": "membership_changed", "conversation_id": dm_channel_id}),
     ).await {
         eprintln!("[realtime] leave_dm_channel: notify room {dm_channel_id}: {e}");
-    }
-
-    // If no members remain, clean up the channel and all associated data
-    let mut rows = conn.query(
-        "SELECT COUNT(*) FROM dm_channel_member WHERE dm_channel_id = ?1",
-        libsql::params![dm_channel_id.clone()],
-    ).await?;
-
-    let remaining: i64 = if let Some(row) = rows.next().await? {
-        row.get(0)?
-    } else {
-        0
-    };
-
-    if remaining == 0 {
-        conn.execute("DELETE FROM message_envelope WHERE conversation_id = ?1", libsql::params![dm_channel_id.clone()]).await?;
-        conn.execute("DELETE FROM dm_channel WHERE id = ?1", libsql::params![dm_channel_id]).await?;
     }
 
     Ok(())

--- a/pollis-core/src/commands/groups/channels.rs
+++ b/pollis-core/src/commands/groups/channels.rs
@@ -42,14 +42,31 @@ pub async fn create_channel(
     _creator_id: String,
     state: &Arc<AppState>,
 ) -> Result<Channel> {
-    let conn = state.remote_db.conn().await?;
     let id = Ulid::new().to_string();
     let channel_type = channel_type.unwrap_or_else(|| "text".to_string());
 
-    conn.execute(
-        "INSERT INTO channels (id, group_id, name, description, channel_type) VALUES (?1, ?2, ?3, ?4, ?5)",
-        libsql::params![id.clone(), group_id.clone(), name.clone(), description.clone(), channel_type.clone()],
-    ).await.map_err(|e| db_err(e.into(), "Channel"))?;
+    // DS seam: route the channel insert through the Delivery Service (which
+    // re-derives group membership server-side) when configured; else direct.
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            let body = serde_json::json!({
+                "id": id,
+                "group_id": group_id,
+                "name": name,
+                "description": description,
+                "channel_type": channel_type,
+                "creator_id": _creator_id,
+            });
+            crate::commands::mls::ds_post_ok(state, "/v1/channels/create", &body).await?;
+        }
+        None => {
+            let conn = state.remote_db.conn().await?;
+            conn.execute(
+                "INSERT INTO channels (id, group_id, name, description, channel_type) VALUES (?1, ?2, ?3, ?4, ?5)",
+                libsql::params![id.clone(), group_id.clone(), name.clone(), description.clone(), channel_type.clone()],
+            ).await.map_err(|e| db_err(e.into(), "Channel"))?;
+        }
+    }
 
     Ok(Channel { id, group_id, name, description, channel_type })
 }
@@ -90,17 +107,32 @@ pub async fn update_channel(
         return Err(Error::Other(anyhow::anyhow!("only group admins can update channels")));
     }
 
-    if let Some(ref n) = name {
-        conn.execute(
-            "UPDATE channels SET name = ?1 WHERE id = ?2",
-            libsql::params![n.clone(), channel_id.clone()],
-        ).await?;
-    }
-    if let Some(ref d) = description {
-        conn.execute(
-            "UPDATE channels SET description = ?1 WHERE id = ?2",
-            libsql::params![d.clone(), channel_id.clone()],
-        ).await?;
+    // DS seam: route the column updates through the Delivery Service (admin
+    // re-derived server-side) when configured; else direct.
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            let body = serde_json::json!({
+                "channel_id": channel_id,
+                "requester_id": requester_id,
+                "name": name,
+                "description": description,
+            });
+            crate::commands::mls::ds_post_ok(state, "/v1/channels/update", &body).await?;
+        }
+        None => {
+            if let Some(ref n) = name {
+                conn.execute(
+                    "UPDATE channels SET name = ?1 WHERE id = ?2",
+                    libsql::params![n.clone(), channel_id.clone()],
+                ).await?;
+            }
+            if let Some(ref d) = description {
+                conn.execute(
+                    "UPDATE channels SET description = ?1 WHERE id = ?2",
+                    libsql::params![d.clone(), channel_id.clone()],
+                ).await?;
+            }
+        }
     }
 
     let mut rows = conn.query(
@@ -141,7 +173,7 @@ pub async fn delete_channel(
 
     let mut role_rows = conn.query(
         "SELECT role FROM group_member WHERE group_id = ?1 AND user_id = ?2",
-        libsql::params![group_id.clone(), requester_id],
+        libsql::params![group_id.clone(), requester_id.clone()],
     ).await?;
 
     let role: String = if let Some(row) = role_rows.next().await? {
@@ -154,20 +186,33 @@ pub async fn delete_channel(
         return Err(Error::Other(anyhow::anyhow!("only group admins can delete channels")));
     }
 
-    conn.execute(
-        "DELETE FROM message_envelope WHERE conversation_id = ?1",
-        libsql::params![channel_id.clone()],
-    ).await?;
+    // DS seam: route the envelope/watermark/channel deletes through the Delivery
+    // Service (one transactional, admin-gated write) when configured; else direct.
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            let body = serde_json::json!({
+                "channel_id": channel_id,
+                "requester_id": requester_id,
+            });
+            crate::commands::mls::ds_post_ok(state, "/v1/channels/delete", &body).await?;
+        }
+        None => {
+            conn.execute(
+                "DELETE FROM message_envelope WHERE conversation_id = ?1",
+                libsql::params![channel_id.clone()],
+            ).await?;
 
-    conn.execute(
-        "DELETE FROM conversation_watermark WHERE conversation_id = ?1",
-        libsql::params![channel_id.clone()],
-    ).await?;
+            conn.execute(
+                "DELETE FROM conversation_watermark WHERE conversation_id = ?1",
+                libsql::params![channel_id.clone()],
+            ).await?;
 
-    conn.execute(
-        "DELETE FROM channels WHERE id = ?1",
-        libsql::params![channel_id],
-    ).await?;
+            conn.execute(
+                "DELETE FROM channels WHERE id = ?1",
+                libsql::params![channel_id],
+            ).await?;
+        }
+    }
 
     if let Err(e) = crate::commands::livekit::publish_membership_changed_to_room(
         &state.livekit,

--- a/pollis-core/src/commands/groups/groups.rs
+++ b/pollis-core/src/commands/groups/groups.rs
@@ -107,34 +107,59 @@ pub async fn create_group(
     create_default_voice_channel: Option<bool>,
     state: &Arc<AppState>,
 ) -> Result<Group> {
-    let conn = state.remote_db.conn().await?;
     let id = Ulid::new().to_string();
     let now = chrono::Utc::now().to_rfc3339();
+    // Default channel ids are generated up front so the same value goes into the
+    // DB write (direct or DS) regardless of which path runs.
+    let text_channel_id =
+        create_default_text_channel.unwrap_or(false).then(|| Ulid::new().to_string());
+    let voice_channel_id =
+        create_default_voice_channel.unwrap_or(false).then(|| Ulid::new().to_string());
 
-    conn.execute(
-        "INSERT INTO groups (id, name, description, owner_id, created_at) VALUES (?1, ?2, ?3, ?4, ?5)",
-        libsql::params![id.clone(), name.clone(), description.clone(), owner_id.clone(), now.clone()],
-    ).await.map_err(|e| db_err(e.into(), "Group"))?;
+    // DS seam: route the group + admin-member + default-channel inserts through
+    // the Delivery Service (one transactional, server-authorized write) when
+    // configured; else write directly to Turso.
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            let body = serde_json::json!({
+                "id": id,
+                "name": name,
+                "description": description,
+                "owner_id": owner_id,
+                "default_text_channel_id": text_channel_id,
+                "default_voice_channel_id": voice_channel_id,
+                "created_at": now,
+            });
+            crate::commands::mls::ds_post_ok(state, "/v1/groups/create", &body).await?;
+        }
+        None => {
+            let conn = state.remote_db.conn().await?;
+            conn.execute(
+                "INSERT INTO groups (id, name, description, owner_id, created_at) VALUES (?1, ?2, ?3, ?4, ?5)",
+                libsql::params![id.clone(), name.clone(), description.clone(), owner_id.clone(), now.clone()],
+            ).await.map_err(|e| db_err(e.into(), "Group"))?;
 
-    conn.execute(
-        "INSERT INTO group_member (group_id, user_id, role) VALUES (?1, ?2, 'admin')",
-        libsql::params![id.clone(), owner_id.clone()],
-    ).await.map_err(|e| db_err(e.into(), "Group member"))?;
+            conn.execute(
+                "INSERT INTO group_member (group_id, user_id, role) VALUES (?1, ?2, 'admin')",
+                libsql::params![id.clone(), owner_id.clone()],
+            ).await.map_err(|e| db_err(e.into(), "Group member"))?;
 
-    if create_default_text_channel.unwrap_or(false) {
-        conn.execute(
-            "INSERT INTO channels (id, group_id, name, description, channel_type) \
-             VALUES (?1, ?2, 'General', NULL, 'text')",
-            libsql::params![Ulid::new().to_string(), id.clone()],
-        ).await.map_err(|e| db_err(e.into(), "Channel"))?;
-    }
+            if let Some(text_id) = &text_channel_id {
+                conn.execute(
+                    "INSERT INTO channels (id, group_id, name, description, channel_type) \
+                     VALUES (?1, ?2, 'General', NULL, 'text')",
+                    libsql::params![text_id.clone(), id.clone()],
+                ).await.map_err(|e| db_err(e.into(), "Channel"))?;
+            }
 
-    if create_default_voice_channel.unwrap_or(false) {
-        conn.execute(
-            "INSERT INTO channels (id, group_id, name, description, channel_type) \
-             VALUES (?1, ?2, 'Voice Chat', NULL, 'voice')",
-            libsql::params![Ulid::new().to_string(), id.clone()],
-        ).await.map_err(|e| db_err(e.into(), "Channel"))?;
+            if let Some(voice_id) = &voice_channel_id {
+                conn.execute(
+                    "INSERT INTO channels (id, group_id, name, description, channel_type) \
+                     VALUES (?1, ?2, 'Voice Chat', NULL, 'voice')",
+                    libsql::params![voice_id.clone(), id.clone()],
+                ).await.map_err(|e| db_err(e.into(), "Channel"))?;
+            }
+        }
     }
 
     // Create the per-group MLS group — all channels in this group share it.
@@ -179,23 +204,39 @@ pub async fn update_group(
         return Err(Error::Other(anyhow::anyhow!("only group admins can update group settings")));
     }
 
-    if let Some(ref n) = name {
-        conn.execute(
-            "UPDATE groups SET name = ?1 WHERE id = ?2",
-            libsql::params![n.clone(), group_id.clone()],
-        ).await?;
-    }
-    if let Some(ref d) = description {
-        conn.execute(
-            "UPDATE groups SET description = ?1 WHERE id = ?2",
-            libsql::params![d.clone(), group_id.clone()],
-        ).await?;
-    }
-    if let Some(ref u) = icon_url {
-        conn.execute(
-            "UPDATE groups SET icon_url = ?1 WHERE id = ?2",
-            libsql::params![u.clone(), group_id.clone()],
-        ).await?;
+    // DS seam: route the column updates through the Delivery Service (which
+    // re-derives the admin role server-side) when configured; else direct.
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            let body = serde_json::json!({
+                "group_id": group_id,
+                "requester_id": requester_id,
+                "name": name,
+                "description": description,
+                "icon_url": icon_url,
+            });
+            crate::commands::mls::ds_post_ok(state, "/v1/groups/update", &body).await?;
+        }
+        None => {
+            if let Some(ref n) = name {
+                conn.execute(
+                    "UPDATE groups SET name = ?1 WHERE id = ?2",
+                    libsql::params![n.clone(), group_id.clone()],
+                ).await?;
+            }
+            if let Some(ref d) = description {
+                conn.execute(
+                    "UPDATE groups SET description = ?1 WHERE id = ?2",
+                    libsql::params![d.clone(), group_id.clone()],
+                ).await?;
+            }
+            if let Some(ref u) = icon_url {
+                conn.execute(
+                    "UPDATE groups SET icon_url = ?1 WHERE id = ?2",
+                    libsql::params![u.clone(), group_id.clone()],
+                ).await?;
+            }
+        }
     }
 
     let mut rows = conn.query(
@@ -239,11 +280,24 @@ pub async fn delete_group(
         return Err(Error::Other(anyhow::anyhow!("only group admins can delete the group")));
     }
 
-    // CASCADE deletes group_member and channels entries
-    conn.execute(
-        "DELETE FROM groups WHERE id = ?1",
-        libsql::params![group_id],
-    ).await?;
+    // CASCADE deletes group_member and channels entries. DS seam: route the
+    // delete through the Delivery Service (admin re-checked server-side) when
+    // configured; else direct.
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            let body = serde_json::json!({
+                "group_id": group_id,
+                "requester_id": requester_id,
+            });
+            crate::commands::mls::ds_post_ok(state, "/v1/groups/delete", &body).await?;
+        }
+        None => {
+            conn.execute(
+                "DELETE FROM groups WHERE id = ?1",
+                libsql::params![group_id],
+            ).await?;
+        }
+    }
 
     Ok(())
 }

--- a/pollis-core/src/commands/groups/invites.rs
+++ b/pollis-core/src/commands/groups/invites.rs
@@ -74,10 +74,25 @@ pub async fn send_group_invite(
     }
 
     let id = Ulid::new().to_string();
-    conn.execute(
-        "INSERT INTO group_invite (id, group_id, inviter_id, invitee_id) VALUES (?1, ?2, ?3, ?4)",
-        libsql::params![id, group_id.clone(), inviter_id.clone(), invitee_id.clone()],
-    ).await.map_err(|e| db_err(e.into(), "Invite"))?;
+    // DS seam: route the invite insert through the Delivery Service (inviter's
+    // admin role re-derived server-side) when configured; else direct.
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            let body = serde_json::json!({
+                "id": id,
+                "group_id": group_id,
+                "inviter_id": inviter_id,
+                "invitee_id": invitee_id,
+            });
+            crate::commands::mls::ds_post_ok(state, "/v1/invites/create", &body).await?;
+        }
+        None => {
+            conn.execute(
+                "INSERT INTO group_invite (id, group_id, inviter_id, invitee_id) VALUES (?1, ?2, ?3, ?4)",
+                libsql::params![id, group_id.clone(), inviter_id.clone(), invitee_id.clone()],
+            ).await.map_err(|e| db_err(e.into(), "Invite"))?;
+        }
+    }
 
     // Reconcile adds the invitee's devices to the MLS tree now so their
     // Welcome is ready before they accept — no dependency on simultaneous
@@ -153,13 +168,27 @@ pub async fn accept_group_invite(
         return Err(Error::Other(anyhow::anyhow!("invite not found or already processed")));
     };
 
-    add_member_to_group(&conn, &group_id, &user_id).await?;
+    // DS seam: route the member-add + invite-delete through the Delivery Service
+    // (one transactional write, authorized as the invitee server-side) when
+    // configured; else direct.
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            let body = serde_json::json!({
+                "invite_id": invite_id,
+                "user_id": user_id,
+            });
+            crate::commands::mls::ds_post_ok(state, "/v1/invites/accept", &body).await?;
+        }
+        None => {
+            add_member_to_group(&conn, &group_id, &user_id).await?;
 
-    // Delete the invite row — accepted invites don't need to be retained.
-    conn.execute(
-        "DELETE FROM group_invite WHERE id = ?1",
-        libsql::params![invite_id],
-    ).await?;
+            // Delete the invite row — accepted invites don't need to be retained.
+            conn.execute(
+                "DELETE FROM group_invite WHERE id = ?1",
+                libsql::params![invite_id],
+            ).await?;
+        }
+    }
 
     // Notify existing group members so they see the new member.
     // The accepting user isn't connected to the group room yet, so use
@@ -185,18 +214,31 @@ pub async fn decline_group_invite(
 
     let mut rows = conn.query(
         "SELECT 1 FROM group_invite WHERE id = ?1 AND invitee_id = ?2",
-        libsql::params![invite_id.clone(), user_id],
+        libsql::params![invite_id.clone(), user_id.clone()],
     ).await?;
 
     if rows.next().await?.is_none() {
         return Err(Error::Other(anyhow::anyhow!("invite not found or already processed")));
     }
 
-    // Delete the invite row — declined invites don't need to be retained.
-    conn.execute(
-        "DELETE FROM group_invite WHERE id = ?1",
-        libsql::params![invite_id],
-    ).await?;
+    // Delete the invite row — declined invites don't need to be retained. DS
+    // seam: route the delete (scoped to the invitee server-side) through the
+    // Delivery Service when configured; else direct.
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            let body = serde_json::json!({
+                "invite_id": invite_id,
+                "user_id": user_id,
+            });
+            crate::commands::mls::ds_post_ok(state, "/v1/invites/decline", &body).await?;
+        }
+        None => {
+            conn.execute(
+                "DELETE FROM group_invite WHERE id = ?1",
+                libsql::params![invite_id],
+            ).await?;
+        }
+    }
 
     Ok(())
 }

--- a/pollis-core/src/commands/groups/join_requests.rs
+++ b/pollis-core/src/commands/groups/join_requests.rs
@@ -52,16 +52,30 @@ pub async fn request_group_access(
     let id = Ulid::new().to_string();
     // Upsert: new insert, or reset a prior rejected/approved row back to pending.
     // reviewed_by and reviewed_at are intentionally preserved so the history of
-    // who reviewed the previous request is available for future UI use.
-    conn.execute(
-        "INSERT INTO group_join_request (id, group_id, requester_id, status, created_at)
-         VALUES (?1, ?2, ?3, 'pending', datetime('now'))
-         ON CONFLICT(group_id, requester_id) DO UPDATE SET
-             id         = excluded.id,
-             status     = 'pending',
-             created_at = excluded.created_at",
-        libsql::params![id, group_id.clone(), requester_id],
-    ).await.map_err(|e| db_err(e.into(), "Join request"))?;
+    // who reviewed the previous request is available for future UI use. DS seam:
+    // route the upsert (authorized as the requester server-side) through the
+    // Delivery Service when configured; else direct.
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            let body = serde_json::json!({
+                "id": id,
+                "group_id": group_id,
+                "requester_id": requester_id,
+            });
+            crate::commands::mls::ds_post_ok(state, "/v1/join-requests/create", &body).await?;
+        }
+        None => {
+            conn.execute(
+                "INSERT INTO group_join_request (id, group_id, requester_id, status, created_at)
+                 VALUES (?1, ?2, ?3, 'pending', datetime('now'))
+                 ON CONFLICT(group_id, requester_id) DO UPDATE SET
+                     id         = excluded.id,
+                     status     = 'pending',
+                     created_at = excluded.created_at",
+                libsql::params![id, group_id.clone(), requester_id],
+            ).await.map_err(|e| db_err(e.into(), "Join request"))?;
+        }
+    }
 
     // Notify the group's existing admins so the pending-request list (menu
     // badge + bottom bar) refreshes live instead of waiting for a manual
@@ -189,12 +203,26 @@ pub async fn approve_join_request(
 
     let now = chrono::Utc::now().to_rfc3339();
 
-    add_member_to_group(&conn, &group_id, &requester_id).await?;
+    // DS seam: route the member-add + request-approve through the Delivery
+    // Service (one transactional, admin-gated write) when configured; else direct.
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            let body = serde_json::json!({
+                "request_id": request_id,
+                "approver_id": approver_id,
+                "reviewed_at": now,
+            });
+            crate::commands::mls::ds_post_ok(state, "/v1/join-requests/approve", &body).await?;
+        }
+        None => {
+            add_member_to_group(&conn, &group_id, &requester_id).await?;
 
-    conn.execute(
-        "UPDATE group_join_request SET status = 'approved', reviewed_by = ?1, reviewed_at = ?2 WHERE id = ?3",
-        libsql::params![approver_id.clone(), now, request_id],
-    ).await?;
+            conn.execute(
+                "UPDATE group_join_request SET status = 'approved', reviewed_by = ?1, reviewed_at = ?2 WHERE id = ?3",
+                libsql::params![approver_id.clone(), now, request_id],
+            ).await?;
+        }
+    }
 
     // Reconcile adds the requester's devices to the MLS tree.
     if let Err(e) = crate::commands::mls::reconcile_group_mls_impl(
@@ -259,10 +287,24 @@ pub async fn reject_join_request(
     }
 
     let now = chrono::Utc::now().to_rfc3339();
-    conn.execute(
-        "UPDATE group_join_request SET status = 'rejected', reviewed_by = ?1, reviewed_at = ?2 WHERE id = ?3",
-        libsql::params![approver_id, now, request_id],
-    ).await?;
+    // DS seam: route the status update through the Delivery Service (admin
+    // re-derived server-side) when configured; else direct.
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            let body = serde_json::json!({
+                "request_id": request_id,
+                "approver_id": approver_id,
+                "reviewed_at": now,
+            });
+            crate::commands::mls::ds_post_ok(state, "/v1/join-requests/reject", &body).await?;
+        }
+        None => {
+            conn.execute(
+                "UPDATE group_join_request SET status = 'rejected', reviewed_by = ?1, reviewed_at = ?2 WHERE id = ?3",
+                libsql::params![approver_id, now, request_id],
+            ).await?;
+        }
+    }
 
     Ok(())
 }

--- a/pollis-core/src/commands/groups/membership.rs
+++ b/pollis-core/src/commands/groups/membership.rs
@@ -90,10 +90,24 @@ pub async fn remove_member_from_group(
         )));
     }
 
-    conn.execute(
-        "DELETE FROM group_member WHERE group_id = ?1 AND user_id = ?2",
-        libsql::params![group_id.clone(), user_id.clone()],
-    ).await?;
+    // DS seam: route the member-row delete through the Delivery Service (which
+    // re-derives the admin/self rule server-side) when configured; else direct.
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            let body = serde_json::json!({
+                "group_id": group_id,
+                "user_id": user_id,
+                "requester_id": requester_id,
+            });
+            crate::commands::mls::ds_post_ok(state, "/v1/members/remove", &body).await?;
+        }
+        None => {
+            conn.execute(
+                "DELETE FROM group_member WHERE group_id = ?1 AND user_id = ?2",
+                libsql::params![group_id.clone(), user_id.clone()],
+            ).await?;
+        }
+    }
 
     // Reconcile removes the member's leaves from the MLS tree.
     if let Err(e) = crate::commands::mls::reconcile_group_mls_impl(
@@ -152,10 +166,24 @@ pub async fn leave_group(
     //     )));
     // }
 
-    conn.execute(
-        "DELETE FROM group_member WHERE group_id = ?1 AND user_id = ?2",
-        libsql::params![group_id.clone(), user_id.clone()],
-    ).await?;
+    // DS seam: route the leaver's member-row delete (and, when the group empties,
+    // the group delete) through the Delivery Service — one server-authorized
+    // write scoped to the signer's own row — when configured; else direct.
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            let body = serde_json::json!({
+                "group_id": group_id,
+                "user_id": user_id,
+            });
+            crate::commands::mls::ds_post_ok(state, "/v1/groups/leave", &body).await?;
+        }
+        None => {
+            conn.execute(
+                "DELETE FROM group_member WHERE group_id = ?1 AND user_id = ?2",
+                libsql::params![group_id.clone(), user_id.clone()],
+            ).await?;
+        }
+    }
 
     // A user cannot commit their own removal in MLS ("remove_members with self
     // as target" is rejected by the spec).  Instead, wipe the local group state
@@ -178,8 +206,10 @@ pub async fn leave_group(
         eprintln!("[realtime] leave_group: notify group {group_id}: {e}");
     }
 
-    // If no members remain, delete the group (cascades to channels, invites, etc.)
-    if member_count <= 1 {
+    // If no members remain, delete the group (cascades to channels, invites,
+    // etc.). On the DS path this is handled server-side inside the leave write,
+    // so only the direct path issues it here.
+    if state.config.pollis_delivery_url.is_none() && member_count <= 1 {
         conn.execute(
             "DELETE FROM groups WHERE id = ?1",
             libsql::params![group_id],
@@ -230,10 +260,26 @@ pub async fn set_member_role(
         return Err(Error::Other(anyhow::anyhow!("user is not a member of this group")));
     }
 
-    conn.execute(
-        "UPDATE group_member SET role = ?1 WHERE group_id = ?2 AND user_id = ?3",
-        libsql::params![role, group_id.clone(), user_id],
-    ).await?;
+    // DS seam: route the role update through the Delivery Service (admin
+    // re-derived server-side, target-membership re-checked) when configured;
+    // else direct.
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            let body = serde_json::json!({
+                "group_id": group_id,
+                "user_id": user_id,
+                "role": role,
+                "requester_id": requester_id,
+            });
+            crate::commands::mls::ds_post_ok(state, "/v1/members/role", &body).await?;
+        }
+        None => {
+            conn.execute(
+                "UPDATE group_member SET role = ?1 WHERE group_id = ?2 AND user_id = ?3",
+                libsql::params![role, group_id.clone(), user_id],
+            ).await?;
+        }
+    }
 
     // Notify other online group members so their members list refreshes.
     // Best-effort realtime push; routed through the livekit boundary so this

--- a/pollis-core/src/commands/messages/edit_delete.rs
+++ b/pollis-core/src/commands/messages/edit_delete.rs
@@ -108,24 +108,39 @@ pub async fn delete_message(
         // Remove the original message envelope and any pending edit so
         // late-joiners or unsynced devices never receive the now-deleted
         // content. Then write the tombstone envelope so every existing
-        // member soft-deletes on next ingest.
-        conn.execute(
-            "DELETE FROM message_envelope WHERE id = ?1",
-            libsql::params![message_id.clone()],
-        ).await?;
-        conn.execute(
-            "DELETE FROM message_envelope WHERE target_message_id = ?1 AND type = 'edit'",
-            libsql::params![message_id.clone()],
-        ).await?;
-
-        let tombstone_id = Ulid::new().to_string();
+        // member soft-deletes on next ingest. The server re-verifies admin
+        // authority (it must not trust the client's branch choice). DS seam:
+        // route the whole 3-write op (one transaction server-side) through the
+        // Delivery Service when configured; else direct.
         let now = chrono::Utc::now().to_rfc3339();
-        conn.execute(
-            "INSERT INTO message_envelope
-                 (id, conversation_id, sender_id, ciphertext, sent_at, type, target_message_id)
-             VALUES (?1, ?2, ?3, '', ?4, 'delete', ?5)",
-            libsql::params![tombstone_id, conversation_id.clone(), user_id.clone(), now.clone(), message_id.clone()],
-        ).await?;
+        match state.config.pollis_delivery_url.as_deref() {
+            Some(_) => {
+                let body = serde_json::json!({
+                    "message_id": message_id,
+                    "conversation_id": conversation_id,
+                    "msg_sender_id": msg_sender_id,
+                });
+                crate::commands::mls::ds_post_ok(state, "/v1/messages/delete", &body).await?;
+            }
+            None => {
+                conn.execute(
+                    "DELETE FROM message_envelope WHERE id = ?1",
+                    libsql::params![message_id.clone()],
+                ).await?;
+                conn.execute(
+                    "DELETE FROM message_envelope WHERE target_message_id = ?1 AND type = 'edit'",
+                    libsql::params![message_id.clone()],
+                ).await?;
+
+                let tombstone_id = Ulid::new().to_string();
+                conn.execute(
+                    "INSERT INTO message_envelope
+                         (id, conversation_id, sender_id, ciphertext, sent_at, type, target_message_id)
+                     VALUES (?1, ?2, ?3, '', ?4, 'delete', ?5)",
+                    libsql::params![tombstone_id, conversation_id.clone(), user_id.clone(), now.clone(), message_id.clone()],
+                ).await?;
+            }
+        }
 
         // Soft-delete locally and collect orphaned attachments. The admin
         // may not have a local row (joined after the message was sent and
@@ -163,7 +178,7 @@ pub async fn delete_message(
         };
 
         for att in orphaned {
-            cleanup_attachment(&state, &att).await;
+            cleanup_attachment(state, &att).await;
         }
 
         // Broadcast so currently-connected clients invalidate their message
@@ -183,19 +198,32 @@ pub async fn delete_message(
         return Ok(());
     }
 
-    // Self-delete path (caller is the original sender).
-    //
-    // Remove the message envelope. Best-effort — may already be gone.
-    conn.execute(
-        "DELETE FROM message_envelope WHERE id = ?1 AND sender_id = ?2",
-        libsql::params![message_id.clone(), user_id.clone()],
-    ).await?;
+    // Self-delete path (caller is the original sender). Remove the message
+    // envelope (best-effort — may already be gone) and any pending edit. DS
+    // seam: route both deletes (one transaction server-side, scoped to the
+    // authenticated sender) through the Delivery Service when configured.
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            let body = serde_json::json!({
+                "message_id": message_id,
+                "conversation_id": conversation_id,
+                "msg_sender_id": user_id,
+            });
+            crate::commands::mls::ds_post_ok(state, "/v1/messages/delete", &body).await?;
+        }
+        None => {
+            conn.execute(
+                "DELETE FROM message_envelope WHERE id = ?1 AND sender_id = ?2",
+                libsql::params![message_id.clone(), user_id.clone()],
+            ).await?;
 
-    // Remove any pending edit envelope for this message.
-    conn.execute(
-        "DELETE FROM message_envelope WHERE target_message_id = ?1 AND type = 'edit'",
-        libsql::params![message_id.clone()],
-    ).await?;
+            // Remove any pending edit envelope for this message.
+            conn.execute(
+                "DELETE FROM message_envelope WHERE target_message_id = ?1 AND type = 'edit'",
+                libsql::params![message_id.clone()],
+            ).await?;
+        }
+    }
 
     // Read the local plaintext content before deleting so we can inspect any
     // embedded attachment metadata. Then delete the local row and compute
@@ -238,7 +266,7 @@ pub async fn delete_message(
     };
 
     for att in orphaned {
-        cleanup_attachment(&state, &att).await;
+        cleanup_attachment(state, &att).await;
     }
 
     Ok(())
@@ -341,14 +369,25 @@ fn filter_orphaned_locally_all(
 /// both: failures are logged, never bubbled. The attachment_object row is
 /// removed first — if R2 deletion fails, a future re-upload will re-register
 /// the row and overwrite the object, restoring a consistent state.
-async fn cleanup_attachment(state: &AppState, att: &AttachmentRef) {
+async fn cleanup_attachment(state: &Arc<AppState>, att: &AttachmentRef) {
+    // DS seam: remove the dedup row through the Delivery Service when
+    // configured; else direct. Best-effort either way (a convergent re-upload
+    // re-creates the row), so failures are logged, never bubbled.
     let remote_result = async {
-        let conn = state.remote_db.conn().await?;
-        conn.execute(
-            "DELETE FROM attachment_object WHERE content_hash = ?1",
-            libsql::params![att.content_hash.clone()],
-        ).await?;
-        Ok::<_, crate::error::Error>(())
+        match state.config.pollis_delivery_url.as_deref() {
+            Some(_) => {
+                let body = serde_json::json!({ "content_hash": att.content_hash });
+                crate::commands::mls::ds_post_ok(state, "/v1/attachments/delete", &body).await
+            }
+            None => {
+                let conn = state.remote_db.conn().await?;
+                conn.execute(
+                    "DELETE FROM attachment_object WHERE content_hash = ?1",
+                    libsql::params![att.content_hash.clone()],
+                ).await?;
+                Ok::<_, crate::error::Error>(())
+            }
+        }
     }
     .await;
 
@@ -461,21 +500,38 @@ pub async fn edit_message(
         format!("mls:{}", hex::encode(&mls_bytes))
     };
 
-    // Replace any existing edit envelope for this message with the new one.
-    // DELETE + INSERT rather than ON CONFLICT to stay compatible with older libsql.
-    let conn = state.remote_db.conn().await?;
-    conn.execute(
-        "DELETE FROM message_envelope
-         WHERE conversation_id = ?1 AND target_message_id = ?2 AND type = 'edit'",
-        libsql::params![conversation_id.clone(), message_id.clone()],
-    ).await?;
+    // Replace any existing edit envelope for this message with the new one
+    // (DELETE + INSERT, single transaction on the DS side). DS seam: route the
+    // replace through the Delivery Service when configured; else direct.
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            let body = serde_json::json!({
+                "envelope_id": envelope_id,
+                "conversation_id": conversation_id,
+                "target_message_id": message_id,
+                "sender_id": user_id,
+                "ciphertext": ciphertext_remote,
+                "sent_at": now,
+            });
+            crate::commands::mls::ds_post_ok(state, "/v1/messages/edit", &body).await?;
+        }
+        None => {
+            // DELETE + INSERT rather than ON CONFLICT to stay compatible with older libsql.
+            let conn = state.remote_db.conn().await?;
+            conn.execute(
+                "DELETE FROM message_envelope
+                 WHERE conversation_id = ?1 AND target_message_id = ?2 AND type = 'edit'",
+                libsql::params![conversation_id.clone(), message_id.clone()],
+            ).await?;
 
-    conn.execute(
-        "INSERT INTO message_envelope
-             (id, conversation_id, sender_id, ciphertext, sent_at, type, target_message_id)
-         VALUES (?1, ?2, ?3, ?4, ?5, 'edit', ?6)",
-        libsql::params![envelope_id, conversation_id.clone(), user_id.clone(), ciphertext_remote, now, message_id.clone()],
-    ).await?;
+            conn.execute(
+                "INSERT INTO message_envelope
+                     (id, conversation_id, sender_id, ciphertext, sent_at, type, target_message_id)
+                 VALUES (?1, ?2, ?3, ?4, ?5, 'edit', ?6)",
+                libsql::params![envelope_id, conversation_id.clone(), user_id.clone(), ciphertext_remote, now, message_id.clone()],
+            ).await?;
+        }
+    }
 
     // Notify recipients via LiveKit so they invalidate their cache immediately.
     // Non-fatal — errors are logged, not returned.

--- a/pollis-core/src/commands/messages/ingest.rs
+++ b/pollis-core/src/commands/messages/ingest.rs
@@ -131,23 +131,51 @@ pub async fn ingest_channel_envelopes_inner(
         &envelopes,
     ).await?;
 
+    // DS seam: advance this device's watermark + run envelope GC through the
+    // Delivery Service when configured; else direct. Both are best-effort (the
+    // direct path logs and continues), so DS failures are logged too.
     if let (Some(ts), Some(did)) = (watermark_ts, device_id.as_ref()) {
-        if let Err(e) = conn.execute(
-            "INSERT INTO conversation_watermark (conversation_id, user_id, device_id, last_fetched_at)
-             VALUES (?1, ?2, ?3, ?4)
-             ON CONFLICT(conversation_id, user_id, device_id) DO UPDATE SET
-               last_fetched_at = MAX(last_fetched_at, excluded.last_fetched_at)",
-            libsql::params![channel_id.to_string(), user_id.to_string(), did.clone(), ts],
-        ).await {
-            eprintln!("[watermark] ingest_channel: upsert failed: {e}");
+        match state.config.pollis_delivery_url.as_deref() {
+            Some(_) => {
+                let body = serde_json::json!({
+                    "conversation_id": channel_id,
+                    "user_id": user_id,
+                    "device_id": did,
+                    "last_fetched_at": ts,
+                });
+                if let Err(e) = crate::commands::mls::ds_post_ok(state, "/v1/watermarks/advance", &body).await {
+                    eprintln!("[watermark] ingest_channel: DS advance failed: {e}");
+                }
+            }
+            None => {
+                if let Err(e) = conn.execute(
+                    "INSERT INTO conversation_watermark (conversation_id, user_id, device_id, last_fetched_at)
+                     VALUES (?1, ?2, ?3, ?4)
+                     ON CONFLICT(conversation_id, user_id, device_id) DO UPDATE SET
+                       last_fetched_at = MAX(last_fetched_at, excluded.last_fetched_at)",
+                    libsql::params![channel_id.to_string(), user_id.to_string(), did.clone(), ts],
+                ).await {
+                    eprintln!("[watermark] ingest_channel: upsert failed: {e}");
+                }
+            }
         }
     }
 
-    if let Err(e) = conn.execute(
-        CLEANUP_CHANNEL_ENVELOPES,
-        libsql::params![channel_id.to_string()],
-    ).await {
-        eprintln!("[ingest] channel cleanup failed: {e}");
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            let body = serde_json::json!({ "conversation_id": channel_id, "is_dm": false });
+            if let Err(e) = crate::commands::mls::ds_post_ok(state, "/v1/envelopes/gc", &body).await {
+                eprintln!("[ingest] channel cleanup (DS) failed: {e}");
+            }
+        }
+        None => {
+            if let Err(e) = conn.execute(
+                CLEANUP_CHANNEL_ENVELOPES,
+                libsql::params![channel_id.to_string()],
+            ).await {
+                eprintln!("[ingest] channel cleanup failed: {e}");
+            }
+        }
     }
 
     Ok(())
@@ -356,23 +384,49 @@ pub async fn ingest_dm_envelopes_inner(
         &envelopes,
     ).await?;
 
+    // DS seam — see ingest_channel_envelopes_inner. DM cleanup uses the DM query.
     if let (Some(ts), Some(did)) = (watermark_ts, device_id.as_ref()) {
-        if let Err(e) = conn.execute(
-            "INSERT INTO conversation_watermark (conversation_id, user_id, device_id, last_fetched_at)
-             VALUES (?1, ?2, ?3, ?4)
-             ON CONFLICT(conversation_id, user_id, device_id) DO UPDATE SET
-               last_fetched_at = MAX(last_fetched_at, excluded.last_fetched_at)",
-            libsql::params![dm_channel_id.to_string(), user_id.to_string(), did.clone(), ts],
-        ).await {
-            eprintln!("[watermark] ingest_dm: upsert failed: {e}");
+        match state.config.pollis_delivery_url.as_deref() {
+            Some(_) => {
+                let body = serde_json::json!({
+                    "conversation_id": dm_channel_id,
+                    "user_id": user_id,
+                    "device_id": did,
+                    "last_fetched_at": ts,
+                });
+                if let Err(e) = crate::commands::mls::ds_post_ok(state, "/v1/watermarks/advance", &body).await {
+                    eprintln!("[watermark] ingest_dm: DS advance failed: {e}");
+                }
+            }
+            None => {
+                if let Err(e) = conn.execute(
+                    "INSERT INTO conversation_watermark (conversation_id, user_id, device_id, last_fetched_at)
+                     VALUES (?1, ?2, ?3, ?4)
+                     ON CONFLICT(conversation_id, user_id, device_id) DO UPDATE SET
+                       last_fetched_at = MAX(last_fetched_at, excluded.last_fetched_at)",
+                    libsql::params![dm_channel_id.to_string(), user_id.to_string(), did.clone(), ts],
+                ).await {
+                    eprintln!("[watermark] ingest_dm: upsert failed: {e}");
+                }
+            }
         }
     }
 
-    if let Err(e) = conn.execute(
-        CLEANUP_DM_ENVELOPES,
-        libsql::params![dm_channel_id.to_string()],
-    ).await {
-        eprintln!("[ingest] dm cleanup failed: {e}");
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            let body = serde_json::json!({ "conversation_id": dm_channel_id, "is_dm": true });
+            if let Err(e) = crate::commands::mls::ds_post_ok(state, "/v1/envelopes/gc", &body).await {
+                eprintln!("[ingest] dm cleanup (DS) failed: {e}");
+            }
+        }
+        None => {
+            if let Err(e) = conn.execute(
+                CLEANUP_DM_ENVELOPES,
+                libsql::params![dm_channel_id.to_string()],
+            ).await {
+                eprintln!("[ingest] dm cleanup failed: {e}");
+            }
+        }
     }
 
     Ok(())

--- a/pollis-core/src/commands/messages/reactions.rs
+++ b/pollis-core/src/commands/messages/reactions.rs
@@ -22,15 +22,28 @@ pub async fn add_reaction(
     emoji: String,
     state: &Arc<AppState>,
 ) -> Result<()> {
-    let conn = state.remote_db.conn().await?;
-    let id = Ulid::new().to_string();
-    let now = chrono::Utc::now().to_rfc3339();
-
-    conn.execute(
-        "INSERT OR IGNORE INTO message_reaction (id, message_id, user_id, emoji, created_at)
-         VALUES (?1, ?2, ?3, ?4, ?5)",
-        libsql::params![id, message_id, user_id, emoji, now],
-    ).await?;
+    // DS seam: the server generates the row id + timestamp and binds the
+    // reacting user to the authenticated identity.
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            let body = serde_json::json!({
+                "message_id": message_id,
+                "emoji": emoji,
+                "user_id": user_id,
+            });
+            crate::commands::mls::ds_post_ok(state, "/v1/reactions/add", &body).await?;
+        }
+        None => {
+            let conn = state.remote_db.conn().await?;
+            let id = Ulid::new().to_string();
+            let now = chrono::Utc::now().to_rfc3339();
+            conn.execute(
+                "INSERT OR IGNORE INTO message_reaction (id, message_id, user_id, emoji, created_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                libsql::params![id, message_id, user_id, emoji, now],
+            ).await?;
+        }
+    }
 
     Ok(())
 }
@@ -43,12 +56,23 @@ pub async fn remove_reaction(
     emoji: String,
     state: &Arc<AppState>,
 ) -> Result<()> {
-    let conn = state.remote_db.conn().await?;
-
-    conn.execute(
-        "DELETE FROM message_reaction WHERE message_id = ?1 AND user_id = ?2 AND emoji = ?3",
-        libsql::params![message_id, user_id, emoji],
-    ).await?;
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            let body = serde_json::json!({
+                "message_id": message_id,
+                "emoji": emoji,
+                "user_id": user_id,
+            });
+            crate::commands::mls::ds_post_ok(state, "/v1/reactions/remove", &body).await?;
+        }
+        None => {
+            let conn = state.remote_db.conn().await?;
+            conn.execute(
+                "DELETE FROM message_reaction WHERE message_id = ?1 AND user_id = ?2 AND emoji = ?3",
+                libsql::params![message_id, user_id, emoji],
+            ).await?;
+        }
+    }
 
     Ok(())
 }

--- a/pollis-core/src/commands/messages/send.rs
+++ b/pollis-core/src/commands/messages/send.rs
@@ -128,13 +128,29 @@ pub async fn send_message(
         mls_ct_str
     };
 
-    // Post to Turso for offline delivery.
-    let conn = state.remote_db.conn().await?;
-    conn.execute(
-        "INSERT INTO message_envelope (id, conversation_id, sender_id, ciphertext, reply_to_id, sent_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-        libsql::params![id.clone(), conversation_id.clone(), sender_id.clone(), ciphertext_remote, reply_to_id.clone(), now.clone()],
-    ).await?;
+    // Post to Turso for offline delivery. DS seam: route the envelope write
+    // through the Delivery Service (the write API) when configured; else direct.
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            let body = serde_json::json!({
+                "id": id,
+                "conversation_id": conversation_id,
+                "sender_id": sender_id,
+                "ciphertext": ciphertext_remote,
+                "reply_to_id": reply_to_id,
+                "sent_at": now,
+            });
+            crate::commands::mls::ds_post_ok(state, "/v1/messages/send", &body).await?;
+        }
+        None => {
+            let conn = state.remote_db.conn().await?;
+            conn.execute(
+                "INSERT INTO message_envelope (id, conversation_id, sender_id, ciphertext, reply_to_id, sent_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                libsql::params![id.clone(), conversation_id.clone(), sender_id.clone(), ciphertext_remote, reply_to_id.clone(), now.clone()],
+            ).await?;
+        }
+    }
 
     // Notify recipients via LiveKit. Non-fatal — errors are logged, not returned.
     let uname = sender_username.as_deref();

--- a/pollis-core/src/commands/mls/device.rs
+++ b/pollis-core/src/commands/mls/device.rs
@@ -180,6 +180,14 @@ pub async fn ensure_device_cert(
     // round-trip to u64 for signature verification later.
     let issued_at_str = issued_at.to_string();
 
+    // BOOTSTRAP — stays DIRECT, never routed through the DS (#419 domain D).
+    // This UPDATE sets `mls_signature_pub`, which is the exact column the DS
+    // reads to authenticate a signed request (`auth::verify_request`). Until it
+    // is populated this device cannot produce a signature the DS will accept, so
+    // the write that establishes the credential cannot be authenticated by that
+    // credential. Device cert (re)publish therefore writes Turso directly; every
+    // post-enrolment domain-D write (key packages, push tokens, cert re-sign) is
+    // signed and routed through the DS. See `pollis_delivery::devices` docs.
     conn.execute(
         "UPDATE user_device \
          SET device_cert = ?1, \
@@ -273,7 +281,11 @@ pub async fn resign_stale_device_certs(
         out
     };
 
-    let mut count = 0;
+    // Sign every stale device's cert with the account identity key (held only in
+    // the OS keystore) BEFORE any remote write, collecting the cert columns. The
+    // re-sign never touches `mls_signature_pub` — only the cert columns — so it
+    // cannot change a device's DS-auth credential.
+    let mut signed: Vec<(String, Vec<u8>, String)> = Vec::with_capacity(devices.len());
     for (device_id, sig_pub_bytes) in devices {
         let issued_at = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -289,24 +301,51 @@ pub async fn resign_stale_device_certs(
             issued_at,
         )
         .await?;
+        signed.push((device_id, cert, issued_at.to_string()));
+    }
+    let count = signed.len();
 
-        let issued_at_str = issued_at.to_string();
-        conn.execute(
-            "UPDATE user_device \
-             SET device_cert = ?1, \
-                 cert_issued_at = ?2, \
-                 cert_identity_version = ?3 \
-             WHERE device_id = ?4 AND user_id = ?5",
-            libsql::params![
-                cert,
-                issued_at_str,
-                identity_version as i64,
-                device_id.clone(),
-                user_id
-            ],
-        )
-        .await?;
-        count += 1;
+    // DS seam: re-stamp the cert columns through the Delivery Service (the write
+    // API) when configured — user-scoped: the actor re-signs certs for any of
+    // THEIR OWN devices, never another user's — else UPDATE directly.
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            if !signed.is_empty() {
+                use base64::Engine as _;
+                let certs: Vec<serde_json::Value> = signed
+                    .iter()
+                    .map(|(device_id, cert, issued_at_str)| {
+                        serde_json::json!({
+                            "device_id": device_id,
+                            "device_cert": base64::engine::general_purpose::STANDARD.encode(cert),
+                            "cert_issued_at": issued_at_str,
+                            "cert_identity_version": identity_version as i64,
+                        })
+                    })
+                    .collect();
+                let body = serde_json::json!({ "certs": certs, "user_id": user_id });
+                crate::commands::mls::ds_post_ok(state, "/v1/devices/resign", &body).await?;
+            }
+        }
+        None => {
+            for (device_id, cert, issued_at_str) in &signed {
+                conn.execute(
+                    "UPDATE user_device \
+                     SET device_cert = ?1, \
+                         cert_issued_at = ?2, \
+                         cert_identity_version = ?3 \
+                     WHERE device_id = ?4 AND user_id = ?5",
+                    libsql::params![
+                        cert.clone(),
+                        issued_at_str.clone(),
+                        identity_version as i64,
+                        device_id.clone(),
+                        user_id
+                    ],
+                )
+                .await?;
+            }
+        }
     }
 
     eprintln!(

--- a/pollis-core/src/commands/mls/ds_client.rs
+++ b/pollis-core/src/commands/mls/ds_client.rs
@@ -145,3 +145,18 @@ pub async fn ds_post(
         .map_err(|e| Error::Other(anyhow::anyhow!("ds_post {path}: {e}")))?;
     Ok(resp)
 }
+
+/// [`ds_post`] for writes that must NOT silently fail: any non-2xx becomes an
+/// `Err` carrying the status + body. Use this when the direct-write path it
+/// replaces propagated its error (`conn.execute(...).await?`). For best-effort
+/// writes (the direct path logged and continued) call [`ds_post`] and log
+/// instead.
+pub async fn ds_post_ok(state: &Arc<AppState>, path: &str, body: &serde_json::Value) -> Result<()> {
+    let resp = ds_post(state, path, body).await?;
+    if !resp.status().is_success() {
+        let s = resp.status();
+        let txt = resp.text().await.unwrap_or_default();
+        return Err(Error::Other(anyhow::anyhow!("ds_post {path} {s}: {txt}")));
+    }
+    Ok(())
+}

--- a/pollis-core/src/commands/mls/key_packages.rs
+++ b/pollis-core/src/commands/mls/key_packages.rs
@@ -82,6 +82,67 @@ pub async fn generate_mls_key_package(
     Ok(serde_json::json!({ "ref_hex": ref_hex, "key_package_bytes": kp_bytes }))
 }
 
+/// Shape `(ref_hash, key_package_bytes)` pairs into the DS write-API
+/// `packages` array: each `key_package` is base64 (STANDARD), since the bytes
+/// are binary (the domain convention — see `pollis_delivery::devices`).
+fn kp_packages_json(pairs: &[(String, Vec<u8>)]) -> Vec<serde_json::Value> {
+    use base64::Engine as _;
+    pairs
+        .iter()
+        .map(|(ref_hex, kp)| {
+            serde_json::json!({
+                "ref_hash": ref_hex,
+                "key_package": base64::engine::general_purpose::STANDARD.encode(kp),
+            })
+        })
+        .collect()
+}
+
+/// Build one fresh `KeyPackage` for this device backed by the current local DB,
+/// returning `(ref_hex, tls_bytes)`. All packages share the stable device
+/// signing key, so a single `device_cert` covers every package this device
+/// ships. Locks the local DB for the (sync) openmls work, dropping the guard
+/// before returning.
+async fn build_one_key_package(
+    state: &Arc<AppState>,
+    user_id: &str,
+    device_id: &str,
+) -> Result<(String, Vec<u8>)> {
+    let guard = state.local_db.lock().await;
+    let db = guard.as_ref().ok_or_else(|| {
+        crate::error::Error::Other(anyhow::anyhow!("Not signed in"))
+    })?;
+    let provider = PollisProvider::new(db.conn());
+
+    let (sig_keys, sig_pub_bytes) =
+        load_or_create_device_signer(&provider, user_id, device_id)?;
+
+    let credential = make_credential(user_id, device_id);
+    let sig_pub = OpenMlsSignaturePublicKey::new(
+        sig_pub_bytes.into(),
+        CS.signature_algorithm(),
+    ).map_err(|e| crate::error::Error::Other(anyhow::anyhow!("sig pub key: {e}")))?;
+    let cred_with_key = CredentialWithKey {
+        credential,
+        signature_key: sig_pub.into(),
+    };
+
+    let bundle = KeyPackage::builder()
+        .build(CS, &provider, &sig_keys, cred_with_key)
+        .map_err(|e| crate::error::Error::Other(anyhow::anyhow!("kp build: {e}")))?;
+
+    let kp = bundle.key_package();
+    let hash_ref = kp
+        .hash_ref(provider.crypto())
+        .map_err(|e| crate::error::Error::Other(anyhow::anyhow!("kp hash_ref: {e}")))?;
+    let ref_hex = hex::encode(hash_ref.as_slice());
+    let kp_bytes = kp
+        .tls_serialize_detached()
+        .map_err(|e| crate::error::Error::Other(anyhow::anyhow!("kp serialize: {e}")))?;
+
+    Ok((ref_hex, kp_bytes))
+}
+
 /// Upload a TLS-serialised `KeyPackage` (produced by `generate_mls_key_package`)
 /// to the remote `mls_key_package` table so other users can claim it.
 pub async fn publish_mls_key_package(
@@ -92,17 +153,40 @@ pub async fn publish_mls_key_package(
 ) -> Result<()> {
     let device_id = state.device_id.lock().await.clone()
         .ok_or_else(|| crate::error::Error::Other(anyhow::anyhow!("device_id not set")))?;
-    let conn = state.remote_db.conn().await?;
-    conn.execute(
-        "INSERT OR IGNORE INTO mls_key_package (ref_hash, user_id, key_package, device_id) \
-         VALUES (?1, ?2, ?3, ?4)",
-        libsql::params![ref_hex, user_id, key_package_bytes, device_id],
-    ).await?;
+
+    // DS seam: route the owner-scoped publish through the Delivery Service (the
+    // write API) when configured; else write Turso directly.
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            let packages = kp_packages_json(&[(ref_hex, key_package_bytes)]);
+            let body = serde_json::json!({
+                "device_id": device_id,
+                "packages": packages,
+                "user_id": user_id,
+            });
+            crate::commands::mls::ds_post_ok(state, "/v1/key-packages", &body).await?;
+        }
+        None => {
+            let conn = state.remote_db.conn().await?;
+            conn.execute(
+                "INSERT OR IGNORE INTO mls_key_package (ref_hash, user_id, key_package, device_id) \
+                 VALUES (?1, ?2, ?3, ?4)",
+                libsql::params![ref_hex, user_id, key_package_bytes, device_id],
+            ).await?;
+        }
+    }
     Ok(())
 }
 
 /// Atomically claim one unclaimed `KeyPackage` for `target_user_id` from the
 /// remote table and return its TLS bytes.  Returns `null` if none are available.
+///
+/// NOT routed through the DS (#419 domain D). This claim mutates a *peer's* row
+/// (`claimed = 1` on `target_user_id`'s package) as the add path consumes it, so
+/// it is not owner-scoped and does not fit the owner-signature write pattern. Per
+/// the migration plan it folds into `/v1/commits` as a DS-side step of the add
+/// (the commit that adds the device), keeping claim + commit atomic — a later
+/// domain, never a standalone "claim someone else's KP" client endpoint.
 pub async fn fetch_mls_key_package(
     state: &Arc<AppState>,
     target_user_id: String,
@@ -144,62 +228,43 @@ pub async fn ensure_mls_key_package(
 ) -> Result<()> {
     const TARGET: i64 = 5;
 
-    let conn = state.remote_db.conn().await?;
-
-    // Remove unclaimed packages for THIS device only — their private keys may
-    // no longer exist in the current local DB (e.g. after a wipe).
-    // Also clean up legacy packages with NULL device_id for this user.
-    conn.execute(
-        "DELETE FROM mls_key_package WHERE user_id = ?1 AND claimed = 0 \
-         AND (device_id = ?2 OR device_id IS NULL)",
-        libsql::params![user_id, device_id],
-    ).await?;
-
-    // Generate and publish TARGET fresh packages. They all share the same
-    // stable device signing key so one `device_cert` in `user_device`
-    // covers every key package this device ever ships.
+    // Build TARGET fresh packages locally (their private keys live in the local
+    // DB) before any remote write, so the DS replenish is a single batched call.
+    let mut pairs: Vec<(String, Vec<u8>)> = Vec::with_capacity(TARGET as usize);
     for _ in 0..TARGET {
-        let (ref_hex, kp_bytes) = {
-            let guard = state.local_db.lock().await;
-            let db = guard.as_ref().ok_or_else(|| {
-                crate::error::Error::Other(anyhow::anyhow!("Not signed in"))
-            })?;
-            let provider = PollisProvider::new(db.conn());
+        pairs.push(build_one_key_package(state, user_id, device_id).await?);
+    }
 
-            let (sig_keys, sig_pub_bytes) =
-                load_or_create_device_signer(&provider, user_id, device_id)?;
-
-            let credential = make_credential(user_id, device_id);
-            let sig_pub = OpenMlsSignaturePublicKey::new(
-                sig_pub_bytes.into(),
-                CS.signature_algorithm(),
-            ).map_err(|e| crate::error::Error::Other(anyhow::anyhow!("sig pub key: {e}")))?;
-            let cred_with_key = CredentialWithKey {
-                credential,
-                signature_key: sig_pub.into(),
-            };
-
-            let bundle = KeyPackage::builder()
-                .build(CS, &provider, &sig_keys, cred_with_key)
-                .map_err(|e| crate::error::Error::Other(anyhow::anyhow!("kp build: {e}")))?;
-
-            let kp = bundle.key_package();
-            let hash_ref = kp
-                .hash_ref(provider.crypto())
-                .map_err(|e| crate::error::Error::Other(anyhow::anyhow!("kp hash_ref: {e}")))?;
-            let ref_hex = hex::encode(hash_ref.as_slice());
-            let kp_bytes = kp
-                .tls_serialize_detached()
-                .map_err(|e| crate::error::Error::Other(anyhow::anyhow!("kp serialize: {e}")))?;
-
-            (ref_hex, kp_bytes)
-        };
-
-        conn.execute(
-            "INSERT OR IGNORE INTO mls_key_package (ref_hash, user_id, key_package, device_id) \
-             VALUES (?1, ?2, ?3, ?4)",
-            libsql::params![ref_hex, user_id, kp_bytes, device_id],
-        ).await?;
+    // DS seam: the replenish endpoint clears this device's stale unclaimed
+    // packages and inserts the fresh pool in ONE transaction (owner-scoped to the
+    // signer); else do the equivalent delete-then-insert directly.
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            let body = serde_json::json!({
+                "device_id": device_id,
+                "packages": kp_packages_json(&pairs),
+                "user_id": user_id,
+            });
+            crate::commands::mls::ds_post_ok(state, "/v1/key-packages/replenish", &body).await?;
+        }
+        None => {
+            let conn = state.remote_db.conn().await?;
+            // Remove unclaimed packages for THIS device only — their private keys
+            // may no longer exist in the current local DB (e.g. after a wipe).
+            // Also clean up legacy packages with NULL device_id for this user.
+            conn.execute(
+                "DELETE FROM mls_key_package WHERE user_id = ?1 AND claimed = 0 \
+                 AND (device_id = ?2 OR device_id IS NULL)",
+                libsql::params![user_id, device_id],
+            ).await?;
+            for (ref_hex, kp_bytes) in &pairs {
+                conn.execute(
+                    "INSERT OR IGNORE INTO mls_key_package (ref_hash, user_id, key_package, device_id) \
+                     VALUES (?1, ?2, ?3, ?4)",
+                    libsql::params![ref_hex.clone(), user_id, kp_bytes.clone(), device_id],
+                ).await?;
+            }
+        }
     }
 
     Ok(())
@@ -215,17 +280,22 @@ pub(super) async fn replenish_key_packages(
 ) -> Result<()> {
     const TARGET: i64 = 5;
 
-    let conn = state.remote_db.conn().await?;
-    let mut rows = conn.query(
-        "SELECT COUNT(*) FROM mls_key_package WHERE user_id = ?1 AND device_id = ?2 AND claimed = 0",
-        libsql::params![user_id, device_id],
-    ).await?;
-    let remaining: i64 = if let Some(row) = rows.next().await? {
-        row.get(0)?
-    } else {
-        0
+    // Counting remaining packages is a READ — it stays direct on the local
+    // libsql handle even when DS writes are enabled.
+    let remaining: i64 = {
+        let conn = state.remote_db.conn().await?;
+        let mut rows = conn.query(
+            "SELECT COUNT(*) FROM mls_key_package WHERE user_id = ?1 AND device_id = ?2 AND claimed = 0",
+            libsql::params![user_id, device_id],
+        ).await?;
+        let n = if let Some(row) = rows.next().await? {
+            row.get(0)?
+        } else {
+            0
+        };
+        drop(rows);
+        n
     };
-    drop(rows);
 
     let needed = TARGET - remaining;
     if needed <= 0 {
@@ -234,48 +304,33 @@ pub(super) async fn replenish_key_packages(
 
     eprintln!("[mls] replenish: {remaining} unclaimed KPs, publishing {needed} more");
 
+    // Build the top-up packages locally before any remote write.
+    let mut pairs: Vec<(String, Vec<u8>)> = Vec::with_capacity(needed as usize);
     for _ in 0..needed {
-        let (ref_hex, kp_bytes) = {
-            let guard = state.local_db.lock().await;
-            let db = guard.as_ref().ok_or_else(|| {
-                crate::error::Error::Other(anyhow::anyhow!("Not signed in"))
-            })?;
-            let provider = PollisProvider::new(db.conn());
+        pairs.push(build_one_key_package(state, user_id, device_id).await?);
+    }
 
-            let (sig_keys, sig_pub_bytes) =
-                load_or_create_device_signer(&provider, user_id, device_id)?;
-
-            let credential = make_credential(user_id, device_id);
-            let sig_pub = OpenMlsSignaturePublicKey::new(
-                sig_pub_bytes.into(),
-                CS.signature_algorithm(),
-            ).map_err(|e| crate::error::Error::Other(anyhow::anyhow!("sig pub key: {e}")))?;
-            let cred_with_key = CredentialWithKey {
-                credential,
-                signature_key: sig_pub.into(),
-            };
-
-            let bundle = KeyPackage::builder()
-                .build(CS, &provider, &sig_keys, cred_with_key)
-                .map_err(|e| crate::error::Error::Other(anyhow::anyhow!("kp build: {e}")))?;
-
-            let kp = bundle.key_package();
-            let hash_ref = kp
-                .hash_ref(provider.crypto())
-                .map_err(|e| crate::error::Error::Other(anyhow::anyhow!("kp hash_ref: {e}")))?;
-            let ref_hex = hex::encode(hash_ref.as_slice());
-            let kp_bytes = kp
-                .tls_serialize_detached()
-                .map_err(|e| crate::error::Error::Other(anyhow::anyhow!("kp serialize: {e}")))?;
-
-            (ref_hex, kp_bytes)
-        };
-
-        conn.execute(
-            "INSERT OR IGNORE INTO mls_key_package (ref_hash, user_id, key_package, device_id) \
-             VALUES (?1, ?2, ?3, ?4)",
-            libsql::params![ref_hex, user_id, kp_bytes, device_id],
-        ).await?;
+    // DS seam: a top-up is insert-only (no delete), so it routes through the
+    // owner-scoped publish endpoint; else INSERT OR IGNORE directly.
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            let body = serde_json::json!({
+                "device_id": device_id,
+                "packages": kp_packages_json(&pairs),
+                "user_id": user_id,
+            });
+            crate::commands::mls::ds_post_ok(state, "/v1/key-packages", &body).await?;
+        }
+        None => {
+            let conn = state.remote_db.conn().await?;
+            for (ref_hex, kp_bytes) in &pairs {
+                conn.execute(
+                    "INSERT OR IGNORE INTO mls_key_package (ref_hash, user_id, key_package, device_id) \
+                     VALUES (?1, ?2, ?3, ?4)",
+                    libsql::params![ref_hex.clone(), user_id, kp_bytes.clone(), device_id],
+                ).await?;
+            }
+        }
     }
 
     Ok(())

--- a/pollis-core/src/commands/mls/mod.rs
+++ b/pollis-core/src/commands/mls/mod.rs
@@ -22,7 +22,7 @@ pub use provider::{
 pub use device::{ensure_device_cert, load_or_create_device_signer, resign_stale_device_certs};
 
 // ── Signed Delivery-Service write client (4 `X-Pollis-*` headers) ────────────
-pub(crate) use ds_client::ds_post;
+pub(crate) use ds_client::{ds_post, ds_post_ok};
 
 // ── Key packages ─────────────────────────────────────────────────────────────
 pub use key_packages::{

--- a/pollis-core/src/commands/push.rs
+++ b/pollis-core/src/commands/push.rs
@@ -36,17 +36,33 @@ pub async fn register_push_token(
     state: &Arc<AppState>,
 ) -> Result<()> {
     let now = chrono::Utc::now().to_rfc3339();
-    let conn = state.remote_db.conn().await?;
-    conn.execute(
-        "INSERT INTO push_token (token, user_id, platform, updated_at)
-         VALUES (?1, ?2, ?3, ?4)
-         ON CONFLICT(token) DO UPDATE SET
-             user_id = excluded.user_id,
-             platform = excluded.platform,
-             updated_at = excluded.updated_at",
-        libsql::params![token, user_id, platform, now],
-    )
-    .await?;
+
+    // DS seam: route the owner-scoped upsert through the Delivery Service (the
+    // write API) when configured; else write Turso directly.
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            let body = serde_json::json!({
+                "token": token,
+                "platform": platform,
+                "updated_at": now,
+                "user_id": user_id,
+            });
+            crate::commands::mls::ds_post_ok(state, "/v1/push-tokens", &body).await?;
+        }
+        None => {
+            let conn = state.remote_db.conn().await?;
+            conn.execute(
+                "INSERT INTO push_token (token, user_id, platform, updated_at)
+                 VALUES (?1, ?2, ?3, ?4)
+                 ON CONFLICT(token) DO UPDATE SET
+                     user_id = excluded.user_id,
+                     platform = excluded.platform,
+                     updated_at = excluded.updated_at",
+                libsql::params![token, user_id, platform, now],
+            )
+            .await?;
+        }
+    }
     Ok(())
 }
 

--- a/pollis-core/src/commands/r2.rs
+++ b/pollis-core/src/commands/r2.rs
@@ -461,12 +461,25 @@ pub async fn upload_media(
             )));
         }
 
-        // Register in Turso so future uploads of the same file skip R2.
-        let conn = state.remote_db.conn().await?;
-        conn.execute(
-            "INSERT OR IGNORE INTO attachment_object (content_hash, r2_key) VALUES (?1, ?2)",
-            libsql::params![content_hash.clone(), r2_key.clone()],
-        ).await?;
+        // Register in Turso so future uploads of the same file skip R2. DS seam:
+        // route the dedup-row write through the Delivery Service when configured;
+        // else direct.
+        match state.config.pollis_delivery_url.as_deref() {
+            Some(_) => {
+                let body = serde_json::json!({
+                    "content_hash": content_hash,
+                    "r2_key": r2_key,
+                });
+                crate::commands::mls::ds_post_ok(state, "/v1/attachments/register", &body).await?;
+            }
+            None => {
+                let conn = state.remote_db.conn().await?;
+                conn.execute(
+                    "INSERT OR IGNORE INTO attachment_object (content_hash, r2_key) VALUES (?1, ?2)",
+                    libsql::params![content_hash.clone(), r2_key.clone()],
+                ).await?;
+            }
+        }
     }
 
     Ok(MediaUploadResult {

--- a/pollis-core/src/commands/user.rs
+++ b/pollis-core/src/commands/user.rs
@@ -46,17 +46,33 @@ pub async fn update_user_profile(
     avatar_url: Option<String>,
     state: &Arc<AppState>,
 ) -> Result<()> {
-    let conn = state.remote_db.conn().await?;
-
-    conn.execute(
-        "UPDATE users SET
-            username = COALESCE(?2, username),
-            preferred_name = COALESCE(?3, preferred_name),
-            phone = COALESCE(?4, phone),
-            avatar_url = COALESCE(?5, avatar_url)
-         WHERE id = ?1",
-        libsql::params![user_id, username, preferred_name, phone, avatar_url],
-    ).await?;
+    // DS seam: route the profile write through the Delivery Service (the write
+    // API) when configured; else write Turso directly. Server-side authz binds
+    // the edit to the authenticated user's own row.
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            let body = serde_json::json!({
+                "user_id": user_id,
+                "username": username,
+                "preferred_name": preferred_name,
+                "phone": phone,
+                "avatar_url": avatar_url,
+            });
+            crate::commands::mls::ds_post_ok(state, "/v1/profile/update", &body).await?;
+        }
+        None => {
+            let conn = state.remote_db.conn().await?;
+            conn.execute(
+                "UPDATE users SET
+                    username = COALESCE(?2, username),
+                    preferred_name = COALESCE(?3, preferred_name),
+                    phone = COALESCE(?4, phone),
+                    avatar_url = COALESCE(?5, avatar_url)
+                 WHERE id = ?1",
+                libsql::params![user_id, username, preferred_name, phone, avatar_url],
+            ).await?;
+        }
+    }
 
     Ok(())
 }
@@ -120,12 +136,26 @@ pub async fn save_preferences(
 ) -> Result<()> {
     upsert_local_preferences(state, &preferences_json).await;
 
-    let conn = state.remote_db.conn().await?;
-    conn.execute(
-        "INSERT INTO user_preferences (user_id, preferences, updated_at) VALUES (?1, ?2, datetime('now'))
-         ON CONFLICT(user_id) DO UPDATE SET preferences = ?2, updated_at = datetime('now')",
-        libsql::params![user_id.clone(), preferences_json.clone()],
-    ).await?;
+    // DS seam: route the remote preferences upsert through the Delivery Service
+    // when configured; else write Turso directly. The local cache above is
+    // written unconditionally either way.
+    match state.config.pollis_delivery_url.as_deref() {
+        Some(_) => {
+            let body = serde_json::json!({
+                "user_id": user_id,
+                "preferences": preferences_json,
+            });
+            crate::commands::mls::ds_post_ok(state, "/v1/profile/preferences", &body).await?;
+        }
+        None => {
+            let conn = state.remote_db.conn().await?;
+            conn.execute(
+                "INSERT INTO user_preferences (user_id, preferences, updated_at) VALUES (?1, ?2, datetime('now'))
+                 ON CONFLICT(user_id) DO UPDATE SET preferences = ?2, updated_at = datetime('now')",
+                libsql::params![user_id.clone(), preferences_json.clone()],
+            ).await?;
+        }
+    }
 
     Ok(())
 }

--- a/pollis-delivery/src/account.rs
+++ b/pollis-delivery/src/account.rs
@@ -1,0 +1,776 @@
+//! Domains E + G — account lifecycle, identity rotation, recovery, and the
+//! security-audit log.
+//!
+//! This is the riskiest write surface in #419: it touches the **account-key
+//! transparency log** (`account_key_log`, fed to `verifiable-log-builder`'s
+//! account tenant → verify.pollis.com), the destructive **account-deletion**
+//! and **identity-reset** bulk wipes, the **device-enrollment** approval rows,
+//! and the **security-event** audit trail.
+//!
+//! Every endpoint follows the domain-A..D convention ([`crate::messages`],
+//! [`crate::devices`]): a thin axum handler `gate`s the request, parses the
+//! body, calls a pure `apply_*(conn, authed, body)` that embeds BOTH
+//! authorization and the write, and maps the result to a response. The handler
+//! and the integration harness share the `apply_*` fn, so the test suite
+//! exercises the exact authz + atomicity the production handler runs.
+//!
+//! ## Where the writes land
+//!
+//! Every table here — `users`, `account_key_log`, `account_recovery`,
+//! `security_event`, `device_enrollment_request`, `group_member`,
+//! `dm_channel_member`, `mls_key_package`, `message_envelope`, `groups`,
+//! `user_device` — lives in the **MAIN DB** (`state.db`). None of them is on the
+//! commit-log DB, so all `apply_*` fns run on the main connection. (The MLS
+//! Welcome purge that identity-reset also performs is a SEPARATE log-DB write
+//! routed through [`crate::writes::welcomes_purge`].)
+//!
+//! ## Authorization — every op is SELF-scoped
+//!
+//! A user rotates / deletes / recovers / audits only THEIR OWN account.
+//! [`resolve_actor`] binds the target user to the authenticated signer (a body
+//! `user_id` that differs from the signer is `Forbidden`), and every statement
+//! is scoped `WHERE … user_id = actor` (or, for the enrollment rows, the request
+//! must belong to the actor). Nothing is re-derived from client-supplied ids.
+//!
+//! ## The two hard requirements
+//!
+//! 1. **`account_key_log` CAS.** `account_key_log` is an append-only, seq-ordered
+//!    transparency log keyed `UNIQUE (user_id, identity_version)`. A fork or gap
+//!    corrupts the published account-key transparency tree. So
+//!    [`apply_rotate_identity`] models the commit-log CAS ([`crate::commit`]):
+//!    the `account_key_log` append is a single conditional `INSERT … SELECT …
+//!    WHERE <based_on == current head> … ON CONFLICT DO NOTHING`, and the
+//!    `users.identity_version` bump + the `account_recovery` rewrap ride in the
+//!    SAME transaction, gated by that one CAS. Two concurrent rotations at the
+//!    same head → SQLite serializes the writers; exactly one append lands and
+//!    advances the head, the other sees the new head and inserts nothing →
+//!    `Conflict`. No fork, no gap.
+//!
+//! 2. **`delete_account` / `reset_identity_and_recover` are each ONE
+//!    transaction.** Their bulk deletes (and the ownership-handoff promotions)
+//!    all commit together or not at all — a half-deleted account is a corrupt
+//!    state. [`apply_delete_account`] and [`apply_reset_recover`] run every
+//!    statement inside a single libsql transaction.
+//!
+//! ## What stays DIRECT (bootstrap — deliberately NOT here)
+//!
+//! A write that ESTABLISHES the signing credential cannot be authenticated by
+//! that credential. These remain on the client's direct Turso path:
+//!
+//!   - **Account creation** (`auth.rs` verify_otp INSERT `users`) — no device
+//!     key exists yet.
+//!   - **First account-identity establishment** (`account_identity.rs`
+//!     `generate_account_identity`, version 1) — runs at signup BEFORE
+//!     `register_device` / `ensure_device_cert`, so no device signing key is
+//!     enrolled and the local DB isn't even open. Single-device, single-shot, no
+//!     concurrency: the `UNIQUE (user_id, identity_version)` index is its only
+//!     (sufficient) guard. Rotations (version ≥ 2) DO route here, CAS-guarded.
+//!   - **Device registration / first cert publish** (`register_device`,
+//!     `ensure_device_cert`) — domain-D bootstrap (see [`crate::devices`]).
+//!   - **Enrollment *request*** (`start_device_enrollment` INSERT
+//!     `device_enrollment_request`) — the requesting device is pre-enrollment:
+//!     its `user_device.mls_signature_pub` is still NULL and its local DB is
+//!     closed, so it cannot produce a signature the DS would accept. Enrollment
+//!     *approval* / *rejection* (run on an already-enrolled sibling) DO route.
+//!   - **Secret-Key recovery security-event** (`recover_with_secret_key`) — runs
+//!     pre-finalize, before this device has published a cert.
+//!   - **Logout device removal** (`auth.rs` logout DELETE `user_device`) — by the
+//!     time it runs the local DB is unloaded and the in-memory session is
+//!     cleared, so there is no signing key available.
+
+use axum::{
+    body::Bytes,
+    extract::State,
+    http::{HeaderMap, Method, StatusCode, Uri},
+    response::{IntoResponse, Response},
+    Json,
+};
+use libsql::Connection;
+use serde::Deserialize;
+
+use crate::error::{AppError, AuthRejection};
+use crate::writes::{bad_request, gate, ok_json, outcome_response, resolve_actor, WriteOutcome};
+use crate::AppState;
+
+fn b64_decode(s: &str) -> anyhow::Result<Vec<u8>> {
+    use base64::Engine as _;
+    Ok(base64::engine::general_purpose::STANDARD.decode(s)?)
+}
+
+// ── POST /v1/account/rotate-identity ─────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct RotateIdentityBody {
+    /// The `identity_version` the client read BEFORE rotating — i.e. the head of
+    /// `account_key_log` it believes it is appending onto. The new version is
+    /// `based_on_version + 1`. This is the CAS expectation, the exact analogue of
+    /// a commit's `based_on_epoch`.
+    pub based_on_version: i64,
+    /// New account identity public key, base64 (STANDARD).
+    pub account_id_pub: String,
+    /// New `account_recovery` blob, all base64 (STANDARD).
+    pub salt: String,
+    pub nonce: String,
+    pub wrapped_key: String,
+    /// Self-scope: when signed it must equal the authenticated user.
+    #[serde(default)]
+    pub user_id: Option<String>,
+}
+
+/// The outcome of an identity rotation. Distinct from [`WriteOutcome`] because a
+/// rotation has a THIRD terminal state — a CAS loss — that maps to 409 (not 200
+/// / 403), exactly like a commit losing its epoch.
+pub enum RotateOutcome {
+    /// The rotation won its version. `new_version` is the version now recorded.
+    Applied { new_version: i64 },
+    /// The signer may not rotate this account (`user_id` ≠ signer).
+    Forbidden,
+    /// A concurrent rotation already advanced the head past `based_on_version`
+    /// (or `based_on_version` was stale). `head_version` is the current head; the
+    /// client must re-read and retry. No fork was created.
+    Conflict { head_version: i64 },
+}
+
+/// POST /v1/account/rotate-identity — rotate a user's account identity key,
+/// CAS-guarded so two concurrent rotations can never fork the account-key
+/// transparency log. The `account_key_log` append, the `users.identity_version`
+/// bump, and the `account_recovery` rewrap are ONE atomic transaction.
+pub async fn rotate_identity(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: RotateIdentityBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    rotate_outcome_response(apply_rotate_identity(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// Map a [`RotateOutcome`] to its HTTP response (200 / 403 / 409).
+pub(crate) fn rotate_outcome_response(outcome: RotateOutcome) -> Result<Response, AppError> {
+    Ok(match outcome {
+        RotateOutcome::Applied { new_version } => {
+            ok_json(serde_json::json!({ "status": "ok", "identity_version": new_version }))
+        }
+        RotateOutcome::Forbidden => AuthRejection::Forbidden.into_response(),
+        RotateOutcome::Conflict { head_version } => (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({ "status": "conflict", "head_version": head_version })),
+        )
+            .into_response(),
+    })
+}
+
+/// Append `account_key_log` at `based_on_version + 1` IFF that version is the
+/// current head, then bump `users.identity_version` and rewrap
+/// `account_recovery` in the SAME transaction. The CAS is the conditional INSERT
+/// — modeled on [`crate::commit::submit_commit`]:
+///
+/// ```sql
+/// INSERT INTO account_key_log (user_id, account_id_pub, identity_version)
+/// SELECT ?1, ?2, ?3
+/// WHERE ?4 = (SELECT COALESCE(MAX(identity_version), 0)
+///             FROM account_key_log WHERE user_id = ?1)
+/// ON CONFLICT(user_id, identity_version) DO NOTHING
+/// ```
+/// (`?3 = based_on_version + 1`, `?4 = based_on_version`.)
+///
+/// Exactly one of two racing rotations at the same head appends (advancing the
+/// head); the other's `WHERE` now sees the new head and inserts nothing →
+/// `affected == 0` → `Conflict`, transaction rolled back. The `ON CONFLICT DO
+/// NOTHING` is the backstop the `UNIQUE (user_id, identity_version)` index
+/// enforces. No fork, no gap, append-only.
+pub async fn apply_rotate_identity(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &RotateIdentityBody,
+) -> anyhow::Result<RotateOutcome> {
+    let actor = match resolve_actor(authed, body.user_id.as_deref()) {
+        Ok(a) => a,
+        Err(_) => return Ok(RotateOutcome::Forbidden),
+    };
+    let pub_bytes = b64_decode(&body.account_id_pub)?;
+    let salt = b64_decode(&body.salt)?;
+    let nonce = b64_decode(&body.nonce)?;
+    let wrapped = b64_decode(&body.wrapped_key)?;
+    let new_version = body.based_on_version + 1;
+
+    let tx = conn.transaction().await?;
+
+    // The atomic CAS: append at `new_version` only if `based_on_version` is the
+    // current head of THIS user's account_key_log.
+    let affected = tx
+        .execute(
+            "INSERT INTO account_key_log (user_id, account_id_pub, identity_version) \
+             SELECT ?1, ?2, ?3 \
+             WHERE ?4 = (SELECT COALESCE(MAX(identity_version), 0) \
+                         FROM account_key_log WHERE user_id = ?1) \
+             ON CONFLICT(user_id, identity_version) DO NOTHING",
+            libsql::params![
+                actor.clone(),
+                pub_bytes.clone(),
+                new_version,
+                body.based_on_version
+            ],
+        )
+        .await?;
+
+    if affected == 0 {
+        // Lost the race (or a stale based_on_version). Report the real head so
+        // the client re-reads and retries; nothing was written.
+        let head = current_key_log_head(&tx, &actor).await?;
+        drop(tx);
+        return Ok(RotateOutcome::Conflict { head_version: head });
+    }
+
+    // Won the version. Bump the live identity + rewrap the recovery blob, both
+    // bound to `new_version` so the three rows can never disagree.
+    tx.execute(
+        "UPDATE users SET account_id_pub = ?1, identity_version = ?2 WHERE id = ?3",
+        libsql::params![pub_bytes, new_version, actor.clone()],
+    )
+    .await?;
+
+    tx.execute(
+        "INSERT INTO account_recovery \
+         (user_id, identity_version, salt, nonce, wrapped_key, created_at, updated_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5, datetime('now'), datetime('now')) \
+         ON CONFLICT(user_id) DO UPDATE SET \
+             identity_version = excluded.identity_version, \
+             salt = excluded.salt, \
+             nonce = excluded.nonce, \
+             wrapped_key = excluded.wrapped_key, \
+             updated_at = datetime('now')",
+        libsql::params![actor, new_version, salt, nonce, wrapped],
+    )
+    .await?;
+
+    tx.commit().await?;
+    Ok(RotateOutcome::Applied { new_version })
+}
+
+/// The current head of a user's `account_key_log` = `MAX(identity_version)` (0
+/// for a user with no log rows yet). `&Transaction` derefs to `&Connection`.
+async fn current_key_log_head(conn: &Connection, user_id: &str) -> anyhow::Result<i64> {
+    let mut rows = conn
+        .query(
+            "SELECT COALESCE(MAX(identity_version), 0) FROM account_key_log WHERE user_id = ?1",
+            libsql::params![user_id.to_string()],
+        )
+        .await?;
+    Ok(match rows.next().await? {
+        Some(row) => row.get(0)?,
+        None => 0,
+    })
+}
+
+// ── POST /v1/security-events ─────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct SecurityEventBody {
+    pub kind: String,
+    #[serde(default)]
+    pub device_id: Option<String>,
+    #[serde(default)]
+    pub metadata: Option<String>,
+    /// Self-scope: when signed it must equal the authenticated user.
+    #[serde(default)]
+    pub user_id: Option<String>,
+}
+
+/// POST /v1/security-events — append a row to the actor's own security-audit
+/// log (`security_event`). Self-scoped: the row's `user_id` is the signer.
+pub async fn record_security_event(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: SecurityEventBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_record_security_event(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// INSERT a `security_event` with `user_id = actor`. The row is always
+/// attributed to the signer, so a caller can never forge an audit entry under
+/// another user.
+pub async fn apply_record_security_event(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &SecurityEventBody,
+) -> anyhow::Result<WriteOutcome> {
+    let actor = match resolve_actor(authed, body.user_id.as_deref()) {
+        Ok(a) => a,
+        Err(o) => return Ok(o),
+    };
+    conn.execute(
+        "INSERT INTO security_event (id, user_id, kind, device_id, metadata) \
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        libsql::params![
+            ulid::Ulid::new().to_string(),
+            actor,
+            body.kind.clone(),
+            body.device_id.clone(),
+            body.metadata.clone(),
+        ],
+    )
+    .await?;
+    Ok(WriteOutcome::Ok)
+}
+
+// ── POST /v1/enrollment/approve ──────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct ApproveEnrollmentBody {
+    pub request_id: String,
+    /// base64 (STANDARD) of `approver_pub || nonce || ciphertext`.
+    pub wrapped_account_key: String,
+    pub approved_by_device_id: String,
+    /// Self-scope: when signed it must equal the authenticated user.
+    #[serde(default)]
+    pub user_id: Option<String>,
+}
+
+/// POST /v1/enrollment/approve — flip a pending enrollment request the actor
+/// OWNS to `approved`, attaching the wrapped account key. The approving device
+/// has already verified the code / status / expiry client-side; this is the
+/// server-bound state transition. Self-scoped: the request's `user_id` must
+/// equal the signer (a sibling device of the same account).
+pub async fn approve_enrollment(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: ApproveEnrollmentBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_approve_enrollment(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// UPDATE the request `WHERE id = ? AND user_id = actor`. The `user_id = actor`
+/// bind is the authz: a signer can only approve enrollments for THEIR OWN
+/// account. `affected == 0` → the request isn't theirs (or doesn't exist) →
+/// `Forbidden`.
+pub async fn apply_approve_enrollment(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &ApproveEnrollmentBody,
+) -> anyhow::Result<WriteOutcome> {
+    let actor = match resolve_actor(authed, body.user_id.as_deref()) {
+        Ok(a) => a,
+        Err(o) => return Ok(o),
+    };
+    let wrapped = b64_decode(&body.wrapped_account_key)?;
+    let affected = conn
+        .execute(
+            "UPDATE device_enrollment_request \
+             SET wrapped_account_key = ?1, status = 'approved', approved_by_device_id = ?2 \
+             WHERE id = ?3 AND user_id = ?4",
+            libsql::params![
+                wrapped,
+                body.approved_by_device_id.clone(),
+                body.request_id.clone(),
+                actor,
+            ],
+        )
+        .await?;
+    if affected == 0 {
+        return Ok(WriteOutcome::Forbidden);
+    }
+    Ok(WriteOutcome::Ok)
+}
+
+// ── POST /v1/enrollment/reject ───────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct RejectEnrollmentBody {
+    pub request_id: String,
+    pub approved_by_device_id: String,
+    #[serde(default)]
+    pub user_id: Option<String>,
+}
+
+/// POST /v1/enrollment/reject — flip a pending enrollment request the actor OWNS
+/// to `rejected`. Self-scoped like [`approve_enrollment`].
+pub async fn reject_enrollment(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: RejectEnrollmentBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_reject_enrollment(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// UPDATE the request to `rejected` `WHERE id = ? AND user_id = actor`.
+/// `affected == 0` → not the actor's request → `Forbidden`.
+pub async fn apply_reject_enrollment(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &RejectEnrollmentBody,
+) -> anyhow::Result<WriteOutcome> {
+    let actor = match resolve_actor(authed, body.user_id.as_deref()) {
+        Ok(a) => a,
+        Err(o) => return Ok(o),
+    };
+    let affected = conn
+        .execute(
+            "UPDATE device_enrollment_request \
+             SET status = 'rejected', approved_by_device_id = ?1 \
+             WHERE id = ?2 AND user_id = ?3",
+            libsql::params![body.approved_by_device_id.clone(), body.request_id.clone(), actor],
+        )
+        .await?;
+    if affected == 0 {
+        return Ok(WriteOutcome::Forbidden);
+    }
+    Ok(WriteOutcome::Ok)
+}
+
+// ── POST /v1/devices/revoke ──────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct RevokeDeviceBody {
+    /// The device being revoked (one of the actor's OWN devices, not the caller).
+    pub device_id: String,
+    #[serde(default)]
+    pub user_id: Option<String>,
+}
+
+/// POST /v1/devices/revoke — drop the revoked device's unclaimed key packages
+/// and tombstone its `user_device` row (`revoked_at`). Self-scoped: both writes
+/// are bound `user_id = actor`, so a caller can only revoke their OWN devices.
+/// The MLS reconcile that removes the revoked leaf from each tree stays
+/// client-side (it commits through `/v1/commits`).
+pub async fn revoke_device(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: RevokeDeviceBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_revoke_device(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// DELETE the revoked device's unclaimed key packages, then tombstone its row —
+/// one transaction, both `WHERE user_id = actor`.
+pub async fn apply_revoke_device(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &RevokeDeviceBody,
+) -> anyhow::Result<WriteOutcome> {
+    let actor = match resolve_actor(authed, body.user_id.as_deref()) {
+        Ok(a) => a,
+        Err(o) => return Ok(o),
+    };
+    let tx = conn.transaction().await?;
+    tx.execute(
+        "DELETE FROM mls_key_package WHERE user_id = ?1 AND device_id = ?2",
+        libsql::params![actor.clone(), body.device_id.clone()],
+    )
+    .await?;
+    tx.execute(
+        "UPDATE user_device SET revoked_at = datetime('now') \
+         WHERE device_id = ?1 AND user_id = ?2 AND revoked_at IS NULL",
+        libsql::params![body.device_id.clone(), actor],
+    )
+    .await?;
+    tx.commit().await?;
+    Ok(WriteOutcome::Ok)
+}
+
+// ── POST /v1/account/reset-recover ───────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct ResetRecoverBody {
+    /// The device performing the reset — its `user_device` row is KEPT (it stays
+    /// enrolled under the new identity); every OTHER device of the actor is
+    /// dropped. `None` → drop ALL of the actor's devices.
+    #[serde(default)]
+    pub current_device_id: Option<String>,
+    #[serde(default)]
+    pub user_id: Option<String>,
+}
+
+/// POST /v1/account/reset-recover — the membership/device wipe that follows an
+/// identity reset, as ONE transaction. Removes the actor from all groups/DMs
+/// (with ownership handoff), drops their stale key packages, and orphans their
+/// OTHER devices. The MLS Welcome purge is a separate log-DB call
+/// (`/v1/welcomes/purge`); the identity rotation itself is
+/// `/v1/account/rotate-identity`.
+pub async fn reset_recover(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: ResetRecoverBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_reset_recover(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// All of identity-reset's main-DB cleanup, in one transaction. Self-scoped: the
+/// actor is the signer, and every statement is bound to `user_id = actor` (the
+/// admin promotions touch related rows as a server-authorized consequence of the
+/// actor leaving — exactly mirroring [`apply_delete_account`]).
+pub async fn apply_reset_recover(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &ResetRecoverBody,
+) -> anyhow::Result<WriteOutcome> {
+    let actor = match resolve_actor(authed, body.user_id.as_deref()) {
+        Ok(a) => a,
+        Err(o) => return Ok(o),
+    };
+    let tx = conn.transaction().await?;
+    handoff_group_ownership(&tx, &actor).await?;
+
+    tx.execute(
+        "DELETE FROM group_member WHERE user_id = ?1",
+        libsql::params![actor.clone()],
+    )
+    .await?;
+    tx.execute(
+        "DELETE FROM dm_channel_member WHERE user_id = ?1",
+        libsql::params![actor.clone()],
+    )
+    .await?;
+    tx.execute(
+        "DELETE FROM mls_key_package WHERE user_id = ?1",
+        libsql::params![actor.clone()],
+    )
+    .await?;
+
+    // Orphan the actor's OTHER devices; keep the current one (it re-enrolls under
+    // the new identity). `None` → drop them all.
+    match &body.current_device_id {
+        Some(dev) => {
+            tx.execute(
+                "DELETE FROM user_device WHERE user_id = ?1 AND device_id != ?2",
+                libsql::params![actor.clone(), dev.clone()],
+            )
+            .await?;
+        }
+        None => {
+            tx.execute(
+                "DELETE FROM user_device WHERE user_id = ?1",
+                libsql::params![actor.clone()],
+            )
+            .await?;
+        }
+    }
+
+    tx.commit().await?;
+    Ok(WriteOutcome::Ok)
+}
+
+// ── POST /v1/account/delete ──────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct DeleteAccountBody {
+    #[serde(default)]
+    pub user_id: Option<String>,
+}
+
+/// POST /v1/account/delete — permanently delete the actor's account, as ONE
+/// transaction. Handles group ownership (delete empty groups / promote a sole
+/// admin's successor), removes sent envelopes, key packages, and memberships,
+/// then deletes the `users` row (cascading `dm_channel_member`, `group_invite`,
+/// `user_device`, `account_recovery`, `security_event`, …).
+pub async fn delete_account(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    // An empty body is valid when signed (actor from auth).
+    let parsed: DeleteAccountBody = if body.is_empty() {
+        DeleteAccountBody { user_id: None }
+    } else {
+        match serde_json::from_slice(&body) {
+            Ok(b) => b,
+            Err(_) => return Ok(bad_request("invalid body")),
+        }
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_delete_account(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// Every remote-data delete of account deletion, in one transaction. Self-scoped
+/// to the signer.
+pub async fn apply_delete_account(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &DeleteAccountBody,
+) -> anyhow::Result<WriteOutcome> {
+    let actor = match resolve_actor(authed, body.user_id.as_deref()) {
+        Ok(a) => a,
+        Err(o) => return Ok(o),
+    };
+    let tx = conn.transaction().await?;
+    handoff_group_ownership(&tx, &actor).await?;
+
+    tx.execute(
+        "DELETE FROM message_envelope WHERE sender_id = ?1",
+        libsql::params![actor.clone()],
+    )
+    .await?;
+    tx.execute(
+        "DELETE FROM mls_key_package WHERE user_id = ?1",
+        libsql::params![actor.clone()],
+    )
+    .await?;
+    tx.execute(
+        "DELETE FROM group_member WHERE user_id = ?1",
+        libsql::params![actor.clone()],
+    )
+    .await?;
+    // The user row last — FK ON DELETE CASCADE clears dm_channel_member,
+    // group_invite, user_device, account_recovery, security_event, …
+    tx.execute(
+        "DELETE FROM users WHERE id = ?1",
+        libsql::params![actor.clone()],
+    )
+    .await?;
+
+    tx.commit().await?;
+    Ok(WriteOutcome::Ok)
+}
+
+/// Group-ownership handoff shared by [`apply_delete_account`] and
+/// [`apply_reset_recover`]: for every group the actor belongs to, delete the
+/// group if they are its sole member, else promote a successor if they are its
+/// sole admin. Runs inside the caller's transaction (`&Transaction` derefs to
+/// `&Connection`). Mirrors the direct logic this replaces in `auth.rs` /
+/// `device_enrollment.rs`.
+async fn handoff_group_ownership(conn: &Connection, actor: &str) -> anyhow::Result<()> {
+    let mut memberships: Vec<(String, String)> = Vec::new();
+    {
+        let mut rows = conn
+            .query(
+                "SELECT group_id, role FROM group_member WHERE user_id = ?1",
+                libsql::params![actor.to_string()],
+            )
+            .await?;
+        while let Some(row) = rows.next().await? {
+            memberships.push((row.get(0)?, row.get(1)?));
+        }
+    }
+
+    for (gid, role) in &memberships {
+        let member_count: i64 = {
+            let mut rows = conn
+                .query(
+                    "SELECT COUNT(*) FROM group_member WHERE group_id = ?1",
+                    libsql::params![gid.clone()],
+                )
+                .await?;
+            match rows.next().await? {
+                Some(row) => row.get(0)?,
+                None => 0,
+            }
+        };
+
+        if member_count <= 1 {
+            // Sole member — delete the entire group (cascades channels, invites…).
+            conn.execute(
+                "DELETE FROM groups WHERE id = ?1",
+                libsql::params![gid.clone()],
+            )
+            .await?;
+        } else if role == "admin" {
+            let other_admins: i64 = {
+                let mut rows = conn
+                    .query(
+                        "SELECT COUNT(*) FROM group_member \
+                         WHERE group_id = ?1 AND role = 'admin' AND user_id != ?2",
+                        libsql::params![gid.clone(), actor.to_string()],
+                    )
+                    .await?;
+                match rows.next().await? {
+                    Some(row) => row.get(0)?,
+                    None => 0,
+                }
+            };
+            if other_admins == 0 {
+                let candidate: Option<String> = {
+                    let mut rows = conn
+                        .query(
+                            "SELECT user_id FROM group_member \
+                             WHERE group_id = ?1 AND user_id != ?2 LIMIT 1",
+                            libsql::params![gid.clone(), actor.to_string()],
+                        )
+                        .await?;
+                    match rows.next().await? {
+                        Some(row) => Some(row.get(0)?),
+                        None => None,
+                    }
+                };
+                if let Some(new_admin) = candidate {
+                    conn.execute(
+                        "UPDATE group_member SET role = 'admin' \
+                         WHERE group_id = ?1 AND user_id = ?2",
+                        libsql::params![gid.clone(), new_admin],
+                    )
+                    .await?;
+                }
+            }
+        }
+    }
+    Ok(())
+}

--- a/pollis-delivery/src/devices.rs
+++ b/pollis-delivery/src/devices.rs
@@ -1,0 +1,358 @@
+//! Domain D — key-packages, device-cert re-signing, and push tokens.
+//!
+//! These are the **owner-scoped** client writes in the key-package / device /
+//! push-token surface (#419 §D). Every endpoint copies the domain-A convention
+//! ([`crate::messages`]): a thin axum handler `gate`s the request, parses the
+//! body, calls a pure `apply_*(conn, authed, body) -> WriteOutcome` that embeds
+//! BOTH authorization and the write, and maps the outcome to 200/403/400/500.
+//! The handler and the integration harness share the `apply_*` fn, so the test
+//! suite exercises the exact authz the production handler runs.
+//!
+//! ## Where the writes land
+//!
+//! Every domain-D table — `mls_key_package`, `user_device`, `push_token` — lives
+//! in the **MAIN DB** (`state.db`), so all `apply_*` fns run on the main
+//! connection.
+//!
+//! ## Authorization
+//!
+//! Every write here is **owner-scoped**: a user publishes/replenishes key
+//! packages, re-signs device certs, and registers push tokens only for THEIR OWN
+//! account. [`resolve_actor`] proves a signed request acts as itself (a
+//! body-supplied `user_id` that differs from the authenticated user is
+//! `Forbidden`), and the write then binds `user_id = actor` server-side so a
+//! caller can never attach a row to another user. On the no-auth path
+//! (`authed == None`) the actor comes from the body, mirroring `commit::submit`.
+//!
+//! ## What is NOT here — the bootstrap writes (kept direct in pollis-core)
+//!
+//! Two domain-D writes deliberately stay on the client's direct path and are
+//! absent from this module:
+//!
+//!   - **device registration** (`auth.rs::register_device`, INSERT `user_device`)
+//!     and **first device-cert publish** (`device.rs::ensure_device_cert`, the
+//!     UPDATE that sets `user_device.mls_signature_pub`).
+//!
+//! These are the **bootstrap** writes. DS auth ([`crate::auth::verify_request`])
+//! authenticates a request by looking up `user_device.mls_signature_pub` for the
+//! `(user_id, device_id)` and verifying the Ed25519 signature against it. Until
+//! that column is populated a device CANNOT produce a signature the DS will
+//! accept (it would 401) — and the write that populates it is `ensure_device_cert`
+//! itself. That is an irreducible chicken-and-egg: the write that establishes the
+//! signing credential cannot be authenticated by that same credential. So device
+//! registration + the cert publish remain direct; everything a device does
+//! *after* it is enrolled (key packages, push tokens, cert re-signing) is signed
+//! and routed here. Folding the bootstrap behind an OTP-session-gated DS endpoint
+//! is the prerequisite for flipping clients to a read-only Turso token, and is
+//! out of scope for this owner-scoped-signature slice.
+//!
+//! **Key-package CLAIM** (`fetch_mls_key_package`, the `claimed = 1` UPDATE on a
+//! *peer's* row) is likewise absent: it is not owner-scoped (you claim someone
+//! else's package while adding their device) and per the migration plan it folds
+//! into `/v1/commits` as a DS-side step of the add path, never a standalone
+//! client endpoint.
+
+use axum::{
+    body::Bytes,
+    extract::State,
+    http::{HeaderMap, Method, Uri},
+    response::Response,
+};
+use libsql::Connection;
+use serde::Deserialize;
+
+use crate::error::AppError;
+use crate::writes::{bad_request, gate, outcome_response, resolve_actor, WriteOutcome};
+use crate::AppState;
+
+fn b64_decode(s: &str) -> anyhow::Result<Vec<u8>> {
+    use base64::Engine as _;
+    Ok(base64::engine::general_purpose::STANDARD.decode(s)?)
+}
+
+// ── Key-package entries ──────────────────────────────────────────────────────
+
+/// One published key package: its hex hash-ref and the TLS-serialized
+/// `KeyPackage` bytes, base64 (STANDARD) since they are binary.
+#[derive(Deserialize)]
+pub struct KeyPackageEntry {
+    pub ref_hash: String,
+    /// base64 (STANDARD) of the TLS-serialized `KeyPackage`.
+    pub key_package: String,
+}
+
+// ── POST /v1/key-packages ────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct PublishKeyPackagesBody {
+    /// The publishing device. Must be one of the actor's own devices; the rows
+    /// are written with `user_id = actor` regardless, so this only labels which
+    /// device produced them.
+    pub device_id: String,
+    pub packages: Vec<KeyPackageEntry>,
+    /// No-auth fallback for the actor; when signed it must equal the
+    /// authenticated user.
+    #[serde(default)]
+    pub user_id: Option<String>,
+}
+
+/// POST /v1/key-packages — publish (insert-only) one or more key packages for
+/// the actor's own device. Idempotent (`INSERT OR IGNORE` keyed on `ref_hash`),
+/// so a retry is benign. Used by both the single-package publish and the
+/// replenish-top-up client paths (neither deletes).
+pub async fn publish_key_packages(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: PublishKeyPackagesBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_publish_key_packages(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// INSERT OR IGNORE each key package with `user_id = actor`. Authz: the actor is
+/// the signer (a body `user_id` that differs is `Forbidden`); rows are bound to
+/// the actor, so a caller can never publish a package under another user.
+pub async fn apply_publish_key_packages(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &PublishKeyPackagesBody,
+) -> anyhow::Result<WriteOutcome> {
+    let actor = match resolve_actor(authed, body.user_id.as_deref()) {
+        Ok(a) => a,
+        Err(o) => return Ok(o),
+    };
+    for pkg in &body.packages {
+        let kp = match b64_decode(&pkg.key_package) {
+            Ok(b) => b,
+            // A malformed package is the whole write's problem; surface as 500
+            // (the handler maps decode-at-parse to 400, but here it is a bad row).
+            Err(e) => return Err(e),
+        };
+        conn.execute(
+            "INSERT OR IGNORE INTO mls_key_package (ref_hash, user_id, key_package, device_id) \
+             VALUES (?1, ?2, ?3, ?4)",
+            libsql::params![pkg.ref_hash.clone(), actor.clone(), kp, body.device_id.clone()],
+        )
+        .await?;
+    }
+    Ok(WriteOutcome::Ok)
+}
+
+// ── POST /v1/key-packages/replenish ──────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct ReplenishKeyPackagesBody {
+    pub device_id: String,
+    pub packages: Vec<KeyPackageEntry>,
+    #[serde(default)]
+    pub user_id: Option<String>,
+}
+
+/// POST /v1/key-packages/replenish — atomically clear this device's stale
+/// unclaimed key packages and publish a fresh pool. One transaction so the pool
+/// is never observed empty mid-refill.
+pub async fn replenish_key_packages(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: ReplenishKeyPackagesBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_replenish_key_packages(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// DELETE the actor's stale unclaimed packages for `device_id` (and legacy
+/// NULL-device rows), then INSERT the fresh pool — one transaction. Authz:
+/// owner-scoped; the DELETE and every INSERT are bound to `user_id = actor`, so
+/// a caller can only ever rotate their own device's pool.
+pub async fn apply_replenish_key_packages(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &ReplenishKeyPackagesBody,
+) -> anyhow::Result<WriteOutcome> {
+    let actor = match resolve_actor(authed, body.user_id.as_deref()) {
+        Ok(a) => a,
+        Err(o) => return Ok(o),
+    };
+    // Decode every package up front so a bad blob aborts before we touch the DB.
+    let mut decoded: Vec<(String, Vec<u8>)> = Vec::with_capacity(body.packages.len());
+    for pkg in &body.packages {
+        decoded.push((pkg.ref_hash.clone(), b64_decode(&pkg.key_package)?));
+    }
+    let tx = conn.transaction().await?;
+    // Remove unclaimed packages for THIS device only — their private keys may no
+    // longer exist in the device's current local DB (e.g. after a wipe). Also
+    // clear legacy packages with NULL device_id for this user.
+    tx.execute(
+        "DELETE FROM mls_key_package WHERE user_id = ?1 AND claimed = 0 \
+         AND (device_id = ?2 OR device_id IS NULL)",
+        libsql::params![actor.clone(), body.device_id.clone()],
+    )
+    .await?;
+    for (ref_hash, kp) in &decoded {
+        tx.execute(
+            "INSERT OR IGNORE INTO mls_key_package (ref_hash, user_id, key_package, device_id) \
+             VALUES (?1, ?2, ?3, ?4)",
+            libsql::params![ref_hash.clone(), actor.clone(), kp.clone(), body.device_id.clone()],
+        )
+        .await?;
+    }
+    tx.commit().await?;
+    Ok(WriteOutcome::Ok)
+}
+
+// ── POST /v1/devices/resign ──────────────────────────────────────────────────
+
+/// One re-signed cross-signing cert for a device of the actor's account.
+#[derive(Deserialize)]
+pub struct ResignedCert {
+    pub device_id: String,
+    /// base64 (STANDARD) of the signed cert bytes.
+    pub device_cert: String,
+    /// Unix seconds, decimal ASCII (stored as TEXT for lossless round-trip).
+    pub cert_issued_at: String,
+    pub cert_identity_version: i64,
+}
+
+#[derive(Deserialize)]
+pub struct ResignDeviceCertsBody {
+    pub certs: Vec<ResignedCert>,
+    #[serde(default)]
+    pub user_id: Option<String>,
+}
+
+/// POST /v1/devices/resign — re-stamp the cross-signing certs the client signed
+/// (with the account identity key) onto the actor's own `user_device` rows after
+/// an identity rotation. Does NOT touch `mls_signature_pub` — only the cert
+/// columns — so it cannot change any device's auth credential.
+pub async fn resign_device_certs(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: ResignDeviceCertsBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_resign_device_certs(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// UPDATE each device's cert columns, every statement scoped
+/// `WHERE device_id = ? AND user_id = actor`. Authz: user-scoped — the actor may
+/// re-sign certs for any device of THEIR OWN account (a whole-fleet operation
+/// after rotation), but the `user_id = actor` bind makes another user's rows
+/// untouchable.
+pub async fn apply_resign_device_certs(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &ResignDeviceCertsBody,
+) -> anyhow::Result<WriteOutcome> {
+    let actor = match resolve_actor(authed, body.user_id.as_deref()) {
+        Ok(a) => a,
+        Err(o) => return Ok(o),
+    };
+    let tx = conn.transaction().await?;
+    for cert in &body.certs {
+        let cert_bytes = b64_decode(&cert.device_cert)?;
+        tx.execute(
+            "UPDATE user_device \
+             SET device_cert = ?1, cert_issued_at = ?2, cert_identity_version = ?3 \
+             WHERE device_id = ?4 AND user_id = ?5",
+            libsql::params![
+                cert_bytes,
+                cert.cert_issued_at.clone(),
+                cert.cert_identity_version,
+                cert.device_id.clone(),
+                actor.clone(),
+            ],
+        )
+        .await?;
+    }
+    tx.commit().await?;
+    Ok(WriteOutcome::Ok)
+}
+
+// ── POST /v1/push-tokens ─────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct PushTokenBody {
+    pub token: String,
+    pub platform: String,
+    /// RFC3339 timestamp the client stamped. Plain text (never parsed here).
+    pub updated_at: String,
+    #[serde(default)]
+    pub user_id: Option<String>,
+}
+
+/// POST /v1/push-tokens — upsert this device's Expo push token. Keyed on the
+/// token (unique per install), so re-registering after an account switch
+/// reassigns ownership rather than duplicating.
+pub async fn register_push_token(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: PushTokenBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_register_push_token(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// Upsert the push token with `user_id = actor`. Authz: owner-scoped — the token
+/// is bound to the actor, so a caller can never register a token under another
+/// user (the body's `user_id`, if present, must equal the signer).
+pub async fn apply_register_push_token(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &PushTokenBody,
+) -> anyhow::Result<WriteOutcome> {
+    let actor = match resolve_actor(authed, body.user_id.as_deref()) {
+        Ok(a) => a,
+        Err(o) => return Ok(o),
+    };
+    conn.execute(
+        "INSERT INTO push_token (token, user_id, platform, updated_at) \
+         VALUES (?1, ?2, ?3, ?4) \
+         ON CONFLICT(token) DO UPDATE SET \
+             user_id = excluded.user_id, \
+             platform = excluded.platform, \
+             updated_at = excluded.updated_at",
+        libsql::params![body.token.clone(), actor, body.platform.clone(), body.updated_at.clone()],
+    )
+    .await?;
+    Ok(WriteOutcome::Ok)
+}

--- a/pollis-delivery/src/groups.rs
+++ b/pollis-delivery/src/groups.rs
@@ -1,0 +1,1071 @@
+//! Domain B — groups / channels / membership / invites / join-requests.
+//!
+//! The second write-domain in Goal B (#419). It copies the convention domain A
+//! ([`crate::messages`]) established verbatim:
+//!
+//!   - **Bodies** — one `#[derive(Deserialize)] *Body` per endpoint, plain JSON.
+//!   - **Pure conn-level fns** — `apply_*(conn, authed, body)` embed BOTH the
+//!     authorization decision AND the write, returning [`WriteOutcome`]. The real
+//!     axum handler and the in-process test harness both call the *same*
+//!     `apply_*`, so server-side authz is exercised with zero duplication.
+//!   - **axum handlers** — `(State, Method, Uri, HeaderMap, Bytes) -> Response`:
+//!     `gate` → parse → `apply_*` → map outcome to 200 / 403 / 400 / 500.
+//!
+//! ## Where the writes land
+//!
+//! Every domain-B table (`groups`, `channels`, `group_member`, `group_invite`,
+//! `group_join_request`, plus the `conversation_watermark` / `message_envelope`
+//! rows a channel-delete cleans up) lives in the **MAIN DB** (`state.db`). So all
+//! `apply_*` fns run on the main connection.
+//!
+//! ## Authorization (the security core)
+//!
+//! `gate` proves *which user* signed; each `apply_*` then proves they're allowed:
+//!   - create group: the actor is the creator (`owner_id` bound to the signer).
+//!   - create channel: the actor is a current member of the group.
+//!   - update/delete channel, update/delete group, role change, member remove,
+//!     invite create, join-request approve/reject: the actor's role is
+//!     **re-derived server-side** from `group_member` and must be `admin` (member
+//!     remove additionally allows self-removal).
+//!   - invite accept/decline: the actor is the invitee (writes are scoped
+//!     `invitee_id = :actor`).
+//!   - leave group: the actor is a current member (removes only their own row).
+//!   - join-request create: the actor is the requester.
+//!
+//! On the no-auth path (`authed == None`, only when `POLLIS_DS_REQUIRE_AUTH` is
+//! off) the role/identity checks are skipped and the actor comes from the body,
+//! mirroring `commit::submit`, `writes.rs`, and `messages.rs`.
+
+use axum::{
+    body::Bytes,
+    extract::State,
+    http::{HeaderMap, Method, Uri},
+    response::Response,
+};
+use libsql::Connection;
+use serde::Deserialize;
+
+use crate::error::AppError;
+use crate::writes::{bad_request, gate, outcome_response, resolve_actor, WriteOutcome};
+use crate::AppState;
+
+// ── Shared authz helpers ─────────────────────────────────────────────────────
+
+/// The actor's role in `group_id`, re-derived server-side from `group_member`.
+/// `None` when the actor is not a member. Every admin-gated domain-B write
+/// re-derives this rather than trusting any client-supplied role.
+async fn group_role(
+    conn: &Connection,
+    group_id: &str,
+    user_id: &str,
+) -> anyhow::Result<Option<String>> {
+    let mut rows = conn
+        .query(
+            "SELECT role FROM group_member WHERE group_id = ?1 AND user_id = ?2",
+            libsql::params![group_id.to_string(), user_id.to_string()],
+        )
+        .await?;
+    Ok(match rows.next().await? {
+        Some(row) => Some(row.get::<String>(0)?),
+        None => None,
+    })
+}
+
+/// True when the actor is a current admin of `group_id` (re-derived server-side).
+async fn is_admin(conn: &Connection, group_id: &str, user_id: &str) -> anyhow::Result<bool> {
+    Ok(group_role(conn, group_id, user_id).await?.as_deref() == Some("admin"))
+}
+
+/// The group that owns a channel, or `None` if the channel doesn't exist.
+async fn channel_group_id(conn: &Connection, channel_id: &str) -> anyhow::Result<Option<String>> {
+    let mut rows = conn
+        .query(
+            "SELECT group_id FROM channels WHERE id = ?1",
+            libsql::params![channel_id.to_string()],
+        )
+        .await?;
+    Ok(match rows.next().await? {
+        Some(row) => Some(row.get::<String>(0)?),
+        None => None,
+    })
+}
+
+/// Add `user_id` to `group_id` as a plain member and seed their per-(channel,
+/// device) watermarks. Mirrors `pollis_core`'s `add_member_to_group` byte-for-
+/// byte (idempotent `INSERT OR IGNORE` + best-effort watermark seed) so accepting
+/// an invite / approving a join request through the DS lands the exact same rows.
+/// Takes a bare [`Connection`] so it composes inside a caller's transaction
+/// (`&Transaction` derefs to `&Connection`).
+async fn add_member_rows(conn: &Connection, group_id: &str, user_id: &str) -> anyhow::Result<()> {
+    conn.execute(
+        "INSERT OR IGNORE INTO group_member (group_id, user_id, role) VALUES (?1, ?2, 'member')",
+        libsql::params![group_id.to_string(), user_id.to_string()],
+    )
+    .await?;
+    // Seed watermark rows for every (channel, device) pair so pre-join messages
+    // don't block envelope cleanup. Best-effort — mirrors the core helper, which
+    // logs and continues on failure.
+    let _ = conn
+        .execute(
+            "INSERT OR IGNORE INTO conversation_watermark (conversation_id, user_id, device_id, last_fetched_at)
+             SELECT c.id, ?1, ud.device_id, datetime('now')
+             FROM channels c
+             JOIN user_device ud ON ud.user_id = ?1
+             WHERE c.group_id = ?2",
+            libsql::params![user_id.to_string(), group_id.to_string()],
+        )
+        .await;
+    Ok(())
+}
+
+// ── POST /v1/groups/create ───────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct CreateGroupBody {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    /// The creator; bound to the authenticated user when signed.
+    #[serde(default)]
+    pub owner_id: Option<String>,
+    /// When present, also create a default `#General` text channel with this id.
+    #[serde(default)]
+    pub default_text_channel_id: Option<String>,
+    /// When present, also create a default `Voice Chat` voice channel with this id.
+    #[serde(default)]
+    pub default_voice_channel_id: Option<String>,
+    pub created_at: String,
+}
+
+pub async fn create_group(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: CreateGroupBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_create_group(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// INSERT the group, its creator's admin `group_member`, and any default
+/// channels — all in one transaction. Authz: a signed request may only create a
+/// group it owns (`owner_id` bound to the signer).
+pub async fn apply_create_group(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &CreateGroupBody,
+) -> anyhow::Result<WriteOutcome> {
+    let owner = match resolve_actor(authed, body.owner_id.as_deref()) {
+        Ok(o) => o,
+        Err(o) => return Ok(o),
+    };
+    let tx = conn.transaction().await?;
+    tx.execute(
+        "INSERT INTO groups (id, name, description, owner_id, created_at) VALUES (?1, ?2, ?3, ?4, ?5)",
+        libsql::params![
+            body.id.clone(),
+            body.name.clone(),
+            body.description.clone(),
+            owner.clone(),
+            body.created_at.clone(),
+        ],
+    )
+    .await?;
+    tx.execute(
+        "INSERT INTO group_member (group_id, user_id, role) VALUES (?1, ?2, 'admin')",
+        libsql::params![body.id.clone(), owner.clone()],
+    )
+    .await?;
+    if let Some(text_id) = &body.default_text_channel_id {
+        tx.execute(
+            "INSERT INTO channels (id, group_id, name, description, channel_type) \
+             VALUES (?1, ?2, 'General', NULL, 'text')",
+            libsql::params![text_id.clone(), body.id.clone()],
+        )
+        .await?;
+    }
+    if let Some(voice_id) = &body.default_voice_channel_id {
+        tx.execute(
+            "INSERT INTO channels (id, group_id, name, description, channel_type) \
+             VALUES (?1, ?2, 'Voice Chat', NULL, 'voice')",
+            libsql::params![voice_id.clone(), body.id.clone()],
+        )
+        .await?;
+    }
+    tx.commit().await?;
+    Ok(WriteOutcome::Ok)
+}
+
+// ── POST /v1/groups/update ───────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct UpdateGroupBody {
+    pub group_id: String,
+    #[serde(default)]
+    pub requester_id: Option<String>,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub icon_url: Option<String>,
+}
+
+pub async fn update_group(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: UpdateGroupBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_update_group(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// Update a group's mutable settings. Authz: the actor is a re-derived admin.
+pub async fn apply_update_group(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &UpdateGroupBody,
+) -> anyhow::Result<WriteOutcome> {
+    let requester = match resolve_actor(authed, body.requester_id.as_deref()) {
+        Ok(r) => r,
+        Err(o) => return Ok(o),
+    };
+    if authed.is_some() && !is_admin(conn, &body.group_id, &requester).await? {
+        return Ok(WriteOutcome::Forbidden);
+    }
+    if let Some(n) = &body.name {
+        conn.execute(
+            "UPDATE groups SET name = ?1 WHERE id = ?2",
+            libsql::params![n.clone(), body.group_id.clone()],
+        )
+        .await?;
+    }
+    if let Some(d) = &body.description {
+        conn.execute(
+            "UPDATE groups SET description = ?1 WHERE id = ?2",
+            libsql::params![d.clone(), body.group_id.clone()],
+        )
+        .await?;
+    }
+    if let Some(u) = &body.icon_url {
+        conn.execute(
+            "UPDATE groups SET icon_url = ?1 WHERE id = ?2",
+            libsql::params![u.clone(), body.group_id.clone()],
+        )
+        .await?;
+    }
+    Ok(WriteOutcome::Ok)
+}
+
+// ── POST /v1/groups/delete ───────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct DeleteGroupBody {
+    pub group_id: String,
+    #[serde(default)]
+    pub requester_id: Option<String>,
+}
+
+pub async fn delete_group(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: DeleteGroupBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_delete_group(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// Delete a group (CASCADE removes members/channels/invites). Authz: admin.
+pub async fn apply_delete_group(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &DeleteGroupBody,
+) -> anyhow::Result<WriteOutcome> {
+    let requester = match resolve_actor(authed, body.requester_id.as_deref()) {
+        Ok(r) => r,
+        Err(o) => return Ok(o),
+    };
+    if authed.is_some() && !is_admin(conn, &body.group_id, &requester).await? {
+        return Ok(WriteOutcome::Forbidden);
+    }
+    conn.execute(
+        "DELETE FROM groups WHERE id = ?1",
+        libsql::params![body.group_id.clone()],
+    )
+    .await?;
+    Ok(WriteOutcome::Ok)
+}
+
+// ── POST /v1/groups/leave ────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct LeaveGroupBody {
+    pub group_id: String,
+    /// The leaver; bound to the authenticated user when signed.
+    #[serde(default)]
+    pub user_id: Option<String>,
+}
+
+pub async fn leave_group(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: LeaveGroupBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_leave_group(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// Remove the actor's own membership; if the group is now empty, delete it.
+/// Authz: the actor is a current member (a signed request may only remove its
+/// OWN row — `user_id` is bound to the signer).
+pub async fn apply_leave_group(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &LeaveGroupBody,
+) -> anyhow::Result<WriteOutcome> {
+    let user = match resolve_actor(authed, body.user_id.as_deref()) {
+        Ok(u) => u,
+        Err(o) => return Ok(o),
+    };
+    if authed.is_some() && group_role(conn, &body.group_id, &user).await?.is_none() {
+        return Ok(WriteOutcome::Forbidden);
+    }
+    let tx = conn.transaction().await?;
+    tx.execute(
+        "DELETE FROM group_member WHERE group_id = ?1 AND user_id = ?2",
+        libsql::params![body.group_id.clone(), user.clone()],
+    )
+    .await?;
+    let mut count_rows = tx
+        .query(
+            "SELECT COUNT(*) FROM group_member WHERE group_id = ?1",
+            libsql::params![body.group_id.clone()],
+        )
+        .await?;
+    let remaining: i64 = match count_rows.next().await? {
+        Some(row) => row.get(0)?,
+        None => 0,
+    };
+    drop(count_rows);
+    if remaining == 0 {
+        tx.execute(
+            "DELETE FROM groups WHERE id = ?1",
+            libsql::params![body.group_id.clone()],
+        )
+        .await?;
+    }
+    tx.commit().await?;
+    Ok(WriteOutcome::Ok)
+}
+
+// ── POST /v1/channels/create ─────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct CreateChannelBody {
+    pub id: String,
+    pub group_id: String,
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    pub channel_type: String,
+    /// The creator; bound to the authenticated user when signed.
+    #[serde(default)]
+    pub creator_id: Option<String>,
+}
+
+pub async fn create_channel(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: CreateChannelBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_create_channel(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// INSERT a channel. Authz: the actor is a current member of the owning group.
+pub async fn apply_create_channel(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &CreateChannelBody,
+) -> anyhow::Result<WriteOutcome> {
+    let creator = match resolve_actor(authed, body.creator_id.as_deref()) {
+        Ok(c) => c,
+        Err(o) => return Ok(o),
+    };
+    if authed.is_some() && group_role(conn, &body.group_id, &creator).await?.is_none() {
+        return Ok(WriteOutcome::Forbidden);
+    }
+    conn.execute(
+        "INSERT INTO channels (id, group_id, name, description, channel_type) VALUES (?1, ?2, ?3, ?4, ?5)",
+        libsql::params![
+            body.id.clone(),
+            body.group_id.clone(),
+            body.name.clone(),
+            body.description.clone(),
+            body.channel_type.clone(),
+        ],
+    )
+    .await?;
+    Ok(WriteOutcome::Ok)
+}
+
+// ── POST /v1/channels/update ─────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct UpdateChannelBody {
+    pub channel_id: String,
+    #[serde(default)]
+    pub requester_id: Option<String>,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+pub async fn update_channel(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: UpdateChannelBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_update_channel(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// Update a channel's name/description. Authz: admin of the owning group.
+pub async fn apply_update_channel(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &UpdateChannelBody,
+) -> anyhow::Result<WriteOutcome> {
+    let requester = match resolve_actor(authed, body.requester_id.as_deref()) {
+        Ok(r) => r,
+        Err(o) => return Ok(o),
+    };
+    let group_id = match channel_group_id(conn, &body.channel_id).await? {
+        Some(g) => g,
+        None => return Ok(WriteOutcome::Forbidden),
+    };
+    if authed.is_some() && !is_admin(conn, &group_id, &requester).await? {
+        return Ok(WriteOutcome::Forbidden);
+    }
+    if let Some(n) = &body.name {
+        conn.execute(
+            "UPDATE channels SET name = ?1 WHERE id = ?2",
+            libsql::params![n.clone(), body.channel_id.clone()],
+        )
+        .await?;
+    }
+    if let Some(d) = &body.description {
+        conn.execute(
+            "UPDATE channels SET description = ?1 WHERE id = ?2",
+            libsql::params![d.clone(), body.channel_id.clone()],
+        )
+        .await?;
+    }
+    Ok(WriteOutcome::Ok)
+}
+
+// ── POST /v1/channels/delete ─────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct DeleteChannelBody {
+    pub channel_id: String,
+    #[serde(default)]
+    pub requester_id: Option<String>,
+}
+
+pub async fn delete_channel(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: DeleteChannelBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_delete_channel(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// Delete a channel and its envelopes/watermarks in one transaction. Authz:
+/// admin of the owning group (a destructive op).
+pub async fn apply_delete_channel(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &DeleteChannelBody,
+) -> anyhow::Result<WriteOutcome> {
+    let requester = match resolve_actor(authed, body.requester_id.as_deref()) {
+        Ok(r) => r,
+        Err(o) => return Ok(o),
+    };
+    let group_id = match channel_group_id(conn, &body.channel_id).await? {
+        Some(g) => g,
+        None => return Ok(WriteOutcome::Forbidden),
+    };
+    if authed.is_some() && !is_admin(conn, &group_id, &requester).await? {
+        return Ok(WriteOutcome::Forbidden);
+    }
+    let tx = conn.transaction().await?;
+    tx.execute(
+        "DELETE FROM message_envelope WHERE conversation_id = ?1",
+        libsql::params![body.channel_id.clone()],
+    )
+    .await?;
+    tx.execute(
+        "DELETE FROM conversation_watermark WHERE conversation_id = ?1",
+        libsql::params![body.channel_id.clone()],
+    )
+    .await?;
+    tx.execute(
+        "DELETE FROM channels WHERE id = ?1",
+        libsql::params![body.channel_id.clone()],
+    )
+    .await?;
+    tx.commit().await?;
+    Ok(WriteOutcome::Ok)
+}
+
+// ── POST /v1/members/remove ──────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct RemoveMemberBody {
+    pub group_id: String,
+    /// The member being removed.
+    pub user_id: String,
+    /// The actor; bound to the authenticated user when signed.
+    #[serde(default)]
+    pub requester_id: Option<String>,
+}
+
+pub async fn remove_member(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: RemoveMemberBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_remove_member(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// Remove a member. Authz: the actor removes themselves (leave) OR is a
+/// re-derived admin. A non-admin can never remove anyone but themselves.
+pub async fn apply_remove_member(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &RemoveMemberBody,
+) -> anyhow::Result<WriteOutcome> {
+    let requester = match resolve_actor(authed, body.requester_id.as_deref()) {
+        Ok(r) => r,
+        Err(o) => return Ok(o),
+    };
+    if authed.is_some()
+        && requester != body.user_id
+        && !is_admin(conn, &body.group_id, &requester).await?
+    {
+        return Ok(WriteOutcome::Forbidden);
+    }
+    conn.execute(
+        "DELETE FROM group_member WHERE group_id = ?1 AND user_id = ?2",
+        libsql::params![body.group_id.clone(), body.user_id.clone()],
+    )
+    .await?;
+    Ok(WriteOutcome::Ok)
+}
+
+// ── POST /v1/members/role ────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct SetMemberRoleBody {
+    pub group_id: String,
+    /// The member whose role is being changed.
+    pub user_id: String,
+    pub role: String,
+    /// The actor; bound to the authenticated user when signed.
+    #[serde(default)]
+    pub requester_id: Option<String>,
+}
+
+pub async fn set_member_role(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: SetMemberRoleBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_set_member_role(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// Promote/demote a member. Authz: the actor is a re-derived admin, the target
+/// is a current member, and the new role is valid (`admin` / `member`).
+pub async fn apply_set_member_role(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &SetMemberRoleBody,
+) -> anyhow::Result<WriteOutcome> {
+    if body.role != "admin" && body.role != "member" {
+        return Ok(WriteOutcome::Forbidden);
+    }
+    let requester = match resolve_actor(authed, body.requester_id.as_deref()) {
+        Ok(r) => r,
+        Err(o) => return Ok(o),
+    };
+    if authed.is_some() && !is_admin(conn, &body.group_id, &requester).await? {
+        return Ok(WriteOutcome::Forbidden);
+    }
+    // Target must be a current member.
+    if group_role(conn, &body.group_id, &body.user_id)
+        .await?
+        .is_none()
+    {
+        return Ok(WriteOutcome::Forbidden);
+    }
+    conn.execute(
+        "UPDATE group_member SET role = ?1 WHERE group_id = ?2 AND user_id = ?3",
+        libsql::params![body.role.clone(), body.group_id.clone(), body.user_id.clone()],
+    )
+    .await?;
+    Ok(WriteOutcome::Ok)
+}
+
+// ── POST /v1/invites/create ──────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct CreateInviteBody {
+    pub id: String,
+    pub group_id: String,
+    /// The inviter; bound to the authenticated user when signed.
+    #[serde(default)]
+    pub inviter_id: Option<String>,
+    pub invitee_id: String,
+}
+
+pub async fn create_invite(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: CreateInviteBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_create_invite(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// INSERT a pending invite. Authz: the inviter is a re-derived admin. (Invitee
+/// resolution, block checks, and dup detection stay client-side reads.)
+pub async fn apply_create_invite(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &CreateInviteBody,
+) -> anyhow::Result<WriteOutcome> {
+    let inviter = match resolve_actor(authed, body.inviter_id.as_deref()) {
+        Ok(i) => i,
+        Err(o) => return Ok(o),
+    };
+    if authed.is_some() && !is_admin(conn, &body.group_id, &inviter).await? {
+        return Ok(WriteOutcome::Forbidden);
+    }
+    conn.execute(
+        "INSERT INTO group_invite (id, group_id, inviter_id, invitee_id) VALUES (?1, ?2, ?3, ?4)",
+        libsql::params![
+            body.id.clone(),
+            body.group_id.clone(),
+            inviter,
+            body.invitee_id.clone(),
+        ],
+    )
+    .await?;
+    Ok(WriteOutcome::Ok)
+}
+
+// ── POST /v1/invites/accept ──────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct AcceptInviteBody {
+    pub invite_id: String,
+    /// The invitee; bound to the authenticated user when signed.
+    #[serde(default)]
+    pub user_id: Option<String>,
+}
+
+pub async fn accept_invite(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: AcceptInviteBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_accept_invite(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// Accept an invite: add the actor as a member and delete the invite, in one
+/// transaction. Authz: the invite is addressed to the actor (`invitee_id` is
+/// re-derived server-side and must equal the signer) — a signer cannot accept
+/// someone else's invite.
+pub async fn apply_accept_invite(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &AcceptInviteBody,
+) -> anyhow::Result<WriteOutcome> {
+    let user = match resolve_actor(authed, body.user_id.as_deref()) {
+        Ok(u) => u,
+        Err(o) => return Ok(o),
+    };
+    // Resolve the group from an invite addressed to THIS actor; missing → the
+    // invite doesn't exist or isn't theirs.
+    let mut rows = conn
+        .query(
+            "SELECT group_id FROM group_invite WHERE id = ?1 AND invitee_id = ?2",
+            libsql::params![body.invite_id.clone(), user.clone()],
+        )
+        .await?;
+    let group_id: String = match rows.next().await? {
+        Some(row) => row.get(0)?,
+        None => return Ok(WriteOutcome::Forbidden),
+    };
+    drop(rows);
+
+    let tx = conn.transaction().await?;
+    add_member_rows(&tx, &group_id, &user).await?;
+    tx.execute(
+        "DELETE FROM group_invite WHERE id = ?1",
+        libsql::params![body.invite_id.clone()],
+    )
+    .await?;
+    tx.commit().await?;
+    Ok(WriteOutcome::Ok)
+}
+
+// ── POST /v1/invites/decline ─────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct DeclineInviteBody {
+    pub invite_id: String,
+    /// The invitee; bound to the authenticated user when signed.
+    #[serde(default)]
+    pub user_id: Option<String>,
+}
+
+pub async fn decline_invite(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: DeclineInviteBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_decline_invite(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// Decline an invite. The DELETE is scoped `invitee_id = :actor`, so a signer can
+/// only ever decline their own invite.
+pub async fn apply_decline_invite(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &DeclineInviteBody,
+) -> anyhow::Result<WriteOutcome> {
+    let user = match resolve_actor(authed, body.user_id.as_deref()) {
+        Ok(u) => u,
+        Err(o) => return Ok(o),
+    };
+    conn.execute(
+        "DELETE FROM group_invite WHERE id = ?1 AND invitee_id = ?2",
+        libsql::params![body.invite_id.clone(), user],
+    )
+    .await?;
+    Ok(WriteOutcome::Ok)
+}
+
+// ── POST /v1/join-requests/create ────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct CreateJoinRequestBody {
+    pub id: String,
+    pub group_id: String,
+    /// The requester; bound to the authenticated user when signed.
+    #[serde(default)]
+    pub requester_id: Option<String>,
+}
+
+pub async fn create_join_request(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: CreateJoinRequestBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_create_join_request(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// UPSERT a pending join request (or reset a prior rejected/approved row back to
+/// pending). Authz: the actor requests for THEMSELVES (`requester_id` bound to
+/// the signer). Group-existence / not-already-member checks stay client-side.
+pub async fn apply_create_join_request(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &CreateJoinRequestBody,
+) -> anyhow::Result<WriteOutcome> {
+    let requester = match resolve_actor(authed, body.requester_id.as_deref()) {
+        Ok(r) => r,
+        Err(o) => return Ok(o),
+    };
+    conn.execute(
+        "INSERT INTO group_join_request (id, group_id, requester_id, status, created_at)
+         VALUES (?1, ?2, ?3, 'pending', datetime('now'))
+         ON CONFLICT(group_id, requester_id) DO UPDATE SET
+             id         = excluded.id,
+             status     = 'pending',
+             created_at = excluded.created_at",
+        libsql::params![body.id.clone(), body.group_id.clone(), requester],
+    )
+    .await?;
+    Ok(WriteOutcome::Ok)
+}
+
+// ── POST /v1/join-requests/approve ───────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct ApproveJoinRequestBody {
+    pub request_id: String,
+    /// The approver; bound to the authenticated user when signed.
+    #[serde(default)]
+    pub approver_id: Option<String>,
+    pub reviewed_at: String,
+}
+
+pub async fn approve_join_request(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: ApproveJoinRequestBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_approve_join_request(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// Approve a pending join request: add the requester as a member and flip the row
+/// to `approved`, in one transaction. Authz: the approver is a re-derived admin.
+pub async fn apply_approve_join_request(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &ApproveJoinRequestBody,
+) -> anyhow::Result<WriteOutcome> {
+    let approver = match resolve_actor(authed, body.approver_id.as_deref()) {
+        Ok(a) => a,
+        Err(o) => return Ok(o),
+    };
+    let mut rows = conn
+        .query(
+            "SELECT group_id, requester_id FROM group_join_request WHERE id = ?1 AND status = 'pending'",
+            libsql::params![body.request_id.clone()],
+        )
+        .await?;
+    let (group_id, requester_id): (String, String) = match rows.next().await? {
+        Some(row) => (row.get(0)?, row.get(1)?),
+        None => return Ok(WriteOutcome::Forbidden),
+    };
+    drop(rows);
+
+    if authed.is_some() && !is_admin(conn, &group_id, &approver).await? {
+        return Ok(WriteOutcome::Forbidden);
+    }
+
+    let tx = conn.transaction().await?;
+    add_member_rows(&tx, &group_id, &requester_id).await?;
+    tx.execute(
+        "UPDATE group_join_request SET status = 'approved', reviewed_by = ?1, reviewed_at = ?2 WHERE id = ?3",
+        libsql::params![approver, body.reviewed_at.clone(), body.request_id.clone()],
+    )
+    .await?;
+    tx.commit().await?;
+    Ok(WriteOutcome::Ok)
+}
+
+// ── POST /v1/join-requests/reject ────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct RejectJoinRequestBody {
+    pub request_id: String,
+    /// The approver; bound to the authenticated user when signed.
+    #[serde(default)]
+    pub approver_id: Option<String>,
+    pub reviewed_at: String,
+}
+
+pub async fn reject_join_request(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: RejectJoinRequestBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_reject_join_request(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// Reject a pending join request. Authz: the approver is a re-derived admin.
+pub async fn apply_reject_join_request(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &RejectJoinRequestBody,
+) -> anyhow::Result<WriteOutcome> {
+    let approver = match resolve_actor(authed, body.approver_id.as_deref()) {
+        Ok(a) => a,
+        Err(o) => return Ok(o),
+    };
+    let mut rows = conn
+        .query(
+            "SELECT group_id FROM group_join_request WHERE id = ?1 AND status = 'pending'",
+            libsql::params![body.request_id.clone()],
+        )
+        .await?;
+    let group_id: String = match rows.next().await? {
+        Some(row) => row.get(0)?,
+        None => return Ok(WriteOutcome::Forbidden),
+    };
+    drop(rows);
+
+    if authed.is_some() && !is_admin(conn, &group_id, &approver).await? {
+        return Ok(WriteOutcome::Forbidden);
+    }
+    conn.execute(
+        "UPDATE group_join_request SET status = 'rejected', reviewed_by = ?1, reviewed_at = ?2 WHERE id = ?3",
+        libsql::params![approver, body.reviewed_at.clone(), body.request_id.clone()],
+    )
+    .await?;
+    Ok(WriteOutcome::Ok)
+}

--- a/pollis-delivery/src/lib.rs
+++ b/pollis-delivery/src/lib.rs
@@ -19,6 +19,7 @@
 //! That keeps existing unsigned clients and the integration harness working
 //! until a follow-up makes the pollis-core client sign + send the headers.
 
+pub mod account;
 pub mod auth;
 pub mod commit;
 pub mod db;
@@ -168,6 +169,18 @@ pub fn build_router_with_state(state: AppState) -> Router {
         .route("/v1/key-packages/replenish", post(devices::replenish_key_packages))
         .route("/v1/devices/resign", post(devices::resign_device_certs))
         .route("/v1/push-tokens", post(devices::register_push_token))
+        // Domains E + G (#419) — account lifecycle / identity rotation /
+        // recovery / device-enrollment / security audit. All land on the MAIN
+        // DB. The account-identity bootstrap (signup version-1 establishment),
+        // device registration, the enrollment *request*, and logout device
+        // removal stay on the client's direct path (see `account` module docs).
+        .route("/v1/account/rotate-identity", post(account::rotate_identity))
+        .route("/v1/account/delete", post(account::delete_account))
+        .route("/v1/account/reset-recover", post(account::reset_recover))
+        .route("/v1/security-events", post(account::record_security_event))
+        .route("/v1/enrollment/approve", post(account::approve_enrollment))
+        .route("/v1/enrollment/reject", post(account::reject_enrollment))
+        .route("/v1/devices/revoke", post(account::revoke_device))
         .with_state(state)
 }
 

--- a/pollis-delivery/src/lib.rs
+++ b/pollis-delivery/src/lib.rs
@@ -22,6 +22,7 @@
 pub mod auth;
 pub mod commit;
 pub mod db;
+pub mod devices;
 pub mod error;
 pub mod messages;
 pub mod writes;
@@ -132,6 +133,14 @@ pub fn build_router_with_state(state: AppState) -> Router {
         .route("/v1/envelopes/gc", post(messages::envelope_gc))
         .route("/v1/attachments/register", post(messages::register_attachment))
         .route("/v1/attachments/delete", post(messages::delete_attachment))
+        // Domain D (#419) — key-packages / device-cert re-sign / push tokens.
+        // All land on the MAIN DB. Device registration + the FIRST cert publish
+        // are bootstrap writes that stay on the client's direct path (see
+        // `devices` module docs).
+        .route("/v1/key-packages", post(devices::publish_key_packages))
+        .route("/v1/key-packages/replenish", post(devices::replenish_key_packages))
+        .route("/v1/devices/resign", post(devices::resign_device_certs))
+        .route("/v1/push-tokens", post(devices::register_push_token))
         .with_state(state)
 }
 

--- a/pollis-delivery/src/lib.rs
+++ b/pollis-delivery/src/lib.rs
@@ -24,6 +24,7 @@ pub mod commit;
 pub mod db;
 pub mod error;
 pub mod messages;
+pub mod profile;
 pub mod writes;
 
 use std::sync::Arc;
@@ -132,6 +133,14 @@ pub fn build_router_with_state(state: AppState) -> Router {
         .route("/v1/envelopes/gc", post(messages::envelope_gc))
         .route("/v1/attachments/register", post(messages::register_attachment))
         .route("/v1/attachments/delete", post(messages::delete_attachment))
+        // Domain C (#419) — profile / preferences / blocks / DMs. All land on
+        // the MAIN DB.
+        .route("/v1/profile/update", post(profile::update_profile))
+        .route("/v1/profile/preferences", post(profile::save_preferences))
+        .route("/v1/blocks/add", post(profile::block_user))
+        .route("/v1/blocks/remove", post(profile::unblock_user))
+        .route("/v1/dm/create", post(profile::create_dm))
+        .route("/v1/dm/accept", post(profile::accept_dm))
         .with_state(state)
 }
 

--- a/pollis-delivery/src/lib.rs
+++ b/pollis-delivery/src/lib.rs
@@ -160,6 +160,9 @@ pub fn build_router_with_state(state: AppState) -> Router {
         .route("/v1/blocks/remove", post(profile::unblock_user))
         .route("/v1/dm/create", post(profile::create_dm))
         .route("/v1/dm/accept", post(profile::accept_dm))
+        .route("/v1/dm/add", post(profile::add_dm_member))
+        .route("/v1/dm/remove", post(profile::remove_dm_member))
+        .route("/v1/dm/leave", post(profile::leave_dm))
         // Domain D (#419) — key-packages / device-cert re-sign / push tokens.
         // All land on the MAIN DB. Device registration + the FIRST cert publish
         // are bootstrap writes that stay on the client's direct path (see

--- a/pollis-delivery/src/lib.rs
+++ b/pollis-delivery/src/lib.rs
@@ -23,6 +23,7 @@ pub mod auth;
 pub mod commit;
 pub mod db;
 pub mod error;
+pub mod messages;
 pub mod writes;
 
 use std::sync::Arc;
@@ -120,6 +121,17 @@ pub fn build_router_with_state(state: AppState) -> Router {
         .route("/v1/welcomes/ack", post(writes::welcomes_ack))
         .route("/v1/welcomes/reset", post(writes::welcomes_reset))
         .route("/v1/welcomes/purge", post(writes::welcomes_purge))
+        // Domain A (#419) — messages / envelopes / watermarks / reactions /
+        // attachments. All land on the MAIN DB.
+        .route("/v1/messages/send", post(messages::send_message))
+        .route("/v1/messages/edit", post(messages::edit_message))
+        .route("/v1/messages/delete", post(messages::delete_message))
+        .route("/v1/reactions/add", post(messages::add_reaction))
+        .route("/v1/reactions/remove", post(messages::remove_reaction))
+        .route("/v1/watermarks/advance", post(messages::advance_watermark))
+        .route("/v1/envelopes/gc", post(messages::envelope_gc))
+        .route("/v1/attachments/register", post(messages::register_attachment))
+        .route("/v1/attachments/delete", post(messages::delete_attachment))
         .with_state(state)
 }
 

--- a/pollis-delivery/src/lib.rs
+++ b/pollis-delivery/src/lib.rs
@@ -23,6 +23,7 @@ pub mod auth;
 pub mod commit;
 pub mod db;
 pub mod error;
+pub mod groups;
 pub mod messages;
 pub mod writes;
 
@@ -132,6 +133,23 @@ pub fn build_router_with_state(state: AppState) -> Router {
         .route("/v1/envelopes/gc", post(messages::envelope_gc))
         .route("/v1/attachments/register", post(messages::register_attachment))
         .route("/v1/attachments/delete", post(messages::delete_attachment))
+        // Domain B (#419) — groups / channels / membership / invites /
+        // join-requests. All land on the MAIN DB.
+        .route("/v1/groups/create", post(groups::create_group))
+        .route("/v1/groups/update", post(groups::update_group))
+        .route("/v1/groups/delete", post(groups::delete_group))
+        .route("/v1/groups/leave", post(groups::leave_group))
+        .route("/v1/channels/create", post(groups::create_channel))
+        .route("/v1/channels/update", post(groups::update_channel))
+        .route("/v1/channels/delete", post(groups::delete_channel))
+        .route("/v1/members/remove", post(groups::remove_member))
+        .route("/v1/members/role", post(groups::set_member_role))
+        .route("/v1/invites/create", post(groups::create_invite))
+        .route("/v1/invites/accept", post(groups::accept_invite))
+        .route("/v1/invites/decline", post(groups::decline_invite))
+        .route("/v1/join-requests/create", post(groups::create_join_request))
+        .route("/v1/join-requests/approve", post(groups::approve_join_request))
+        .route("/v1/join-requests/reject", post(groups::reject_join_request))
         .with_state(state)
 }
 

--- a/pollis-delivery/src/messages.rs
+++ b/pollis-delivery/src/messages.rs
@@ -57,19 +57,11 @@ use libsql::Connection;
 use serde::Deserialize;
 use ulid::Ulid;
 
-use crate::error::{AppError, AuthRejection};
-use crate::writes::{bad_request, gate, is_member, ok_json};
+use crate::error::AppError;
+use crate::writes::{
+    bad_request, gate, is_member, ok_json, outcome_response, resolve_actor, WriteOutcome,
+};
 use crate::AppState;
-
-/// The result of an authorized write: either it was applied, or the
-/// authenticated user was not allowed to make it (→ 403). A genuine failure
-/// (DB error, etc.) is an `Err` on the enclosing `anyhow::Result`, mapped to 500
-/// by the handler. Shared across every domain-A endpoint so the handler ⇆
-/// harness pair stays uniform; promote to a crate-level type if B/C/D want it.
-pub enum WriteOutcome {
-    Ok,
-    Forbidden,
-}
 
 // ── Envelope GC SQL (mirrors pollis-core's ingest.rs, byte-for-byte) ─────────
 //
@@ -130,22 +122,6 @@ DELETE FROM message_envelope
 ///     (`Forbidden`).
 ///   - auth OFF (`authed = None`) → the body's actor (the no-auth path has no
 ///     signed identity). Missing/empty → `Forbidden` (no actor at all).
-fn resolve_actor(
-    authed: Option<&str>,
-    body_actor: Option<&str>,
-) -> Result<String, WriteOutcome> {
-    match authed {
-        Some(u) => match body_actor {
-            Some(b) if b != u => Err(WriteOutcome::Forbidden),
-            _ => Ok(u.to_string()),
-        },
-        None => match body_actor {
-            Some(b) if !b.is_empty() => Ok(b.to_string()),
-            _ => Err(WriteOutcome::Forbidden),
-        },
-    }
-}
-
 /// The original sender of a `type='message'` envelope, if it's still present
 /// (it may have aged out via watermark/TTL GC).
 async fn original_sender(conn: &Connection, message_id: &str) -> anyhow::Result<Option<String>> {
@@ -810,15 +786,4 @@ pub async fn apply_delete_attachment(
     )
     .await?;
     Ok(WriteOutcome::Ok)
-}
-
-// ── helpers ──────────────────────────────────────────────────────────────────
-
-/// Map a [`WriteOutcome`] to the standard response: 200 on success, 403 on a
-/// refused authz check.
-fn outcome_response(outcome: WriteOutcome) -> Result<Response, AppError> {
-    Ok(match outcome {
-        WriteOutcome::Ok => ok_json(serde_json::json!({ "status": "ok" })),
-        WriteOutcome::Forbidden => AuthRejection::Forbidden.into_response(),
-    })
 }

--- a/pollis-delivery/src/messages.rs
+++ b/pollis-delivery/src/messages.rs
@@ -1,0 +1,824 @@
+//! Domain A — message envelopes, edits/deletes, reactions, watermarks, and
+//! attachment dedup rows. The **reference vertical slice** for Goal B (#419):
+//! every later write-domain (B/C/D) copies the shape established here.
+//!
+//! ## The per-domain convention (copy this)
+//!
+//!   - **Bodies** — one `#[derive(Deserialize)] *Body` per endpoint. Binary
+//!     fields are base64 (STANDARD); everything else is plain JSON. (Domain A
+//!     has no binary fields — `ciphertext` is already the `"mls:<hex>"` text the
+//!     client stores, and content hashes / R2 keys are text.)
+//!   - **Pure conn-level fns** — `apply_*` functions take a bare
+//!     [`Connection`], the authenticated user (`Option<&str>`; `None` only on
+//!     the no-auth path), and a parsed `*Body`. They embed BOTH the
+//!     authorization decision AND the write, returning [`WriteOutcome`]. Putting
+//!     authz inside the pure fn (rather than the axum handler, as `writes.rs`
+//!     does) is deliberate: it makes the in-process test harness exercise the
+//!     *exact* same authz the production handler runs, with zero duplication —
+//!     both call sites are reduced to `gate → parse → apply → map outcome`.
+//!   - **axum handlers** — `(State, Method, Uri, HeaderMap, Bytes) -> Response`,
+//!     all identical in shape. They `gate` (shared auth, see
+//!     [`crate::writes::gate`]), parse, call the matching `apply_*`, and map the
+//!     outcome to 200 / 403 / 400 / 500.
+//!
+//! ## Where the writes land
+//!
+//! Every domain-A table lives in the **MAIN DB** (`state.db`), NOT the commit-log
+//! DB — these are message-delivery rows, not MLS control-plane rows. So all
+//! `apply_*` fns run on the main connection.
+//!
+//! ## Authorization (the security core)
+//!
+//! `gate` proves *which user* signed the request; each `apply_*` then proves the
+//! user is *allowed* to make that specific write:
+//!   - send / edit / delete: the user is a current member of the conversation
+//!     (reusing [`crate::writes::is_member`]); edit/delete of a specific message
+//!     additionally requires the user be the message's sender, or — for an
+//!     admin-delete — a group admin of the channel's owning group.
+//!   - reactions: the user is a member, and may only write/remove their OWN
+//!     reaction (`user_id` is bound to the authenticated user).
+//!   - watermark: the row is per `(conversation, user, device)`; the user may
+//!     only advance their own.
+//!   - envelope GC: the user is a member. (See the TODO on [`apply_envelope_gc`]
+//!     — moving the *trigger* server-side does not yet make GC many-member
+//!     correct; that redesign is out of scope for this slice.)
+//!
+//! On the no-auth path (`authed == None`, only reachable when the DS runs with
+//! `POLLIS_DS_REQUIRE_AUTH` off) the membership/identity checks are skipped and
+//! the actor comes from the body — mirroring `commit::submit` and `writes.rs`.
+
+use axum::{
+    body::Bytes,
+    extract::State,
+    http::{HeaderMap, Method, Uri},
+    response::{IntoResponse, Response},
+};
+use libsql::Connection;
+use serde::Deserialize;
+use ulid::Ulid;
+
+use crate::error::{AppError, AuthRejection};
+use crate::writes::{bad_request, gate, is_member, ok_json};
+use crate::AppState;
+
+/// The result of an authorized write: either it was applied, or the
+/// authenticated user was not allowed to make it (→ 403). A genuine failure
+/// (DB error, etc.) is an `Err` on the enclosing `anyhow::Result`, mapped to 500
+/// by the handler. Shared across every domain-A endpoint so the handler ⇆
+/// harness pair stays uniform; promote to a crate-level type if B/C/D want it.
+pub enum WriteOutcome {
+    Ok,
+    Forbidden,
+}
+
+// ── Envelope GC SQL (mirrors pollis-core's ingest.rs, byte-for-byte) ─────────
+//
+// Envelope cleanup: TTL gate OR watermark gate (OR'd — either alone deletes).
+// The watermark gate is keyed on (user, device): a multi-device user whose other
+// device hasn't synced keeps envelopes alive until every device catches up or the
+// 30-day TTL expires. Copied verbatim from `pollis_core::commands::messages::ingest`
+// so moving the *trigger* behind the DS does not change deletion behavior.
+
+const CLEANUP_CHANNEL_ENVELOPES: &str = "\
+DELETE FROM message_envelope
+ WHERE conversation_id = ?1
+   AND (
+     sent_at < datetime('now', '-30 days')
+     OR sent_at < (
+       SELECT CASE
+                WHEN COUNT(ud.device_id) = COUNT(cw.last_fetched_at)
+                THEN MIN(cw.last_fetched_at)
+                ELSE NULL
+              END
+       FROM group_member gm
+       JOIN channels c ON c.id = ?1 AND c.group_id = gm.group_id
+       JOIN user_device ud ON ud.user_id = gm.user_id
+       LEFT JOIN conversation_watermark cw
+              ON cw.conversation_id = ?1
+             AND cw.user_id = ud.user_id
+             AND cw.device_id = ud.device_id
+     )
+   )";
+
+const CLEANUP_DM_ENVELOPES: &str = "\
+DELETE FROM message_envelope
+ WHERE conversation_id = ?1
+   AND (
+     sent_at < datetime('now', '-30 days')
+     OR sent_at < (
+       SELECT CASE
+                WHEN COUNT(ud.device_id) = COUNT(cw.last_fetched_at)
+                THEN MIN(cw.last_fetched_at)
+                ELSE NULL
+              END
+       FROM dm_channel_member dcm
+       JOIN user_device ud ON ud.user_id = dcm.user_id
+       LEFT JOIN conversation_watermark cw
+              ON cw.conversation_id = ?1
+             AND cw.user_id = ud.user_id
+             AND cw.device_id = ud.device_id
+       WHERE dcm.dm_channel_id = ?1
+     )
+   )";
+
+// ── Shared authz helpers ─────────────────────────────────────────────────────
+
+/// Resolve the acting user for a domain-A write.
+///
+///   - auth ON (`authed = Some`) → the authenticated user. A body-supplied actor
+///     (if any) must equal it, else the request is forging another identity
+///     (`Forbidden`).
+///   - auth OFF (`authed = None`) → the body's actor (the no-auth path has no
+///     signed identity). Missing/empty → `Forbidden` (no actor at all).
+fn resolve_actor(
+    authed: Option<&str>,
+    body_actor: Option<&str>,
+) -> Result<String, WriteOutcome> {
+    match authed {
+        Some(u) => match body_actor {
+            Some(b) if b != u => Err(WriteOutcome::Forbidden),
+            _ => Ok(u.to_string()),
+        },
+        None => match body_actor {
+            Some(b) if !b.is_empty() => Ok(b.to_string()),
+            _ => Err(WriteOutcome::Forbidden),
+        },
+    }
+}
+
+/// The original sender of a `type='message'` envelope, if it's still present
+/// (it may have aged out via watermark/TTL GC).
+async fn original_sender(conn: &Connection, message_id: &str) -> anyhow::Result<Option<String>> {
+    let mut rows = conn
+        .query(
+            "SELECT sender_id FROM message_envelope WHERE id = ?1 AND type = 'message'",
+            libsql::params![message_id.to_string()],
+        )
+        .await?;
+    Ok(match rows.next().await? {
+        Some(row) => Some(row.get::<String>(0)?),
+        None => None,
+    })
+}
+
+/// The conversation a message belongs to, resolved from any envelope carrying
+/// its id (used to membership-gate reactions, which only know `message_id`).
+async fn conversation_for_message(
+    conn: &Connection,
+    message_id: &str,
+) -> anyhow::Result<Option<String>> {
+    let mut rows = conn
+        .query(
+            "SELECT conversation_id FROM message_envelope WHERE id = ?1 LIMIT 1",
+            libsql::params![message_id.to_string()],
+        )
+        .await?;
+    Ok(match rows.next().await? {
+        Some(row) => Some(row.get::<String>(0)?),
+        None => None,
+    })
+}
+
+/// The caller's role in the group that owns `conversation_id` (a text channel).
+/// `None` when the conversation is not a group channel (e.g. a DM, which has no
+/// `channels` row and no admin concept) or the caller is not a member.
+async fn channel_group_role(
+    conn: &Connection,
+    conversation_id: &str,
+    user_id: &str,
+) -> anyhow::Result<Option<String>> {
+    let mut rows = conn
+        .query(
+            "SELECT gm.role FROM channels c \
+             JOIN group_member gm ON gm.group_id = c.group_id \
+             WHERE c.id = ?1 AND gm.user_id = ?2",
+            libsql::params![conversation_id.to_string(), user_id.to_string()],
+        )
+        .await?;
+    Ok(match rows.next().await? {
+        Some(row) => Some(row.get::<String>(0)?),
+        None => None,
+    })
+}
+
+fn now_rfc3339() -> String {
+    // RFC3339 with no extra deps — mirrors pollis-core's chrono output closely
+    // enough for the textual `sent_at`/`created_at` columns (lexical ordering is
+    // all the GC/watermark logic relies on).
+    chrono_like_now()
+}
+
+/// Minimal RFC3339-ish timestamp. pollis-delivery has no `chrono` dep, so format
+/// the unix epoch as an ISO-8601 UTC string. Only used for tombstone/reaction
+/// rows whose timestamps are compared lexically, never parsed.
+fn chrono_like_now() -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0) as i64;
+    // Days since epoch → civil date (Howard Hinnant's algorithm).
+    let days = secs.div_euclid(86_400);
+    let rem = secs.rem_euclid(86_400);
+    let (hh, mm, ss) = (rem / 3600, (rem % 3600) / 60, rem % 60);
+    let z = days + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    format!("{y:04}-{m:02}-{d:02}T{hh:02}:{mm:02}:{ss:02}+00:00")
+}
+
+// ── POST /v1/messages/send ───────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct SendMessageBody {
+    pub id: String,
+    pub conversation_id: String,
+    /// Bound to the authenticated user when signed; the no-auth fallback only.
+    #[serde(default)]
+    pub sender_id: Option<String>,
+    /// The `"mls:<hex>"` ciphertext string the client persists — plain text, not
+    /// binary, so no base64.
+    pub ciphertext: String,
+    #[serde(default)]
+    pub reply_to_id: Option<String>,
+    pub sent_at: String,
+}
+
+pub async fn send_message(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: SendMessageBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_send_message(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// INSERT a `type='message'` envelope (the send). Authz: the sender is a current
+/// member of the conversation, and a signed request may only send as itself.
+pub async fn apply_send_message(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &SendMessageBody,
+) -> anyhow::Result<WriteOutcome> {
+    let sender = match resolve_actor(authed, body.sender_id.as_deref()) {
+        Ok(s) => s,
+        Err(o) => return Ok(o),
+    };
+    if authed.is_some() && !is_member(conn, &body.conversation_id, &sender).await? {
+        return Ok(WriteOutcome::Forbidden);
+    }
+    conn.execute(
+        "INSERT INTO message_envelope \
+             (id, conversation_id, sender_id, ciphertext, reply_to_id, sent_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        libsql::params![
+            body.id.clone(),
+            body.conversation_id.clone(),
+            sender,
+            body.ciphertext.clone(),
+            body.reply_to_id.clone(),
+            body.sent_at.clone(),
+        ],
+    )
+    .await?;
+    Ok(WriteOutcome::Ok)
+}
+
+// ── POST /v1/messages/edit ───────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct EditMessageBody {
+    pub envelope_id: String,
+    pub conversation_id: String,
+    pub target_message_id: String,
+    #[serde(default)]
+    pub sender_id: Option<String>,
+    pub ciphertext: String,
+    pub sent_at: String,
+}
+
+pub async fn edit_message(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: EditMessageBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_edit_message(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// Replace the single pending edit envelope (DELETE prior + INSERT new) in one
+/// transaction. Authz: the editor is a member AND — when the original message
+/// envelope is still present — its sender (edits are sender-only).
+pub async fn apply_edit_message(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &EditMessageBody,
+) -> anyhow::Result<WriteOutcome> {
+    let sender = match resolve_actor(authed, body.sender_id.as_deref()) {
+        Ok(s) => s,
+        Err(o) => return Ok(o),
+    };
+    if authed.is_some() {
+        if !is_member(conn, &body.conversation_id, &sender).await? {
+            return Ok(WriteOutcome::Forbidden);
+        }
+        if let Some(orig) = original_sender(conn, &body.target_message_id).await? {
+            if orig != sender {
+                return Ok(WriteOutcome::Forbidden);
+            }
+        }
+    }
+    let tx = conn.transaction().await?;
+    tx.execute(
+        "DELETE FROM message_envelope \
+         WHERE conversation_id = ?1 AND target_message_id = ?2 AND type = 'edit'",
+        libsql::params![body.conversation_id.clone(), body.target_message_id.clone()],
+    )
+    .await?;
+    tx.execute(
+        "INSERT INTO message_envelope \
+             (id, conversation_id, sender_id, ciphertext, sent_at, type, target_message_id) \
+         VALUES (?1, ?2, ?3, ?4, ?5, 'edit', ?6)",
+        libsql::params![
+            body.envelope_id.clone(),
+            body.conversation_id.clone(),
+            sender,
+            body.ciphertext.clone(),
+            body.sent_at.clone(),
+            body.target_message_id.clone(),
+        ],
+    )
+    .await?;
+    tx.commit().await?;
+    Ok(WriteOutcome::Ok)
+}
+
+// ── POST /v1/messages/delete ─────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct DeleteMessageBody {
+    pub message_id: String,
+    pub conversation_id: String,
+    /// The original sender the client resolved (from the remote envelope or its
+    /// local cache). Only consulted to pick self-vs-admin WHEN the envelope has
+    /// already aged out; never trusted for the admin authz decision (the server
+    /// re-derives the role independently).
+    #[serde(default)]
+    pub msg_sender_id: Option<String>,
+    /// No-auth fallback for the acting user.
+    #[serde(default)]
+    pub actor_id: Option<String>,
+}
+
+pub async fn delete_message(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: DeleteMessageBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_delete_message(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// Delete a message. Self-delete (actor is the sender) removes the envelope +
+/// any pending edit. Admin-delete (actor is a group admin of the channel) also
+/// writes a `type='delete'` tombstone so every member soft-deletes on next
+/// ingest. The self-path SQL is scoped `sender_id = :actor` and the admin path
+/// is gated on a re-derived admin role, so trusting the client's branch hint is
+/// safe — a wrong hint deletes nothing or is refused.
+pub async fn apply_delete_message(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &DeleteMessageBody,
+) -> anyhow::Result<WriteOutcome> {
+    let actor = match resolve_actor(authed, body.actor_id.as_deref()) {
+        Ok(a) => a,
+        Err(o) => return Ok(o),
+    };
+
+    // Prefer the authoritative remote envelope; fall back to the client's hint
+    // only when it's been GC'd.
+    let effective_sender = original_sender(conn, &body.message_id)
+        .await?
+        .or_else(|| body.msg_sender_id.clone());
+    let is_self_delete = effective_sender.as_deref() == Some(actor.as_str());
+
+    if is_self_delete {
+        let tx = conn.transaction().await?;
+        tx.execute(
+            "DELETE FROM message_envelope WHERE id = ?1 AND sender_id = ?2",
+            libsql::params![body.message_id.clone(), actor.clone()],
+        )
+        .await?;
+        tx.execute(
+            "DELETE FROM message_envelope WHERE target_message_id = ?1 AND type = 'edit'",
+            libsql::params![body.message_id.clone()],
+        )
+        .await?;
+        tx.commit().await?;
+        return Ok(WriteOutcome::Ok);
+    }
+
+    // Admin-delete: the actor must be an admin of the group owning this channel.
+    // Skipped on the no-auth path (mirrors submit / writes.rs).
+    if authed.is_some() {
+        match channel_group_role(conn, &body.conversation_id, &actor).await? {
+            Some(role) if role == "admin" => {}
+            _ => return Ok(WriteOutcome::Forbidden),
+        }
+    }
+
+    let tombstone_id = Ulid::new().to_string();
+    let now = now_rfc3339();
+    let tx = conn.transaction().await?;
+    tx.execute(
+        "DELETE FROM message_envelope WHERE id = ?1",
+        libsql::params![body.message_id.clone()],
+    )
+    .await?;
+    tx.execute(
+        "DELETE FROM message_envelope WHERE target_message_id = ?1 AND type = 'edit'",
+        libsql::params![body.message_id.clone()],
+    )
+    .await?;
+    tx.execute(
+        "INSERT INTO message_envelope \
+             (id, conversation_id, sender_id, ciphertext, sent_at, type, target_message_id) \
+         VALUES (?1, ?2, ?3, '', ?4, 'delete', ?5)",
+        libsql::params![
+            tombstone_id,
+            body.conversation_id.clone(),
+            actor,
+            now,
+            body.message_id.clone(),
+        ],
+    )
+    .await?;
+    tx.commit().await?;
+    Ok(WriteOutcome::Ok)
+}
+
+// ── POST /v1/reactions/add  &  /v1/reactions/remove ──────────────────────────
+
+#[derive(Deserialize)]
+pub struct ReactionBody {
+    pub message_id: String,
+    pub emoji: String,
+    /// No-auth fallback for the reacting user.
+    #[serde(default)]
+    pub user_id: Option<String>,
+}
+
+pub async fn add_reaction(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: ReactionBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_add_reaction(&conn, authed.as_deref(), &parsed).await?)
+}
+
+pub async fn remove_reaction(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: ReactionBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_remove_reaction(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// A reaction is membership-gated through the reacted-to message's envelope.
+/// When the envelope has aged out we cannot resolve the conversation, so we
+/// allow the write (it is already scoped to the actor's own `user_id`) —
+/// reacting to a still-locally-visible but GC'd message must keep working.
+pub async fn apply_add_reaction(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &ReactionBody,
+) -> anyhow::Result<WriteOutcome> {
+    let user = match resolve_actor(authed, body.user_id.as_deref()) {
+        Ok(u) => u,
+        Err(o) => return Ok(o),
+    };
+    if authed.is_some() {
+        if let Some(conv) = conversation_for_message(conn, &body.message_id).await? {
+            if !is_member(conn, &conv, &user).await? {
+                return Ok(WriteOutcome::Forbidden);
+            }
+        }
+    }
+    let id = Ulid::new().to_string();
+    let now = now_rfc3339();
+    conn.execute(
+        "INSERT OR IGNORE INTO message_reaction (id, message_id, user_id, emoji, created_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        libsql::params![id, body.message_id.clone(), user, body.emoji.clone(), now],
+    )
+    .await?;
+    Ok(WriteOutcome::Ok)
+}
+
+pub async fn apply_remove_reaction(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &ReactionBody,
+) -> anyhow::Result<WriteOutcome> {
+    let user = match resolve_actor(authed, body.user_id.as_deref()) {
+        Ok(u) => u,
+        Err(o) => return Ok(o),
+    };
+    // A user may only ever remove their OWN reaction — the DELETE is scoped to
+    // `user_id = :user`, so even without a membership lookup it cannot touch
+    // anyone else's row. We still membership-gate when determinable.
+    if authed.is_some() {
+        if let Some(conv) = conversation_for_message(conn, &body.message_id).await? {
+            if !is_member(conn, &conv, &user).await? {
+                return Ok(WriteOutcome::Forbidden);
+            }
+        }
+    }
+    conn.execute(
+        "DELETE FROM message_reaction WHERE message_id = ?1 AND user_id = ?2 AND emoji = ?3",
+        libsql::params![body.message_id.clone(), user, body.emoji.clone()],
+    )
+    .await?;
+    Ok(WriteOutcome::Ok)
+}
+
+// ── POST /v1/watermarks/advance ──────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct WatermarkBody {
+    pub conversation_id: String,
+    /// No-auth fallback; when signed it must equal the authenticated user.
+    #[serde(default)]
+    pub user_id: Option<String>,
+    pub device_id: String,
+    pub last_fetched_at: String,
+}
+
+pub async fn advance_watermark(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: WatermarkBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_advance_watermark(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// Monotone UPSERT of a `(conversation, user, device)` watermark. Authz: the row
+/// belongs to the actor (`user_id` bound to the authenticated user).
+pub async fn apply_advance_watermark(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &WatermarkBody,
+) -> anyhow::Result<WriteOutcome> {
+    let user = match resolve_actor(authed, body.user_id.as_deref()) {
+        Ok(u) => u,
+        Err(o) => return Ok(o),
+    };
+    conn.execute(
+        "INSERT INTO conversation_watermark \
+             (conversation_id, user_id, device_id, last_fetched_at) \
+         VALUES (?1, ?2, ?3, ?4) \
+         ON CONFLICT(conversation_id, user_id, device_id) DO UPDATE SET \
+             last_fetched_at = MAX(last_fetched_at, excluded.last_fetched_at)",
+        libsql::params![
+            body.conversation_id.clone(),
+            user,
+            body.device_id.clone(),
+            body.last_fetched_at.clone(),
+        ],
+    )
+    .await?;
+    Ok(WriteOutcome::Ok)
+}
+
+// ── POST /v1/envelopes/gc ────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct EnvelopeGcBody {
+    pub conversation_id: String,
+    /// `true` → DM cleanup query; `false` → group-channel cleanup query.
+    pub is_dm: bool,
+    /// No-auth fallback for the acting user.
+    #[serde(default)]
+    pub actor_id: Option<String>,
+}
+
+pub async fn envelope_gc(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: EnvelopeGcBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_envelope_gc(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// Run the TTL-or-watermark envelope GC for a conversation. Authz: the actor is
+/// a current member.
+///
+/// TODO(#419): GC should be gated on the MIN watermark across ALL members rather
+/// than triggered by whichever member happens to ingest. The SQL already
+/// AND-gates deletion on `COUNT(devices) == COUNT(watermarks)` plus `MIN(cw)` and
+/// the 30-day TTL, so moving the *trigger* server-side here is behavior-
+/// preserving — but it does NOT by itself make the trigger many-member correct.
+/// That redesign is deliberately out of scope for this slice; do not change the
+/// deletion predicate here.
+pub async fn apply_envelope_gc(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &EnvelopeGcBody,
+) -> anyhow::Result<WriteOutcome> {
+    let actor = match resolve_actor(authed, body.actor_id.as_deref()) {
+        Ok(a) => a,
+        Err(o) => return Ok(o),
+    };
+    if authed.is_some() && !is_member(conn, &body.conversation_id, &actor).await? {
+        return Ok(WriteOutcome::Forbidden);
+    }
+    let sql = if body.is_dm {
+        CLEANUP_DM_ENVELOPES
+    } else {
+        CLEANUP_CHANNEL_ENVELOPES
+    };
+    conn.execute(sql, libsql::params![body.conversation_id.clone()])
+        .await?;
+    Ok(WriteOutcome::Ok)
+}
+
+// ── POST /v1/attachments/register  &  /v1/attachments/delete ─────────────────
+
+#[derive(Deserialize)]
+pub struct AttachmentRegisterBody {
+    pub content_hash: String,
+    pub r2_key: String,
+}
+
+#[derive(Deserialize)]
+pub struct AttachmentDeleteBody {
+    pub content_hash: String,
+}
+
+pub async fn register_attachment(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: AttachmentRegisterBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_register_attachment(&conn, authed.as_deref(), &parsed).await?)
+}
+
+pub async fn delete_attachment(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: AttachmentDeleteBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_delete_attachment(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// Register a convergent-encryption dedup row (`content_hash → r2_key`). Authz:
+/// any authenticated user. There is no conversation context at upload time —
+/// the row is content-addressed and identical for every uploader — so there is
+/// nothing finer to gate on. The signature still proves a real device, which is
+/// all the no-token model can assert here.
+pub async fn apply_register_attachment(
+    conn: &Connection,
+    _authed: Option<&str>,
+    body: &AttachmentRegisterBody,
+) -> anyhow::Result<WriteOutcome> {
+    conn.execute(
+        "INSERT OR IGNORE INTO attachment_object (content_hash, r2_key) VALUES (?1, ?2)",
+        libsql::params![body.content_hash.clone(), body.r2_key.clone()],
+    )
+    .await?;
+    Ok(WriteOutcome::Ok)
+}
+
+/// Delete a dedup row during message-delete attachment cleanup. Authz: any
+/// authenticated user.
+///
+/// TODO(#419): this should be server-side reference-counted — a shared
+/// convergent row must only be removed once NO member's message references the
+/// hash. Current client semantics are best-effort local ref-counting + an
+/// unconditional remote delete (convergent re-upload re-creates the row), and
+/// this preserves them; promote to a counted delete in a later domain pass.
+pub async fn apply_delete_attachment(
+    conn: &Connection,
+    _authed: Option<&str>,
+    body: &AttachmentDeleteBody,
+) -> anyhow::Result<WriteOutcome> {
+    conn.execute(
+        "DELETE FROM attachment_object WHERE content_hash = ?1",
+        libsql::params![body.content_hash.clone()],
+    )
+    .await?;
+    Ok(WriteOutcome::Ok)
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+/// Map a [`WriteOutcome`] to the standard response: 200 on success, 403 on a
+/// refused authz check.
+fn outcome_response(outcome: WriteOutcome) -> Result<Response, AppError> {
+    Ok(match outcome {
+        WriteOutcome::Ok => ok_json(serde_json::json!({ "status": "ok" })),
+        WriteOutcome::Forbidden => AuthRejection::Forbidden.into_response(),
+    })
+}

--- a/pollis-delivery/src/profile.rs
+++ b/pollis-delivery/src/profile.rs
@@ -1,0 +1,464 @@
+//! Domain C (#419) — profile / preferences / blocks / DMs. Every CLIENT remote
+//! write in this domain routes through the DS, copying the domain-A shape in
+//! [`crate::messages`] verbatim:
+//!
+//!   - **Bodies** — one `#[derive(Deserialize)] *Body` per endpoint, plain JSON
+//!     (no binary fields in this domain).
+//!   - **Pure conn-level fns** — `apply_*` take a bare [`Connection`] (the MAIN
+//!     DB), the authenticated user (`Option<&str>`; `None` only on the no-auth
+//!     path), and a parsed `*Body`. They embed BOTH the authorization decision
+//!     AND the write, returning [`WriteOutcome`], so the in-process harness and
+//!     the production axum handler exercise the *exact* same authz.
+//!   - **axum handlers** — `(State, Method, Uri, HeaderMap, Bytes) -> Response`,
+//!     all identical: `gate` → parse → `apply_*` → map outcome.
+//!
+//! ## Where the writes land
+//!
+//! Every domain-C table — `users`, `user_preferences`, `user_block`,
+//! `dm_channel`, `dm_channel_member`, `conversation_watermark` — lives in the
+//! **MAIN DB** (`state.db`), NOT the commit-log DB. So all `apply_*` fns run on
+//! the main connection.
+//!
+//! ## Authorization (the security core)
+//!
+//! `gate` proves *which user* signed the request; each `apply_*` then proves the
+//! user may make that specific write:
+//!   - profile update / preferences: the actor may only edit their OWN row
+//!     (`user_id` bound to the authenticated user).
+//!   - block / unblock: the blocker may only manage their OWN block list
+//!     (`blocker_id` bound to the authenticated user).
+//!   - DM create: the creator is the authenticated user, and no proposed pairing
+//!     may be blocked in either direction (re-checked server-side).
+//!   - DM accept: the authenticated user is the recipient flipping their OWN
+//!     membership row to accepted.
+//!
+//! On the no-auth path (`authed == None`, only reachable when the DS runs with
+//! `POLLIS_DS_REQUIRE_AUTH` off) the identity checks fall back to the body actor
+//! and membership/block checks are skipped — mirroring `messages` / `writes`.
+
+use axum::{
+    body::Bytes,
+    extract::State,
+    http::{HeaderMap, Method, Uri},
+    response::Response,
+};
+use libsql::Connection;
+use serde::Deserialize;
+
+use crate::error::AppError;
+use crate::writes::{bad_request, gate, outcome_response, resolve_actor, WriteOutcome};
+use crate::AppState;
+
+// ── Shared block helper ──────────────────────────────────────────────────────
+
+/// True when `user_a` has blocked `user_b` OR vice versa. Mirrors pollis-core's
+/// `blocks::is_blocked_either_way` (a symmetric `user_block` lookup) so the
+/// server re-derives the block relationship rather than trusting the client.
+async fn is_blocked_either_way(
+    conn: &Connection,
+    user_a: &str,
+    user_b: &str,
+) -> anyhow::Result<bool> {
+    let mut rows = conn
+        .query(
+            "SELECT 1 FROM user_block \
+             WHERE (blocker_id = ?1 AND blocked_id = ?2) \
+                OR (blocker_id = ?2 AND blocked_id = ?1) \
+             LIMIT 1",
+            libsql::params![user_a.to_string(), user_b.to_string()],
+        )
+        .await?;
+    Ok(rows.next().await?.is_some())
+}
+
+// ── POST /v1/profile/update ──────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct UpdateProfileBody {
+    /// The profile being edited; when signed it must equal the authenticated
+    /// user (you can only edit your OWN profile).
+    pub user_id: String,
+    #[serde(default)]
+    pub username: Option<String>,
+    #[serde(default)]
+    pub preferred_name: Option<String>,
+    #[serde(default)]
+    pub phone: Option<String>,
+    #[serde(default)]
+    pub avatar_url: Option<String>,
+}
+
+pub async fn update_profile(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: UpdateProfileBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_update_profile(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// COALESCE-UPDATE the user's own profile row. Authz: the actor may only edit
+/// their own `users` row (`user_id` bound to the authenticated user).
+pub async fn apply_update_profile(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &UpdateProfileBody,
+) -> anyhow::Result<WriteOutcome> {
+    let user = match resolve_actor(authed, Some(body.user_id.as_str())) {
+        Ok(u) => u,
+        Err(o) => return Ok(o),
+    };
+    conn.execute(
+        "UPDATE users SET \
+            username = COALESCE(?2, username), \
+            preferred_name = COALESCE(?3, preferred_name), \
+            phone = COALESCE(?4, phone), \
+            avatar_url = COALESCE(?5, avatar_url) \
+         WHERE id = ?1",
+        libsql::params![
+            user,
+            body.username.clone(),
+            body.preferred_name.clone(),
+            body.phone.clone(),
+            body.avatar_url.clone(),
+        ],
+    )
+    .await?;
+    Ok(WriteOutcome::Ok)
+}
+
+// ── POST /v1/profile/preferences ─────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct SavePreferencesBody {
+    /// The owner of the preferences; when signed it must equal the authenticated
+    /// user (you can only edit your OWN preferences).
+    pub user_id: String,
+    pub preferences: String,
+}
+
+pub async fn save_preferences(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: SavePreferencesBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_save_preferences(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// UPSERT the user's `user_preferences` row. Authz: the actor may only write
+/// their own preferences (`user_id` bound to the authenticated user).
+pub async fn apply_save_preferences(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &SavePreferencesBody,
+) -> anyhow::Result<WriteOutcome> {
+    let user = match resolve_actor(authed, Some(body.user_id.as_str())) {
+        Ok(u) => u,
+        Err(o) => return Ok(o),
+    };
+    conn.execute(
+        "INSERT INTO user_preferences (user_id, preferences, updated_at) \
+             VALUES (?1, ?2, datetime('now')) \
+         ON CONFLICT(user_id) DO UPDATE SET \
+             preferences = ?2, updated_at = datetime('now')",
+        libsql::params![user, body.preferences.clone()],
+    )
+    .await?;
+    Ok(WriteOutcome::Ok)
+}
+
+// ── POST /v1/blocks/add ──────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct BlockBody {
+    /// The user doing the blocking; when signed it must equal the authenticated
+    /// user (you manage only your OWN block list).
+    pub blocker_id: String,
+    pub blocked_id: String,
+}
+
+pub async fn block_user(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: BlockBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_block_user(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// Insert a block row and reset the blocker's `accepted_at` for every DM shared
+/// with the blocked user (so an unblock later resurfaces the channel as a
+/// request), in one transaction. Authz: the blocker is the authenticated user.
+pub async fn apply_block_user(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &BlockBody,
+) -> anyhow::Result<WriteOutcome> {
+    let blocker = match resolve_actor(authed, Some(body.blocker_id.as_str())) {
+        Ok(b) => b,
+        Err(o) => return Ok(o),
+    };
+    // You cannot block yourself — an invalid state; refuse it.
+    if blocker == body.blocked_id {
+        return Ok(WriteOutcome::Forbidden);
+    }
+    let tx = conn.transaction().await?;
+    tx.execute(
+        "INSERT OR IGNORE INTO user_block (blocker_id, blocked_id) VALUES (?1, ?2)",
+        libsql::params![blocker.clone(), body.blocked_id.clone()],
+    )
+    .await?;
+    tx.execute(
+        "UPDATE dm_channel_member \
+            SET accepted_at = NULL \
+          WHERE user_id = ?1 \
+            AND dm_channel_id IN ( \
+                SELECT dm_channel_id FROM dm_channel_member WHERE user_id = ?2 \
+            )",
+        libsql::params![blocker, body.blocked_id.clone()],
+    )
+    .await?;
+    tx.commit().await?;
+    Ok(WriteOutcome::Ok)
+}
+
+// ── POST /v1/blocks/remove ───────────────────────────────────────────────────
+
+pub async fn unblock_user(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: BlockBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_unblock_user(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// Delete a block row. Authz: the blocker is the authenticated user — the DELETE
+/// is scoped `blocker_id = :blocker`, so it can never touch another user's list.
+pub async fn apply_unblock_user(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &BlockBody,
+) -> anyhow::Result<WriteOutcome> {
+    let blocker = match resolve_actor(authed, Some(body.blocker_id.as_str())) {
+        Ok(b) => b,
+        Err(o) => return Ok(o),
+    };
+    conn.execute(
+        "DELETE FROM user_block WHERE blocker_id = ?1 AND blocked_id = ?2",
+        libsql::params![blocker, body.blocked_id.clone()],
+    )
+    .await?;
+    Ok(WriteOutcome::Ok)
+}
+
+// ── POST /v1/dm/create ───────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct CreateDmBody {
+    /// The new channel id (a ULID the client generated).
+    pub id: String,
+    /// The creator; when signed it must equal the authenticated user.
+    pub creator_id: String,
+    /// Every participant (may or may not include the creator — the creator is
+    /// always inserted as auto-accepted regardless).
+    pub member_ids: Vec<String>,
+    pub created_at: String,
+}
+
+pub async fn create_dm(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: CreateDmBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_create_dm(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// Create a DM channel: insert `dm_channel`, the creator's auto-accepted
+/// membership, each other member as a pending request, and seed every member's
+/// per-device watermark — all in one transaction. Authz: the creator is the
+/// authenticated user, and no proposed pairing may be blocked in either
+/// direction (re-checked server-side; a blocked write is `Forbidden`).
+pub async fn apply_create_dm(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &CreateDmBody,
+) -> anyhow::Result<WriteOutcome> {
+    let creator = match resolve_actor(authed, Some(body.creator_id.as_str())) {
+        Ok(c) => c,
+        Err(o) => return Ok(o),
+    };
+
+    // The other participants (everyone but the creator, de-duplicated).
+    let mut others: Vec<String> = Vec::new();
+    for m in &body.member_ids {
+        if *m != creator && !others.contains(m) {
+            others.push(m.clone());
+        }
+    }
+
+    // Re-check blocks server-side: refuse if ANY pairing is blocked either way.
+    // Skipped on the no-auth path (mirrors the membership skips in `messages`).
+    if authed.is_some() {
+        for other in &others {
+            if is_blocked_either_way(conn, &creator, other).await? {
+                return Ok(WriteOutcome::Forbidden);
+            }
+        }
+    }
+
+    let tx = conn.transaction().await?;
+    tx.execute(
+        "INSERT INTO dm_channel (id, created_by, created_at) VALUES (?1, ?2, ?3)",
+        libsql::params![body.id.clone(), creator.clone(), body.created_at.clone()],
+    )
+    .await?;
+    // Creator is auto-accepted (they initiated the conversation).
+    tx.execute(
+        "INSERT INTO dm_channel_member (dm_channel_id, user_id, added_by, added_at, accepted_at) \
+         VALUES (?1, ?2, ?3, ?4, ?4)",
+        libsql::params![
+            body.id.clone(),
+            creator.clone(),
+            creator.clone(),
+            body.created_at.clone()
+        ],
+    )
+    .await?;
+    // Every other member starts un-accepted — a pending request.
+    for other in &others {
+        tx.execute(
+            "INSERT OR IGNORE INTO dm_channel_member \
+                 (dm_channel_id, user_id, added_by, added_at, accepted_at) \
+             VALUES (?1, ?2, ?3, ?4, NULL)",
+            libsql::params![
+                body.id.clone(),
+                other.clone(),
+                creator.clone(),
+                body.created_at.clone()
+            ],
+        )
+        .await?;
+    }
+    // Seed a watermark for every (member, device) pair so envelope cleanup isn't
+    // blocked by devices that didn't exist at channel creation.
+    for member in std::iter::once(&creator).chain(others.iter()) {
+        tx.execute(
+            "INSERT OR IGNORE INTO conversation_watermark \
+                 (conversation_id, user_id, device_id, last_fetched_at) \
+             SELECT ?1, ?2, ud.device_id, datetime('now') \
+             FROM user_device ud WHERE ud.user_id = ?2",
+            libsql::params![body.id.clone(), member.clone()],
+        )
+        .await?;
+    }
+    tx.commit().await?;
+    Ok(WriteOutcome::Ok)
+}
+
+// ── POST /v1/dm/accept ───────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct AcceptDmBody {
+    pub dm_channel_id: String,
+    /// The accepting member; when signed it must equal the authenticated user
+    /// (you accept your OWN pending request, never someone else's).
+    pub user_id: String,
+    pub accepted_at: String,
+}
+
+pub async fn accept_dm(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: AcceptDmBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_accept_dm(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// Flip the actor's own `dm_channel_member.accepted_at` from NULL → now. Authz:
+/// the accepter is the authenticated user — the UPDATE is scoped `user_id =
+/// :user` so it can only ever accept the actor's OWN request, and the
+/// `accepted_at IS NULL` guard keeps it idempotent.
+pub async fn apply_accept_dm(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &AcceptDmBody,
+) -> anyhow::Result<WriteOutcome> {
+    let user = match resolve_actor(authed, Some(body.user_id.as_str())) {
+        Ok(u) => u,
+        Err(o) => return Ok(o),
+    };
+    conn.execute(
+        "UPDATE dm_channel_member \
+            SET accepted_at = ?3 \
+          WHERE dm_channel_id = ?1 \
+            AND user_id = ?2 \
+            AND accepted_at IS NULL",
+        libsql::params![body.dm_channel_id.clone(), user, body.accepted_at.clone()],
+    )
+    .await?;
+    Ok(WriteOutcome::Ok)
+}

--- a/pollis-delivery/src/profile.rs
+++ b/pollis-delivery/src/profile.rs
@@ -462,3 +462,252 @@ pub async fn apply_accept_dm(
     .await?;
     Ok(WriteOutcome::Ok)
 }
+
+// ── Shared DM membership helper ──────────────────────────────────────────────
+
+/// True when `user_id` is a current member of DM channel `dm_channel_id`. A
+/// dedicated `dm_channel_member` lookup (NOT the broader `writes::is_member`,
+/// which also matches groups/channels) — DM churn only ever concerns the DM
+/// membership table.
+async fn is_dm_member(
+    conn: &Connection,
+    dm_channel_id: &str,
+    user_id: &str,
+) -> anyhow::Result<bool> {
+    let mut rows = conn
+        .query(
+            "SELECT 1 FROM dm_channel_member \
+             WHERE dm_channel_id = ?1 AND user_id = ?2 LIMIT 1",
+            libsql::params![dm_channel_id.to_string(), user_id.to_string()],
+        )
+        .await?;
+    Ok(rows.next().await?.is_some())
+}
+
+// ── POST /v1/dm/add ──────────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct AddDmMemberBody {
+    pub dm_channel_id: String,
+    /// The user being added.
+    pub user_id: String,
+    /// The actor performing the add; when signed it must equal the authenticated
+    /// user, and that user must already be a member of the DM.
+    pub added_by: String,
+    pub added_at: String,
+}
+
+pub async fn add_dm_member(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: AddDmMemberBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_add_dm_member(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// Insert a `dm_channel_member` row for `user_id` and seed that member's
+/// per-device watermarks, in one transaction. Authz: the actor (`added_by`) is
+/// the authenticated user AND a current member of the DM — a non-member cannot
+/// pull someone into a conversation it isn't part of. Membership is re-derived
+/// server-side; skipped only on the no-auth path (mirrors `apply_create_dm`'s
+/// block re-check).
+pub async fn apply_add_dm_member(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &AddDmMemberBody,
+) -> anyhow::Result<WriteOutcome> {
+    let actor = match resolve_actor(authed, Some(body.added_by.as_str())) {
+        Ok(a) => a,
+        Err(o) => return Ok(o),
+    };
+    // The actor must already belong to the DM to add anyone to it.
+    if authed.is_some() && !is_dm_member(conn, &body.dm_channel_id, &actor).await? {
+        return Ok(WriteOutcome::Forbidden);
+    }
+    let tx = conn.transaction().await?;
+    tx.execute(
+        "INSERT OR IGNORE INTO dm_channel_member (dm_channel_id, user_id, added_by, added_at) \
+         VALUES (?1, ?2, ?3, ?4)",
+        libsql::params![
+            body.dm_channel_id.clone(),
+            body.user_id.clone(),
+            actor.clone(),
+            body.added_at.clone()
+        ],
+    )
+    .await?;
+    // Seed a watermark for every device of the new member so pre-join messages
+    // don't block envelope cleanup indefinitely.
+    tx.execute(
+        "INSERT OR IGNORE INTO conversation_watermark \
+             (conversation_id, user_id, device_id, last_fetched_at) \
+         SELECT ?1, ?2, ud.device_id, datetime('now') \
+         FROM user_device ud WHERE ud.user_id = ?2",
+        libsql::params![body.dm_channel_id.clone(), body.user_id.clone()],
+    )
+    .await?;
+    tx.commit().await?;
+    Ok(WriteOutcome::Ok)
+}
+
+// ── POST /v1/dm/remove ───────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct RemoveDmMemberBody {
+    pub dm_channel_id: String,
+    /// The user being removed.
+    pub user_id: String,
+    /// The actor performing the removal; when signed it must equal the
+    /// authenticated user. Authz: the actor may remove only themselves OR (as the
+    /// channel creator) another member.
+    pub requester_id: String,
+}
+
+pub async fn remove_dm_member(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: RemoveDmMemberBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_remove_dm_member(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// Delete a `dm_channel_member` row. Authz (replicates the client's current
+/// rule, server-side): the actor (`requester_id`, bound to the authenticated
+/// user) may remove only themselves, or — as the channel's creator — any member.
+/// The creator check is re-derived from `dm_channel.created_by`; skipped only on
+/// the no-auth path.
+pub async fn apply_remove_dm_member(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &RemoveDmMemberBody,
+) -> anyhow::Result<WriteOutcome> {
+    let actor = match resolve_actor(authed, Some(body.requester_id.as_str())) {
+        Ok(a) => a,
+        Err(o) => return Ok(o),
+    };
+    if authed.is_some() && actor != body.user_id {
+        // Not a self-removal — the actor must be the channel creator.
+        let mut rows = conn
+            .query(
+                "SELECT created_by FROM dm_channel WHERE id = ?1",
+                libsql::params![body.dm_channel_id.clone()],
+            )
+            .await?;
+        match rows.next().await? {
+            Some(row) => {
+                let creator: String = row.get(0)?;
+                if actor != creator {
+                    return Ok(WriteOutcome::Forbidden);
+                }
+            }
+            // Channel doesn't exist — nothing to remove; refuse rather than
+            // silently no-op a write the actor isn't entitled to.
+            None => return Ok(WriteOutcome::Forbidden),
+        }
+    }
+    conn.execute(
+        "DELETE FROM dm_channel_member WHERE dm_channel_id = ?1 AND user_id = ?2",
+        libsql::params![body.dm_channel_id.clone(), body.user_id.clone()],
+    )
+    .await?;
+    Ok(WriteOutcome::Ok)
+}
+
+// ── POST /v1/dm/leave ────────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct LeaveDmBody {
+    pub dm_channel_id: String,
+    /// The leaving member; when signed it must equal the authenticated user
+    /// (you may only remove your OWN membership).
+    pub user_id: String,
+}
+
+pub async fn leave_dm(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+        Ok(a) => a,
+        Err(resp) => return Ok(resp),
+    };
+    let parsed: LeaveDmBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return Ok(bad_request("invalid body")),
+    };
+    let conn = state.db.conn()?;
+    outcome_response(apply_leave_dm(&conn, authed.as_deref(), &parsed).await?)
+}
+
+/// Remove the actor's own `dm_channel_member` row and, when the channel is left
+/// empty, tear it down (its envelopes + the `dm_channel` row) — all in one
+/// transaction so a DM never lingers half-deleted. Authz: self only — the actor
+/// (`user_id`, bound to the authenticated user) may leave only their own
+/// membership; `resolve_actor` already refuses any other `user_id`.
+pub async fn apply_leave_dm(
+    conn: &Connection,
+    authed: Option<&str>,
+    body: &LeaveDmBody,
+) -> anyhow::Result<WriteOutcome> {
+    let user = match resolve_actor(authed, Some(body.user_id.as_str())) {
+        Ok(u) => u,
+        Err(o) => return Ok(o),
+    };
+    let tx = conn.transaction().await?;
+    tx.execute(
+        "DELETE FROM dm_channel_member WHERE dm_channel_id = ?1 AND user_id = ?2",
+        libsql::params![body.dm_channel_id.clone(), user],
+    )
+    .await?;
+    // If no members remain, clean up the channel and all associated data.
+    let mut rows = tx
+        .query(
+            "SELECT COUNT(*) FROM dm_channel_member WHERE dm_channel_id = ?1",
+            libsql::params![body.dm_channel_id.clone()],
+        )
+        .await?;
+    let remaining: i64 = match rows.next().await? {
+        Some(row) => row.get(0)?,
+        None => 0,
+    };
+    drop(rows);
+    if remaining == 0 {
+        tx.execute(
+            "DELETE FROM message_envelope WHERE conversation_id = ?1",
+            libsql::params![body.dm_channel_id.clone()],
+        )
+        .await?;
+        tx.execute(
+            "DELETE FROM dm_channel WHERE id = ?1",
+            libsql::params![body.dm_channel_id.clone()],
+        )
+        .await?;
+    }
+    tx.commit().await?;
+    Ok(WriteOutcome::Ok)
+}

--- a/pollis-delivery/src/writes.rs
+++ b/pollis-delivery/src/writes.rs
@@ -33,7 +33,10 @@ use crate::AppState;
 
 /// The outcome of the shared auth gate: either an authenticated user (auth
 /// enforced + verified), or `None` (auth disabled — the no-auth path).
-type Authed = Option<String>;
+///
+/// `pub(crate)` so sibling write-domain modules (e.g. [`crate::messages`]) reuse
+/// the exact same gate type instead of re-declaring the no-auth contract.
+pub(crate) type Authed = Option<String>;
 
 /// Run the same auth gate as `submit`: when `require_auth` is on, verify the
 /// device signature over the raw body and return the authenticated `user_id`;
@@ -41,7 +44,11 @@ type Authed = Option<String>;
 ///
 /// Returns `Ok(Err(response))` when auth is enforced but the request is
 /// rejected — the caller forwards that response unchanged.
-async fn gate(
+///
+/// `pub(crate)` so every write-domain module (commits, welcomes, messages, …)
+/// shares ONE auth gate. Adding a new domain must not re-implement
+/// `auth::verify_request` plumbing — it calls this.
+pub(crate) async fn gate(
     state: &AppState,
     headers: &HeaderMap,
     method: &Method,
@@ -91,7 +98,7 @@ fn resolve_recipient(authed: Authed, body_user_id: Option<String>) -> Result<Str
     }
 }
 
-fn bad_request(msg: &str) -> Response {
+pub(crate) fn bad_request(msg: &str) -> Response {
     (
         StatusCode::BAD_REQUEST,
         Json(serde_json::json!({ "error": msg })),
@@ -99,7 +106,7 @@ fn bad_request(msg: &str) -> Response {
         .into_response()
 }
 
-fn ok_json(value: serde_json::Value) -> Response {
+pub(crate) fn ok_json(value: serde_json::Value) -> Response {
     (StatusCode::OK, Json(value)).into_response()
 }
 

--- a/pollis-delivery/src/writes.rs
+++ b/pollis-delivery/src/writes.rs
@@ -110,6 +110,55 @@ pub(crate) fn ok_json(value: serde_json::Value) -> Response {
     (StatusCode::OK, Json(value)).into_response()
 }
 
+// ── Shared write-result helpers (every domain reuses these) ──────────────────
+
+/// The result of an authorized write: either it was applied, or the
+/// authenticated user was not allowed to make it (→ 403). A genuine failure (DB
+/// error, etc.) is an `Err` on the enclosing `anyhow::Result`, mapped to 500 by
+/// the handler. Shared across every write-domain module so the handler ⇆ harness
+/// pair stays uniform.
+///
+/// `pub` (not `pub(crate)`) so the integration-test harness — an external crate —
+/// can match on it when driving the `apply_*` fns directly.
+pub enum WriteOutcome {
+    Ok,
+    Forbidden,
+}
+
+/// Map a [`WriteOutcome`] to the HTTP response (200 ok / 403 forbidden).
+pub(crate) fn outcome_response(outcome: WriteOutcome) -> Result<Response, AppError> {
+    Ok(match outcome {
+        WriteOutcome::Ok => ok_json(serde_json::json!({ "status": "ok" })),
+        WriteOutcome::Forbidden => AuthRejection::Forbidden.into_response(),
+    })
+}
+
+/// Resolve the actor a write is performed as.
+///
+///   - auth ON  → the authenticated user. If the body also carries an actor id,
+///                it must equal the authenticated user (else `Forbidden`).
+///   - auth OFF → the body's actor id (no signed identity on the no-auth path).
+///                Missing/empty → `Forbidden`.
+///
+/// Returns the actor or [`WriteOutcome::Forbidden`] so `apply_*` fns can `?`-bail
+/// uniformly. (Distinct from [`resolve_recipient`], which returns an HTTP
+/// response for the welcome endpoints' 400-on-missing contract.)
+pub(crate) fn resolve_actor(
+    authed: Option<&str>,
+    body_actor: Option<&str>,
+) -> Result<String, WriteOutcome> {
+    match authed {
+        Some(u) => match body_actor {
+            Some(b) if b != u => Err(WriteOutcome::Forbidden),
+            _ => Ok(u.to_string()),
+        },
+        None => match body_actor {
+            Some(b) if !b.is_empty() => Ok(b.to_string()),
+            _ => Err(WriteOutcome::Forbidden),
+        },
+    }
+}
+
 /// Membership check against the main DB: is `user_id` a current member of the
 /// MLS conversation `conversation_id`?
 ///

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -88,6 +88,9 @@ rusqlite = { version = "0.31", features = ["bundled-sqlcipher"] }
 # clients use, so flows exercise the deployed DS submission path end to end.
 pollis-delivery = { path = "../pollis-delivery" }
 axum = "0.7"
+# Used by the flows harness to base64-encode device signatures / cert blobs
+# when crafting signed DS requests (signed_post_status + domain-D seams).
+base64 = "0.22"
 
 [target.'cfg(unix)'.dependencies]
 # setrlimit(RLIMIT_NOFILE, ...) at startup so we don't hit the macOS default

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -88,6 +88,9 @@ rusqlite = { version = "0.31", features = ["bundled-sqlcipher"] }
 # clients use, so flows exercise the deployed DS submission path end to end.
 pollis-delivery = { path = "../pollis-delivery" }
 axum = "0.7"
+# Used by the flows harness's `signed_post_status` to base64-encode the Ed25519
+# request signature when driving the DS over raw HTTP (server-side authz tests).
+base64 = "0.22"
 
 [target.'cfg(unix)'.dependencies]
 # setrlimit(RLIMIT_NOFILE, ...) at startup so we don't hit the macOS default

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -88,6 +88,9 @@ rusqlite = { version = "0.31", features = ["bundled-sqlcipher"] }
 # clients use, so flows exercise the deployed DS submission path end to end.
 pollis-delivery = { path = "../pollis-delivery" }
 axum = "0.7"
+# Used by the flows harness' `signed_post_status` to base64-encode the device
+# signature exactly as `ds_client::ds_post` does.
+base64 = "0.22"
 
 [target.'cfg(unix)'.dependencies]
 # setrlimit(RLIMIT_NOFILE, ...) at startup so we don't hit the macOS default

--- a/src-tauri/tests/flows/harness.rs
+++ b/src-tauri/tests/flows/harness.rs
@@ -942,6 +942,84 @@ async fn delivery_dm_accept(
     }
 }
 
+/// `POST /v1/dm/add`.
+async fn delivery_dm_add(
+    axum::extract::State(state): axum::extract::State<DsState>,
+    method: axum::http::Method,
+    uri: axum::http::Uri,
+    headers: axum::http::HeaderMap,
+    body: axum::body::Bytes,
+) -> axum::response::Response {
+    let authed = match ds_auth(&state.main, &method, &uri, &headers, &body).await {
+        Ok(u) => u,
+        Err(resp) => return resp,
+    };
+    let parsed: pollis_delivery::profile::AddDmMemberBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return ds_bad_request(),
+    };
+    let conn = match state.main.conn().await {
+        Ok(c) => c,
+        Err(e) => return ds_internal_error(format!("conn: {e}")),
+    };
+    match pollis_delivery::profile::apply_add_dm_member(&conn, Some(&authed), &parsed).await {
+        Ok(o) => ds_outcome(o),
+        Err(e) => ds_internal_error(format!("dm/add: {e}")),
+    }
+}
+
+/// `POST /v1/dm/remove`.
+async fn delivery_dm_remove(
+    axum::extract::State(state): axum::extract::State<DsState>,
+    method: axum::http::Method,
+    uri: axum::http::Uri,
+    headers: axum::http::HeaderMap,
+    body: axum::body::Bytes,
+) -> axum::response::Response {
+    let authed = match ds_auth(&state.main, &method, &uri, &headers, &body).await {
+        Ok(u) => u,
+        Err(resp) => return resp,
+    };
+    let parsed: pollis_delivery::profile::RemoveDmMemberBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return ds_bad_request(),
+    };
+    let conn = match state.main.conn().await {
+        Ok(c) => c,
+        Err(e) => return ds_internal_error(format!("conn: {e}")),
+    };
+    match pollis_delivery::profile::apply_remove_dm_member(&conn, Some(&authed), &parsed).await {
+        Ok(o) => ds_outcome(o),
+        Err(e) => ds_internal_error(format!("dm/remove: {e}")),
+    }
+}
+
+/// `POST /v1/dm/leave`.
+async fn delivery_dm_leave(
+    axum::extract::State(state): axum::extract::State<DsState>,
+    method: axum::http::Method,
+    uri: axum::http::Uri,
+    headers: axum::http::HeaderMap,
+    body: axum::body::Bytes,
+) -> axum::response::Response {
+    let authed = match ds_auth(&state.main, &method, &uri, &headers, &body).await {
+        Ok(u) => u,
+        Err(resp) => return resp,
+    };
+    let parsed: pollis_delivery::profile::LeaveDmBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return ds_bad_request(),
+    };
+    let conn = match state.main.conn().await {
+        Ok(c) => c,
+        Err(e) => return ds_internal_error(format!("conn: {e}")),
+    };
+    match pollis_delivery::profile::apply_leave_dm(&conn, Some(&authed), &parsed).await {
+        Ok(o) => ds_outcome(o),
+        Err(e) => ds_internal_error(format!("dm/leave: {e}")),
+    }
+}
+
 /// Boot an axum router exposing the DS's full write surface (`/v1/commits` plus
 /// the W4–W8 endpoints) backed by the shared `RemoteDb`, bind it on a loopback
 /// port, and serve it on a DEDICATED OS thread with its own runtime so the
@@ -1195,6 +1273,9 @@ async fn spawn_in_process_delivery(main: Arc<RemoteDb>, log: Arc<RemoteDb>) -> S
                     )
                     .route("/v1/dm/create", axum::routing::post(delivery_dm_create))
                     .route("/v1/dm/accept", axum::routing::post(delivery_dm_accept))
+                    .route("/v1/dm/add", axum::routing::post(delivery_dm_add))
+                    .route("/v1/dm/remove", axum::routing::post(delivery_dm_remove))
+                    .route("/v1/dm/leave", axum::routing::post(delivery_dm_leave))
                     // Domain D (#419) — all on the MAIN DB.
                     .route("/v1/key-packages", axum::routing::post(delivery_key_packages))
                     .route(

--- a/src-tauri/tests/flows/harness.rs
+++ b/src-tauri/tests/flows/harness.rs
@@ -1070,6 +1070,222 @@ async fn delivery_push_tokens(
     }
 }
 
+// ─── Domains E + G (#419) — account lifecycle / identity rotation / recovery /
+// device-enrollment / security audit ─────────────────────────────────────────
+//
+// Every endpoint runs the SAME pure `apply_*` fn the production axum handler
+// runs, against the MAIN DB (none of these tables is on the log DB). Auth is
+// always enforced here, so the flows suite exercises the signed write +
+// server-side self-scoped authz (and, for rotate-identity, the account_key_log
+// CAS) end to end.
+
+/// Map a domain-E [`pollis_delivery::account::RotateOutcome`] to a Response —
+/// 200 (+ new version) / 403 / 409 (CAS loss), mirroring the production handler.
+fn ds_rotate_outcome(outcome: pollis_delivery::account::RotateOutcome) -> axum::response::Response {
+    use axum::response::IntoResponse;
+    use pollis_delivery::account::RotateOutcome;
+    match outcome {
+        RotateOutcome::Applied { new_version } => (
+            axum::http::StatusCode::OK,
+            axum::Json(serde_json::json!({ "status": "ok", "identity_version": new_version })),
+        )
+            .into_response(),
+        RotateOutcome::Forbidden => {
+            pollis_delivery::error::AuthRejection::Forbidden.into_response()
+        }
+        RotateOutcome::Conflict { head_version } => (
+            axum::http::StatusCode::CONFLICT,
+            axum::Json(serde_json::json!({ "status": "conflict", "head_version": head_version })),
+        )
+            .into_response(),
+    }
+}
+
+/// `POST /v1/account/rotate-identity`.
+async fn delivery_account_rotate_identity(
+    axum::extract::State(state): axum::extract::State<DsState>,
+    method: axum::http::Method,
+    uri: axum::http::Uri,
+    headers: axum::http::HeaderMap,
+    body: axum::body::Bytes,
+) -> axum::response::Response {
+    let authed = match ds_auth(&state.main, &method, &uri, &headers, &body).await {
+        Ok(u) => u,
+        Err(resp) => return resp,
+    };
+    let parsed: pollis_delivery::account::RotateIdentityBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return ds_bad_request(),
+    };
+    let conn = match state.main.conn().await {
+        Ok(c) => c,
+        Err(e) => return ds_internal_error(format!("conn: {e}")),
+    };
+    match pollis_delivery::account::apply_rotate_identity(&conn, Some(&authed), &parsed).await {
+        Ok(o) => ds_rotate_outcome(o),
+        Err(e) => ds_internal_error(format!("account/rotate-identity: {e}")),
+    }
+}
+
+/// `POST /v1/account/delete`.
+async fn delivery_account_delete(
+    axum::extract::State(state): axum::extract::State<DsState>,
+    method: axum::http::Method,
+    uri: axum::http::Uri,
+    headers: axum::http::HeaderMap,
+    body: axum::body::Bytes,
+) -> axum::response::Response {
+    let authed = match ds_auth(&state.main, &method, &uri, &headers, &body).await {
+        Ok(u) => u,
+        Err(resp) => return resp,
+    };
+    let parsed: pollis_delivery::account::DeleteAccountBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return ds_bad_request(),
+    };
+    let conn = match state.main.conn().await {
+        Ok(c) => c,
+        Err(e) => return ds_internal_error(format!("conn: {e}")),
+    };
+    match pollis_delivery::account::apply_delete_account(&conn, Some(&authed), &parsed).await {
+        Ok(o) => ds_outcome(o),
+        Err(e) => ds_internal_error(format!("account/delete: {e}")),
+    }
+}
+
+/// `POST /v1/account/reset-recover`.
+async fn delivery_account_reset_recover(
+    axum::extract::State(state): axum::extract::State<DsState>,
+    method: axum::http::Method,
+    uri: axum::http::Uri,
+    headers: axum::http::HeaderMap,
+    body: axum::body::Bytes,
+) -> axum::response::Response {
+    let authed = match ds_auth(&state.main, &method, &uri, &headers, &body).await {
+        Ok(u) => u,
+        Err(resp) => return resp,
+    };
+    let parsed: pollis_delivery::account::ResetRecoverBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return ds_bad_request(),
+    };
+    let conn = match state.main.conn().await {
+        Ok(c) => c,
+        Err(e) => return ds_internal_error(format!("conn: {e}")),
+    };
+    match pollis_delivery::account::apply_reset_recover(&conn, Some(&authed), &parsed).await {
+        Ok(o) => ds_outcome(o),
+        Err(e) => ds_internal_error(format!("account/reset-recover: {e}")),
+    }
+}
+
+/// `POST /v1/security-events`.
+async fn delivery_security_events(
+    axum::extract::State(state): axum::extract::State<DsState>,
+    method: axum::http::Method,
+    uri: axum::http::Uri,
+    headers: axum::http::HeaderMap,
+    body: axum::body::Bytes,
+) -> axum::response::Response {
+    let authed = match ds_auth(&state.main, &method, &uri, &headers, &body).await {
+        Ok(u) => u,
+        Err(resp) => return resp,
+    };
+    let parsed: pollis_delivery::account::SecurityEventBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return ds_bad_request(),
+    };
+    let conn = match state.main.conn().await {
+        Ok(c) => c,
+        Err(e) => return ds_internal_error(format!("conn: {e}")),
+    };
+    match pollis_delivery::account::apply_record_security_event(&conn, Some(&authed), &parsed).await
+    {
+        Ok(o) => ds_outcome(o),
+        Err(e) => ds_internal_error(format!("security-events: {e}")),
+    }
+}
+
+/// `POST /v1/enrollment/approve`.
+async fn delivery_enrollment_approve(
+    axum::extract::State(state): axum::extract::State<DsState>,
+    method: axum::http::Method,
+    uri: axum::http::Uri,
+    headers: axum::http::HeaderMap,
+    body: axum::body::Bytes,
+) -> axum::response::Response {
+    let authed = match ds_auth(&state.main, &method, &uri, &headers, &body).await {
+        Ok(u) => u,
+        Err(resp) => return resp,
+    };
+    let parsed: pollis_delivery::account::ApproveEnrollmentBody = match serde_json::from_slice(&body)
+    {
+        Ok(b) => b,
+        Err(_) => return ds_bad_request(),
+    };
+    let conn = match state.main.conn().await {
+        Ok(c) => c,
+        Err(e) => return ds_internal_error(format!("conn: {e}")),
+    };
+    match pollis_delivery::account::apply_approve_enrollment(&conn, Some(&authed), &parsed).await {
+        Ok(o) => ds_outcome(o),
+        Err(e) => ds_internal_error(format!("enrollment/approve: {e}")),
+    }
+}
+
+/// `POST /v1/enrollment/reject`.
+async fn delivery_enrollment_reject(
+    axum::extract::State(state): axum::extract::State<DsState>,
+    method: axum::http::Method,
+    uri: axum::http::Uri,
+    headers: axum::http::HeaderMap,
+    body: axum::body::Bytes,
+) -> axum::response::Response {
+    let authed = match ds_auth(&state.main, &method, &uri, &headers, &body).await {
+        Ok(u) => u,
+        Err(resp) => return resp,
+    };
+    let parsed: pollis_delivery::account::RejectEnrollmentBody = match serde_json::from_slice(&body)
+    {
+        Ok(b) => b,
+        Err(_) => return ds_bad_request(),
+    };
+    let conn = match state.main.conn().await {
+        Ok(c) => c,
+        Err(e) => return ds_internal_error(format!("conn: {e}")),
+    };
+    match pollis_delivery::account::apply_reject_enrollment(&conn, Some(&authed), &parsed).await {
+        Ok(o) => ds_outcome(o),
+        Err(e) => ds_internal_error(format!("enrollment/reject: {e}")),
+    }
+}
+
+/// `POST /v1/devices/revoke`.
+async fn delivery_devices_revoke(
+    axum::extract::State(state): axum::extract::State<DsState>,
+    method: axum::http::Method,
+    uri: axum::http::Uri,
+    headers: axum::http::HeaderMap,
+    body: axum::body::Bytes,
+) -> axum::response::Response {
+    let authed = match ds_auth(&state.main, &method, &uri, &headers, &body).await {
+        Ok(u) => u,
+        Err(resp) => return resp,
+    };
+    let parsed: pollis_delivery::account::RevokeDeviceBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return ds_bad_request(),
+    };
+    let conn = match state.main.conn().await {
+        Ok(c) => c,
+        Err(e) => return ds_internal_error(format!("conn: {e}")),
+    };
+    match pollis_delivery::account::apply_revoke_device(&conn, Some(&authed), &parsed).await {
+        Ok(o) => ds_outcome(o),
+        Err(e) => ds_internal_error(format!("devices/revoke: {e}")),
+    }
+}
+
 /// Boot an axum router exposing the DS's full write surface (`/v1/commits` plus
 /// the W4–W8 endpoints) backed by the shared `RemoteDb`, bind it on a loopback
 /// port, and serve it on a DEDICATED OS thread with its own runtime so the
@@ -1203,6 +1419,29 @@ async fn spawn_in_process_delivery(main: Arc<RemoteDb>, log: Arc<RemoteDb>) -> S
                     )
                     .route("/v1/devices/resign", axum::routing::post(delivery_devices_resign))
                     .route("/v1/push-tokens", axum::routing::post(delivery_push_tokens))
+                    // Domains E + G (#419) — all on the MAIN DB.
+                    .route(
+                        "/v1/account/rotate-identity",
+                        axum::routing::post(delivery_account_rotate_identity),
+                    )
+                    .route("/v1/account/delete", axum::routing::post(delivery_account_delete))
+                    .route(
+                        "/v1/account/reset-recover",
+                        axum::routing::post(delivery_account_reset_recover),
+                    )
+                    .route(
+                        "/v1/security-events",
+                        axum::routing::post(delivery_security_events),
+                    )
+                    .route(
+                        "/v1/enrollment/approve",
+                        axum::routing::post(delivery_enrollment_approve),
+                    )
+                    .route(
+                        "/v1/enrollment/reject",
+                        axum::routing::post(delivery_enrollment_reject),
+                    )
+                    .route("/v1/devices/revoke", axum::routing::post(delivery_devices_revoke))
                     .with_state(state);
                 // Bind :0 so the OS hands us a free port; read it back before serving.
                 let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))

--- a/src-tauri/tests/flows/harness.rs
+++ b/src-tauri/tests/flows/harness.rs
@@ -213,6 +213,18 @@ fn ds_ok() -> axum::response::Response {
         .into_response()
 }
 
+/// Map a domain-A [`pollis_delivery::messages::WriteOutcome`] to a Response —
+/// 200 on success, 403 on a refused authz check.
+fn ds_outcome(outcome: pollis_delivery::messages::WriteOutcome) -> axum::response::Response {
+    use axum::response::IntoResponse;
+    match outcome {
+        pollis_delivery::messages::WriteOutcome::Ok => ds_ok(),
+        pollis_delivery::messages::WriteOutcome::Forbidden => {
+            pollis_delivery::error::AuthRejection::Forbidden.into_response()
+        }
+    }
+}
+
 /// The `/v1/commits` submit handler, driven against the SHARED `RemoteDb` so
 /// the DS writes land on the exact handle the clients read from. Mirrors
 /// `pollis_delivery`'s real `submit` arm: verify the signature over the raw
@@ -396,6 +408,249 @@ async fn delivery_welcomes_purge(
     }
 }
 
+// ─── Domain A (#419) — messages / envelopes / watermarks / reactions ────────
+//
+// Every domain-A endpoint runs the SAME pure `apply_*` fn the production axum
+// handler runs, against the MAIN DB (these tables are not on the log DB). Auth
+// is always enforced here (`ds_auth` → `Some(authed)`), so the flows suite
+// exercises the signed write + server-side authz path end to end.
+
+/// `POST /v1/messages/send`.
+async fn delivery_messages_send(
+    axum::extract::State(state): axum::extract::State<DsState>,
+    method: axum::http::Method,
+    uri: axum::http::Uri,
+    headers: axum::http::HeaderMap,
+    body: axum::body::Bytes,
+) -> axum::response::Response {
+    let authed = match ds_auth(&state.main, &method, &uri, &headers, &body).await {
+        Ok(u) => u,
+        Err(resp) => return resp,
+    };
+    let parsed: pollis_delivery::messages::SendMessageBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return ds_bad_request(),
+    };
+    let conn = match state.main.conn().await {
+        Ok(c) => c,
+        Err(e) => return ds_internal_error(format!("conn: {e}")),
+    };
+    match pollis_delivery::messages::apply_send_message(&conn, Some(&authed), &parsed).await {
+        Ok(o) => ds_outcome(o),
+        Err(e) => ds_internal_error(format!("messages/send: {e}")),
+    }
+}
+
+/// `POST /v1/messages/edit`.
+async fn delivery_messages_edit(
+    axum::extract::State(state): axum::extract::State<DsState>,
+    method: axum::http::Method,
+    uri: axum::http::Uri,
+    headers: axum::http::HeaderMap,
+    body: axum::body::Bytes,
+) -> axum::response::Response {
+    let authed = match ds_auth(&state.main, &method, &uri, &headers, &body).await {
+        Ok(u) => u,
+        Err(resp) => return resp,
+    };
+    let parsed: pollis_delivery::messages::EditMessageBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return ds_bad_request(),
+    };
+    let conn = match state.main.conn().await {
+        Ok(c) => c,
+        Err(e) => return ds_internal_error(format!("conn: {e}")),
+    };
+    match pollis_delivery::messages::apply_edit_message(&conn, Some(&authed), &parsed).await {
+        Ok(o) => ds_outcome(o),
+        Err(e) => ds_internal_error(format!("messages/edit: {e}")),
+    }
+}
+
+/// `POST /v1/messages/delete`.
+async fn delivery_messages_delete(
+    axum::extract::State(state): axum::extract::State<DsState>,
+    method: axum::http::Method,
+    uri: axum::http::Uri,
+    headers: axum::http::HeaderMap,
+    body: axum::body::Bytes,
+) -> axum::response::Response {
+    let authed = match ds_auth(&state.main, &method, &uri, &headers, &body).await {
+        Ok(u) => u,
+        Err(resp) => return resp,
+    };
+    let parsed: pollis_delivery::messages::DeleteMessageBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return ds_bad_request(),
+    };
+    let conn = match state.main.conn().await {
+        Ok(c) => c,
+        Err(e) => return ds_internal_error(format!("conn: {e}")),
+    };
+    match pollis_delivery::messages::apply_delete_message(&conn, Some(&authed), &parsed).await {
+        Ok(o) => ds_outcome(o),
+        Err(e) => ds_internal_error(format!("messages/delete: {e}")),
+    }
+}
+
+/// `POST /v1/reactions/add`.
+async fn delivery_reactions_add(
+    axum::extract::State(state): axum::extract::State<DsState>,
+    method: axum::http::Method,
+    uri: axum::http::Uri,
+    headers: axum::http::HeaderMap,
+    body: axum::body::Bytes,
+) -> axum::response::Response {
+    let authed = match ds_auth(&state.main, &method, &uri, &headers, &body).await {
+        Ok(u) => u,
+        Err(resp) => return resp,
+    };
+    let parsed: pollis_delivery::messages::ReactionBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return ds_bad_request(),
+    };
+    let conn = match state.main.conn().await {
+        Ok(c) => c,
+        Err(e) => return ds_internal_error(format!("conn: {e}")),
+    };
+    match pollis_delivery::messages::apply_add_reaction(&conn, Some(&authed), &parsed).await {
+        Ok(o) => ds_outcome(o),
+        Err(e) => ds_internal_error(format!("reactions/add: {e}")),
+    }
+}
+
+/// `POST /v1/reactions/remove`.
+async fn delivery_reactions_remove(
+    axum::extract::State(state): axum::extract::State<DsState>,
+    method: axum::http::Method,
+    uri: axum::http::Uri,
+    headers: axum::http::HeaderMap,
+    body: axum::body::Bytes,
+) -> axum::response::Response {
+    let authed = match ds_auth(&state.main, &method, &uri, &headers, &body).await {
+        Ok(u) => u,
+        Err(resp) => return resp,
+    };
+    let parsed: pollis_delivery::messages::ReactionBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return ds_bad_request(),
+    };
+    let conn = match state.main.conn().await {
+        Ok(c) => c,
+        Err(e) => return ds_internal_error(format!("conn: {e}")),
+    };
+    match pollis_delivery::messages::apply_remove_reaction(&conn, Some(&authed), &parsed).await {
+        Ok(o) => ds_outcome(o),
+        Err(e) => ds_internal_error(format!("reactions/remove: {e}")),
+    }
+}
+
+/// `POST /v1/watermarks/advance`.
+async fn delivery_watermarks_advance(
+    axum::extract::State(state): axum::extract::State<DsState>,
+    method: axum::http::Method,
+    uri: axum::http::Uri,
+    headers: axum::http::HeaderMap,
+    body: axum::body::Bytes,
+) -> axum::response::Response {
+    let authed = match ds_auth(&state.main, &method, &uri, &headers, &body).await {
+        Ok(u) => u,
+        Err(resp) => return resp,
+    };
+    let parsed: pollis_delivery::messages::WatermarkBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return ds_bad_request(),
+    };
+    let conn = match state.main.conn().await {
+        Ok(c) => c,
+        Err(e) => return ds_internal_error(format!("conn: {e}")),
+    };
+    match pollis_delivery::messages::apply_advance_watermark(&conn, Some(&authed), &parsed).await {
+        Ok(o) => ds_outcome(o),
+        Err(e) => ds_internal_error(format!("watermarks/advance: {e}")),
+    }
+}
+
+/// `POST /v1/envelopes/gc`.
+async fn delivery_envelopes_gc(
+    axum::extract::State(state): axum::extract::State<DsState>,
+    method: axum::http::Method,
+    uri: axum::http::Uri,
+    headers: axum::http::HeaderMap,
+    body: axum::body::Bytes,
+) -> axum::response::Response {
+    let authed = match ds_auth(&state.main, &method, &uri, &headers, &body).await {
+        Ok(u) => u,
+        Err(resp) => return resp,
+    };
+    let parsed: pollis_delivery::messages::EnvelopeGcBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return ds_bad_request(),
+    };
+    let conn = match state.main.conn().await {
+        Ok(c) => c,
+        Err(e) => return ds_internal_error(format!("conn: {e}")),
+    };
+    match pollis_delivery::messages::apply_envelope_gc(&conn, Some(&authed), &parsed).await {
+        Ok(o) => ds_outcome(o),
+        Err(e) => ds_internal_error(format!("envelopes/gc: {e}")),
+    }
+}
+
+/// `POST /v1/attachments/register`.
+async fn delivery_attachments_register(
+    axum::extract::State(state): axum::extract::State<DsState>,
+    method: axum::http::Method,
+    uri: axum::http::Uri,
+    headers: axum::http::HeaderMap,
+    body: axum::body::Bytes,
+) -> axum::response::Response {
+    let authed = match ds_auth(&state.main, &method, &uri, &headers, &body).await {
+        Ok(u) => u,
+        Err(resp) => return resp,
+    };
+    let parsed: pollis_delivery::messages::AttachmentRegisterBody =
+        match serde_json::from_slice(&body) {
+            Ok(b) => b,
+            Err(_) => return ds_bad_request(),
+        };
+    let conn = match state.main.conn().await {
+        Ok(c) => c,
+        Err(e) => return ds_internal_error(format!("conn: {e}")),
+    };
+    match pollis_delivery::messages::apply_register_attachment(&conn, Some(&authed), &parsed).await {
+        Ok(o) => ds_outcome(o),
+        Err(e) => ds_internal_error(format!("attachments/register: {e}")),
+    }
+}
+
+/// `POST /v1/attachments/delete`.
+async fn delivery_attachments_delete(
+    axum::extract::State(state): axum::extract::State<DsState>,
+    method: axum::http::Method,
+    uri: axum::http::Uri,
+    headers: axum::http::HeaderMap,
+    body: axum::body::Bytes,
+) -> axum::response::Response {
+    let authed = match ds_auth(&state.main, &method, &uri, &headers, &body).await {
+        Ok(u) => u,
+        Err(resp) => return resp,
+    };
+    let parsed: pollis_delivery::messages::AttachmentDeleteBody =
+        match serde_json::from_slice(&body) {
+            Ok(b) => b,
+            Err(_) => return ds_bad_request(),
+        };
+    let conn = match state.main.conn().await {
+        Ok(c) => c,
+        Err(e) => return ds_internal_error(format!("conn: {e}")),
+    };
+    match pollis_delivery::messages::apply_delete_attachment(&conn, Some(&authed), &parsed).await {
+        Ok(o) => ds_outcome(o),
+        Err(e) => ds_internal_error(format!("attachments/delete: {e}")),
+    }
+}
+
 /// Boot an axum router exposing the DS's full write surface (`/v1/commits` plus
 /// the W4–W8 endpoints) backed by the shared `RemoteDb`, bind it on a loopback
 /// port, and serve it on a DEDICATED OS thread with its own runtime so the
@@ -431,6 +686,31 @@ async fn spawn_in_process_delivery(main: Arc<RemoteDb>, log: Arc<RemoteDb>) -> S
                     .route(
                         "/v1/welcomes/purge",
                         axum::routing::post(delivery_welcomes_purge),
+                    )
+                    // Domain A (#419) — all on the MAIN DB.
+                    .route("/v1/messages/send", axum::routing::post(delivery_messages_send))
+                    .route("/v1/messages/edit", axum::routing::post(delivery_messages_edit))
+                    .route(
+                        "/v1/messages/delete",
+                        axum::routing::post(delivery_messages_delete),
+                    )
+                    .route("/v1/reactions/add", axum::routing::post(delivery_reactions_add))
+                    .route(
+                        "/v1/reactions/remove",
+                        axum::routing::post(delivery_reactions_remove),
+                    )
+                    .route(
+                        "/v1/watermarks/advance",
+                        axum::routing::post(delivery_watermarks_advance),
+                    )
+                    .route("/v1/envelopes/gc", axum::routing::post(delivery_envelopes_gc))
+                    .route(
+                        "/v1/attachments/register",
+                        axum::routing::post(delivery_attachments_register),
+                    )
+                    .route(
+                        "/v1/attachments/delete",
+                        axum::routing::post(delivery_attachments_delete),
                     )
                     .with_state(state);
                 // Bind :0 so the OS hands us a free port; read it back before serving.
@@ -506,6 +786,49 @@ pub(crate) async fn raw_post_status(
         .nth(1)
         .and_then(|c| c.parse::<u16>().ok())
         .unwrap_or_else(|| panic!("could not parse status from: {status_line:?}"))
+}
+
+/// Sign `body` with `client`'s stable device key — byte-for-byte as
+/// `ds_client::ds_post` does — and POST it to `{delivery_url}{path}`, returning
+/// the HTTP status. This is the ONLY way to drive a *validly signed* request as
+/// an arbitrary user, which is what the domain-A authorization tests need: a
+/// non-member / non-sender must get 403 (proved identity, lacking permission),
+/// not the 401 an unsigned/garbled request gets.
+pub(crate) async fn signed_post_status(client: &TestClient, path: &str, body: &[u8]) -> u16 {
+    use openmls_traits::signatures::Signer;
+
+    let base = delivery_url().await;
+    let user_id = client.user_id().to_string();
+    let device_id = client
+        .state
+        .device_id
+        .lock()
+        .await
+        .clone()
+        .expect("client device_id set");
+    let timestamp = pollis_delivery::auth::now_unix();
+    let message = pollis_delivery::auth::canonical_message("POST", path, timestamp, body);
+
+    let signature_b64 = {
+        let guard = client.state.local_db.lock().await;
+        let db = guard.as_ref().expect("client local db open");
+        let provider = pollis_lib::commands::mls::PollisProvider::new(db.conn());
+        let (signer, _pub) =
+            pollis_lib::commands::mls::load_or_create_device_signer(&provider, &user_id, &device_id)
+                .expect("load device signer");
+        let sig = signer.sign(&message).expect("sign request");
+        use base64::Engine as _;
+        base64::engine::general_purpose::STANDARD.encode(sig)
+    };
+
+    let ts_str = timestamp.to_string();
+    let headers = [
+        ("X-Pollis-User", user_id.as_str()),
+        ("X-Pollis-Device", device_id.as_str()),
+        ("X-Pollis-Timestamp", ts_str.as_str()),
+        ("X-Pollis-Signature", signature_b64.as_str()),
+    ];
+    raw_post_status(&base, path, &headers, body).await
 }
 
 // ─── Client ─────────────────────────────────────────────────────────────────

--- a/src-tauri/tests/flows/harness.rs
+++ b/src-tauri/tests/flows/harness.rs
@@ -213,13 +213,13 @@ fn ds_ok() -> axum::response::Response {
         .into_response()
 }
 
-/// Map a domain-A [`pollis_delivery::messages::WriteOutcome`] to a Response —
+/// Map a domain-A [`pollis_delivery::writes::WriteOutcome`] to a Response —
 /// 200 on success, 403 on a refused authz check.
-fn ds_outcome(outcome: pollis_delivery::messages::WriteOutcome) -> axum::response::Response {
+fn ds_outcome(outcome: pollis_delivery::writes::WriteOutcome) -> axum::response::Response {
     use axum::response::IntoResponse;
     match outcome {
-        pollis_delivery::messages::WriteOutcome::Ok => ds_ok(),
-        pollis_delivery::messages::WriteOutcome::Forbidden => {
+        pollis_delivery::writes::WriteOutcome::Ok => ds_ok(),
+        pollis_delivery::writes::WriteOutcome::Forbidden => {
             pollis_delivery::error::AuthRejection::Forbidden.into_response()
         }
     }

--- a/src-tauri/tests/flows/harness.rs
+++ b/src-tauri/tests/flows/harness.rs
@@ -651,6 +651,135 @@ async fn delivery_attachments_delete(
     }
 }
 
+// ─── Domain B (#419) — groups / channels / membership / invites / join-reqs ──
+//
+// Every domain-B endpoint runs the SAME pure `apply_*` fn the production axum
+// handler runs, against the MAIN DB. Auth is always enforced here, so the flows
+// suite exercises the signed write + server-side authz path end to end.
+
+/// Generate a domain-B delivery handler: gate → parse → run the `apply_*`
+/// against the MAIN DB → map the outcome. Collapses the otherwise-identical
+/// per-endpoint boilerplate the domain-A handlers spell out by hand.
+macro_rules! delivery_b {
+    ($name:ident, $body:ty, $apply:path, $label:literal) => {
+        async fn $name(
+            axum::extract::State(state): axum::extract::State<DsState>,
+            method: axum::http::Method,
+            uri: axum::http::Uri,
+            headers: axum::http::HeaderMap,
+            body: axum::body::Bytes,
+        ) -> axum::response::Response {
+            let authed = match ds_auth(&state.main, &method, &uri, &headers, &body).await {
+                Ok(u) => u,
+                Err(resp) => return resp,
+            };
+            let parsed: $body = match serde_json::from_slice(&body) {
+                Ok(b) => b,
+                Err(_) => return ds_bad_request(),
+            };
+            let conn = match state.main.conn().await {
+                Ok(c) => c,
+                Err(e) => return ds_internal_error(format!("conn: {e}")),
+            };
+            match $apply(&conn, Some(&authed), &parsed).await {
+                Ok(o) => ds_outcome(o),
+                Err(e) => ds_internal_error(format!("{}: {e}", $label)),
+            }
+        }
+    };
+}
+
+delivery_b!(
+    delivery_groups_create,
+    pollis_delivery::groups::CreateGroupBody,
+    pollis_delivery::groups::apply_create_group,
+    "groups/create"
+);
+delivery_b!(
+    delivery_groups_update,
+    pollis_delivery::groups::UpdateGroupBody,
+    pollis_delivery::groups::apply_update_group,
+    "groups/update"
+);
+delivery_b!(
+    delivery_groups_delete,
+    pollis_delivery::groups::DeleteGroupBody,
+    pollis_delivery::groups::apply_delete_group,
+    "groups/delete"
+);
+delivery_b!(
+    delivery_groups_leave,
+    pollis_delivery::groups::LeaveGroupBody,
+    pollis_delivery::groups::apply_leave_group,
+    "groups/leave"
+);
+delivery_b!(
+    delivery_channels_create,
+    pollis_delivery::groups::CreateChannelBody,
+    pollis_delivery::groups::apply_create_channel,
+    "channels/create"
+);
+delivery_b!(
+    delivery_channels_update,
+    pollis_delivery::groups::UpdateChannelBody,
+    pollis_delivery::groups::apply_update_channel,
+    "channels/update"
+);
+delivery_b!(
+    delivery_channels_delete,
+    pollis_delivery::groups::DeleteChannelBody,
+    pollis_delivery::groups::apply_delete_channel,
+    "channels/delete"
+);
+delivery_b!(
+    delivery_members_remove,
+    pollis_delivery::groups::RemoveMemberBody,
+    pollis_delivery::groups::apply_remove_member,
+    "members/remove"
+);
+delivery_b!(
+    delivery_members_role,
+    pollis_delivery::groups::SetMemberRoleBody,
+    pollis_delivery::groups::apply_set_member_role,
+    "members/role"
+);
+delivery_b!(
+    delivery_invites_create,
+    pollis_delivery::groups::CreateInviteBody,
+    pollis_delivery::groups::apply_create_invite,
+    "invites/create"
+);
+delivery_b!(
+    delivery_invites_accept,
+    pollis_delivery::groups::AcceptInviteBody,
+    pollis_delivery::groups::apply_accept_invite,
+    "invites/accept"
+);
+delivery_b!(
+    delivery_invites_decline,
+    pollis_delivery::groups::DeclineInviteBody,
+    pollis_delivery::groups::apply_decline_invite,
+    "invites/decline"
+);
+delivery_b!(
+    delivery_join_requests_create,
+    pollis_delivery::groups::CreateJoinRequestBody,
+    pollis_delivery::groups::apply_create_join_request,
+    "join-requests/create"
+);
+delivery_b!(
+    delivery_join_requests_approve,
+    pollis_delivery::groups::ApproveJoinRequestBody,
+    pollis_delivery::groups::apply_approve_join_request,
+    "join-requests/approve"
+);
+delivery_b!(
+    delivery_join_requests_reject,
+    pollis_delivery::groups::RejectJoinRequestBody,
+    pollis_delivery::groups::apply_reject_join_request,
+    "join-requests/reject"
+);
+
 /// Boot an axum router exposing the DS's full write surface (`/v1/commits` plus
 /// the W4–W8 endpoints) backed by the shared `RemoteDb`, bind it on a loopback
 /// port, and serve it on a DEDICATED OS thread with its own runtime so the
@@ -711,6 +840,53 @@ async fn spawn_in_process_delivery(main: Arc<RemoteDb>, log: Arc<RemoteDb>) -> S
                     .route(
                         "/v1/attachments/delete",
                         axum::routing::post(delivery_attachments_delete),
+                    )
+                    // Domain B (#419) — groups / channels / membership / invites
+                    // / join-requests. All on the MAIN DB.
+                    .route("/v1/groups/create", axum::routing::post(delivery_groups_create))
+                    .route("/v1/groups/update", axum::routing::post(delivery_groups_update))
+                    .route("/v1/groups/delete", axum::routing::post(delivery_groups_delete))
+                    .route("/v1/groups/leave", axum::routing::post(delivery_groups_leave))
+                    .route(
+                        "/v1/channels/create",
+                        axum::routing::post(delivery_channels_create),
+                    )
+                    .route(
+                        "/v1/channels/update",
+                        axum::routing::post(delivery_channels_update),
+                    )
+                    .route(
+                        "/v1/channels/delete",
+                        axum::routing::post(delivery_channels_delete),
+                    )
+                    .route(
+                        "/v1/members/remove",
+                        axum::routing::post(delivery_members_remove),
+                    )
+                    .route("/v1/members/role", axum::routing::post(delivery_members_role))
+                    .route(
+                        "/v1/invites/create",
+                        axum::routing::post(delivery_invites_create),
+                    )
+                    .route(
+                        "/v1/invites/accept",
+                        axum::routing::post(delivery_invites_accept),
+                    )
+                    .route(
+                        "/v1/invites/decline",
+                        axum::routing::post(delivery_invites_decline),
+                    )
+                    .route(
+                        "/v1/join-requests/create",
+                        axum::routing::post(delivery_join_requests_create),
+                    )
+                    .route(
+                        "/v1/join-requests/approve",
+                        axum::routing::post(delivery_join_requests_approve),
+                    )
+                    .route(
+                        "/v1/join-requests/reject",
+                        axum::routing::post(delivery_join_requests_reject),
                     )
                     .with_state(state);
                 // Bind :0 so the OS hands us a free port; read it back before serving.

--- a/src-tauri/tests/flows/harness.rs
+++ b/src-tauri/tests/flows/harness.rs
@@ -651,6 +651,123 @@ async fn delivery_attachments_delete(
     }
 }
 
+// ─── Domain D (#419) — key-packages / device-cert re-sign / push tokens ──────
+//
+// Every domain-D endpoint runs the SAME pure `apply_*` fn the production axum
+// handler runs, against the MAIN DB (these tables are not on the log DB). Auth
+// is always enforced here, so the flows suite exercises the signed write +
+// owner-scoped authz path end to end. `/v1/key-packages/replenish` runs in EVERY
+// test's `sign_up` (via `initialize_identity` → `ensure_mls_key_package`), so a
+// regression in the signed key-package path fails the whole suite immediately.
+
+/// `POST /v1/key-packages`.
+async fn delivery_key_packages(
+    axum::extract::State(state): axum::extract::State<DsState>,
+    method: axum::http::Method,
+    uri: axum::http::Uri,
+    headers: axum::http::HeaderMap,
+    body: axum::body::Bytes,
+) -> axum::response::Response {
+    let authed = match ds_auth(&state.main, &method, &uri, &headers, &body).await {
+        Ok(u) => u,
+        Err(resp) => return resp,
+    };
+    let parsed: pollis_delivery::devices::PublishKeyPackagesBody =
+        match serde_json::from_slice(&body) {
+            Ok(b) => b,
+            Err(_) => return ds_bad_request(),
+        };
+    let conn = match state.main.conn().await {
+        Ok(c) => c,
+        Err(e) => return ds_internal_error(format!("conn: {e}")),
+    };
+    match pollis_delivery::devices::apply_publish_key_packages(&conn, Some(&authed), &parsed).await {
+        Ok(o) => ds_outcome(o),
+        Err(e) => ds_internal_error(format!("key-packages: {e}")),
+    }
+}
+
+/// `POST /v1/key-packages/replenish`.
+async fn delivery_key_packages_replenish(
+    axum::extract::State(state): axum::extract::State<DsState>,
+    method: axum::http::Method,
+    uri: axum::http::Uri,
+    headers: axum::http::HeaderMap,
+    body: axum::body::Bytes,
+) -> axum::response::Response {
+    let authed = match ds_auth(&state.main, &method, &uri, &headers, &body).await {
+        Ok(u) => u,
+        Err(resp) => return resp,
+    };
+    let parsed: pollis_delivery::devices::ReplenishKeyPackagesBody =
+        match serde_json::from_slice(&body) {
+            Ok(b) => b,
+            Err(_) => return ds_bad_request(),
+        };
+    let conn = match state.main.conn().await {
+        Ok(c) => c,
+        Err(e) => return ds_internal_error(format!("conn: {e}")),
+    };
+    match pollis_delivery::devices::apply_replenish_key_packages(&conn, Some(&authed), &parsed).await
+    {
+        Ok(o) => ds_outcome(o),
+        Err(e) => ds_internal_error(format!("key-packages/replenish: {e}")),
+    }
+}
+
+/// `POST /v1/devices/resign`.
+async fn delivery_devices_resign(
+    axum::extract::State(state): axum::extract::State<DsState>,
+    method: axum::http::Method,
+    uri: axum::http::Uri,
+    headers: axum::http::HeaderMap,
+    body: axum::body::Bytes,
+) -> axum::response::Response {
+    let authed = match ds_auth(&state.main, &method, &uri, &headers, &body).await {
+        Ok(u) => u,
+        Err(resp) => return resp,
+    };
+    let parsed: pollis_delivery::devices::ResignDeviceCertsBody =
+        match serde_json::from_slice(&body) {
+            Ok(b) => b,
+            Err(_) => return ds_bad_request(),
+        };
+    let conn = match state.main.conn().await {
+        Ok(c) => c,
+        Err(e) => return ds_internal_error(format!("conn: {e}")),
+    };
+    match pollis_delivery::devices::apply_resign_device_certs(&conn, Some(&authed), &parsed).await {
+        Ok(o) => ds_outcome(o),
+        Err(e) => ds_internal_error(format!("devices/resign: {e}")),
+    }
+}
+
+/// `POST /v1/push-tokens`.
+async fn delivery_push_tokens(
+    axum::extract::State(state): axum::extract::State<DsState>,
+    method: axum::http::Method,
+    uri: axum::http::Uri,
+    headers: axum::http::HeaderMap,
+    body: axum::body::Bytes,
+) -> axum::response::Response {
+    let authed = match ds_auth(&state.main, &method, &uri, &headers, &body).await {
+        Ok(u) => u,
+        Err(resp) => return resp,
+    };
+    let parsed: pollis_delivery::devices::PushTokenBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return ds_bad_request(),
+    };
+    let conn = match state.main.conn().await {
+        Ok(c) => c,
+        Err(e) => return ds_internal_error(format!("conn: {e}")),
+    };
+    match pollis_delivery::devices::apply_register_push_token(&conn, Some(&authed), &parsed).await {
+        Ok(o) => ds_outcome(o),
+        Err(e) => ds_internal_error(format!("push-tokens: {e}")),
+    }
+}
+
 /// Boot an axum router exposing the DS's full write surface (`/v1/commits` plus
 /// the W4–W8 endpoints) backed by the shared `RemoteDb`, bind it on a loopback
 /// port, and serve it on a DEDICATED OS thread with its own runtime so the
@@ -712,6 +829,14 @@ async fn spawn_in_process_delivery(main: Arc<RemoteDb>, log: Arc<RemoteDb>) -> S
                         "/v1/attachments/delete",
                         axum::routing::post(delivery_attachments_delete),
                     )
+                    // Domain D (#419) — all on the MAIN DB.
+                    .route("/v1/key-packages", axum::routing::post(delivery_key_packages))
+                    .route(
+                        "/v1/key-packages/replenish",
+                        axum::routing::post(delivery_key_packages_replenish),
+                    )
+                    .route("/v1/devices/resign", axum::routing::post(delivery_devices_resign))
+                    .route("/v1/push-tokens", axum::routing::post(delivery_push_tokens))
                     .with_state(state);
                 // Bind :0 so the OS hands us a free port; read it back before serving.
                 let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))

--- a/src-tauri/tests/flows/harness.rs
+++ b/src-tauri/tests/flows/harness.rs
@@ -651,6 +651,169 @@ async fn delivery_attachments_delete(
     }
 }
 
+// ─── Domain C (#419) — profile / preferences / blocks / DMs ─────────────────
+//
+// Every domain-C endpoint runs the SAME pure `apply_*` fn the production axum
+// handler runs, against the MAIN DB (these tables are not on the log DB). Auth
+// is always enforced here, so the flows suite exercises the signed write +
+// server-side authz path end to end.
+
+/// `POST /v1/profile/update`.
+async fn delivery_profile_update(
+    axum::extract::State(state): axum::extract::State<DsState>,
+    method: axum::http::Method,
+    uri: axum::http::Uri,
+    headers: axum::http::HeaderMap,
+    body: axum::body::Bytes,
+) -> axum::response::Response {
+    let authed = match ds_auth(&state.main, &method, &uri, &headers, &body).await {
+        Ok(u) => u,
+        Err(resp) => return resp,
+    };
+    let parsed: pollis_delivery::profile::UpdateProfileBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return ds_bad_request(),
+    };
+    let conn = match state.main.conn().await {
+        Ok(c) => c,
+        Err(e) => return ds_internal_error(format!("conn: {e}")),
+    };
+    match pollis_delivery::profile::apply_update_profile(&conn, Some(&authed), &parsed).await {
+        Ok(o) => ds_outcome(o),
+        Err(e) => ds_internal_error(format!("profile/update: {e}")),
+    }
+}
+
+/// `POST /v1/profile/preferences`.
+async fn delivery_profile_preferences(
+    axum::extract::State(state): axum::extract::State<DsState>,
+    method: axum::http::Method,
+    uri: axum::http::Uri,
+    headers: axum::http::HeaderMap,
+    body: axum::body::Bytes,
+) -> axum::response::Response {
+    let authed = match ds_auth(&state.main, &method, &uri, &headers, &body).await {
+        Ok(u) => u,
+        Err(resp) => return resp,
+    };
+    let parsed: pollis_delivery::profile::SavePreferencesBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return ds_bad_request(),
+    };
+    let conn = match state.main.conn().await {
+        Ok(c) => c,
+        Err(e) => return ds_internal_error(format!("conn: {e}")),
+    };
+    match pollis_delivery::profile::apply_save_preferences(&conn, Some(&authed), &parsed).await {
+        Ok(o) => ds_outcome(o),
+        Err(e) => ds_internal_error(format!("profile/preferences: {e}")),
+    }
+}
+
+/// `POST /v1/blocks/add`.
+async fn delivery_blocks_add(
+    axum::extract::State(state): axum::extract::State<DsState>,
+    method: axum::http::Method,
+    uri: axum::http::Uri,
+    headers: axum::http::HeaderMap,
+    body: axum::body::Bytes,
+) -> axum::response::Response {
+    let authed = match ds_auth(&state.main, &method, &uri, &headers, &body).await {
+        Ok(u) => u,
+        Err(resp) => return resp,
+    };
+    let parsed: pollis_delivery::profile::BlockBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return ds_bad_request(),
+    };
+    let conn = match state.main.conn().await {
+        Ok(c) => c,
+        Err(e) => return ds_internal_error(format!("conn: {e}")),
+    };
+    match pollis_delivery::profile::apply_block_user(&conn, Some(&authed), &parsed).await {
+        Ok(o) => ds_outcome(o),
+        Err(e) => ds_internal_error(format!("blocks/add: {e}")),
+    }
+}
+
+/// `POST /v1/blocks/remove`.
+async fn delivery_blocks_remove(
+    axum::extract::State(state): axum::extract::State<DsState>,
+    method: axum::http::Method,
+    uri: axum::http::Uri,
+    headers: axum::http::HeaderMap,
+    body: axum::body::Bytes,
+) -> axum::response::Response {
+    let authed = match ds_auth(&state.main, &method, &uri, &headers, &body).await {
+        Ok(u) => u,
+        Err(resp) => return resp,
+    };
+    let parsed: pollis_delivery::profile::BlockBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return ds_bad_request(),
+    };
+    let conn = match state.main.conn().await {
+        Ok(c) => c,
+        Err(e) => return ds_internal_error(format!("conn: {e}")),
+    };
+    match pollis_delivery::profile::apply_unblock_user(&conn, Some(&authed), &parsed).await {
+        Ok(o) => ds_outcome(o),
+        Err(e) => ds_internal_error(format!("blocks/remove: {e}")),
+    }
+}
+
+/// `POST /v1/dm/create`.
+async fn delivery_dm_create(
+    axum::extract::State(state): axum::extract::State<DsState>,
+    method: axum::http::Method,
+    uri: axum::http::Uri,
+    headers: axum::http::HeaderMap,
+    body: axum::body::Bytes,
+) -> axum::response::Response {
+    let authed = match ds_auth(&state.main, &method, &uri, &headers, &body).await {
+        Ok(u) => u,
+        Err(resp) => return resp,
+    };
+    let parsed: pollis_delivery::profile::CreateDmBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return ds_bad_request(),
+    };
+    let conn = match state.main.conn().await {
+        Ok(c) => c,
+        Err(e) => return ds_internal_error(format!("conn: {e}")),
+    };
+    match pollis_delivery::profile::apply_create_dm(&conn, Some(&authed), &parsed).await {
+        Ok(o) => ds_outcome(o),
+        Err(e) => ds_internal_error(format!("dm/create: {e}")),
+    }
+}
+
+/// `POST /v1/dm/accept`.
+async fn delivery_dm_accept(
+    axum::extract::State(state): axum::extract::State<DsState>,
+    method: axum::http::Method,
+    uri: axum::http::Uri,
+    headers: axum::http::HeaderMap,
+    body: axum::body::Bytes,
+) -> axum::response::Response {
+    let authed = match ds_auth(&state.main, &method, &uri, &headers, &body).await {
+        Ok(u) => u,
+        Err(resp) => return resp,
+    };
+    let parsed: pollis_delivery::profile::AcceptDmBody = match serde_json::from_slice(&body) {
+        Ok(b) => b,
+        Err(_) => return ds_bad_request(),
+    };
+    let conn = match state.main.conn().await {
+        Ok(c) => c,
+        Err(e) => return ds_internal_error(format!("conn: {e}")),
+    };
+    match pollis_delivery::profile::apply_accept_dm(&conn, Some(&authed), &parsed).await {
+        Ok(o) => ds_outcome(o),
+        Err(e) => ds_internal_error(format!("dm/accept: {e}")),
+    }
+}
+
 /// Boot an axum router exposing the DS's full write surface (`/v1/commits` plus
 /// the W4–W8 endpoints) backed by the shared `RemoteDb`, bind it on a loopback
 /// port, and serve it on a DEDICATED OS thread with its own runtime so the
@@ -712,6 +875,22 @@ async fn spawn_in_process_delivery(main: Arc<RemoteDb>, log: Arc<RemoteDb>) -> S
                         "/v1/attachments/delete",
                         axum::routing::post(delivery_attachments_delete),
                     )
+                    // Domain C (#419) — all on the MAIN DB.
+                    .route(
+                        "/v1/profile/update",
+                        axum::routing::post(delivery_profile_update),
+                    )
+                    .route(
+                        "/v1/profile/preferences",
+                        axum::routing::post(delivery_profile_preferences),
+                    )
+                    .route("/v1/blocks/add", axum::routing::post(delivery_blocks_add))
+                    .route(
+                        "/v1/blocks/remove",
+                        axum::routing::post(delivery_blocks_remove),
+                    )
+                    .route("/v1/dm/create", axum::routing::post(delivery_dm_create))
+                    .route("/v1/dm/accept", axum::routing::post(delivery_dm_accept))
                     .with_state(state);
                 // Bind :0 so the OS hands us a free port; read it back before serving.
                 let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))

--- a/src-tauri/tests/flows/security.rs
+++ b/src-tauri/tests/flows/security.rs
@@ -167,3 +167,63 @@ async fn ds_rejects_domain_a_writes_lacking_authorization() {
     drop(bob);
     drop(mallory);
 }
+
+/// Domain-D (#419) server-side AUTHORIZATION: every domain-D write is
+/// owner-scoped, so a *validly signed* request that names another user as the
+/// owner must be refused at 403 (not 401 — the signature is real). This proves a
+/// device cannot publish key packages or register a push token *under another
+/// user's identity*, which would let it impersonate that user in MLS adds or
+/// hijack their push delivery.
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn ds_rejects_domain_d_writes_for_another_user() {
+    wipe().await;
+
+    let mut alice = TestClient::new().await;
+    let mut mallory = TestClient::new().await;
+
+    let alice_profile = alice.sign_up("alice@test.local").await;
+    // Mallory is fully enrolled (real device key) so the rejections below are
+    // "not your account" (403), never "unknown device" (401).
+    let _mallory = mallory.sign_up("mallory@test.local").await;
+
+    let mallory_device = mallory
+        .state
+        .device_id
+        .lock()
+        .await
+        .clone()
+        .expect("mallory device_id");
+
+    // (1) Mallory signs a key-package publish that attributes the rows to ALICE.
+    //     resolve_actor refuses the body's user_id ≠ signer → 403.
+    let kp_body = serde_json::to_vec(&json!({
+        "device_id": mallory_device,
+        "packages": [{ "ref_hash": "deadbeef", "key_package": "AA==" }],
+        "user_id": alice_profile.id,
+    }))
+    .expect("serialize key-package body");
+    let code = signed_post_status(&mallory, "/v1/key-packages", &kp_body).await;
+    assert_eq!(
+        code, 403,
+        "a validly-signed key-package publish naming ANOTHER user must be FORBIDDEN, got {code}"
+    );
+
+    // (2) Mallory signs a push-token registration under ALICE's user_id → 403,
+    //     so she can't redirect alice's background notifications to her device.
+    let push_body = serde_json::to_vec(&json!({
+        "token": "ExponentPushToken[mallory]",
+        "platform": "ios",
+        "updated_at": "2026-01-01T00:00:00+00:00",
+        "user_id": alice_profile.id,
+    }))
+    .expect("serialize push-token body");
+    let code = signed_post_status(&mallory, "/v1/push-tokens", &push_body).await;
+    assert_eq!(
+        code, 403,
+        "a validly-signed push-token register naming ANOTHER user must be FORBIDDEN, got {code}"
+    );
+
+    drop(alice);
+    drop(mallory);
+}

--- a/src-tauri/tests/flows/security.rs
+++ b/src-tauri/tests/flows/security.rs
@@ -12,7 +12,8 @@
 //! Welcome-ack it drives is a *correctly signed* DS write, and the suite only
 //! passes because those succeed. This file proves the negative.
 
-use crate::harness::{delivery_url, raw_post_status, wipe, TestClient};
+use crate::harness::{delivery_url, raw_post_status, signed_post_status, wipe, TestClient};
+use serde_json::json;
 use serial_test::serial;
 
 #[tokio::test(flavor = "multi_thread")]
@@ -76,4 +77,93 @@ async fn ds_rejects_unsigned_or_invalid_writes() {
     );
 
     drop(alice);
+}
+
+/// Domain-A (#419) server-side AUTHORIZATION: a *validly signed* message write
+/// must still be refused when the signer lacks permission. Authentication proves
+/// who they are; authorization is what they lack. This is the security core of
+/// the slice — the membership / sender checks live on the DS, so a client cannot
+/// write into a conversation it doesn't belong to, nor edit a message it didn't
+/// send, even with a perfectly good device signature.
+///
+/// Two refusals, both at 403 (not 401 — the requests are correctly signed):
+///   1. a NON-member signs a `messages/send` into someone else's channel;
+///   2. a member-but-NON-sender signs a `messages/edit` of another user's
+///      message.
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn ds_rejects_domain_a_writes_lacking_authorization() {
+    wipe().await;
+
+    let mut alice = TestClient::new().await;
+    let mut bob = TestClient::new().await;
+    let mut mallory = TestClient::new().await;
+
+    let _alice = alice.sign_up("alice@test.local").await;
+    let bob_profile = bob.sign_up("bob@test.local").await;
+    // Mallory is a fully enrolled user (real registered device key) but never
+    // joins alice's group — so a 403 below is "not a member", never "unknown
+    // device" (which would be 401).
+    let _mallory = mallory.sign_up("mallory@test.local").await;
+
+    let group_id = alice.create_group("Private").await;
+    let channel_id = alice.general_channel_id(&group_id).await;
+
+    // Bob joins so he is a current member (but not the sender of alice's msg).
+    alice.invite(&group_id, &bob_profile.username).await;
+    let invite_id = bob
+        .first_pending_invite()
+        .await
+        .expect("bob invite")["id"]
+        .as_str()
+        .expect("invite id")
+        .to_string();
+    bob.accept_invite(&invite_id).await;
+    bob.poll().await;
+    alice.process_commits_for(&channel_id).await;
+
+    // Alice sends a real message; its envelope (sender_id = alice) now exists
+    // remotely for the edit-authz path to resolve against.
+    let msg_id = alice
+        .send_channel_message_id(&channel_id, "alice's message")
+        .await;
+
+    // (1) Non-member send → 403. Mallory signs the exact body the client seam
+    //     would, but she is not a member of `channel_id`.
+    let send_body = serde_json::to_vec(&json!({
+        "id": "01TESTNONMEMBERSENDXXXXXXX",
+        "conversation_id": channel_id,
+        "sender_id": mallory.user_id(),
+        "ciphertext": "mls:00",
+        "reply_to_id": null,
+        "sent_at": "2026-01-01T00:00:00+00:00",
+    }))
+    .expect("serialize send body");
+    let code = signed_post_status(&mallory, "/v1/messages/send", &send_body).await;
+    assert_eq!(
+        code, 403,
+        "a validly-signed send from a non-member must be FORBIDDEN, got {code}"
+    );
+
+    // (2) Member-but-non-sender edit → 403. Bob is a current member, so he
+    //     passes the membership gate, but the target message's sender is alice,
+    //     so the sender-only edit check refuses him.
+    let edit_body = serde_json::to_vec(&json!({
+        "envelope_id": "01TESTBOGUSEDITENVXXXXXXXX",
+        "conversation_id": channel_id,
+        "target_message_id": msg_id,
+        "sender_id": bob.user_id(),
+        "ciphertext": "mls:00",
+        "sent_at": "2026-01-01T00:00:00+00:00",
+    }))
+    .expect("serialize edit body");
+    let code = signed_post_status(&bob, "/v1/messages/edit", &edit_body).await;
+    assert_eq!(
+        code, 403,
+        "a validly-signed edit of someone else's message must be FORBIDDEN, got {code}"
+    );
+
+    drop(alice);
+    drop(bob);
+    drop(mallory);
 }

--- a/src-tauri/tests/flows/security.rs
+++ b/src-tauri/tests/flows/security.rs
@@ -331,3 +331,157 @@ async fn ds_rejects_domain_d_writes_for_another_user() {
     drop(alice);
     drop(mallory);
 }
+
+/// Domains E + G (#419) server-side AUTHORIZATION: every account-lifecycle op is
+/// SELF-scoped — a user rotates / deletes / recovers / audits / approves only
+/// THEIR OWN account. A *validly signed* request that names ANOTHER user as the
+/// target must be refused at 403 (not 401 — the signature is real). This proves a
+/// device cannot rotate another user's identity key (which would let it take over
+/// the account-key transparency log), delete their account, forge an audit event
+/// under their name, or approve a device onto their account.
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn ds_rejects_domain_eg_writes_for_another_user() {
+    wipe().await;
+
+    let mut alice = TestClient::new().await;
+    let mut mallory = TestClient::new().await;
+
+    let alice_profile = alice.sign_up("alice@test.local").await;
+    // Mallory is fully enrolled (real device key) so the rejections below are
+    // "not your account" (403), never "unknown device" (401).
+    let _mallory = mallory.sign_up("mallory@test.local").await;
+
+    // (1) Mallory signs an identity rotation that names ALICE → 403. resolve_actor
+    //     refuses the body's user_id ≠ signer BEFORE any account_key_log touch, so
+    //     the transparency log is never even reached.
+    let rotate_body = serde_json::to_vec(&json!({
+        "based_on_version": 1,
+        "account_id_pub": "AA==",
+        "salt": "AA==",
+        "nonce": "AA==",
+        "wrapped_key": "AA==",
+        "user_id": alice_profile.id,
+    }))
+    .expect("serialize rotate body");
+    let code = signed_post_status(&mallory, "/v1/account/rotate-identity", &rotate_body).await;
+    assert_eq!(
+        code, 403,
+        "a validly-signed identity rotation of ANOTHER user must be FORBIDDEN, got {code}"
+    );
+
+    // (2) Mallory signs an account deletion naming ALICE → 403.
+    let delete_body = serde_json::to_vec(&json!({ "user_id": alice_profile.id }))
+        .expect("serialize delete body");
+    let code = signed_post_status(&mallory, "/v1/account/delete", &delete_body).await;
+    assert_eq!(
+        code, 403,
+        "a validly-signed account deletion of ANOTHER user must be FORBIDDEN, got {code}"
+    );
+
+    // (3) Mallory signs a security-event forging ALICE's audit log → 403.
+    let event_body = serde_json::to_vec(&json!({
+        "kind": "identity_reset",
+        "user_id": alice_profile.id,
+    }))
+    .expect("serialize event body");
+    let code = signed_post_status(&mallory, "/v1/security-events", &event_body).await;
+    assert_eq!(
+        code, 403,
+        "a validly-signed security-event under ANOTHER user's name must be FORBIDDEN, got {code}"
+    );
+
+    // (4) Mallory signs an enrollment approval naming ALICE → 403 (she may only
+    //     approve enrollments onto her OWN account).
+    let approve_body = serde_json::to_vec(&json!({
+        "request_id": "01TESTENROLLREQXXXXXXXXXXX",
+        "wrapped_account_key": "AA==",
+        "approved_by_device_id": "01TESTDEVICEXXXXXXXXXXXXXX",
+        "user_id": alice_profile.id,
+    }))
+    .expect("serialize approve body");
+    let code = signed_post_status(&mallory, "/v1/enrollment/approve", &approve_body).await;
+    assert_eq!(
+        code, 403,
+        "a validly-signed enrollment approval onto ANOTHER user's account must be FORBIDDEN, got {code}"
+    );
+
+    drop(alice);
+    drop(mallory);
+}
+
+/// Domain E (#419) `account_key_log` CAS — the transparency-log analogue of the
+/// commit-log fork test (`concurrent_commits_at_same_epoch_must_not_fork_a_member`).
+///
+/// `account_key_log` is an append-only, transparency-backed log keyed
+/// `UNIQUE (user_id, identity_version)`. If two rotations from the same head both
+/// landed, the published account-key tree would FORK. The CAS in
+/// `apply_rotate_identity` (`INSERT … WHERE based_on == current head … ON CONFLICT
+/// DO NOTHING`) must let exactly one win: the second rotation that names the SAME
+/// `based_on_version` after the first has advanced the head is rejected with 409,
+/// and the log keeps exactly ONE row at the new version.
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn account_key_log_cas_rejects_second_rotation_at_same_version() {
+    wipe().await;
+
+    let mut alice = TestClient::new().await;
+    let _alice = alice.sign_up("alice@test.local").await;
+
+    // sign_up established alice's account identity at version 1 (the direct
+    // bootstrap write), so both rotations below claim the same head: version 1.
+    let rotate = |pubk: &str| {
+        serde_json::to_vec(&json!({
+            "based_on_version": 1,
+            "account_id_pub": pubk,
+            "salt": "AQ==",
+            "nonce": "Ag==",
+            "wrapped_key": "Aw==",
+        }))
+        .expect("serialize rotate body")
+    };
+
+    // First rotation from head=1 wins → 200, advancing the head to version 2.
+    let first = signed_post_status(&alice, "/v1/account/rotate-identity", &rotate("EAAA")).await;
+    assert_eq!(
+        first, 200,
+        "the first rotation from the current head must be ACCEPTED, got {first}"
+    );
+
+    // Second rotation ALSO claims head=1 (a stale/duplicate append, exactly the
+    // concurrent-fork shape). The CAS sees the head is now 2 ≠ 1 → 409. No fork.
+    let second = signed_post_status(&alice, "/v1/account/rotate-identity", &rotate("IAAA")).await;
+    assert_eq!(
+        second, 409,
+        "a second rotation from an already-consumed head must CONFLICT (no fork), got {second}"
+    );
+
+    // The append-only log holds exactly ONE row at version 2 — the winner's. A
+    // fork would show two distinct rows at the same (user_id, identity_version).
+    let conn = alice
+        .state
+        .remote_db
+        .conn()
+        .await
+        .expect("remote conn");
+    let mut rows = conn
+        .query(
+            "SELECT COUNT(*) FROM account_key_log WHERE user_id = ?1 AND identity_version = 2",
+            libsql::params![alice.user_id().to_string()],
+        )
+        .await
+        .expect("account_key_log count query");
+    let count: i64 = rows
+        .next()
+        .await
+        .expect("row")
+        .expect("some row")
+        .get(0)
+        .expect("count");
+    assert_eq!(
+        count, 1,
+        "account_key_log must hold exactly one row at version 2 (no fork), got {count}"
+    );
+
+    drop(alice);
+}

--- a/src-tauri/tests/flows/security.rs
+++ b/src-tauri/tests/flows/security.rs
@@ -272,6 +272,77 @@ async fn ds_rejects_domain_c_writes_lacking_authorization() {
     drop(bob);
 }
 
+/// Goal-B STRAGGLERS (#419) server-side AUTHORIZATION: DM membership churn. A
+/// *validly signed* `dm/add` or `dm/remove` from a user who is NOT in the DM must
+/// be refused at 403 (not 401 — the signature is real). DM membership is
+/// re-derived server-side, so an outsider can neither pull a third party into a
+/// conversation it isn't part of, nor evict an existing member.
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn ds_rejects_dm_churn_by_non_member() {
+    wipe().await;
+
+    let mut alice = TestClient::new().await;
+    let mut bob = TestClient::new().await;
+    let mut mallory = TestClient::new().await;
+
+    let alice_profile = alice.sign_up("alice@test.local").await;
+    let bob_profile = bob.sign_up("bob@test.local").await;
+    // Mallory is fully enrolled (real device key) so the rejections below are
+    // "not a member" (403), never "unknown device" (401).
+    let _mallory = mallory.sign_up("mallory@test.local").await;
+
+    // Alice and Bob share a DM; Mallory is an outsider.
+    let dm_id = alice
+        .create_dm(&[alice_profile.id.as_str(), bob_profile.id.as_str()])
+        .await;
+
+    // (1) Mallory signs an add into alice+bob's DM → 403 (she isn't a member, so
+    //     she cannot add anyone — the actor membership check refuses it).
+    let add_body = serde_json::to_vec(&json!({
+        "dm_channel_id": dm_id,
+        "user_id": mallory.user_id(),
+        "added_by": mallory.user_id(),
+        "added_at": "2026-01-01T00:00:00+00:00",
+    }))
+    .expect("serialize dm/add body");
+    let code = signed_post_status(&mallory, "/v1/dm/add", &add_body).await;
+    assert_eq!(
+        code, 403,
+        "a validly-signed dm/add by a non-member must be FORBIDDEN, got {code}"
+    );
+
+    // (2) Mallory signs a removal of Bob from alice+bob's DM → 403 (she is neither
+    //     the removed user nor the channel creator).
+    let remove_body = serde_json::to_vec(&json!({
+        "dm_channel_id": dm_id,
+        "user_id": bob_profile.id,
+        "requester_id": mallory.user_id(),
+    }))
+    .expect("serialize dm/remove body");
+    let code = signed_post_status(&mallory, "/v1/dm/remove", &remove_body).await;
+    assert_eq!(
+        code, 403,
+        "a validly-signed dm/remove by a non-creator/non-self must be FORBIDDEN, got {code}"
+    );
+
+    // Bob is still a member — the rejected removal changed nothing.
+    let still_member = bob
+        .list_dm_requests()
+        .await
+        .iter()
+        .chain(bob.list_dms().await.iter())
+        .any(|dm| dm["id"].as_str() == Some(dm_id.as_str()));
+    assert!(
+        still_member,
+        "bob must remain a member after the forbidden removal"
+    );
+
+    drop(alice);
+    drop(bob);
+    drop(mallory);
+}
+
 /// Domain-D (#419) server-side AUTHORIZATION: every domain-D write is
 /// owner-scoped, so a *validly signed* request that names another user as the
 /// owner must be refused at 403 (not 401 — the signature is real). This proves a

--- a/src-tauri/tests/flows/security.rs
+++ b/src-tauri/tests/flows/security.rs
@@ -167,3 +167,53 @@ async fn ds_rejects_domain_a_writes_lacking_authorization() {
     drop(bob);
     drop(mallory);
 }
+
+/// Domain-C (#419) server-side AUTHORIZATION: a *validly signed* profile / block
+/// write must still be refused when the signer targets ANOTHER user's row. You
+/// may only edit your OWN profile and manage your OWN block list — the DS binds
+/// the actor in the body to the authenticated signer, so a perfectly good device
+/// signature cannot be used to write as someone else.
+///
+/// Two refusals, both at 403 (not 401 — the requests are correctly signed):
+///   1. alice signs a `profile/update` whose `user_id` is BOB's;
+///   2. alice signs a `blocks/add` whose `blocker_id` is BOB's.
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn ds_rejects_domain_c_writes_lacking_authorization() {
+    wipe().await;
+
+    let mut alice = TestClient::new().await;
+    let mut bob = TestClient::new().await;
+
+    let _alice = alice.sign_up("alice@test.local").await;
+    let bob_profile = bob.sign_up("bob@test.local").await;
+
+    // (1) alice signs a profile edit for BOB's row → 403. The signature proves
+    //     she is alice; the body claims to edit bob, which the actor binding
+    //     refuses.
+    let profile_body = serde_json::to_vec(&json!({
+        "user_id": bob_profile.id,
+        "username": "hacked-by-alice",
+    }))
+    .expect("serialize profile body");
+    let code = signed_post_status(&alice, "/v1/profile/update", &profile_body).await;
+    assert_eq!(
+        code, 403,
+        "a validly-signed profile edit of someone else's row must be FORBIDDEN, got {code}"
+    );
+
+    // (2) alice signs a block AS BOB → 403. You manage only your own block list.
+    let block_body = serde_json::to_vec(&json!({
+        "blocker_id": bob_profile.id,
+        "blocked_id": alice.user_id(),
+    }))
+    .expect("serialize block body");
+    let code = signed_post_status(&alice, "/v1/blocks/add", &block_body).await;
+    assert_eq!(
+        code, 403,
+        "a validly-signed block on another user's behalf must be FORBIDDEN, got {code}"
+    );
+
+    drop(alice);
+    drop(bob);
+}

--- a/src-tauri/tests/flows/security.rs
+++ b/src-tauri/tests/flows/security.rs
@@ -167,3 +167,71 @@ async fn ds_rejects_domain_a_writes_lacking_authorization() {
     drop(bob);
     drop(mallory);
 }
+
+/// Domain-B (#419) server-side AUTHORIZATION: a *validly signed* group/channel
+/// admin op must still be refused when the signer is only a plain member. The
+/// admin role is re-derived server-side from `group_member`, so a non-admin
+/// cannot remove another member or delete a channel even with a perfect device
+/// signature.
+///
+/// Two refusals, both 403 (the requests are correctly signed):
+///   1. a member-but-NON-admin signs `members/remove` targeting the admin;
+///   2. the same member signs `channels/delete` of the group's channel.
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn ds_rejects_domain_b_admin_ops_lacking_authorization() {
+    wipe().await;
+
+    let mut alice = TestClient::new().await;
+    let mut bob = TestClient::new().await;
+
+    let alice_profile = alice.sign_up("alice@test.local").await;
+    let bob_profile = bob.sign_up("bob@test.local").await;
+
+    // Alice owns the group (admin). Bob joins as a plain member.
+    let group_id = alice.create_group("Private").await;
+    let channel_id = alice.general_channel_id(&group_id).await;
+
+    alice.invite(&group_id, &bob_profile.username).await;
+    let invite_id = bob
+        .first_pending_invite()
+        .await
+        .expect("bob invite")["id"]
+        .as_str()
+        .expect("invite id")
+        .to_string();
+    bob.accept_invite(&invite_id).await;
+    bob.poll().await;
+    alice.process_commits_for(&channel_id).await;
+
+    // (1) Non-admin tries to remove the admin → 403. Bob is a member, so the
+    //     request is well-formed and signed, but removing *another* member is
+    //     admin-only, and the server re-derives Bob's role as `member`.
+    let remove_body = serde_json::to_vec(&json!({
+        "group_id": group_id,
+        "user_id": alice_profile.id,
+        "requester_id": bob.user_id(),
+    }))
+    .expect("serialize remove body");
+    let code = signed_post_status(&bob, "/v1/members/remove", &remove_body).await;
+    assert_eq!(
+        code, 403,
+        "a non-admin removing another member must be FORBIDDEN, got {code}"
+    );
+
+    // (2) Non-admin tries to delete a channel → 403. Destructive channel ops are
+    //     admin-only; Bob's re-derived role is `member`.
+    let delete_body = serde_json::to_vec(&json!({
+        "channel_id": channel_id,
+        "requester_id": bob.user_id(),
+    }))
+    .expect("serialize delete body");
+    let code = signed_post_status(&bob, "/v1/channels/delete", &delete_body).await;
+    assert_eq!(
+        code, 403,
+        "a non-admin deleting a channel must be FORBIDDEN, got {code}"
+    );
+
+    drop(alice);
+    drop(bob);
+}


### PR DESCRIPTION
Routes every remaining client remote write behind the Delivery Service (now a general write-API server), so the client can eventually hold a **read-only token on the entire main DB** (the mobile-app-review win). Builds on Goal A's signed-client foundation. **No schema change** — uses existing tables; apply-migrations is a no-op.

### Domains routed (~43 new `POST /v1/...` endpoints, all signed + server-side-authorized)
- **A** messages / envelopes / watermarks / reactions / attachments
- **B** groups / channels / membership / invites / join-requests
- **C** profile / preferences / blocks / DMs (+ DM membership churn)
- **D** key-packages / device-cert resign / push-tokens
- **E/G** account lifecycle / identity rotation / recovery / security-audit

Each endpoint runs the same pure `apply_*(conn, authed, body)` fn in production and in the in-process test harness, with authz (member/admin/owner) re-derived server-side. Multi-table ops are transactional. **Flows suite: 40/0** with auth enforced.

### ⚠️ Review-worthy
- **`account_key_log` CAS** (E/G): identity rotation appends to the transparency-backed account-key log via a commit-log-style conditional `INSERT … WHERE based_on_version = head … ON CONFLICT DO NOTHING` (409 on loss), with the `identity_version` bump in one atomic unit. Has a concurrent-rotation CAS test. This backs verify.pollis.com's account-key tenant — **worth a careful read.**
- `delete_account` + `reset_identity_and_recover` are each one DS transaction.

### Still direct (bootstrap — flagged, not a regression)
Writes that *establish* a credential can't be authed by it: account creation (`verify_otp`), `register_device`, `ensure_device_cert`, first identity version, enrollment-request, logout, and the peer key-package claim (folds into `/v1/commits`). These need an **OTP-session-gated bootstrap endpoint** — the last piece before Step 3.

### Not in this PR
- Step 3 (flip client to a read-only main-DB token + delete the direct-write fallbacks).
- The OTP-gated bootstrap endpoint (separate branch, in progress).