### PR TITLE
fix(tui): stop remote-querying on the UI tick + redirect stderr off the ratatui screen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6380,6 +6380,7 @@ dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
  "crossterm",
+ "libc",
  "libsql",
  "pollis-core",
  "pollis-delivery",

--- a/package.json
+++ b/package.json
@@ -7,12 +7,14 @@
     "dev": "WEBKIT_DISABLE_COMPOSITING_MODE=1 GDK_BACKEND=x11 pnpm tauri dev",
     "dev:tauri": "pnpm dev",
     "dev:frontend": "pnpm --filter frontend dev",
+    "cli": "sh -c 'if [ -f .env.development ]; then set -a; . ./.env.development; set +a; fi; export POLLIS_DATA_DIR=\"${POLLIS_DATA_DIR:-$HOME/.local/share/pollis-tui}\"; cargo run -p pollis-tui --bin pollis'",
+    "dev:cli": "pnpm cli",
     "lint": "pnpm --filter frontend lint",
     "clean": "pnpm --filter frontend clean && cargo clean",
-    "build:tauri": "sh -c 'if [ -f .env.development ]; then set -a; . .env.development; set +a; fi; pnpm tauri build'",
-    "build:tauri:linux": "sh -c 'if [ -f .env.development ]; then set -a; . .env.development; set +a; fi; pnpm tauri build --target x86_64-unknown-linux-gnu'",
-    "build:tauri:macos": "sh -c 'if [ -f .env.development ]; then set -a; . .env.development; set +a; fi; pnpm tauri build --target universal-apple-darwin'",
-    "build:tauri:windows": "sh -c 'if [ -f .env.development ]; then set -a; . .env.development; set +a; fi; pnpm tauri build --target x86_64-pc-windows-msvc'"
+    "build:tauri": "sh -c 'if [ -f .env.development ]; then set -a; . ./.env.development; set +a; fi; pnpm tauri build'",
+    "build:tauri:linux": "sh -c 'if [ -f .env.development ]; then set -a; . ./.env.development; set +a; fi; pnpm tauri build --target x86_64-unknown-linux-gnu'",
+    "build:tauri:macos": "sh -c 'if [ -f .env.development ]; then set -a; . ./.env.development; set +a; fi; pnpm tauri build --target universal-apple-darwin'",
+    "build:tauri:windows": "sh -c 'if [ -f .env.development ]; then set -a; . ./.env.development; set +a; fi; pnpm tauri build --target x86_64-pc-windows-msvc'"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2",

