### PR TITLE
fix(deploy): DS deploys actually land + self-verify (/version), fix silent Watchtower no-op

### DIFF
--- a/.github/workflows/delivery-deploy-dev.yml
+++ b/.github/workflows/delivery-deploy-dev.yml
@@ -33,6 +33,12 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
+      # Resolve the exact commit built, so we can bake it into the image and then
+      # verify that same SHA is actually serving after the recreate.
+      - name: Resolve build SHA
+        id: sha
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
@@ -51,11 +57,33 @@ jobs:
           file: pollis-delivery/Dockerfile
           push: true
           tags: ${{ env.IMAGE }}
+          build-args: |
+            GIT_SHA=${{ steps.sha.outputs.sha }}
           cache-from: type=gha,scope=pollis-delivery
           cache-to: type=gha,scope=pollis-delivery,mode=max
 
+      # NO `image=` filter: Watchtower's HTTP-API image filter matches nothing
+      # here (it silently no-op'd every deploy — issue found 2026-07-08). An
+      # unfiltered poke updates all label-enabled containers; only `delivery` and
+      # `delivery-dev` carry the label and they track distinct tags (:prod/:dev),
+      # so a :dev push only recreates delivery-dev.
       - name: Trigger Watchtower (recreate dev container)
         run: |
           curl -fsS -G "${{ vars.WATCHTOWER_URL }}/v1/update" \
-            --data-urlencode "image=${IMAGE}" \
             -H "Authorization: Bearer ${{ secrets.WATCHTOWER_TOKEN }}"
+
+      # Do NOT trust "built OK" — confirm the new binary is actually SERVING.
+      # Poll /version until it reports the SHA we just built; fail otherwise, so a
+      # no-op'd recreate can never again leave dev silently versions behind.
+      - name: Verify new image is live
+        run: |
+          EXPECTED='${{ steps.sha.outputs.sha }}'
+          URL='https://api-dev.pollis.com/version'
+          echo "Waiting for $URL to report sha=$EXPECTED"
+          for i in $(seq 1 40); do
+            GOT="$(curl -fsS -m 10 "$URL" | jq -r '.sha' 2>/dev/null || echo '')"
+            if [ "$GOT" = "$EXPECTED" ]; then echo "✓ live sha=$GOT"; exit 0; fi
+            echo "[$((i*6))s] live sha=$GOT (want $EXPECTED)"; sleep 6
+          done
+          echo "::error::Delivery (dev) did not report the new SHA within 240s — the Watchtower recreate did not take effect."
+          exit 1

--- a/.github/workflows/delivery-deploy-prod.yml
+++ b/.github/workflows/delivery-deploy-prod.yml
@@ -36,6 +36,12 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
+      # Resolve the exact commit built, so we can bake it into the image and then
+      # verify that same SHA is actually serving after the recreate.
+      - name: Resolve build SHA
+        id: sha
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
@@ -54,11 +60,33 @@ jobs:
           file: pollis-delivery/Dockerfile
           push: true
           tags: ${{ env.IMAGE }}
+          build-args: |
+            GIT_SHA=${{ steps.sha.outputs.sha }}
           cache-from: type=gha,scope=pollis-delivery
           cache-to: type=gha,scope=pollis-delivery,mode=max
 
+      # NO `image=` filter: Watchtower's HTTP-API image filter matches nothing
+      # here (it silently no-op'd every deploy — issue found 2026-07-08). An
+      # unfiltered poke updates all label-enabled containers; only `delivery` and
+      # `delivery-dev` carry the label and they track distinct tags (:prod/:dev),
+      # so a :prod push only recreates delivery.
       - name: Trigger Watchtower (recreate prod container)
         run: |
           curl -fsS -G "${{ vars.WATCHTOWER_URL }}/v1/update" \
-            --data-urlencode "image=${IMAGE}" \
             -H "Authorization: Bearer ${{ secrets.WATCHTOWER_TOKEN }}"
