### PR TITLE
fix(voice/ui): shared bar height + gate in-channel voice bar on connect (closes #505)

### DIFF
--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -298,7 +298,7 @@ export const Sidebar: React.FC<SidebarProps> = observer(({ isOpen, onToggle }) =
         onClick={onToggle}
         aria-label={`Close sidebar (${toggleSidebarLabel})`}
         title={`Close sidebar (${toggleSidebarLabel})`}
-        className="flex shrink-0 items-center gap-2 px-2.5 py-2 border-t border-line text-xs text-left cursor-pointer transition-colors text-muted hover:text-fg"
+        className="flex shrink-0 items-center gap-2 px-2.5 min-h-bar border-t border-line text-xs text-left cursor-pointer transition-colors text-muted hover:text-fg"
       >
         <span className="flex-1">Close</span>
         <kbd

--- a/frontend/src/components/Voice/stage/VoiceStage.tsx
+++ b/frontend/src/components/Voice/stage/VoiceStage.tsx
@@ -298,10 +298,16 @@ export const VoiceStage: React.FC<VoiceStageProps> = observer(
           )}
         </div>
 
-        {/* ---------- footer (fixed height) ---------- */}
+        {/* ---------- footer (fixed height) ----------
+            Only the default call-tray footer is gated on a completed join
+            (matching the global VoiceBar, which mounts on
+            voiceState.kind === 'joined', not during 'joining'). The
+            not-joined preview keeps its own "Join Voice" CTA in the body, so
+            hiding this bar until connected strands nothing. A `footer`
+            override (e.g. the admin pending-delete bar) always renders. */}
         {footer ? (
           footer
-        ) : (
+        ) : voiceState.kind === "joined" ? (
           <div className="vs-foot">
             <div className="vs-foot-side">
               {isInCall ? (
@@ -361,7 +367,7 @@ export const VoiceStage: React.FC<VoiceStageProps> = observer(
               </button>
             </div>
           </div>
-        )}
+        ) : null}
       </div>
     );
   },

--- a/frontend/src/components/ui/ChatInput.tsx
+++ b/frontend/src/components/ui/ChatInput.tsx
@@ -585,8 +585,9 @@ const ChatInputInner: React.ForwardRefRenderFunction<ChatInputHandle, ChatInputP
         </div>
       )}
 
-      {/* Input row */}
-      <div className="flex items-start gap-1 px-2 py-1.5">
+      {/* Input row — floor its height on the shared chrome-bar token so the
+          composer, in-channel voice bar, and sidebar Close all match. */}
+      <div className="flex items-start gap-1 px-2 py-1.5 min-h-bar">
         <button
           onClick={handlePickFiles}
           disabled={disabled || attachments.length >= maxAttachments}


### PR DESCRIPTION
Closes #505 — two small frontend style fixes.

### 1. Shared chrome-bar height
The composer input row, the in-channel voice bar (VoiceStage footer), and the sidebar "Close" button now all derive their height from the existing `--bar-h` token instead of three independently content-derived heights.
- **Composer** (`ChatInput.tsx`): added `min-h-bar` to the input-row wrapper (was content-driven via `py-1.5`).
- **Sidebar Close** (`Sidebar.tsx`): swapped `py-2` for `min-h-bar`.
- **Voice footer**: already aliased `--bar-h` via `--vs-foot-h` — no change needed.

### 2. Gate the in-channel voice bar on connect
The VoiceStage footer previously always rendered and only swapped its contents by connection state. It now only mounts when `voiceState.kind === 'joined'`, matching the global `VoiceBar` (which also skips the `'joining'` phase). The not-joined preview keeps its own "Join Voice" CTA in the body, so nothing is stranded. The `footer` prop override (admin pending-delete bar) still always renders.

### Verification
`tsc --noEmit` passes; confirmed `min-h-bar` compiles to `min-height: var(--bar-h)` via the Tailwind spacing extension. Static-only (blind) change — no app run.