--- a/pollis-core/src/commands/dm.rs
+++ b/pollis-core/src/commands/dm.rs
@@ -14,7 +14,7 @@ use crate::state::AppState;
 /// block status.
 pub const BLOCK_ERR: &str = "message request pending";
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DmChannel {
     pub id: String,
     pub created_by: String,
@@ -22,7 +22,7 @@ pub struct DmChannel {
     pub members: Vec<DmChannelMember>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DmChannelMember {
     pub user_id: String,
     pub username: Option<String>,

--- a/pollis-core/src/commands/groups/types.rs
+++ b/pollis-core/src/commands/groups/types.rs
@@ -9,7 +9,7 @@ pub struct Group {
     pub created_at: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Channel {
     pub id: String,
     pub group_id: String,
@@ -20,7 +20,7 @@ pub struct Channel {
     pub channel_type: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GroupWithChannels {
     pub id: String,
     pub name: String,

--- a/pollis-tui/Cargo.toml
+++ b/pollis-tui/Cargo.toml
@@ -26,6 +26,8 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"
 ratatui = "0.28"
 crossterm = "0.28"
 anyhow = "1"
+# fd-level stderr redirect (pollis-core's eprintln! must not scroll the TUI).
+libc = "0.2"
 
 [dev-dependencies]
 # Re-declare pollis-core with `test-harness` so the smoke tests get the

--- a/pollis-tui/src/app.rs
+++ b/pollis-tui/src/app.rs
@@ -99,6 +99,19 @@ pub enum Action {
     RejectEnrollment(String),
 }
 
+impl Action {
+    /// Actions the UI refresh tick fires on its own. They run without the
+    /// "working…" busy hint — flashing it on a 750ms timer strobes the status
+    /// line (and for [`Action::Refresh`], the work is a cheap in-memory
+    /// snapshot read anyway).
+    pub fn is_background(&self) -> bool {
+        matches!(
+            self,
+            Action::Refresh | Action::PollEnrollment(_) | Action::LoadPendingEnrollments
+        )
+    }
+}
+
 pub struct App {
     state: Arc<AppState>,
     pub screen: Screen,
@@ -136,6 +149,10 @@ pub struct App {
 
     /// The running background poll loop; cancelled on quit for a clean shutdown.
     sync_loop: Option<sync::SyncLoop>,
+    /// The last sync round whose snapshot the UI consumed. A refresh tick only
+    /// does work when the loop has completed a newer round — the tick itself
+    /// must never issue remote queries (that's the sync loop's job).
+    last_sync_round: u64,
     /// Last-rendered height (in rows) of the message pane, so the key handler can
     /// scroll by whole pages. Updated by the renderer via [`Self::set_msg_height`].
     msg_height: usize,
@@ -159,6 +176,7 @@ impl App {
             enroll_stopped: false,
             approvals: ApprovalState::default(),
             sync_loop: None,
+            last_sync_round: 0,
             msg_height: 0,
         }
     }
@@ -752,21 +770,38 @@ impl App {
                 }
             }
             Action::EnterHome => {
-                // Start the background poll loop (spec §6). It mutates the local
-                // DB; the UI's refresh tick re-reads from it.
+                // Start the background poll loop (spec §6). It does the remote
+                // work and publishes a per-round snapshot; the UI's refresh tick
+                // consumes that snapshot without issuing queries of its own.
                 if self.sync_loop.is_none() {
                     let user_id = self.user_id();
                     self.sync_loop =
                         Some(sync::spawn_loop(self.state.clone(), user_id, SYNC_CADENCE));
                 }
-                // Load the tree once immediately so the sidebar isn't empty while
-                // the first background round runs.
-                return Some(Action::Refresh);
+                // Load the tree once immediately (user-initiated, so a visible
+                // "working…" is fine) so the sidebar isn't empty while the first
+                // background round runs.
+                self.refresh_tree().await;
             }
             Action::Refresh => {
-                self.refresh_tree().await;
-                self.refresh_open().await;
-                self.home.refreshes = self.home.refreshes.wrapping_add(1);
+                // Timer-driven and must stay cheap: consume the sync loop's
+                // latest snapshot; if no new round completed since the last
+                // tick there is nothing to do. The only remote call is the
+                // open conversation's newest-page read, and only once per
+                // completed sync round.
+                let snapshot = self
+                    .sync_loop
+                    .as_ref()
+                    .and_then(|l| l.snapshot.borrow().clone());
+                if let Some(snap) = snapshot {
+                    if snap.round > self.last_sync_round {
+                        self.last_sync_round = snap.round;
+                        let user_id = self.user_id();
+                        self.home.set_tree(snap.tree.clone(), &user_id);
+                        self.refresh_open().await;
+                        self.home.refreshes = self.home.refreshes.wrapping_add(1);
+                    }
+                }
             }
             Action::OpenSelected => self.load_open_first_page().await,
             Action::LoadOlder => self.load_open_older().await,

--- a/pollis-tui/src/data.rs
+++ b/pollis-tui/src/data.rs
@@ -36,7 +36,7 @@ pub const DEFAULT_PAGE: i64 = 50;
 /// DM *requests* are included deliberately: a member added to a DM sees it as a
 /// pending request until they accept, but the MLS group already exists and may
 /// have commits/messages to catch up on — so the sync loop must process it too.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ConversationTree {
     pub groups: Vec<GroupWithChannels>,
     pub dm_channels: Vec<DmChannel>,

--- a/pollis-tui/src/main.rs
+++ b/pollis-tui/src/main.rs
@@ -44,6 +44,13 @@ async fn main() -> Result<()> {
             .context("connecting AppState (Turso + keystore)")?,
     );
 
+    // pollis-core logs with bare `eprintln!` (fine under the desktop shell,
+    // where stderr is a dev terminal). Here stderr IS the UI's terminal — any
+    // write scrolls the screen under ratatui and corrupts the layout — so
+    // redirect fd 2 to a log file for the whole session. This also catches
+    // native-library chatter (e.g. libsql) that no Rust-level capture could.
+    let log_path = redirect_stderr_to_log();
+
     // Restore the terminal even if the render loop panics, so a crash never
     // strands the user in raw mode.
     install_panic_hook();
@@ -53,7 +60,35 @@ async fn main() -> Result<()> {
     // Explicit restore before printing any error to the (now-normal) terminal.
     drop(guard);
 
+    if let Some(path) = log_path {
+        println!("logs: {}", path.display());
+    }
+
     result
+}
+
+/// Point fd 2 at `$POLLIS_DATA_DIR/pollis-tui.log` (fallback: the OS temp dir)
+/// for the lifetime of the process. Returns the log path, or `None` if the file
+/// couldn't be opened — in that case stderr is left alone rather than lost.
+fn redirect_stderr_to_log() -> Option<std::path::PathBuf> {
+    use std::os::fd::AsRawFd;
+
+    let dir = std::env::var_os("POLLIS_DATA_DIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(std::env::temp_dir);
+    let path = dir.join("pollis-tui.log");
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .ok()?;
+    // SAFETY: dup2 onto fd 2 is the standard daemon-style redirect; the source
+    // fd stays open (leaked) so fd 2 never dangles.
+    if unsafe { libc::dup2(file.as_raw_fd(), 2) } == -1 {
+        return None;
+    }
+    std::mem::forget(file);
+    Some(path)
 }
 
 /// The render/input loop. Owns an input thread that forwards key presses over an
@@ -80,10 +115,15 @@ async fn run(guard: &mut TerminalGuard, state: Arc<AppState>) -> Result<()> {
         }
 
         // A queued async action runs after a "working…" frame is painted. Its
-        // follow-up (if any) is processed on the next iteration.
+        // follow-up (if any) is processed on the next iteration. Timer-driven
+        // actions skip the busy hint: painting "working…" every refresh tick
+        // strobes the status line.
         if let Some(action) = pending.take() {
-            app.busy = true;
-            draw(guard, &mut app)?;
+            let background = action.is_background();
+            if !background {
+                app.busy = true;
+                draw(guard, &mut app)?;
+            }
             pending = app.run(action).await;
             app.busy = false;
             continue;

--- a/pollis-tui/src/main.rs
+++ b/pollis-tui/src/main.rs
@@ -76,6 +76,10 @@ fn redirect_stderr_to_log() -> Option<std::path::PathBuf> {
     let dir = std::env::var_os("POLLIS_DATA_DIR")
         .map(std::path::PathBuf::from)
         .unwrap_or_else(std::env::temp_dir);
+    // First run: the data dir may not exist yet (pollis-core creates it later,
+    // during identity setup) — without this the redirect would silently no-op
+    // and the whole first session would render over log spam.
+    std::fs::create_dir_all(&dir).ok();
     let path = dir.join("pollis-tui.log");
     let file = std::fs::OpenOptions::new()
         .create(true)

--- a/pollis-tui/src/sync.rs
+++ b/pollis-tui/src/sync.rs
@@ -35,11 +35,12 @@ use tokio::task::JoinHandle;
 use crate::data;
 
 /// Run one full welcomes → commits(all conversations) → read(all) pass for
-/// `user_id` (§6). Idempotent and safe to call in a loop; returns once the pass
-/// completes. Errors from an individual conversation's commit/read are
-/// surfaced — a broken conversation should be visible, not silently swallowed
-/// (the "messages must work" doctrine).
-pub async fn sync_once(state: &Arc<AppState>, user_id: &str) -> Result<()> {
+/// `user_id` (§6). Idempotent and safe to call in a loop; returns the
+/// conversation tree the round enumerated, so callers (the loop's snapshot,
+/// the UI) can reuse it without re-querying remote. Errors from an individual
+/// conversation's commit/read are surfaced — a broken conversation should be
+/// visible, not silently swallowed (the "messages must work" doctrine).
+pub async fn sync_once(state: &Arc<AppState>, user_id: &str) -> Result<data::ConversationTree> {
     // 1. Welcomes first — draining them may join brand-new groups/DMs, which the
     //    enumeration below then picks up.
     poll_mls_welcomes(state, user_id.to_string()).await?;
@@ -64,7 +65,7 @@ pub async fn sync_once(state: &Arc<AppState>, user_id: &str) -> Result<()> {
         data::dm_messages(state, user_id, &dm.id, None).await?;
     }
 
-    Ok(())
+    Ok(tree)
 }
 
 /// Run [`sync_once`] up to `rounds` times, stopping early once a round makes no
@@ -80,12 +81,23 @@ pub async fn sync_rounds(state: &Arc<AppState>, user_id: &str, rounds: usize) ->
     Ok(rounds)
 }
 
+/// What a completed sync round produced: a monotonically-increasing round
+/// number and the conversation tree that round enumerated. Published over a
+/// `watch` channel so the UI can re-read state the loop already fetched
+/// instead of issuing its own remote queries on every refresh tick.
+pub struct SyncSnapshot {
+    pub round: u64,
+    pub tree: data::ConversationTree,
+}
+
 /// A running background sync loop and its shutdown switch. Dropping it does
 /// **not** stop the task — call [`SyncLoop::cancel`] (graceful, lets the current
 /// round finish) or [`SyncLoop::abort`] (immediate) on shutdown.
 pub struct SyncLoop {
     handle: JoinHandle<()>,
     shutdown: watch::Sender<bool>,
+    /// Latest completed round's snapshot; `None` until the first round lands.
+    pub snapshot: watch::Receiver<Option<Arc<SyncSnapshot>>>,
 }
 
 impl SyncLoop {
@@ -109,17 +121,25 @@ impl SyncLoop {
 /// separate signal. Returns a [`SyncLoop`] handle to cancel it on shutdown.
 pub fn spawn_loop(state: Arc<AppState>, user_id: String, cadence: Duration) -> SyncLoop {
     let (shutdown, mut rx) = watch::channel(false);
+    let (snapshot_tx, snapshot) = watch::channel(None);
     let handle = tokio::spawn(async move {
         let mut ticker = tokio::time::interval(cadence);
         // Skip the immediate first tick's burst semantics on lag — we only care
         // about steady cadence, not catching up missed ticks.
         ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        let mut round: u64 = 0;
         loop {
             tokio::select! {
                 _ = ticker.tick() => {
-                    if let Err(e) = sync_once(&state, &user_id).await {
+                    match sync_once(&state, &user_id).await {
+                        Ok(tree) => {
+                            round += 1;
+                            // Ignore send errors: no receiver just means the UI
+                            // is gone, and the shutdown switch will follow.
+                            let _ = snapshot_tx.send(Some(Arc::new(SyncSnapshot { round, tree })));
+                        }
                         // A failed round is logged, not fatal — the next tick retries.
-                        eprintln!("[sync] round for {user_id} failed: {e}");
+                        Err(e) => eprintln!("[sync] round for {user_id} failed: {e}"),
                     }
                 }
                 changed = rx.changed() => {
@@ -131,7 +151,7 @@ pub fn spawn_loop(state: Arc<AppState>, user_id: String, cadence: Duration) -> S
             }
         }
     });
-    SyncLoop { handle, shutdown }
+    SyncLoop { handle, shutdown, snapshot }
 }
 
 #[cfg(test)]
@@ -160,7 +180,8 @@ mod tests {
                 }
             }
         });
-        let loop_ = SyncLoop { handle, shutdown };
+        let (_snapshot_tx, snapshot) = watch::channel(None);
+        let loop_ = SyncLoop { handle, shutdown, snapshot };
         // Graceful cancel returns the join handle; it should complete promptly.
         let joined = loop_.cancel();
         tokio::time::timeout(Duration::from_secs(5), joined)

--- a/pollis-tui/tests/common/mod.rs
+++ b/pollis-tui/tests/common/mod.rs
@@ -247,6 +247,9 @@ pub async fn spawn_world() -> World {
         livekit_api_key: String::new(),
         livekit_api_secret: String::new(),
         pollis_delivery_url: Some(delivery_url),
+        // Sealed Sender off: the smoke rig exercises sync/enroll flows, not
+        // envelope blinding (mirrors the flows harness default).
+        seal_sender: false,
     };
 
     World {


### PR DESCRIPTION
Fixes the broken/stacking auth menus and the "working… / Unlocked" strobe-then-freeze on the Home screen.

- **Stderr corruption**: pollis-core logs with bare `eprintln!`; under the TUI, stderr IS ratatui's terminal, so every log line scrolled the screen and broke the layout. fd 2 now redirects to `$POLLIS_DATA_DIR/pollis-tui.log` (path printed on exit) — also catches native-lib chatter.
- **Refresh strobe + freeze**: the 750ms UI tick ran `load_conversations` (3 remote Turso queries) + an ingest-backed page fetch inline in the render loop with `busy = true` — flashing "working…" every tick and starving input whenever a round outran the tick. The sync loop now publishes a per-round `SyncSnapshot` over a `watch` channel; the UI tick consumes it from memory and only fetches the open conversation's newest page once per completed sync round. Timer-driven actions no longer set `busy`.
- Adds `Clone` to the pollis-core list DTOs the snapshot carries (`GroupWithChannels`, `Channel`, `DmChannel`, `DmChannelMember`).
- Fixes the pollis-tui test-harness compile break (missing `seal_sender` from #474).

Note: 4 of the 5 TUI smoke tests (`sync`, `send`, `enroll`, `recover`) fail on main too — pre-existing MLS/DS regression, tracked separately. `restart_smoke` + all 21 unit tests pass on this branch.