### PR TITLE
e2e: deps-free smoke test + invalid-otp coverage + CI smoke workflow

### DIFF
--- a/.codesight/wiki/testing.md
+++ b/.codesight/wiki/testing.md
@@ -1,9 +1,10 @@
 # Testing
 
-Pollis has two tiers of automated tests:
+Pollis has three tiers of automated tests:
 
 1. **Unit tests** (in-crate `#[cfg(test)]` modules) — pure logic, in-memory rusqlite schemas, no I/O.
-2. **Integration harness** (`src-tauri/tests/flows.rs`) — drives the real `pollis-core` commands end-to-end against a disposable test Turso database. This document covers the harness.
+2. **Integration harness** (`src-tauri/tests/flows.rs`) — drives the real `pollis-core` commands end-to-end against a disposable test Turso database. Most of this document covers the harness.
+3. **WebDriver E2E tests** (`e2e/`) — drives the real shipped Tauri app (native WebKitGTK WebView, real Rust core) via `tauri-driver`. See [WebDriver E2E tests](#webdriver-e2e-tests-e2e) below.
 
 > The harness is built on top of Tauri's test machinery (`tauri::test::get_ipc_response` + `MockRuntime`). Tauri is the shipping shell, so the harness drives the real command logic through the same dispatch path the app uses, headlessly — `pollis-core` is the unit under test, reached through the `#[tauri::command]` shims exactly as at runtime.
 
@@ -418,3 +419,39 @@ implements. Honest scope: this is machine-checked proof of these pure functions,
 ## Known flakes
 
 - **`channel_message_round_trip`** can fail with "stream not found" during `send_group_invite`'s MLS reconcile — a libsql hrana stream timeout. It passes reliably in isolation and in the current suite, but is sensitive to connection state accumulation. If it flakes again, the first suspect is stream lifetime, not test logic.
+
+## WebDriver E2E tests (`e2e/`)
+
+The only tier that drives the **actual shipped app** — the real WebKitGTK
+WebView inside the Tauri shell, real Rust core, real Tauri IPC — rather than
+`MockRuntime` or a browser build of the frontend. Three scripts under `e2e/`,
+sharing `e2e/lib/harness.js` for the `tauri-driver`/WebKitWebDriver plumbing
+(raw `webdriverio` `remote()` calls, not the wdio test runner — the runner
+intermittently stalls the first WebView command against this webkit2gtk
+build):
+
+| script | proves | needs delivery service / Turso? |
+|---|---|---|
+| `smoke.js` | app launches, login screen renders | no |
+| `e2e.js` | full signup: email → OTP → secret key → PIN → app-ready | yes (writable test Turso) |
+| `invalid-otp.js` | wrong OTP code is rejected, doesn't advance past code entry | yes (writable test Turso) |
+
+```bash
+pnpm --filter @pollis/e2e smoke        # fast, no external deps
+pnpm --filter @pollis/e2e test         # full signup flow
+pnpm --filter @pollis/e2e invalid-otp
+```
+
+`smoke.js` is the CI-friendly one: the logged-out path
+(`checkStoredSession()` in `frontend/src/App.tsx`) resolves entirely from
+local Tauri commands, so it never calls out to the delivery service or
+Turso. `.github/workflows/e2e-smoke.yml` runs it on `workflow_dispatch`. The
+other two need a writable disposable test Turso with the schema applied
+(`scripts/db-apply.sh` against `.env.test` — see `e2e/README.md` for the
+full prerequisites and gotchas) and are for local use / not yet wired into
+CI.
+
+Full details — how the stack is stood up, `.env.test` schema bootstrap,
+`data-testid` conventions, and the WebKitWebDriver quirks (native `.click()`
+doesn't fire React handlers, IPv6-only Vite loopback, orphan-process
+reaping) — live in `e2e/README.md`, not duplicated here.

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -1,0 +1,100 @@
+# On-demand WebDriver smoke test: does the real Tauri app still launch and
+# show the login screen? Runs e2e/smoke.js, which is the only e2e/ script
+# with no delivery-service / shared-Turso dependency (see e2e/README.md and
+# .codesight/wiki/testing.md "WebDriver E2E tests") — the logged-out path
+# resolves entirely from local Tauri commands, so this workflow needs
+# nothing beyond a built `pollis` binary and a virtual display.
+#
+# Manual trigger only (not on every push): a full cargo build + a real
+# (virtual) WebKitGTK window is much heavier than the rest of CI. Run it from
+# the Actions tab when you want a launch/regression smoke check — e.g. before
+# a release, or after touching the auth screen / app bootstrap path.
+name: E2E smoke (login screen)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    # Same rationale as mls-tests.yml: src-tauri/build.rs compiles
+    # pollis-capture-linux inline, whose libspa 0.9 bindgen needs PipeWire
+    # >= 1.0 headers, which ubuntu-24.04 ships and ubuntu-22.04 doesn't.
+    runs-on: ubuntu-24.04
+    env:
+      CARGO_PROFILE_DEV_DEBUG: "0"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            .
+            src-tauri
+
+      # Same list as mls-tests.yml (webkit/gtk for Tauri, alsa/pulse/pipewire
+      # + libva for the media stack pollis-core links even when unused, meson
+      # deps for webrtc-audio-processing-sys's vendored C++ build), plus
+      # webkit2gtk-driver (ships the WebKitWebDriver binary tauri-driver
+      # talks to) and xvfb (no real X server on the runner).
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            webkit2gtk-driver \
+            xvfb \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libxdo-dev \
+            libssl-dev \
+            libasound2-dev \
+            libpulse-dev \
+            libpipewire-0.3-dev \
+            libva-dev \
+            libdbus-1-dev \
+            cmake \
+            clang \
+            ninja-build
+
+      - name: Install meson (newer than apt)
+        run: |
+          python3 -m pip install --user 'meson>=1.3'
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Install tauri-driver
+        run: cargo install tauri-driver --locked
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Clean env: pollis-core/src/config.rs reads config with option_env!,
+      # which bakes values in at compile time. smoke.js never calls the
+      # delivery service or Turso before the login screen renders, so no
+      # .env.test / secrets are needed at all — a completely bare build is
+      # correct here (see e2e/README.md Prerequisites).
+      - name: Build pollis (debug)
+        run: cargo build -p pollis
+
+      - name: Run e2e smoke test
+        working-directory: e2e
+        run: xvfb-run --auto-servernum pnpm smoke
+
+      - name: Upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-smoke-failure
+          path: |
+            e2e/artifacts/FAIL.png
+            e2e/artifacts/FAIL.html
+          if-no-files-found: ignore

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,2 +1,4 @@
 artifacts/
 .tmp-data/
+.tmp-data-smoke/
+.tmp-data-invalid-otp/

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -2,21 +2,41 @@
 
 Drives the **actual native desktop app** — the real WebKitGTK WebView inside the
 Tauri shell, talking to the real Rust core over Tauri IPC — not the browser
-build of the frontend. Proves the flow only the shipped shell can exercise:
-launch → create account → log in → screenshot.
+build of the frontend.
+
+Three scripts, sharing `lib/harness.js` for the tauri-driver/WebKitWebDriver
+plumbing:
+
+| script | what it proves | needs DS? | needs Turso? |
+|---|---|---|---|
+| `smoke.js` | app launches, login screen renders | no | no |
+| `e2e.js` | full signup: email → OTP → secret key → PIN → app-ready | yes | yes (writable) |
+| `invalid-otp.js` | a wrong OTP code is rejected with an inline error, doesn't advance | yes | yes (writable) |
 
 ```bash
-pnpm --filter @pollis/e2e test      # or: node e2e/e2e.js
+pnpm --filter @pollis/e2e smoke        # or: node e2e/smoke.js       (fast, no deps)
+pnpm --filter @pollis/e2e test         # or: node e2e/e2e.js         (full signup flow)
+pnpm --filter @pollis/e2e invalid-otp  # or: node e2e/invalid-otp.js
 ```
 
-Proof screenshots land in `e2e/artifacts/` (`01-auth-screen.png`,
-`99-app-ready.png`); on failure it writes `FAIL.png` + `FAIL.html` and prints
-the testids that were actually on screen.
+`smoke.js` is the one to reach for in CI or as a quick "did I break launch"
+check — `checkStoredSession()` (`frontend/src/App.tsx`) resolves the
+logged-out path entirely from local Tauri commands (`getSession` /
+`listKnownAccounts`), so it never touches the delivery service or Turso. The
+other two need the local delivery service + a writable disposable Turso DB
+(see Prerequisites below).
+
+Proof screenshots land in `e2e/artifacts/` (`smoke-auth-screen.png`,
+`01-auth-screen.png`, `99-app-ready.png`, `invalid-otp-error.png`); on failure
+any script writes `FAIL.png` + `FAIL.html` and prints the testids that were
+actually on screen.
 
 ## How it works
 
-`e2e.js` stands up the whole local stack, then drives the app with raw
-`webdriverio` `remote()` calls:
+Each script stands up its own local stack (`smoke.js` skips the delivery
+service entirely), then drives the app with raw `webdriverio` `remote()`
+calls via helpers in `lib/harness.js` (`reap`, `waitPort`, `waitTestId`,
+`clickTestId`, `typeCode`, `makeShot`, ...):
 
 1. **Vite dev server** on `:5173`. The debug Tauri binary loads its UI from
    `devUrl` (Tauri only embeds the frontend in release builds — and even this
@@ -49,49 +69,52 @@ Nothing talks to prod. No OTP email is ever sent.
   env -u POLLIS_DELIVERY_URL -u TURSO_URL -u TURSO_TOKEN cargo build -p pollis -p pollis-delivery
   ```
 
+  `smoke.js` only launches `target/debug/pollis` (no DS calls before the
+  login screen renders), so `-p pollis` alone is enough for it. `e2e.js` and
+  `invalid-otp.js` need `pollis-delivery` too.
+
   This matters: `pollis-core/src/config.rs` reads env with `option_env!`,
   which **bakes values in at compile time** and beats the runtime environment.
   A binary built with `.env.development` sourced has `api-dev.pollis.com`
   baked in and will silently ignore the local-DS override.
 
-- **`.env.test`** must point at a **writable, disposable** Turso DB with the
+- **`.env.test`** — only needed for `e2e.js` / `invalid-otp.js` (`smoke.js`
+  reads neither TURSO_URL nor POLLIS_DELIVERY_URL). Must point at a
+  **writable, disposable** Turso DB with the
   schema applied. `.env.development`'s Turso token is read-only — signup fails
   on it — which is why all Turso access is redirected to the test DB.
 
   > **Schema bootstrap is a manual, one-time step** (see "Known limitation"
-  > below). The integration test harness already bootstraps `.env.test`
-  > idempotently, so the simplest way to get a current schema is to run it once:
-  >
-  > ```bash
-  > cargo test --features test-harness --test flows
-  > ```
-  >
-  > (Any single scenario is enough — it stamps the baseline + all migrations
-  > into the DB.) Alternatively, apply migrations by hand against a fresh DB:
+  > below). Note the Rust `flows` integration harness does **not** help here
+  > as of `8b41317` (2026-05-05) — it runs against an embedded local libsql
+  > file, not `.env.test`'s real Turso, so running it does nothing for this
+  > DB's schema. Use the CI migration runner directly instead:
   >
   > ```bash
   > set -a; . .env.test; set +a
-  > for f in pollis-core/src/db/migrations/0*.sql; do
-  >   turso db shell "$TURSO_URL" < "$f"
-  > done
+  > bash scripts/db-apply.sh
   > ```
   >
-  > If a run fails with `no such table: …`, the test DB is behind on migrations
-  > — re-run the harness (or apply the missing file).
+  > It's idempotent (tracks applied versions in `schema_migrations`) and is
+  > exactly what CI runs before tests. If a run fails with "duplicate column"
+  > or similar on a migration `db-apply.sh` thinks is pending, the DB's
+  > `schema_migrations` bookkeeping has drifted from its actual schema
+  > (columns/tables applied by hand outside the script at some point) —
+  > diagnose with a manual `SELECT sql FROM sqlite_master WHERE name = '…'`
+  > against the DB before assuming the migration file itself is wrong.
 
 ## Known limitation — no automatic schema bootstrap
 
-`e2e.js` does **not** bring the test DB's schema up itself; it assumes the
-schema is already applied (see above). Auto-bootstrapping was deliberately
-deferred: the `pollis-core` test harness — the source of truth for schema
-setup — is under active change, and duplicating its migration logic here now
-would create churn/conflicts. Once that settles, `e2e.js` should apply the
-baseline + numbered migrations at startup (reading `pollis-core/src/db/
-migrations/*.sql`, gated on `schema_migrations`) so a fresh clone / CI works
-with no manual step. Until then this harness is **not** fully self-contained
-for CI.
+`e2e.js` / `invalid-otp.js` do **not** bring the test DB's schema up
+themselves; they assume the schema is already applied (see above) — that's
+why CI (`.github/workflows/e2e-smoke.yml`) only runs `smoke.js`, which has no
+schema dependency at all. Auto-bootstrapping was deliberately deferred:
+duplicating `scripts/db-apply.sh`'s migration logic here now would create
+churn/conflicts. Until that lands, `e2e.js` and `invalid-otp.js` are for
+local use against a schema you've applied by hand; only `smoke.js` is
+self-contained enough for CI.
 
-## Gotchas encoded in e2e.js (learned the hard way)
+## Gotchas encoded in these scripts (learned the hard way)
 
 - **Clicks**: WebKitWebDriver's native `element.click()` doesn't reliably fire
   React handlers/form submits here; `clickTestId()` dispatches a DOM click via
@@ -108,3 +131,22 @@ for CI.
   error. `e2e.js` reaps all of these on start and on teardown.
 - Vite 3 binds IPv6 loopback only (`[::1]:5173`); port checks probe both
   families.
+- **`smoke.js` still needs placeholder env vars**: `Config::from_env()`
+  (`pollis-core/src/config.rs`) hard-requires `TURSO_URL` / `TURSO_TOKEN` /
+  `R2_S3_ENDPOINT` / `R2_PUBLIC_URL` to be present — baked in at compile time
+  or set at runtime — or the app panics in its Tauri setup hook before any
+  window opens. `smoke.js` supplies unreachable placeholders for these
+  (`REQUIRED_PLACEHOLDERS`), since the login screen never dials any of them.
+  If `Config::from_env()` grows a new required field, `smoke.js` needs a
+  matching placeholder or it starts failing for an unrelated reason.
+
+## CI
+
+`.github/workflows/e2e-smoke.yml` runs `smoke.js` on Linux, triggered
+manually (`workflow_dispatch`) — not on every push, since it needs a real
+(virtual) display and a full `cargo build`, both slower than the rest of CI.
+Trigger it from the Actions tab when you want a smoke check that the app
+still launches. It installs `webkit2gtk` + `webkit2gtk-driver`, `tauri-driver`,
+and wraps the run in `xvfb-run` for a virtual X server. It does not run
+`e2e.js` / `invalid-otp.js` — those need the shared writable test Turso,
+which isn't provisioned in CI yet.

--- a/e2e/e2e.js
+++ b/e2e/e2e.js
@@ -10,140 +10,26 @@
  *
  * Flow: launch → create account (email → dev OTP → save secret key → PIN) →
  * land on the ready app → screenshot. Nothing talks to prod; no email is sent.
+ *
+ * For a fast, network-free check that the app launches and the login screen
+ * renders, see smoke.js instead — it doesn't touch the delivery service or
+ * Turso at all.
  */
 
 const fs = require("fs");
-const net = require("net");
-const os = require("os");
 const path = require("path");
 const { spawn, spawnSync } = require("child_process");
 const dotenv = require("dotenv");
 const { remote } = require("webdriverio");
+const h = require("./lib/harness");
 
-const ROOT = path.resolve(__dirname, "..");
-const UI_PORT = 5173;
-const DS_PORT = 8788;
-const DS_URL = `http://127.0.0.1:${DS_PORT}`;
-const DS_BIN = path.join(ROOT, "target", "debug", "pollis-delivery");
-const APP_BIN = path.join(ROOT, "target", "debug", "pollis");
-const TAURI_DRIVER = path.resolve(os.homedir(), ".cargo", "bin", "tauri-driver");
 const ARTIFACTS = path.join(__dirname, "artifacts");
-
-const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
-
-function reap() {
-  for (const p of ["tauri-driver", "WebKitWebDriver", "bin/vite", "target/debug/pollis-delivery"]) {
-    spawnSync("pkill", ["-9", "-f", p], { stdio: "ignore" });
-  }
-  spawnSync("pkill", ["-9", "-x", "pollis"], { stdio: "ignore" });
-}
-
-function waitPort(port, hosts, ms) {
-  const list = Array.isArray(hosts) ? hosts : [hosts];
-  const end = Date.now() + ms;
-  return new Promise((res, rej) => {
-    const attempt = () => {
-      let pending = list.length;
-      let done = false;
-      for (const host of list) {
-        const s = net.connect({ port, host });
-        s.once("connect", () => { s.destroy(); if (!done) { done = true; res(); } });
-        s.once("error", () => {
-          s.destroy();
-          if (--pending === 0 && !done) {
-            Date.now() > end ? rej(new Error(`timeout ${list}:${port}`)) : setTimeout(attempt, 150);
-          }
-        });
-      }
-    };
-    attempt();
-  });
-}
-
-function curl(url) {
-  spawnSync("curl", ["-s", "-g", "--max-time", "8", "-o", "/dev/null", url]);
-}
-
-function warmVite() {
-  const base = `http://[::1]:${UI_PORT}`;
-  const r = spawnSync("curl", ["-s", "-g", "--max-time", "8", `${base}/`], { encoding: "utf8" });
-  const html = r.stdout || "";
-  const srcs = [...html.matchAll(/<script[^>]+src="([^"]+)"/g)].map((m) => m[1].replace(/^https?:\/\/[^/]+/, ""));
-  for (const s of [...srcs, "/@vite/client", "/src/main.tsx"]) {
-    curl(`${base}${s.startsWith("/") ? "" : "/"}${s}`);
-  }
-}
-
-// ---- app-driving helpers -------------------------------------------------
-
-async function present(browser, testId) {
-  const els = await browser.$$(`[data-testid="${testId}"]`);
-  return els.length > 0;
-}
-
-async function waitTestId(browser, testId, timeoutMs = 30000, label = testId) {
-  const end = Date.now() + timeoutMs;
-  while (Date.now() < end) {
-    if (await present(browser, testId)) {
-      return;
-    }
-    await sleep(400);
-  }
-  throw new Error(`timed out waiting for [data-testid="${label}"]`);
-}
-
-// WebKitWebDriver's native click doesn't reliably fire React handlers here; a
-// DOM click dispatched in-page does.
-async function clickTestId(browser, testId) {
-  await waitTestId(browser, testId);
-  const ok = await browser.execute((id) => {
-    const el = document.querySelector(`[data-testid="${id}"]`);
-    if (el) { el.click(); return true; }
-    return false;
-  }, testId);
-  if (!ok) {
-    throw new Error(`click: ${testId} vanished`);
-  }
-}
-
-async function setTestIdValue(browser, testId, value) {
-  await waitTestId(browser, testId);
-  const el = await browser.$(`[data-testid="${testId}"]`);
-  await el.setValue(value);
-}
-
-// OTP / PIN: N separate <input maxlength=1> boxes, aria-label="OTP digit K".
-async function typeCode(browser, digits) {
-  for (let i = 0; i < digits.length; i++) {
-    const box = await browser.$(`[aria-label="OTP digit ${i + 1}"]`);
-    await box.setValue(digits[i]);
-  }
-}
-
-// Screenshot with a hard timeout: a wedged WebKit compositor can hang the
-// screenshot endpoint indefinitely; don't let that take the whole run down.
-async function shot(browser, name, timeoutMs = 25000) {
-  fs.mkdirSync(ARTIFACTS, { recursive: true });
-  const file = path.join(ARTIFACTS, name);
-  try {
-    await Promise.race([
-      browser.saveScreenshot(file),
-      sleep(timeoutMs).then(() => { throw new Error("screenshot timed out"); }),
-    ]);
-    console.log(`[e2e] screenshot -> ${file}`);
-    return true;
-  } catch (e) {
-    console.log(`[e2e] screenshot ${name} failed (${e.message}) — continuing`);
-    return false;
-  }
-}
-
-// ---- main ----------------------------------------------------------------
+const shot = h.makeShot(ARTIFACTS);
 
 async function main() {
-  reap();
-  const devEnv = dotenv.parse(fs.readFileSync(path.join(ROOT, ".env.development")));
-  const testEnv = dotenv.parse(fs.readFileSync(path.join(ROOT, ".env.test")));
+  h.reap();
+  const devEnv = dotenv.parse(fs.readFileSync(path.join(h.ROOT, ".env.development")));
+  const testEnv = dotenv.parse(fs.readFileSync(path.join(h.ROOT, ".env.test")));
   if (!testEnv.TURSO_URL || !testEnv.TURSO_TOKEN) {
     throw new Error(".env.test missing TURSO_URL/TOKEN (need a writable disposable DB)");
   }
@@ -152,20 +38,15 @@ async function main() {
   const stop = (c) => { try { c && c.kill("SIGKILL"); } catch (_) {} };
 
   // Vite dev server (the UI the debug binary loads).
-  console.log(`[e2e] starting Vite on :${UI_PORT}`);
-  const vite = spawn(
-    "pnpm",
-    ["--filter", "frontend", "dev", "--", "--port", String(UI_PORT), "--strictPort"],
-    { cwd: ROOT, env: { ...process.env, ...devEnv }, stdio: ["ignore", "inherit", "inherit"] }
-  );
+  const vite = h.spawnVite(devEnv);
   children.push(vite);
 
   // Local delivery service.
   const dsEnv = { ...process.env, TURSO_URL: testEnv.TURSO_URL, TURSO_TOKEN: testEnv.TURSO_TOKEN,
-    PORT: String(DS_PORT), DEV_OTP: "000000", RUST_LOG: "pollis_delivery=info" };
+    PORT: String(h.DS_PORT), DEV_OTP: "000000", RUST_LOG: "pollis_delivery=info" };
   delete dsEnv.RESEND_API_KEY; delete dsEnv.LOG_DB_URL; delete dsEnv.LOG_DB_TOKEN; delete dsEnv.LOG_DB_ADMIN_TOKEN;
-  console.log(`[e2e] starting delivery service on ${DS_URL} (DEV_OTP=000000)`);
-  const ds = spawn(DS_BIN, [], { env: dsEnv, stdio: ["ignore", "inherit", "inherit"] });
+  console.log(`[e2e] starting delivery service on ${h.DS_URL} (DEV_OTP=000000)`);
+  const ds = spawn(h.DS_BIN, [], { env: dsEnv, stdio: ["ignore", "inherit", "inherit"] });
   children.push(ds);
 
   // App env: dev creds + writable test DB + local DS. The two WebKit vars
@@ -173,7 +54,7 @@ async function main() {
   // broken on this setup and causes rendering stalls / hung screenshot
   // commands without them.
   const appEnv = { ...process.env, ...devEnv, TURSO_URL: testEnv.TURSO_URL, TURSO_TOKEN: testEnv.TURSO_TOKEN,
-    POLLIS_DELIVERY_URL: DS_URL, POLLIS_DATA_DIR: path.join(__dirname, ".tmp-data"),
+    POLLIS_DELIVERY_URL: h.DS_URL, POLLIS_DATA_DIR: path.join(__dirname, ".tmp-data"),
     WEBKIT_DISABLE_COMPOSITING_MODE: "1", GDK_BACKEND: "x11" };
   fs.rmSync(appEnv.POLLIS_DATA_DIR, { recursive: true, force: true });
   fs.mkdirSync(appEnv.POLLIS_DATA_DIR, { recursive: true });
@@ -182,24 +63,19 @@ async function main() {
   let browser;
   let code = 1;
   try {
-    await waitPort(UI_PORT, ["::1", "127.0.0.1"], 60000);
-    await sleep(3000);
-    warmVite();
-    await sleep(1500);
-    warmVite();
-    console.log("[e2e] Vite up and warmed");
-    await waitPort(DS_PORT, ["127.0.0.1", "::1"], 20000);
+    await h.waitViteReady();
+    await h.waitPort(h.DS_PORT, ["127.0.0.1", "::1"], 20000);
     console.log("[e2e] delivery service up");
 
     // tauri-driver → WebKitWebDriver → app (inherits appEnv).
-    tauriDriver = spawn(TAURI_DRIVER, ["--port", "4444"], {
+    tauriDriver = spawn(h.TAURI_DRIVER, ["--port", "4444"], {
       stdio: ["ignore", "inherit", "inherit"], env: appEnv,
     });
-    await waitPort(4444, "127.0.0.1", 15000);
+    await h.waitPort(4444, "127.0.0.1", 15000);
 
     browser = await remote({
       hostname: "127.0.0.1", port: 4444, path: "/",
-      capabilities: { "tauri:options": { application: APP_BIN } },
+      capabilities: { "tauri:options": { application: h.APP_BIN } },
       logLevel: "error",
       // Fail a wedged command in 45s instead of the default 120s.
       connectionRetryTimeout: 45000,
@@ -208,59 +84,55 @@ async function main() {
 
     // Let the initial Vite page load settle before the first command (mirrors
     // the reliable standalone probe).
-    await sleep(6000);
+    await h.sleep(6000);
 
     const email = `e2e_${Date.now()}@pollis.test`;
     const PIN = "1357";
     console.log(`[e2e] account: ${email}`);
 
     // 1. Auth screen.
-    await waitTestId(browser, "auth-screen", 30000);
+    await h.waitTestId(browser, "auth-screen", 30000);
     await shot(browser, "01-auth-screen.png");
 
     // 2. Email → request OTP.
-    await setTestIdValue(browser, "email-input", email);
-    await clickTestId(browser, "send-otp-button");
-    await waitTestId(browser, "otp-form-container", 20000);
+    await h.setTestIdValue(browser, "email-input", email);
+    await h.clickTestId(browser, "send-otp-button");
+    await h.waitTestId(browser, "otp-form-container", 20000);
     console.log("[e2e] email submitted, OTP form shown");
 
     // 3. Dev OTP 000000 (auto-submits) → new-account secret-key flow.
-    await typeCode(browser, "000000");
-    await waitTestId(browser, "save-secret-key-warning-screen", 45000);
+    await h.typeCode(browser, "000000");
+    await h.waitTestId(browser, "save-secret-key-warning-screen", 45000);
     console.log("[e2e] OTP verified, account bootstrapped");
 
     // 4. Save-secret-key dance.
-    await clickTestId(browser, "save-secret-key-acknowledge-button");
-    await waitTestId(browser, "save-secret-key-screen");
+    await h.clickTestId(browser, "save-secret-key-acknowledge-button");
+    await h.waitTestId(browser, "save-secret-key-screen");
     const secretKey = (await (await browser.$('[data-testid="secret-key-display"]')).getText()).trim();
     if (!secretKey) {
       throw new Error("secret key display was empty");
     }
-    await clickTestId(browser, "secret-key-saved-button");
-    await waitTestId(browser, "save-secret-key-confirm-screen");
-    await setTestIdValue(browser, "secret-key-confirm-input", secretKey);
-    await clickTestId(browser, "confirm-secret-key-button");
+    await h.clickTestId(browser, "secret-key-saved-button");
+    await h.waitTestId(browser, "save-secret-key-confirm-screen");
+    await h.setTestIdValue(browser, "secret-key-confirm-input", secretKey);
+    await h.clickTestId(browser, "confirm-secret-key-button");
     console.log("[e2e] secret key confirmed");
 
     // 5. Create PIN (enter + confirm, each auto-advances/submits).
-    await waitTestId(browser, "pin-create-screen");
-    await typeCode(browser, PIN);
-    await typeCode(browser, PIN);
+    await h.waitTestId(browser, "pin-create-screen");
+    await h.typeCode(browser, PIN);
+    await h.typeCode(browser, PIN);
     console.log("[e2e] PIN created");
 
     // 6. Ready app → proof.
-    await waitTestId(browser, "app-ready", 60000);
+    await h.waitTestId(browser, "app-ready", 60000);
     await shot(browser, "99-app-ready.png");
     console.log("[e2e] SUCCESS: reached app-ready");
     code = 0;
   } catch (err) {
     console.error("[e2e] FAILED:", err.message);
     if (browser) {
-      await shot(browser, "FAIL.png").catch(() => {});
-      const src = await browser.getPageSource().catch(() => "");
-      fs.writeFileSync(path.join(ARTIFACTS, "FAIL.html"), src);
-      const ids = [...src.matchAll(/data-testid="([^"]+)"/g)].map((m) => m[1]);
-      console.error("[e2e] on-screen testids:", [...new Set(ids)].join(", "));
+      await h.dumpFailure(browser, ARTIFACTS, shot);
     }
   } finally {
     if (browser) {
@@ -270,9 +142,9 @@ async function main() {
     for (const c of children) {
       stop(c);
     }
-    reap();
+    h.reap();
   }
   process.exit(code);
 }
 
-main().catch((e) => { console.error("[e2e] fatal:", e); reap(); process.exit(1); });
+main().catch((e) => { console.error("[e2e] fatal:", e); h.reap(); process.exit(1); });

--- a/e2e/invalid-otp.js
+++ b/e2e/invalid-otp.js
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+/*
+ * E2E: a wrong OTP code surfaces an inline error and does not let the user
+ * past the code-entry screen. Same local stack as e2e.js (needs the
+ * delivery service + writable test Turso — see e2e/README.md), but only
+ * drives the auth screen, not the full signup flow.
+ *
+ * Flow: launch → email → request OTP → enter a WRONG 6-digit code →
+ * assert [data-testid="auth-error"] appears and otp-form-container is still
+ * shown (i.e. verification was rejected, not silently accepted).
+ */
+
+const fs = require("fs");
+const path = require("path");
+const { spawn } = require("child_process");
+const dotenv = require("dotenv");
+const { remote } = require("webdriverio");
+const h = require("./lib/harness");
+
+const ARTIFACTS = path.join(__dirname, "artifacts");
+const shot = h.makeShot(ARTIFACTS);
+
+async function main() {
+  h.reap();
+  const devEnv = dotenv.parse(fs.readFileSync(path.join(h.ROOT, ".env.development")));
+  const testEnv = dotenv.parse(fs.readFileSync(path.join(h.ROOT, ".env.test")));
+  if (!testEnv.TURSO_URL || !testEnv.TURSO_TOKEN) {
+    throw new Error(".env.test missing TURSO_URL/TOKEN (need a writable disposable DB)");
+  }
+
+  const children = [];
+  const stop = (c) => { try { c && c.kill("SIGKILL"); } catch (_) {} };
+
+  const vite = h.spawnVite(devEnv);
+  children.push(vite);
+
+  // Local delivery service. DEV_OTP is the code that WOULD verify — the
+  // whole point of this test is to send something else instead.
+  const dsEnv = { ...process.env, TURSO_URL: testEnv.TURSO_URL, TURSO_TOKEN: testEnv.TURSO_TOKEN,
+    PORT: String(h.DS_PORT), DEV_OTP: "000000", RUST_LOG: "pollis_delivery=info" };
+  delete dsEnv.RESEND_API_KEY; delete dsEnv.LOG_DB_URL; delete dsEnv.LOG_DB_TOKEN; delete dsEnv.LOG_DB_ADMIN_TOKEN;
+  console.log(`[invalid-otp] starting delivery service on ${h.DS_URL} (DEV_OTP=000000)`);
+  const ds = spawn(h.DS_BIN, [], { env: dsEnv, stdio: ["ignore", "inherit", "inherit"] });
+  children.push(ds);
+
+  const appEnv = { ...process.env, ...devEnv, TURSO_URL: testEnv.TURSO_URL, TURSO_TOKEN: testEnv.TURSO_TOKEN,
+    POLLIS_DELIVERY_URL: h.DS_URL, POLLIS_DATA_DIR: path.join(__dirname, ".tmp-data-invalid-otp"),
+    WEBKIT_DISABLE_COMPOSITING_MODE: "1", GDK_BACKEND: "x11" };
+  fs.rmSync(appEnv.POLLIS_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(appEnv.POLLIS_DATA_DIR, { recursive: true });
+
+  let tauriDriver;
+  let browser;
+  let code = 1;
+  try {
+    await h.waitViteReady();
+    await h.waitPort(h.DS_PORT, ["127.0.0.1", "::1"], 20000);
+    console.log("[invalid-otp] delivery service up");
+
+    tauriDriver = spawn(h.TAURI_DRIVER, ["--port", "4444"], {
+      stdio: ["ignore", "inherit", "inherit"], env: appEnv,
+    });
+    await h.waitPort(4444, "127.0.0.1", 15000);
+
+    browser = await remote({
+      hostname: "127.0.0.1", port: 4444, path: "/",
+      capabilities: { "tauri:options": { application: h.APP_BIN } },
+      logLevel: "error",
+      connectionRetryTimeout: 45000,
+      connectionRetryCount: 1,
+    });
+
+    await h.sleep(6000);
+
+    const email = `e2e_bad_otp_${Date.now()}@pollis.test`;
+    console.log(`[invalid-otp] account: ${email}`);
+
+    await h.waitTestId(browser, "auth-screen", 30000);
+    await h.setTestIdValue(browser, "email-input", email);
+    await h.clickTestId(browser, "send-otp-button");
+    await h.waitTestId(browser, "otp-form-container", 20000);
+    console.log("[invalid-otp] email submitted, OTP form shown");
+
+    // Wrong code — DEV_OTP is 000000, this is neither that nor a real code.
+    await h.typeCode(browser, "111111");
+    await h.waitTestId(browser, "auth-error", 20000);
+    const errText = (await (await browser.$('[data-testid="auth-error"]')).getText()).trim();
+    if (!errText) {
+      throw new Error("auth-error testid present but empty");
+    }
+    console.log(`[invalid-otp] rejected as expected: "${errText}"`);
+
+    if (!(await h.present(browser, "otp-form-container"))) {
+      throw new Error("otp-form-container vanished — wrong code should not advance past OTP entry");
+    }
+    await shot(browser, "invalid-otp-error.png");
+    console.log("[invalid-otp] SUCCESS: wrong code rejected, still on OTP screen");
+    code = 0;
+  } catch (err) {
+    console.error("[invalid-otp] FAILED:", err.message);
+    if (browser) {
+      await h.dumpFailure(browser, ARTIFACTS, shot);
+    }
+  } finally {
+    if (browser) {
+      await browser.deleteSession().catch(() => {});
+    }
+    stop(tauriDriver);
+    for (const c of children) {
+      stop(c);
+    }
+    h.reap();
+  }
+  process.exit(code);
+}
+
+main().catch((e) => { console.error("[invalid-otp] fatal:", e); h.reap(); process.exit(1); });

--- a/e2e/lib/harness.js
+++ b/e2e/lib/harness.js
@@ -1,0 +1,164 @@
+/*
+ * Shared plumbing for the raw-webdriverio Tauri e2e scripts (e2e.js,
+ * smoke.js, ...). See e2e/README.md for why this drives the real app via
+ * tauri-driver + WebKitWebDriver instead of the wdio test runner.
+ */
+
+const fs = require("fs");
+const net = require("net");
+const os = require("os");
+const path = require("path");
+const { spawn, spawnSync } = require("child_process");
+
+const ROOT = path.resolve(__dirname, "..", "..");
+const UI_PORT = 5173;
+const DS_PORT = 8788;
+const DS_URL = `http://127.0.0.1:${DS_PORT}`;
+const DS_BIN = path.join(ROOT, "target", "debug", "pollis-delivery");
+const APP_BIN = path.join(ROOT, "target", "debug", "pollis");
+const TAURI_DRIVER = path.resolve(os.homedir(), ".cargo", "bin", "tauri-driver");
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function reap() {
+  for (const p of ["tauri-driver", "WebKitWebDriver", "bin/vite", "target/debug/pollis-delivery"]) {
+    spawnSync("pkill", ["-9", "-f", p], { stdio: "ignore" });
+  }
+  spawnSync("pkill", ["-9", "-x", "pollis"], { stdio: "ignore" });
+}
+
+function waitPort(port, hosts, ms) {
+  const list = Array.isArray(hosts) ? hosts : [hosts];
+  const end = Date.now() + ms;
+  return new Promise((res, rej) => {
+    const attempt = () => {
+      let pending = list.length;
+      let done = false;
+      for (const host of list) {
+        const s = net.connect({ port, host });
+        s.once("connect", () => { s.destroy(); if (!done) { done = true; res(); } });
+        s.once("error", () => {
+          s.destroy();
+          if (--pending === 0 && !done) {
+            Date.now() > end ? rej(new Error(`timeout ${list}:${port}`)) : setTimeout(attempt, 150);
+          }
+        });
+      }
+    };
+    attempt();
+  });
+}
+
+function curl(url) {
+  spawnSync("curl", ["-s", "-g", "--max-time", "8", "-o", "/dev/null", url]);
+}
+
+function warmVite() {
+  const base = `http://[::1]:${UI_PORT}`;
+  const r = spawnSync("curl", ["-s", "-g", "--max-time", "8", `${base}/`], { encoding: "utf8" });
+  const html = r.stdout || "";
+  const srcs = [...html.matchAll(/<script[^>]+src="([^"]+)"/g)].map((m) => m[1].replace(/^https?:\/\/[^/]+/, ""));
+  for (const s of [...srcs, "/@vite/client", "/src/main.tsx"]) {
+    curl(`${base}${s.startsWith("/") ? "" : "/"}${s}`);
+  }
+}
+
+function spawnVite(devEnv) {
+  console.log(`[e2e] starting Vite on :${UI_PORT}`);
+  return spawn(
+    "pnpm",
+    ["--filter", "frontend", "dev", "--", "--port", String(UI_PORT), "--strictPort"],
+    { cwd: ROOT, env: { ...process.env, ...devEnv }, stdio: ["ignore", "inherit", "inherit"] }
+  );
+}
+
+async function waitViteReady() {
+  await waitPort(UI_PORT, ["::1", "127.0.0.1"], 60000);
+  await sleep(3000);
+  warmVite();
+  await sleep(1500);
+  warmVite();
+  console.log("[e2e] Vite up and warmed");
+}
+
+// ---- app-driving helpers -------------------------------------------------
+
+async function present(browser, testId) {
+  const els = await browser.$$(`[data-testid="${testId}"]`);
+  return els.length > 0;
+}
+
+async function waitTestId(browser, testId, timeoutMs = 30000, label = testId) {
+  const end = Date.now() + timeoutMs;
+  while (Date.now() < end) {
+    if (await present(browser, testId)) {
+      return;
+    }
+    await sleep(400);
+  }
+  throw new Error(`timed out waiting for [data-testid="${label}"]`);
+}
+
+// WebKitWebDriver's native click doesn't reliably fire React handlers here; a
+// DOM click dispatched in-page does.
+async function clickTestId(browser, testId) {
+  await waitTestId(browser, testId);
+  const ok = await browser.execute((id) => {
+    const el = document.querySelector(`[data-testid="${id}"]`);
+    if (el) { el.click(); return true; }
+    return false;
+  }, testId);
+  if (!ok) {
+    throw new Error(`click: ${testId} vanished`);
+  }
+}
+
+async function setTestIdValue(browser, testId, value) {
+  await waitTestId(browser, testId);
+  const el = await browser.$(`[data-testid="${testId}"]`);
+  await el.setValue(value);
+}
+
+// OTP / PIN: N separate <input maxlength=1> boxes, aria-label="OTP digit K".
+async function typeCode(browser, digits) {
+  for (let i = 0; i < digits.length; i++) {
+    const box = await browser.$(`[aria-label="OTP digit ${i + 1}"]`);
+    await box.setValue(digits[i]);
+  }
+}
+
+function makeShot(artifactsDir) {
+  // Screenshot with a hard timeout: a wedged WebKit compositor can hang the
+  // screenshot endpoint indefinitely; don't let that take the whole run down.
+  return async function shot(browser, name, timeoutMs = 25000) {
+    fs.mkdirSync(artifactsDir, { recursive: true });
+    const file = path.join(artifactsDir, name);
+    try {
+      await Promise.race([
+        browser.saveScreenshot(file),
+        sleep(timeoutMs).then(() => { throw new Error("screenshot timed out"); }),
+      ]);
+      console.log(`[e2e] screenshot -> ${file}`);
+      return true;
+    } catch (e) {
+      console.log(`[e2e] screenshot ${name} failed (${e.message}) — continuing`);
+      return false;
+    }
+  };
+}
+
+async function dumpFailure(browser, artifactsDir, shot) {
+  await shot(browser, "FAIL.png").catch(() => {});
+  const src = await browser.getPageSource().catch(() => "");
+  fs.mkdirSync(artifactsDir, { recursive: true });
+  fs.writeFileSync(path.join(artifactsDir, "FAIL.html"), src);
+  const ids = [...src.matchAll(/data-testid="([^"]+)"/g)].map((m) => m[1]);
+  console.error("[e2e] on-screen testids:", [...new Set(ids)].join(", "));
+}
+
+module.exports = {
+  ROOT, UI_PORT, DS_PORT, DS_URL, DS_BIN, APP_BIN, TAURI_DRIVER,
+  sleep, reap, waitPort, curl, warmVite, spawnVite, waitViteReady,
+  present, waitTestId, clickTestId, setTestIdValue, typeCode,
+  makeShot, dumpFailure,
+};

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -5,7 +5,9 @@
   "description": "End-to-end tests that drive the real Tauri desktop app via WebDriver (tauri-driver + WebKitWebDriver).",
   "type": "commonjs",
   "scripts": {
-    "test": "node ./e2e.js"
+    "test": "node ./e2e.js",
+    "smoke": "node ./smoke.js",
+    "invalid-otp": "node ./invalid-otp.js"
   },
   "devDependencies": {
     "dotenv": "^16",

--- a/e2e/smoke.js
+++ b/e2e/smoke.js
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/*
+ * Fast smoke check: the real Tauri app launches and the login screen
+ * renders. Unlike e2e.js, this never touches the delivery service or Turso —
+ * `checkStoredSession()` (frontend/src/App.tsx) resolves the logged-out path
+ * entirely from local Tauri commands (getSession / listKnownAccounts), so
+ * proving the auth screen shows up needs nothing but Vite + the app binary.
+ * That makes this safe to run in CI with no shared-DB dependency.
+ *
+ * Flow: launch → wait for [data-testid="auth-screen"] → screenshot. Exits
+ * non-zero (with FAIL.png/FAIL.html) if the screen never appears.
+ *
+ * No .env.development required (CI has none — it's Doppler-sourced, not
+ * committed): the login screen doesn't read any of those vars before it
+ * renders, so a missing file just means an empty env override.
+ *
+ * Config::from_env() (pollis-core/src/config.rs) DOES hard-require
+ * TURSO_URL/TURSO_TOKEN/R2_S3_ENDPOINT/R2_PUBLIC_URL to be present — baked
+ * in at compile time via option_env! or present at runtime — or the app
+ * panics in its Tauri setup hook before any window opens, login screen or
+ * not. Since this binary is built with a clean env (no baked secrets — see
+ * README Prerequisites), unresolved placeholders are supplied here so the
+ * app can boot; they are never dialed before auth-screen renders. Same
+ * trick as mls-tests.yml's placeholder `.env.test`.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const { spawn } = require("child_process");
+const dotenv = require("dotenv");
+const { remote } = require("webdriverio");
+const h = require("./lib/harness");
+
+const ARTIFACTS = path.join(__dirname, "artifacts");
+const shot = h.makeShot(ARTIFACTS);
+
+const REQUIRED_PLACEHOLDERS = {
+  TURSO_URL: "libsql://placeholder.invalid",
+  TURSO_TOKEN: "placeholder",
+  R2_S3_ENDPOINT: "https://placeholder.invalid",
+  R2_PUBLIC_URL: "https://placeholder.invalid",
+};
+
+function readDevEnv() {
+  try {
+    return dotenv.parse(fs.readFileSync(path.join(h.ROOT, ".env.development")));
+  } catch {
+    return {};
+  }
+}
+
+async function main() {
+  h.reap();
+  const devEnv = readDevEnv();
+
+  const children = [];
+  const stop = (c) => { try { c && c.kill("SIGKILL"); } catch (_) {} };
+
+  const vite = h.spawnVite(devEnv);
+  children.push(vite);
+
+  // No POLLIS_DELIVERY_URL override — the login screen never calls out to
+  // it, so the baked-in default is never dialed. Placeholders come before
+  // devEnv so a real local .env.development still wins when present.
+  const appEnv = { ...process.env, ...REQUIRED_PLACEHOLDERS, ...devEnv,
+    POLLIS_DATA_DIR: path.join(__dirname, ".tmp-data-smoke"),
+    WEBKIT_DISABLE_COMPOSITING_MODE: "1", GDK_BACKEND: "x11" };
+  fs.rmSync(appEnv.POLLIS_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(appEnv.POLLIS_DATA_DIR, { recursive: true });
+
+  let tauriDriver;
+  let browser;
+  let code = 1;
+  try {
+    await h.waitViteReady();
+
+    tauriDriver = spawn(h.TAURI_DRIVER, ["--port", "4444"], {
+      stdio: ["ignore", "inherit", "inherit"], env: appEnv,
+    });
+    await h.waitPort(4444, "127.0.0.1", 15000);
+
+    browser = await remote({
+      hostname: "127.0.0.1", port: 4444, path: "/",
+      capabilities: { "tauri:options": { application: h.APP_BIN } },
+      logLevel: "error",
+      connectionRetryTimeout: 45000,
+      connectionRetryCount: 1,
+    });
+
+    await h.sleep(6000);
+
+    await h.waitTestId(browser, "auth-screen", 30000);
+    await shot(browser, "smoke-auth-screen.png");
+    console.log("[smoke] SUCCESS: login screen rendered");
+    code = 0;
+  } catch (err) {
+    console.error("[smoke] FAILED:", err.message);
+    if (browser) {
+      await h.dumpFailure(browser, ARTIFACTS, shot);
+    }
+  } finally {
+    if (browser) {
+      await browser.deleteSession().catch(() => {});
+    }
+    stop(tauriDriver);
+    for (const c of children) {
+      stop(c);
+    }
+    h.reap();
+  }
+  process.exit(code);
+}
+
+main().catch((e) => { console.error("[smoke] fatal:", e); h.reap(); process.exit(1); });


### PR DESCRIPTION
Extends the WebDriver e2e harness (`e2e/`, from #439) with a fast CI-friendly smoke test and a second scenario, and wires the smoke test into CI.

## What's here
- **`e2e/smoke.js`** — dependency-free "app launches + login screen renders" check. The logged-out path resolves entirely from local Tauri commands, so this needs no delivery service and no Turso. (Placeholder env vars are supplied because `Config::from_env()` hard-requires `TURSO_URL`/`TURSO_TOKEN`/`R2_*` at startup even though the login screen never dials them.)
- **`e2e/invalid-otp.js`** — a wrong OTP code is rejected with an inline error and doesn't advance past code entry.
- **`e2e/lib/harness.js`** — shared tauri-driver/WebKitWebDriver plumbing; `e2e.js` refactored onto it.
- **`.github/workflows/e2e-smoke.yml`** — `workflow_dispatch`-triggered, `ubuntu-24.04`, installs `webkit2gtk-driver` + `tauri-driver`, runs `smoke.js` under `xvfb-run`. Only runs `smoke.js` (no shared-DB dependency); `e2e.js`/`invalid-otp.js` still need the writable test Turso and stay local-only.

## Verified
All three scripts pass locally against latest `main` (regression check: the pre-existing full-signup flow still reaches app-ready). `smoke.js` verified passing with `.env.development` removed, simulating the CI no-secrets environment.

## Docs
- `e2e/README.md` — documents all three scripts, the harness module, and the placeholder-env gotcha; corrects a stale claim that the Rust flows harness bootstraps `.env.test` (it moved to embedded local libsql in May).
- `.codesight/wiki/testing.md` — adds the WebDriver e2e tier (previously undocumented).

## Known issue (not addressed here)
The shared `.env.test` Turso has `schema_migrations` bookkeeping drift: v4/v5/v6 DDL is already live but unrecorded, and v8 (`message_envelope.sealed`) is genuinely missing. Left for a separate decision (hand-record 4–6 then apply 8, or recreate fresh) — not touched here since CLAUDE.md forbids manual `schema_migrations` inserts.