+
+      # Do NOT trust "built OK" — confirm the new binary is actually SERVING.
+      # Poll /version until it reports the SHA we just built; fail otherwise, so a
+      # no-op'd recreate can never again leave prod silently versions behind.
+      - name: Verify new image is live
+        run: |
+          EXPECTED='${{ steps.sha.outputs.sha }}'
+          URL='https://api.pollis.com/version'
+          echo "Waiting for $URL to report sha=$EXPECTED"
+          for i in $(seq 1 40); do
+            GOT="$(curl -fsS -m 10 "$URL" | jq -r '.sha' 2>/dev/null || echo '')"
+            if [ "$GOT" = "$EXPECTED" ]; then echo "✓ live sha=$GOT"; exit 0; fi
+            echo "[$((i*6))s] live sha=$GOT (want $EXPECTED)"; sleep 6
+          done
+          echo "::error::Delivery (prod) did not report the new SHA within 240s — the Watchtower recreate did not take effect."
+          exit 1

--- a/deploy/delivery.sh
+++ b/deploy/delivery.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# Recreate a Pollis Delivery Service container on the VPS with fresh env pulled
+# from Doppler. This is the ONE place the DS runtime env is injected.
+#
+# Division of labor (keeps secrets off GitHub — see delivery-deploy-*.yml):
+#   - CODE deploys  → GitHub builds+pushes the image and pokes Watchtower, which
+#     recreates the container *preserving* the env this script set. No secrets
+#     ever touch GitHub.
+#   - ENV / SECRET changes (rare) → run THIS script on the box. It re-reads
+#     Doppler and recreates the container with the full, current env. After that,
+#     Watchtower carries the env forward across future code deploys.
+#
+# Requires, on the VPS: docker, and doppler configured with a service token that
+# can read the pollis project (`doppler configure set token <tok>`).
+#
+# Usage (on the VPS):   ./deploy/delivery.sh dev|prod
+set -euo pipefail
+
+ENV_NAME="${1:-}"
+case "$ENV_NAME" in
+  dev)  DCONF=dev_personal; NAME=delivery-dev; TAG=dev;  URL=https://api-dev.pollis.com ;;
+  prod) DCONF=prd_prod;     NAME=delivery;     TAG=prod; URL=https://api.pollis.com ;;
+  *) echo "usage: $0 dev|prod" >&2; exit 2 ;;
+esac
+
+IMAGE="ghcr.io/actuallydan/pollis-delivery:${TAG}"
+NETWORK=livekit_default
+
+# Env vars forwarded into the container. Values come from `doppler run` (never
+# from the command line / process args). Keep in sync with pollis-delivery's
+# Config::from_env + BrokerConfig::from_env.
+ENV_KEYS=(
+  TURSO_URL TURSO_TOKEN LOG_DB_URL LOG_DB_ADMIN_TOKEN
+  RESEND_API_KEY POLLIS_DS_REQUIRE_AUTH PORT
+  LIVEKIT_API_KEY LIVEKIT_API_SECRET LIVEKIT_URL
+  R2_S3_ENDPOINT R2_ACCESS_KEY_ID R2_SECRET_KEY R2_BUCKET
+  TURSO_PLATFORM_TOKEN TURSO_ORG TURSO_DB
+)
+[ "$ENV_NAME" = "dev" ] && ENV_KEYS+=(DEV_OTP)
+
+EFLAGS=()
+for k in "${ENV_KEYS[@]}"; do EFLAGS+=(-e "$k"); done
+
+echo "▶ pulling $IMAGE"
+docker pull "$IMAGE"
+
+echo "▶ recreating $NAME on $NETWORK with fresh env from Doppler ($DCONF)"
+docker rm -f "$NAME" >/dev/null 2>&1 || true
+# `doppler run` populates the environment; `docker run -e KEY` (no value) forwards
+# each var from that environment into the container — no secret on the argv.
+doppler run --project pollis --config "$DCONF" --silent -- \
+  docker run -d \
+    --name "$NAME" \
+    --network "$NETWORK" \
+    --expose 8788 \
+    --restart unless-stopped \
+    --label com.centurylinklabs.watchtower.enable=true \
+    "${EFLAGS[@]}" \
+    "$IMAGE"
+
+echo "▶ verifying $URL/version is serving the new build"
+for i in $(seq 1 30); do
+  sha="$(curl -fsS -m 8 "$URL/version" 2>/dev/null | jq -r '.sha' 2>/dev/null || echo '')"
+  if [ -n "$sha" ] && [ "$sha" != "null" ]; then
+    echo "✓ $NAME is live — /version sha=$sha"
+    docker image prune -f >/dev/null 2>&1 || true
+    exit 0
+  fi
+  sleep 4
+done
+
+echo "✗ $NAME did not answer /version within ~120s — recent logs:" >&2
+docker logs "$NAME" --tail 40 2>&1 || true
+exit 1

