### PR TITLE
fix: retry-safe first-device signup + scrollable auth screens

### DIFF
--- a/frontend/src/components/Auth/EnrollmentApprovalPrompt.tsx
+++ b/frontend/src/components/Auth/EnrollmentApprovalPrompt.tsx
@@ -75,11 +75,12 @@ export const EnrollmentApprovalPrompt: React.FC<EnrollmentApprovalPromptProps> =
       <TitleBar />
 
       <div
-        className="flex-1 flex items-center justify-center"
+        className="flex-1 flex justify-center overflow-y-auto"
         style={{ position: "relative", zIndex: 1, padding: "1rem" }}
       >
         <Card
           padding="lg"
+          className="my-auto"
           style={{
             width: "100%",
             maxWidth: 480,

--- a/frontend/src/components/Auth/EnrollmentGateScreen.tsx
+++ b/frontend/src/components/Auth/EnrollmentGateScreen.tsx
@@ -140,7 +140,7 @@ export const EnrollmentGateScreen: React.FC<EnrollmentGateScreenProps> = ({
       <TitleBar />
 
       <div
-        className="flex-1 flex items-center justify-center"
+        className="flex-1 flex justify-center overflow-y-auto"
         style={{ position: "relative", zIndex: 1, padding: "1rem" }}
       >
         <Card
@@ -148,6 +148,12 @@ export const EnrollmentGateScreen: React.FC<EnrollmentGateScreenProps> = ({
           style={{
             width: "100%",
             maxWidth: 460,
+            // Center vertically when the window is tall enough, but fall back
+            // to scrolling (auto margins + overflow-y-auto on the parent, NOT
+            // items-center) when the card is taller than the viewport so the
+            // top isn't clipped on short windows.
+            marginTop: "auto",
+            marginBottom: "auto",
             // Visually distinct accent border so this doesn't blend with
             // the OTP card.
             border: "2px solid var(--c-accent)",
@@ -377,7 +383,9 @@ const SecretKeyFallbackPane: React.FC<{
       await api.recoverWithSecretKey(userId, value.trim());
       onRecovered();
     } catch (err) {
-      const message = err instanceof Error ? err.message : "Recovery failed";
+      // Surface the real backend reason (Tauri rejects with a string, not an
+      // Error) instead of a generic "Recovery failed".
+      const message = err instanceof Error ? err.message : String(err) || "Recovery failed";
       setError(message);
     } finally {
       setIsLoading(false);
@@ -474,7 +482,10 @@ const ResetConfirmPane: React.FC<{
       const newKey = await api.resetIdentityAndRecover(userId, typedEmail.trim());
       onResetComplete(newKey);
     } catch (err) {
-      const message = err instanceof Error ? err.message : "Reset failed";
+      // Tauri rejects with a serialized string, not an Error — fall back to
+      // String(err) (matching PinEntryScreen) so the real backend reason
+      // surfaces instead of a generic "Reset failed".
+      const message = err instanceof Error ? err.message : String(err) || "Reset failed";
       setError(message);
     } finally {
       setIsLoading(false);

--- a/frontend/src/components/Auth/LoginScreen.tsx
+++ b/frontend/src/components/Auth/LoginScreen.tsx
@@ -36,8 +36,8 @@ export const LoginScreen: React.FC<LoginScreenProps> = ({
 
       <TitleBar />
 
-      <div className="flex-1 flex items-center justify-center" style={{ position: "relative", zIndex: 1 }}>
-        <Card padding="lg" style={{ width: "100%", maxWidth: 360 }}>
+      <div className="flex-1 flex justify-center overflow-y-auto" style={{ position: "relative", zIndex: 1 }}>
+        <Card padding="lg" className="my-auto" style={{ width: "100%", maxWidth: 360 }}>
           {view === "wipe" ? (
             <div data-testid="wipe-confirm-section" className="flex flex-col gap-5">
               <div>

--- a/frontend/src/components/Auth/PinCreateScreen.tsx
+++ b/frontend/src/components/Auth/PinCreateScreen.tsx
@@ -91,10 +91,10 @@ export const PinCreateScreen: React.FC<PinCreateScreenProps> = ({
       </div>
       <TitleBar />
       <div
-        className="flex-1 flex items-center justify-center"
+        className="flex-1 flex justify-center overflow-y-auto"
         style={{ position: "relative", zIndex: 1 }}
       >
-        <Card padding="lg" style={{ width: "100%", maxWidth: 360 }}>
+        <Card padding="lg" className="my-auto" style={{ width: "100%", maxWidth: 360 }}>
           <div className="flex flex-col gap-5">
             <div>
               <h2 className="text-sm font-mono font-semibold" style={{ color: "var(--c-text)" }}>

--- a/frontend/src/components/Auth/PinEntryScreen.tsx
+++ b/frontend/src/components/Auth/PinEntryScreen.tsx
@@ -71,10 +71,10 @@ export const PinEntryScreen: React.FC<PinEntryScreenProps> = ({
       </div>
       <TitleBar />
       <div
-        className="flex-1 flex items-center justify-center"
+        className="flex-1 flex justify-center overflow-y-auto"
         style={{ position: "relative", zIndex: 1 }}
       >
-        <Card padding="lg" style={{ width: "100%", maxWidth: 360 }}>
+        <Card padding="lg" className="my-auto" style={{ width: "100%", maxWidth: 360 }}>
           <div className="flex flex-col gap-5">
             <div>
               <h2 className="text-sm font-mono font-semibold" style={{ color: "var(--c-text)" }}>

--- a/frontend/src/components/Auth/SaveSecretKeyScreen.tsx
+++ b/frontend/src/components/Auth/SaveSecretKeyScreen.tsx
@@ -127,10 +127,10 @@ export const SaveSecretKeyScreen: React.FC<SaveSecretKeyScreenProps> = ({
         </div>
         <TitleBar />
         <div
-          className="flex-1 flex items-center justify-center"
+          className="flex-1 flex justify-center overflow-y-auto"
           style={{ position: "relative", zIndex: 1, padding: "1rem" }}
         >
-          <Card padding="lg" style={{ width: "100%", maxWidth: 480 }}>
+          <Card padding="lg" className="my-auto" style={{ width: "100%", maxWidth: 480 }}>
             <div className="flex flex-col gap-5">
               <div>
                 <h1
@@ -189,10 +189,10 @@ export const SaveSecretKeyScreen: React.FC<SaveSecretKeyScreenProps> = ({
         </div>
         <TitleBar />
         <div
-          className="flex-1 flex items-center justify-center"
+          className="flex-1 flex justify-center overflow-y-auto"
           style={{ position: "relative", zIndex: 1, padding: "1rem", overflowY: "auto" }}
         >
-          <Card padding="lg" style={{ width: "100%", maxWidth: 480 }}>
+          <Card padding="lg" className="my-auto" style={{ width: "100%", maxWidth: 480 }}>
             <div className="flex flex-col gap-5">
               <div>
                 <h1
@@ -287,10 +287,10 @@ export const SaveSecretKeyScreen: React.FC<SaveSecretKeyScreenProps> = ({
       </div>
       <TitleBar />
       <div
-        className="flex-1 flex items-center justify-center"
+        className="flex-1 flex justify-center overflow-y-auto"
         style={{ position: "relative", zIndex: 1, padding: "1rem" }}
       >
-        <Card padding="lg" style={{ width: "100%", maxWidth: 480 }}>
+        <Card padding="lg" className="my-auto" style={{ width: "100%", maxWidth: 480 }}>
           <div className="flex flex-col gap-5">
             <div>
               <h1

--- a/pollis-core/src/commands/auth.rs
+++ b/pollis-core/src/commands/auth.rs
@@ -75,16 +75,21 @@ pub async fn request_otp(
     state: &Arc<AppState>,
     email: String,
 ) -> Result<()> {
+    eprintln!(
+        "[auth] request_otp: email={email} → delivery_url={:?}",
+        state.config.pollis_delivery_url
+    );
     let resp = crate::commands::mls::ds_post_plain(
         state,
         "/v1/auth/request-otp",
         &serde_json::json!({ "email": email }),
     )
     .await?;
-    if !resp.status().is_success() {
-        let s = resp.status();
+    let status = resp.status();
+    eprintln!("[auth] request_otp: DS responded HTTP {status}");
+    if !status.is_success() {
         let txt = resp.text().await.unwrap_or_default();
-        return Err(anyhow::anyhow!("request-otp failed ({s}): {txt}").into());
+        return Err(anyhow::anyhow!("request-otp failed ({status}): {txt}").into());
     }
     Ok(())
 }
@@ -136,6 +141,10 @@ async fn verify_otp_ds(
 
     // 1. verify-otp: DS validates the OTP, creates/loads the account, mints a
     //    session. Unauthenticated (the OTP itself is the proof).
+    eprintln!(
+        "[auth] verify_otp: email={email} → delivery_url={:?}",
+        state.config.pollis_delivery_url
+    );
     let resp = crate::commands::mls::ds_post_plain(
         state,
         "/v1/auth/verify-otp",
@@ -147,6 +156,7 @@ async fn verify_otp_ds(
     )
     .await?;
     let status = resp.status();
+    eprintln!("[auth] verify_otp: DS responded HTTP {status}");
     if status.as_u16() == 401 {
         return Err(anyhow::anyhow!("Invalid code. Please check and try again.").into());
     }
@@ -201,16 +211,36 @@ async fn verify_otp_ds(
     }
 
     let new_secret_key = if !has_identity {
-        // First-device signup (or a pre-identity account). Persist the candidate
-        // device_id (no existing slot for a brand-new user) and set it as this
-        // device's id — the session is bound to it, so establish/register/cert
-        // must all use the same value.
-        let device_id = ensure_device_id(state, &user_id, &candidate_device_id).await?;
+        eprintln!("[auth] verify_otp: first-device path (has_identity=false) user_id={user_id}");
+        // FORCE this device's id to the session-bound candidate — do NOT preserve
+        // whatever the keystore holds. On a genuine first signup the slot is empty,
+        // so this is identical to `ensure_device_id`. But on a RETRY after a
+        // partial-bootstrap failure (a transient establish-identity error, a
+        // dropped connection, etc.) the keystore still holds the ABORTED attempt's
+        // candidate, while this call's verify-otp minted a session bound to a FRESH
+        // candidate. Preserving the stale id makes register-device send a device_id
+        // the session doesn't authorize, which the DS rejects as Forbidden — and it
+        // stays wedged on every retry until the keychain is cleared by hand.
+        // `has_identity == false` guarantees no device was ever registered
+        // (register-device runs AFTER establish-identity, which is what sets the
+        // identity), so the stale id is worthless and overwriting it is safe. This
+        // makes first-device signup idempotent under retry.
+        state
+            .keystore
+            .store_for_user(DEVICE_ID_KEY, &user_id, candidate_device_id.as_bytes())
+            .await?;
+        *state.device_id.lock().await = Some(candidate_device_id.clone());
+        let device_id = candidate_device_id.clone();
 
         // Pure crypto: keygen + Secret Key + wrap, installed into state.unlock.
         let (secret_key, material) =
             crate::commands::account_identity::generate_account_identity_material(state, &user_id)
-                .await?;
+                .await
+                .map_err(|e| {
+                    eprintln!("[auth] verify_otp: generate_account_identity_material FAILED: {e}");
+                    e
+                })?;
+        eprintln!("[auth] verify_otp: identity material ready (device_id={device_id}) → establish-identity");
 
         // 2. establish-identity (session-gated): the DS does the CAS UPDATE +
         //    account_key_log v1 + account_recovery insert.
@@ -227,7 +257,12 @@ async fn verify_otp_ds(
                 "wrapped_key": b64.encode(&material.wrapped_key),
             }),
         )
-        .await?;
+        .await
+        .map_err(|e| {
+            eprintln!("[auth] verify_otp: establish-identity FAILED: {e}");
+            e
+        })?;
+        eprintln!("[auth] verify_otp: establish-identity OK → register-device");
 
         // 3. register-device (session-gated): the DS inserts the user_device row
         //    + seeds watermarks.
@@ -239,7 +274,12 @@ async fn verify_otp_ds(
             &session_token,
             &serde_json::json!({ "device_id": device_id, "device_name": device_name }),
         )
-        .await?;
+        .await
+        .map_err(|e| {
+            eprintln!("[auth] verify_otp: register-device FAILED: {e}");
+            e
+        })?;
+        eprintln!("[auth] verify_otp: register-device OK (first-device bootstrap complete)");
 
         // Stash the session so the pivot — the first publish-device-cert, run by
         // set_pin → ensure_device_cert — can present it.


### PR DESCRIPTION
Two independent fixes surfaced while debugging a wedged signup (separate commits):

**`fix(auth)` — retry-safe first-device signup.** A partial-failure mid-bootstrap (e.g. a transient establish-identity error) persisted a device_id, but each retry bound a fresh verify-otp session to a *new* candidate → register-device sent a device_id the session didn't authorize → DS `Forbidden`, wedged permanently until the keychain was cleared by hand. The first-device path now forces the session-bound candidate (safe: `has_identity==false` ⇒ no device was ever registered). Adds `[auth]` request/verify logging (URL + DS status; never the OTP code).

**`fix(auth-ui)` — scrollable auth screens.** All six auth/enrollment screens centered their card with `items-center` + no overflow, clipping on short windows. Switched to `justify-center` + `overflow-y-auto` + `my-auto` (centers when tall enough, scrolls otherwise). Also unmasked the reset/recovery errors (Tauri rejects with a string, not an `Error`).

Follow-ups (not in this PR): an integration test for the retry wedge (needs a failure-injection hook in the harness), and the dev-DB migration auto-apply workflow.