### PR TITLE
fix(auth): pre-enrollment soft reset — accept the verified-OTP session on the reset endpoints (#487)

### DIFF
--- a/pollis-core/src/commands/account_identity.rs
+++ b/pollis-core/src/commands/account_identity.rs
@@ -520,7 +520,8 @@ pub async fn reset_identity(state: &Arc<AppState>, user_id: &str) -> Result<Stri
             "wrapped_key": b64.encode(&wrapped),
         });
         let resp =
-            crate::commands::mls::ds_post(state, "/v1/account/rotate-identity", &body).await?;
+            crate::commands::mls::ds_post_signed_or_session(state, "/v1/account/rotate-identity", &body)
+                .await?;
         let status = resp.status();
         if status.as_u16() == 409 {
             // A concurrent rotation already won this version. Refuse rather

--- a/pollis-core/src/commands/device_enrollment.rs
+++ b/pollis-core/src/commands/device_enrollment.rs
@@ -720,19 +720,21 @@ pub async fn reset_identity_and_recover(
         // domains E+G) as ONE transaction when configured: the group-ownership
         // handoff, the group/DM membership + key-package deletes, and the
         // other-device orphaning all commit together or not at all — a
-        // half-cleaned account is a corrupt state. The current device CAN sign
-        // here: it was enrolled before the reset, so its `mls_signature_pub`
-        // survives the account-key rotation (the local DB is wiped only below).
+        // half-cleaned account is a corrupt state. Credential: an enrolled
+        // caller (reset from a signed-in session) device-signs; the primary
+        // caller — a PRE-ENROLLMENT device on the login gate, which has no
+        // signing key and no open local DB — authenticates with the
+        // verified-OTP bootstrap session instead (the DS's `gate_or_session`).
         let body = serde_json::json!({ "current_device_id": current_device_id });
-        crate::commands::mls::ds_post_ok(state, "/v1/account/reset-recover", &body).await?;
+        crate::commands::mls::ds_post_signed_or_session_ok(state, "/v1/account/reset-recover", &body)
+            .await?;
 
         // Delete pending MLS welcomes (W8 seam). Route through the Delivery
-        // Service (sole writer of the log DB). The local device row + its
-        // `mls_signature_pub` still exist here (the wipe happens below), so the
-        // signed purge authenticates against the registered device key.
+        // Service (sole writer of the log DB), with the same signed-or-session
+        // credential as the reset-recover write above.
         {
             let body = serde_json::json!({});
-            match crate::commands::mls::ds_post(state, "/v1/welcomes/purge", &body).await {
+            match crate::commands::mls::ds_post_signed_or_session(state, "/v1/welcomes/purge", &body).await {
                 Ok(resp) if resp.status().is_success() => {}
                 Ok(resp) => {
                     let s = resp.status();

--- a/pollis-core/src/commands/mls/ds_client.rs
+++ b/pollis-core/src/commands/mls/ds_client.rs
@@ -206,6 +206,46 @@ pub async fn ds_post_ok(state: &Arc<AppState>, path: &str, body: &serde_json::Va
     Ok(())
 }
 
+/// [`ds_post`] when this device can sign (local DB open, device key enrolled);
+/// otherwise fall back to the verified-OTP bootstrap session ([`ds_post_session`]
+/// with `state.bootstrap_session`). For the account-lifecycle writes reachable
+/// from a PRE-ENROLLMENT device — the soft reset offered on the login gate —
+/// where no signing key exists yet and the user's authorization is the email
+/// OTP they just verified. The DS accepts either credential on these endpoints
+/// (`gate_or_session`).
+pub async fn ds_post_signed_or_session(
+    state: &Arc<AppState>,
+    path: &str,
+    body: &serde_json::Value,
+) -> Result<reqwest::Response> {
+    let can_sign = state.local_db.lock().await.is_some();
+    if can_sign {
+        return ds_post(state, path, body).await;
+    }
+    let token = state.bootstrap_session.lock().await.clone().ok_or_else(|| {
+        Error::Other(anyhow::anyhow!(
+            "not signed in and no verified-email session — verify your email again, then retry"
+        ))
+    })?;
+    ds_post_session(state, path, &token, body).await
+}
+
+/// [`ds_post_signed_or_session`] for writes that must NOT silently fail: any
+/// non-2xx becomes an `Err` carrying the status + body.
+pub async fn ds_post_signed_or_session_ok(
+    state: &Arc<AppState>,
+    path: &str,
+    body: &serde_json::Value,
+) -> Result<()> {
+    let resp = ds_post_signed_or_session(state, path, body).await?;
+    if !resp.status().is_success() {
+        let s = resp.status();
+        let txt = resp.text().await.unwrap_or_default();
+        return Err(Error::Other(anyhow::anyhow!("ds_post {path} {s}: {txt}")));
+    }
+    Ok(())
+}
+
 /// Resolve the DS base URL or error if it isn't configured. Shared by the
 /// unauthenticated + session-bearer bootstrap clients below.
 fn delivery_base(state: &Arc<AppState>) -> Result<String> {

--- a/pollis-core/src/commands/mls/mod.rs
+++ b/pollis-core/src/commands/mls/mod.rs
@@ -25,6 +25,7 @@ pub use device::{ensure_device_cert, load_or_create_device_signer, resign_stale_
 // ── Signed Delivery-Service write client (4 `X-Pollis-*` headers) ────────────
 pub(crate) use ds_client::{
     ds_claim_key_package, ds_post, ds_post_ok, ds_post_plain, ds_post_session_ok,
+    ds_post_signed_or_session, ds_post_signed_or_session_ok,
 };
 
 // ── Key packages ─────────────────────────────────────────────────────────────

--- a/pollis-delivery/src/account.rs
+++ b/pollis-delivery/src/account.rs
@@ -32,6 +32,12 @@
 //! is scoped `WHERE … user_id = actor` (or, for the enrollment rows, the request
 //! must belong to the actor). Nothing is re-derived from client-supplied ids.
 //!
+//! **Credential**: device signature, except `rotate-identity` and
+//! `reset-recover`, which take the signature OR a verified-OTP session
+//! (`gate_or_session`) — the soft reset runs from a PRE-ENROLLMENT device on
+//! the login gate, which has no signing key; its authorization has always been
+//! the email OTP (see `tests/reset_session.rs` for the properties).
+//!
 //! ## The two hard requirements
 //!
 //! 1. **`account_key_log` CAS.** `account_key_log` is an append-only, seq-ordered
@@ -91,7 +97,7 @@ use libsql::Connection;
 use serde::Deserialize;
 
 use crate::error::{AppError, AuthRejection};
-use crate::writes::{bad_request, gate, ok_json, outcome_response, resolve_actor, WriteOutcome};
+use crate::writes::{bad_request, gate, gate_or_session, ok_json, outcome_response, resolve_actor, WriteOutcome};
 use crate::AppState;
 
 fn b64_decode(s: &str) -> anyhow::Result<Vec<u8>> {
@@ -144,7 +150,7 @@ pub async fn rotate_identity(
     headers: HeaderMap,
     body: Bytes,
 ) -> Result<Response, AppError> {
-    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+    let authed = match gate_or_session(&state, &headers, &method, &uri, &body).await? {
         Ok(a) => a,
         Err(resp) => return Ok(resp),
     };
@@ -611,7 +617,7 @@ pub async fn reset_recover(
     headers: HeaderMap,
     body: Bytes,
 ) -> Result<Response, AppError> {
-    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+    let authed = match gate_or_session(&state, &headers, &method, &uri, &body).await? {
         Ok(a) => a,
         Err(resp) => return Ok(resp),
     };

--- a/pollis-delivery/src/auth.rs
+++ b/pollis-delivery/src/auth.rs
@@ -75,7 +75,7 @@ pub const REPLAY_WINDOW_SECS: i64 = 300;
 const H_USER: &str = "x-pollis-user";
 const H_DEVICE: &str = "x-pollis-device";
 const H_TIMESTAMP: &str = "x-pollis-timestamp";
-const H_SIGNATURE: &str = "x-pollis-signature";
+pub(crate) const H_SIGNATURE: &str = "x-pollis-signature";
 
 /// The four headers parsed off an authenticated request, plus the
 /// authenticated identity once the signature checks out.

--- a/pollis-delivery/src/writes.rs
+++ b/pollis-delivery/src/writes.rs
@@ -74,6 +74,42 @@ pub(crate) async fn gate(
     }
 }
 
+/// [`gate`], extended to ALSO accept a verified OTP session (`X-Pollis-Session`)
+/// as the authenticating credential — for the account-lifecycle writes reachable
+/// from a PRE-ENROLLMENT device (the soft reset offered on the login gate). Such
+/// a device by definition has no registered `mls_signature_pub` to sign with:
+/// its proof of authorization is the verified-OTP session, exactly like the
+/// bootstrap endpoints (`crate::bootstrap`), and `user_id` binds from the
+/// session record, never the body. The soft reset was always email-OTP
+/// authorized by design — this enforces that server-side instead of trusting
+/// the client's direct write.
+///
+/// A request carrying the signature header goes through the signature gate
+/// unconditionally, so an enrolled caller keeps the stronger credential and a
+/// bad signature is never "rescued" by a session token.
+pub(crate) async fn gate_or_session(
+    state: &AppState,
+    headers: &HeaderMap,
+    method: &Method,
+    uri: &Uri,
+    body: &Bytes,
+) -> Result<Result<Authed, Response>, AppError> {
+    if !state.require_auth {
+        return Ok(Ok(None));
+    }
+    if headers.contains_key(auth::H_SIGNATURE) {
+        return gate(state, headers, method, uri, body).await;
+    }
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    match crate::session::verify_session(headers, &state.sessions, now) {
+        Ok(claims) => Ok(Ok(Some(claims.user_id))),
+        Err(rej) => Ok(Err(rej.into_response())),
+    }
+}
+
 /// Resolve the recipient/owner a welcome op targets.
 ///
 ///   - auth ON  → the authenticated user. If the body also carries `user_id`,
@@ -452,7 +488,7 @@ pub async fn welcomes_purge(
     headers: HeaderMap,
     body: Bytes,
 ) -> Result<Response, AppError> {
-    let authed = match gate(&state, &headers, &method, &uri, &body).await? {
+    let authed = match gate_or_session(&state, &headers, &method, &uri, &body).await? {
         Ok(a) => a,
         Err(resp) => return Ok(resp),
     };

--- a/pollis-delivery/tests/reset_session.rs
+++ b/pollis-delivery/tests/reset_session.rs
@@ -1,0 +1,361 @@
+//! The pre-enrollment soft-reset path (#487): `/v1/account/rotate-identity`,
+//! `/v1/account/reset-recover`, and `/v1/welcomes/purge` must accept a
+//! verified-OTP session (`X-Pollis-Session`) as the authenticating credential.
+//!
+//! A device performing the soft reset from the login gate has, by definition,
+//! no registered `mls_signature_pub` and no open local DB — it cannot
+//! device-sign. Before this gate existed, the reset flow failed unconditionally
+//! ("not signed in for DS request signing"). These tests drive the real axum
+//! router with auth ENFORCED and prove:
+//!
+//!   1. a verified-OTP session authorizes the rotation / reset / purge;
+//!   2. `user_id` binds from the session — a body naming another user is 403;
+//!   3. no credential at all is 401 (the gate never fails open);
+//!   4. a request that presents a (bad) device signature is NOT rescued by a
+//!      valid session — the stronger credential, once offered, must verify.
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use base64::Engine as _;
+use http_body_util::BodyExt as _;
+use pollis_delivery::db::Db;
+use pollis_delivery::otp::OtpConfig;
+use pollis_delivery::{build_router_with_state, AppState};
+use tower::ServiceExt as _;
+
+// Self-contained schema (foreign_keys=OFF in Db::connect_local): the tables the
+// rotate / reset-recover / purge handlers touch, columns matching the Turso
+// baseline.
+const SCHEMA: &str = "\
+CREATE TABLE users (\
+  id TEXT PRIMARY KEY,\
+  email TEXT NOT NULL UNIQUE,\
+  username TEXT NOT NULL UNIQUE,\
+  phone TEXT,\
+  avatar_url TEXT,\
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),\
+  account_id_pub BLOB,\
+  identity_version INTEGER NOT NULL DEFAULT 1\
+);\
+CREATE TABLE account_key_log (\
+  seq INTEGER PRIMARY KEY AUTOINCREMENT,\
+  user_id TEXT NOT NULL,\
+  account_id_pub BLOB NOT NULL,\
+  identity_version INTEGER NOT NULL,\
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))\
+);\
+CREATE UNIQUE INDEX idx_account_key_log_user_version \
+  ON account_key_log (user_id, identity_version);\
+CREATE TABLE account_recovery (\
+  user_id TEXT PRIMARY KEY,\
+  identity_version INTEGER NOT NULL,\
+  salt BLOB NOT NULL,\
+  nonce BLOB NOT NULL,\
+  wrapped_key BLOB NOT NULL,\
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),\
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))\
+);\
+CREATE TABLE user_device (\
+  device_id TEXT PRIMARY KEY,\
+  user_id TEXT NOT NULL,\
+  device_name TEXT,\
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),\
+  last_seen TEXT NOT NULL DEFAULT (datetime('now')),\
+  device_cert BLOB,\
+  cert_issued_at TEXT,\
+  cert_identity_version INTEGER,\
+  mls_signature_pub BLOB,\
+  revoked_at TEXT\
+);\
+CREATE TABLE groups (\
+  id TEXT PRIMARY KEY,\
+  name TEXT NOT NULL,\
+  description TEXT,\
+  owner_id TEXT NOT NULL,\
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))\
+);\
+CREATE TABLE group_member (\
+  group_id TEXT NOT NULL,\
+  user_id TEXT NOT NULL,\
+  role TEXT NOT NULL DEFAULT 'member',\
+  joined_at TEXT NOT NULL DEFAULT (datetime('now')),\
+  PRIMARY KEY (group_id, user_id)\
+);\
+CREATE TABLE dm_channel_member (\
+  dm_channel_id TEXT NOT NULL,\
+  user_id TEXT NOT NULL,\
+  accepted INTEGER NOT NULL DEFAULT 0,\
+  PRIMARY KEY (dm_channel_id, user_id)\
+);\
+CREATE TABLE mls_key_package (\
+  id INTEGER PRIMARY KEY AUTOINCREMENT,\
+  user_id TEXT NOT NULL,\
+  device_id TEXT,\
+  key_package BLOB NOT NULL,\
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))\
+);\
+CREATE TABLE mls_welcome (\
+  id INTEGER PRIMARY KEY AUTOINCREMENT,\
+  recipient_id TEXT NOT NULL,\
+  conversation_id TEXT,\
+  welcome BLOB,\
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))\
+);";
+
+async fn fresh_db() -> Arc<Db> {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("ds.db");
+    std::mem::forget(dir);
+    let db = Db::connect_local(path.to_str().unwrap()).await.expect("local db");
+    db.conn().unwrap().execute_batch(SCHEMA).await.expect("schema");
+    Arc::new(db)
+}
+
+/// Auth ENFORCED (unlike the bootstrap tests) — the point here is the gate.
+/// OTP is the fixed dev code, no email send, no throttle.
+fn authed_state(db: Arc<Db>) -> AppState {
+    AppState::new(db, true).with_otp_config(OtpConfig {
+        resend_api_key: None,
+        dev_otp: Some("123456".to_string()),
+        ttl_secs: 600,
+        session_ttl_secs: 600,
+        resend_throttle_secs: 0,
+        max_attempts: 5,
+    })
+}
+
+const DEV_CODE: &str = "123456";
+
+async fn send(
+    state: &AppState,
+    path: &str,
+    body: serde_json::Value,
+    session: Option<&str>,
+    // Present a device-signature header (deliberately invalid) to prove the
+    // signature path, once offered, is not rescued by a session.
+    bogus_signature: bool,
+) -> (StatusCode, serde_json::Value) {
+    let mut builder = Request::builder()
+        .method("POST")
+        .uri(path)
+        .header("content-type", "application/json");
+    if let Some(tok) = session {
+        builder = builder.header("X-Pollis-Session", tok);
+    }
+    if bogus_signature {
+        builder = builder
+            .header("X-Pollis-User", "u-any")
+            .header("X-Pollis-Device", "d-any")
+            .header("X-Pollis-Timestamp", "0")
+            .header("X-Pollis-Signature", base64::engine::general_purpose::STANDARD.encode([0u8; 64]));
+    }
+    let req = builder
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+    let resp = build_router_with_state(state.clone())
+        .oneshot(req)
+        .await
+        .unwrap();
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let val = if bytes.is_empty() {
+        serde_json::Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null)
+    };
+    (status, val)
+}
+
+/// request-otp + verify-otp, returning `(user_id, session_token)`.
+async fn login(state: &AppState, email: &str, device_id: &str) -> (String, String) {
+    let (s, _) = send(state, "/v1/auth/request-otp", serde_json::json!({ "email": email }), None, false).await;
+    assert_eq!(s, StatusCode::OK, "request-otp should 200");
+    let (s, body) = send(
+        state,
+        "/v1/auth/verify-otp",
+        serde_json::json!({ "email": email, "code": DEV_CODE, "device_id": device_id }),
+        None,
+        false,
+    )
+    .await;
+    assert_eq!(s, StatusCode::OK, "verify-otp should 200: {body}");
+    (
+        body["user_id"].as_str().expect("user_id").to_string(),
+        body["session_token"].as_str().expect("session_token").to_string(),
+    )
+}
+
+/// [`login`] then version-1 identity establishment — the state every real
+/// account is in before a rotation (the rotate CAS reads the
+/// `account_key_log` head, which signup's establish-identity seeds at 1).
+async fn login_established(state: &AppState, email: &str, device_id: &str) -> (String, String) {
+    let (user_id, token) = login(state, email, device_id).await;
+    let b64 = |bytes: &[u8]| base64::engine::general_purpose::STANDARD.encode(bytes);
+    let (s, body) = send(
+        state,
+        "/v1/auth/establish-identity",
+        serde_json::json!({
+            "account_id_pub": b64(&[9u8; 32]),
+            "salt": b64(&[1u8; 32]),
+            "nonce": b64(&[2u8; 12]),
+            "wrapped_key": b64(&[3u8; 48]),
+        }),
+        Some(&token),
+        false,
+    )
+    .await;
+    assert_eq!(s, StatusCode::OK, "establish-identity should 200: {body}");
+    (user_id, token)
+}
+
+fn rotate_body(based_on_version: i64) -> serde_json::Value {
+    let b64 = |bytes: &[u8]| base64::engine::general_purpose::STANDARD.encode(bytes);
+    serde_json::json!({
+        "based_on_version": based_on_version,
+        "account_id_pub": b64(&[7u8; 32]),
+        "salt": b64(&[1u8; 16]),
+        "nonce": b64(&[2u8; 12]),
+        "wrapped_key": b64(&[3u8; 48]),
+    })
+}
+
+async fn identity_version(db: &Db, user_id: &str) -> i64 {
+    let conn = db.conn().unwrap();
+    let mut rows = conn
+        .query("SELECT identity_version FROM users WHERE id = ?1", libsql::params![user_id])
+        .await
+        .unwrap();
+    rows.next().await.unwrap().expect("user row").get(0).unwrap()
+}
+
+async fn count(db: &Db, sql: &str, user_id: &str) -> i64 {
+    let conn = db.conn().unwrap();
+    let mut rows = conn.query(sql, libsql::params![user_id]).await.unwrap();
+    rows.next().await.unwrap().expect("count row").get(0).unwrap()
+}
+
+// ── 1. Session authorizes the rotation, user bound from the session ──────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rotate_identity_accepts_verified_otp_session() {
+    let db = fresh_db().await;
+    let state = authed_state(Arc::clone(&db));
+    let (user_id, token) = login_established(&state, "alice@example.com", "dev-1").await;
+
+    let (s, body) = send(&state, "/v1/account/rotate-identity", rotate_body(1), Some(&token), false).await;
+    assert_eq!(s, StatusCode::OK, "session-authorized rotation should 200: {body}");
+    assert_eq!(body["identity_version"], serde_json::json!(2));
+    assert_eq!(identity_version(&db, &user_id).await, 2);
+    assert_eq!(
+        count(&db, "SELECT COUNT(*) FROM account_key_log WHERE user_id = ?1", &user_id).await,
+        2,
+        "rotation must append the transparency log (v1 from establish, v2 from rotate)"
+    );
+}
+
+// ── 2. The session binds the actor — a body naming another user is 403 ───────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rotate_identity_session_cannot_act_as_another_user() {
+    let db = fresh_db().await;
+    let state = authed_state(Arc::clone(&db));
+    let (_alice, alice_token) = login_established(&state, "alice@example.com", "dev-1").await;
+    let (bob, _bob_token) = login_established(&state, "bob@example.com", "dev-2").await;
+
+    let mut body = rotate_body(1);
+    body["user_id"] = serde_json::json!(bob);
+    let (s, _) = send(&state, "/v1/account/rotate-identity", body, Some(&alice_token), false).await;
+    assert_eq!(s, StatusCode::FORBIDDEN, "alice's session must not rotate bob's identity");
+    assert_eq!(identity_version(&db, &bob).await, 1, "bob's identity must be untouched");
+}
+
+// ── 3. No credential → 401; the gate never fails open ────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rotate_identity_rejects_missing_and_stale_credentials() {
+    let db = fresh_db().await;
+    let state = authed_state(Arc::clone(&db));
+    let (user_id, _token) = login_established(&state, "alice@example.com", "dev-1").await;
+
+    // No credential at all.
+    let (s, _) = send(&state, "/v1/account/rotate-identity", rotate_body(1), None, false).await;
+    assert_eq!(s, StatusCode::UNAUTHORIZED, "no credential must be rejected");
+
+    // Garbage session token.
+    let (s, _) = send(&state, "/v1/account/rotate-identity", rotate_body(1), Some("nonsense"), false).await;
+    assert_eq!(s, StatusCode::UNAUTHORIZED, "unknown session must be rejected");
+
+    assert_eq!(identity_version(&db, &user_id).await, 1);
+}
+
+// ── 4. A bad signature is never rescued by a valid session ───────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn bad_signature_not_rescued_by_valid_session() {
+    let db = fresh_db().await;
+    let state = authed_state(Arc::clone(&db));
+    let (user_id, token) = login_established(&state, "alice@example.com", "dev-1").await;
+
+    let (s, _) = send(&state, "/v1/account/rotate-identity", rotate_body(1), Some(&token), true).await;
+    assert_eq!(
+        s,
+        StatusCode::UNAUTHORIZED,
+        "a request offering a device signature must stand on that signature"
+    );
+    assert_eq!(identity_version(&db, &user_id).await, 1);
+}
+
+// ── 5. reset-recover with a session: memberships cleared, devices orphaned ───
+
+#[tokio::test(flavor = "multi_thread")]
+async fn reset_recover_accepts_session_and_cleans_up() {
+    let db = fresh_db().await;
+    let state = authed_state(Arc::clone(&db));
+    let (user_id, token) = login(&state, "alice@example.com", "dev-new").await;
+
+    // Seed pre-reset state: a group membership (with a co-admin so handoff is
+    // trivial), a DM membership, a key package, an old enrolled device, and a
+    // pending welcome.
+    {
+        let conn = db.conn().unwrap();
+        for sql in [
+            format!("INSERT INTO groups (id, name, owner_id) VALUES ('g1', 'G', '{user_id}')"),
+            format!("INSERT INTO group_member (group_id, user_id, role) VALUES ('g1', '{user_id}', 'admin')"),
+            "INSERT INTO users (id, email, username) VALUES ('other', 'o@x.com', 'other')".to_string(),
+            "INSERT INTO group_member (group_id, user_id, role) VALUES ('g1', 'other', 'admin')".to_string(),
+            format!("INSERT INTO dm_channel_member (dm_channel_id, user_id) VALUES ('dm1', '{user_id}')"),
+            format!("INSERT INTO mls_key_package (user_id, key_package) VALUES ('{user_id}', x'00')"),
+            format!("INSERT INTO user_device (device_id, user_id) VALUES ('dev-old', '{user_id}')"),
+            format!("INSERT INTO mls_welcome (recipient_id) VALUES ('{user_id}')"),
+        ] {
+            conn.execute(&sql, ()).await.expect("seed");
+        }
+    }
+
+    let (s, body) = send(
+        &state,
+        "/v1/account/reset-recover",
+        serde_json::json!({ "current_device_id": "dev-new" }),
+        Some(&token),
+        false,
+    )
+    .await;
+    assert_eq!(s, StatusCode::OK, "session-authorized reset-recover should 200: {body}");
+
+    assert_eq!(count(&db, "SELECT COUNT(*) FROM group_member WHERE user_id = ?1", &user_id).await, 0);
+    assert_eq!(count(&db, "SELECT COUNT(*) FROM dm_channel_member WHERE user_id = ?1", &user_id).await, 0);
+    assert_eq!(count(&db, "SELECT COUNT(*) FROM mls_key_package WHERE user_id = ?1", &user_id).await, 0);
+    // Other devices orphaned; the resetting device's row (if any) is kept.
+    assert_eq!(
+        count(&db, "SELECT COUNT(*) FROM user_device WHERE user_id = ?1 AND device_id = 'dev-old'", &user_id).await,
+        0,
+        "old device must be orphaned"
+    );
+
+    // The purge leg (same session credential).
+    let (s, _) = send(&state, "/v1/welcomes/purge", serde_json::json!({}), Some(&token), false).await;
+    assert_eq!(s, StatusCode::OK, "session-authorized purge should 200");
+    assert_eq!(count(&db, "SELECT COUNT(*) FROM mls_welcome WHERE recipient_id = ?1", &user_id).await, 0);
+}


### PR DESCRIPTION
Account reset from the login gate has been broken since #419 E+G: it fails unconditionally with `not signed in for DS request signing`. The reset endpoints were routed through the device-signed DS client, but the soft reset's primary caller is a **pre-enrollment device** — no registered `mls_signature_pub`, no open local DB — which by definition cannot sign. Its authorization has always been the verified email OTP (per the flow's own design comment).

- **DS**: new `gate_or_session` — `rotate-identity`, `reset-recover`, and `welcomes/purge` accept a device signature OR a verified-OTP session (`X-Pollis-Session`, same store as the bootstrap endpoints). `user_id` binds from the session record, never the body. A request presenting a signature header must stand on that signature — a bad one is never rescued by a session.
- **Client**: `ds_post_signed_or_session[_ok]` — signs when the local DB is open, else falls back to `state.bootstrap_session` (stashed at verify-otp on both first-device and existing-account paths).
- **Tests** (`pollis-delivery/tests/reset_session.rs`, auth enforced, real router): session authorizes rotate/reset/purge; session cannot act as another user (403); no/garbage credential is 401; bad signature + valid session is 401; reset-recover clears memberships/key-packages and orphans other devices.

Threat-model note: this makes email-OTP-authorized reset *server-enforced*; the pre-#419 path did the same writes directly against Turso with no server-side check at all. The documented tradeoff (email owner can soft-reset, orphaning devices; history stays unreadable) is unchanged, and the `identity_reset` security event still surfaces it.

Verified: 5 new DS tests + full pollis-delivery suite + pollis-core (223) + the complete MLS flows harness (61/61, exercising the signed path). Requires a DS deploy to take effect against api.pollis.com.

Refs #487.