--- a/docs/deployments.md
+++ b/docs/deployments.md
@@ -65,9 +65,11 @@ There are **4 shipped executables/sites**, **3 running backend services**, and
 
 ### Delivery Service (DS) — the API server
 - **From:** `pollis-delivery/`
-- **Pipeline:** `.github/workflows/delivery-deploy-prod.yml` and `delivery-deploy-dev.yml` — `workflow_dispatch` (`-f ref=main`). Builds the image on GitHub runners (off the VPS to avoid LiveKit CPU contention), pushes to **GHCR** (`:prod` / `:dev`), then pokes a token-gated **Watchtower** endpoint on the VPS which pulls the new digest and recreates the container.
-- **Runs at:** VPS (`downpage`-class) → **api.pollis.com** (prod) / **api-dev.pollis.com** (dev). Health: `/health`.
-- **Role:** sole writer to Turso; clients hold read-only tokens and write only via the DS (structural commit-log integrity, #419/#420).
+- **Code deploys:** `.github/workflows/delivery-deploy-prod.yml` and `delivery-deploy-dev.yml` — `workflow_dispatch` (`-f ref=main`). Builds the image on GitHub runners (off the VPS to avoid LiveKit CPU contention) with the git SHA baked in (`--build-arg GIT_SHA`), pushes to **GHCR** (`:prod` / `:dev`), pokes a token-gated **Watchtower** endpoint on the VPS which recreates the container **preserving its env**, then **verifies the new build is actually live** by polling `/version` until it reports the built SHA (fails the deploy otherwise). No secrets ever touch GitHub.
+  - ⚠️ The Watchtower poke is **unfiltered** on purpose. Its HTTP-API `?image=` filter matches nothing here and silently no-op'd every deploy for weeks (found 2026-07-08 — both containers were 11 days stale) until the `/version` check surfaced it. Only `delivery`/`delivery-dev` carry the `com.centurylinklabs.watchtower.enable` label and track distinct tags, so an unfiltered poke updates just the one env's container.
+- **Env / secret changes (rare):** run `deploy/delivery.sh dev|prod` **on the VPS** — it `doppler run`s the full env from Doppler (`dev_personal` / `prd_prod`) and recreates the container. This is the ONE place DS runtime env is injected; Watchtower preserves it across subsequent code deploys. (Doppler is the complete source of truth: `TURSO_*`, `LOG_DB_*`, `RESEND_API_KEY`, `LIVEKIT_*`, `R2_*` incl. `R2_BUCKET`, `TURSO_PLATFORM_TOKEN/ORG/DB`, `PORT`, `POLLIS_DS_REQUIRE_AUTH`, dev `DEV_OTP`.)
+- **Runs at:** VPS (`downpage`-class) → **api.pollis.com** (prod) / **api-dev.pollis.com** (dev). Health: `/health`; build SHA: `/version`.
+- **Role:** sole writer to Turso; clients hold read-only tokens and write only via the DS (structural commit-log integrity, #419/#420). Also the authorized-secrets broker (`/v1/livekit/*`, `/v1/r2/presign`, `/v1/turso/token` — #393).
 
 ### LiveKit + nginx — media SFU (voice / video / screenshare)
 - **From:** `livekit/` (compose + nginx ingress; runs **upstream** LiveKit images, not our build)

--- a/pollis-delivery/Dockerfile
+++ b/pollis-delivery/Dockerfile
@@ -17,6 +17,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /src
 COPY . .
+# Bake the source git SHA into the binary (via `option_env!("GIT_SHA")`, exposed
+# at `/version`) so a deploy can verify the new image is actually running.
+ARG GIT_SHA=unknown
+ENV GIT_SHA=${GIT_SHA}
 RUN cargo build --release -p pollis-delivery \
     && strip target/release/pollis-delivery
 

--- a/pollis-delivery/src/lib.rs
+++ b/pollis-delivery/src/lib.rs
@@ -159,6 +159,7 @@ pub fn build_router_with_log_db(db: Arc<Db>, log_db: Arc<Db>) -> Router {
 pub fn build_router_with_state(state: AppState) -> Router {
     Router::new()
         .route("/health", get(health))
+        .route("/version", get(version))
         .route("/v1/commits", post(submit))
         .route("/v1/commits/:conversation_id", get(commits))
         .route("/v1/group-info", post(writes::group_info))
@@ -272,6 +273,24 @@ pub fn build_router_with_state(state: AppState) -> Router {
 
 async fn health() -> impl IntoResponse {
     (StatusCode::OK, "ok")
+}
+
+/// The git SHA this binary was built from, baked in at compile time by the
+/// Docker build (`ARG GIT_SHA` → `ENV GIT_SHA` → `option_env!`). `"unknown"` for
+/// local `cargo` builds. Exposed at `/version` so a deploy can confirm the new
+/// image is actually LIVE (not merely built) — otherwise a silently no-op'd
+/// recreate leaves the service running an old version indefinitely.
+pub const GIT_SHA: &str = match option_env!("GIT_SHA") {
+    Some(s) => s,
+    None => "unknown",
+};
+
+/// GET /version — the running build's git SHA. Open (no auth), like `/health`.
+async fn version() -> impl IntoResponse {
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({ "service": "pollis-delivery", "sha": GIT_SHA })),
+    )
 }
 
 /// POST /v1/commits — submit a commit. When auth is enforced, the request must


### PR DESCRIPTION
Fixes why DS deploys have silently done nothing — and adds the guardrail that would have caught it.

## Root cause (found while shipping #393)
Both `delivery` and `delivery-dev` had been running an image from **2026-06-27** despite multiple deploys since — including #437 (2026-07-01), so the authorized-secrets broker never actually went live. Cause: the deploy workflow pokes Watchtower with `?image=<tag>`, and that HTTP-API filter matches **zero** containers (`Scanned=0`) — every deploy no-op'd while reporting success. (Watchtower by-name scan works fine; only the image filter is broken.)

## What this PR does
- **`GET /version`** on the DS — the git SHA baked at build time (`ARG GIT_SHA` → `option_env!`).
- **Deploy verification:** both `delivery-deploy-{dev,prod}.yml` now bake `GIT_SHA`, poke Watchtower **without** the broken `?image=` filter, then **poll `/version` until it reports the SHA just built** — failing the deploy if the recreate didn't take. No more silent version drift.
- **`deploy/delivery.sh`** — box-side `doppler run` recreate for env/secret changes (the one place DS runtime env is injected; Watchtower preserves it across code deploys, so **secrets stay off GitHub** — the whole point of the Watchtower design).

Unfiltered poke is safe: only the two `delivery` containers carry the watchtower label and they track distinct tags (`:prod`/`:dev`), so a `:dev` push only recreates `delivery-dev`.

Doppler (`dev_personal`/`prd_prod`) is now the complete DS env source of truth (added `PORT`, `POLLIS_DS_REQUIRE_AUTH`, `DEV_OTP`, `R2_BUCKET`, `TURSO_PLATFORM_TOKEN/ORG/DB`).
