### PR TITLE
fix(capture): dev always rebuilds the helper sidecar + optimized frame hot path (#394)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,20 @@ rust-version = "1.77"
 [profile.dev]
 incremental = true
 
+# The capture helpers do per-pixel work in Rust on the frame hot path
+# (MJPEG decode via zune-jpeg, YUYV/RGB → BGRx packing). At opt-level 0
+# that's ~220ms per 720p frame — the camera drops from 30fps to ~4.5fps
+# and frames queue up seconds of latency in the V4L2 ring. Dev builds of
+# everything else stay unoptimized; the helper + its decoder must not.
+[profile.dev.package.pollis-capture-linux]
+opt-level = 3
+[profile.dev.package.pollis-capture-macos]
+opt-level = 3
+[profile.dev.package.zune-jpeg]
+opt-level = 3
+[profile.dev.package.zune-core]
+opt-level = 3
+
 [profile.release]
 panic = "abort"
 codegen-units = 1

--- a/pollis-capture-linux/src/camera.rs
+++ b/pollis-capture-linux/src/camera.rs
@@ -260,6 +260,10 @@ fn capture_loop(
             Ok(v) => v,
             Err(e) => return Err(anyhow!("dequeue frame: {e}")),
         };
+        // Stamp at dequeue, not at enqueue-to-socket: the timestamp should
+        // reflect when the sensor frame left the driver, so decode/convert
+        // time shows up as measurable latency instead of hiding.
+        let captured_us = now_us();
         let used = (meta.bytesused as usize).min(buf.len());
         let data = &buf[..used];
 
@@ -294,7 +298,7 @@ fn capture_loop(
             width: even_w,
             height: even_h,
             stride,
-            timestamp_us: now_us(),
+            timestamp_us: captured_us,
             bgrx: bgrx.clone(),
         });
     }

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -76,12 +76,19 @@ fn stage_capture_helper() {
     // CI's helper job uploads only the sidecar artifact (see
     // .github/workflows/desktop-release.yml — the build-capture-helper
     // job runs on ubuntu-24.04 to get PipeWire 1.0 headers, the app job
-    // on 22.04 can't compile libspa). If we required both copies before
-    // skipping the rebuild, the app job would always fall through into
-    // an unbuildable nested cargo invocation. Treat the sidecar as the
-    // authoritative pre-staged artifact: when it's present, mirror it to
-    // the dev path (if missing) and skip the inner build entirely.
-    if sidecar.exists() {
+    // on 22.04 can't compile libspa). There the pre-staged sidecar is
+    // authoritative: mirror it to the dev path and skip the inner build,
+    // which the app job couldn't run anyway.
+    //
+    // Only in CI, though. On a dev machine an existing sidecar must NOT
+    // short-circuit the rebuild: `binaries/` is gitignored, and `tauri dev`
+    // re-copies the sidecar over target/<profile>/<helper> on every launch
+    // (externalBin staging), so a stale sidecar would silently pin every
+    // dev run to whatever helper was first staged — that's how a pre-#394
+    // helper without `--mode camera` kept resurrecting itself. Locally we
+    // always rebuild (incremental, own target dir) and overwrite both
+    // staged copies so they can never diverge from the source tree.
+    if sidecar.exists() && std::env::var_os("CI").is_some() {
         if !dev_copy.exists() {
             if let Some(parent) = dev_copy.parent() {
                 std::fs::create_dir_all(parent).ok();


### PR DESCRIPTION
Two dev-environment fixes for the Linux camera path (refs #394):

- **build.rs**: an existing `src-tauri/binaries/` sidecar is only authoritative in CI (prebuilt ubuntu-24.04 artifact). Locally it froze the helper at whatever was first staged — a pre-camera May build kept resurrecting itself via `tauri dev`'s externalBin re-copy, surfacing as `Camera capture failed: For more information, try '--help'.` Dev now always rebuilds and overwrites both staged copies.
- **Cargo.toml**: `opt-level = 3` for the capture helpers + zune-jpeg in dev builds. The per-pixel MJPEG decode/BGRx pack at opt-level 0 ran ~220ms/frame (4.5fps, ~3s of queued latency); optimized it's ~5ms (camera-limited fps, 6ms pipeline latency).
- **camera.rs**: stamp frames at V4L2 dequeue instead of post-decode so decode time is visible in latency measurements.

Verified live on Linux (Razer Kiyo): enumerate → select → 1280x720 MJPG → frames at camera rate with ~6ms helper latency; camera + preview confirmed working in-app.