### PR TITLE
fix(ci): immediate container rollout (fix /version gate)

### DIFF
--- a/.github/workflows/delivery-deploy-dev.yml
+++ b/.github/workflows/delivery-deploy-dev.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Deploy (wrangler)
         if: steps.guard.outputs.ok == 'true'
         working-directory: pollis-delivery
-        run: pnpm exec wrangler deploy -c "$WRANGLER_CONFIG"
+        run: pnpm exec wrangler deploy -c "$WRANGLER_CONFIG" --containers-rollout immediate
 
       # Do NOT trust "deployed OK" — confirm the new binary is actually SERVING.
       # Poll /version until it reports the SHA we just built; fail otherwise. This

--- a/.github/workflows/delivery-deploy-prod.yml
+++ b/.github/workflows/delivery-deploy-prod.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Deploy (wrangler)
         if: steps.guard.outputs.ok == 'true'
         working-directory: pollis-delivery
-        run: pnpm exec wrangler deploy -c "$WRANGLER_CONFIG"
+        run: pnpm exec wrangler deploy -c "$WRANGLER_CONFIG" --containers-rollout immediate
 
       # The #509 tripwire, kept verbatim: confirm the running binary is the new
       # build before calling the deploy done.

--- a/pollis-delivery/wrangler.dev.jsonc
+++ b/pollis-delivery/wrangler.dev.jsonc
@@ -21,6 +21,10 @@
       "image_vars": { "GIT_SHA": "unknown" },
       "instance_type": "basic",
       "max_instances": 1,
+      // Single instance: roll 100% in one step so a deploy replaces the running
+      // instance immediately (gradual rollout stalls with max_instances 1, so the
+      // /version gate never sees the new build).
+      "rollout_step_percentage": 100,
       "name": "pollis-delivery-dev"
     }
   ],

--- a/pollis-delivery/wrangler.prod.jsonc
+++ b/pollis-delivery/wrangler.prod.jsonc
@@ -18,6 +18,10 @@
       "image_vars": { "GIT_SHA": "unknown" },
       "instance_type": "basic",
       "max_instances": 1,
+      // Single instance: roll 100% in one step so a deploy replaces the running
+      // instance immediately (gradual rollout stalls with max_instances 1, so the
+      // /version gate never sees the new build).
+      "rollout_step_percentage": 100,
       "name": "pollis-delivery-prod"
     }
   ],


### PR DESCRIPTION
A single-instance container with the default gradual rollout never evicts its warm instance, so `/version` reports the old build and the deploy verify gate fails (surfaced by the first successful CI deploy). Sets `rollout_step_percentage: 100` + `--containers-rollout immediate`. Verified live: dev rolled to the new SHA in ~6s. Infra only.