### PR TITLE
fix(#396): show real inviter/sender name in DM-request + group-invite status-bar alerts

### DIFF
--- a/.codesight/wiki/notifications.md
+++ b/.codesight/wiki/notifications.md
@@ -46,7 +46,7 @@ const CATEGORIES: Record<Category, CategoryConfig> = {
   voice_self_join:   { sound: 'join'                                                              },
   voice_self_leave:  { sound: 'leave'                                                             },
   dm_request:        { sound: 'ping',  osNotif: true,               alert: true                   },
-  group_invite:      { sound: 'ping',  osNotif: true                                              },
+  group_invite:      { sound: 'ping',  osNotif: true,               alert: true                   },
   enrollment:        { sound: 'ping',  osNotif: true,                            overlay: true    },
 };
 ```
@@ -91,9 +91,16 @@ The membership handler reads the `kind` discriminator (see below):
 
 ```ts
 if (event.kind === 'invite') {
-  notify('group_invite', { roomId: event.conversation_id, title: 'New group invite', body: '...' });
+  notify('group_invite', {
+    roomId: event.conversation_id,
+    title: 'New group invite',
+    body: `${event.inviter_username} invited you to ${event.group_name}`,
+    senderUsername: event.inviter_username ?? 'Someone',
+  });
 }
 ```
+
+`group_invite`'s `alert` needs a `senderUsername` to fire the status-bar alert (the gate is `alert && roomId && senderUsername`). Both the invite and DM-request pings carry the counterparty's public username on the wire — see the payload note below. Before #396 the DM-request alert showed a `'New DM'` placeholder and group invites raised no status-bar alert at all.
 
 ## Pref + permission flow
 
@@ -125,15 +132,28 @@ MembershipChanged {
     conversation_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     kind: Option<String>,
+    // Present on the `invite` kind (issue #396): who invited you, to where.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    inviter_username: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    group_name: Option<String>,
 },
 ```
 
-Wire dispatch (`pollis-core/src/commands/livekit.rs`) reads the `kind` field from the JSON payload. Publishers set it via `serde_json::json!({"type": "membership_changed", ..., "kind": "invite"})`.
+Wire dispatch (`pollis-core/src/commands/livekit/mod.rs`) reads `kind` from the JSON payload. The two **private-inbox** pings are built by dedicated helpers in `livekit_signalling.rs` — `group_invite_inbox_payload` and `dm_created_inbox_payload` — rather than inline JSON, so their identity-bearing shape is unit-tested next to the `assert_no_identity` §5 tests.
+
+**§5 exception — private inbox may carry identity.** The metadata-minimization rule (no sender/actor in a realtime ping) governs *shared-room* broadcasts. `dm_created` and the `invite` kind are sent to the recipient's single-subscriber inbox room (`inbox-{userId}`), so they deliberately carry the counterparty's **public** username (`sender_username` / `inviter_username`) + `group_name` — the same directory metadata `get_pending_invites` and the DM-request query already return. `membership_changed_payload` (the group-room broadcast) stays routing-only.
 
 The frontend type narrows it:
 
 ```ts
-| { type: 'membership_changed'; conversation_id?: string | null; kind?: 'invite' | 'approval' | null }
+| {
+    type: 'membership_changed';
+    conversation_id?: string | null;
+    kind?: 'invite' | 'approval' | null;
+    inviter_username?: string | null;
+    group_name?: string | null;
+  }
 ```
 
 When adding a new use of `MembershipChanged`, decide whether the receiver wants a notification. If yes, define a new `kind` value, set it on the publisher, and add the corresponding `notify(...)` call in the membership handler. If no, omit `kind` and the receiver will silently invalidate queries.

--- a/frontend/src/hooks/useLiveKitRealtime.ts
+++ b/frontend/src/hooks/useLiveKitRealtime.ts
@@ -51,6 +51,8 @@ type RealtimeEvent =
   | {
     type: 'dm_created';
     conversation_id: string;
+    // Creator's public username, so the DM-request alert can name the requester.
+    sender_username?: string | null;
   }
   | {
     type: 'membership_changed';
@@ -59,6 +61,9 @@ type RealtimeEvent =
     // 'approval' = your join request was approved (silent)
     // omitted = generic reconcile (silent — refetch only)
     kind?: 'invite' | 'approval' | null;
+    // Present on the 'invite' kind: who invited you and to which group.
+    inviter_username?: string | null;
+    group_name?: string | null;
   }
   | {
     type: 'voice_joined';
@@ -319,8 +324,10 @@ export function useLiveKitRealtime() {
         notify('dm_request', {
           roomId: event.conversation_id,
           title: 'New conversation',
-          body: 'Someone started a conversation with you',
-          senderUsername: 'New DM',
+          body: event.sender_username
+            ? `${event.sender_username} started a conversation with you`
+            : 'Someone started a conversation with you',
+          senderUsername: event.sender_username ?? 'Someone',
         });
         return;
       }
@@ -355,10 +362,14 @@ export function useLiveKitRealtime() {
         // Only invites raise a user-facing notification. Approvals and
         // generic reconciles are silent — query invalidation handles them.
         if (event.kind === 'invite') {
+          const groupPart = event.group_name ? ` to ${event.group_name}` : '';
           notify('group_invite', {
             roomId: event.conversation_id ?? undefined,
             title: 'New group invite',
-            body: 'You have been invited to a group',
+            body: event.inviter_username
+              ? `${event.inviter_username} invited you${groupPart}`
+              : 'You have been invited to a group',
+            senderUsername: event.inviter_username ?? 'Someone',
           });
         }
         return;

--- a/frontend/src/utils/notify.ts
+++ b/frontend/src/utils/notify.ts
@@ -48,7 +48,7 @@ const CATEGORIES: Record<Category, CategoryConfig> = {
   voice_self_join:   { sound: 'join'                                                              },
   voice_self_leave:  { sound: 'leave'                                                             },
   dm_request:        { sound: 'ping',  osNotif: true,               alert: true                   },
-  group_invite:      { sound: 'ping',  osNotif: true                                              },
+  group_invite:      { sound: 'ping',  osNotif: true,               alert: true                   },
   enrollment:        { sound: 'ping',  osNotif: true,                            overlay: true    },
   incoming_call:     {                  osNotif: true,                            honorsRingtonePref: true },
   // @all in a group: the one channel event that DOES raise an OS ping (unlike

--- a/pollis-core/src/commands/dm.rs
+++ b/pollis-core/src/commands/dm.rs
@@ -147,11 +147,17 @@ pub async fn create_dm_channel(
     }
 
     // Notify non-creator members via their personal inbox rooms so they see
-    // the new DM channel immediately without needing to refresh.
-    let inbox_payload = serde_json::json!({
-        "type": "dm_created",
-        "conversation_id": id,
-    });
+    // the new DM channel immediately without needing to refresh. Carry the
+    // creator's username so the recipient's status-bar alert can name the
+    // requester instead of a placeholder (issue #396).
+    let creator_username = members
+        .iter()
+        .find(|m| m.user_id == creator_id)
+        .and_then(|m| m.username.clone());
+    let inbox_payload = crate::commands::livekit_signalling::dm_created_inbox_payload(
+        &id,
+        creator_username.as_deref(),
+    );
     for member in members.iter().filter(|m| m.user_id != creator_id) {
         if let Err(e) = crate::commands::livekit::publish_to_user_inbox(
             state, &member.user_id, inbox_payload.clone(),

--- a/pollis-core/src/commands/groups/invites.rs
+++ b/pollis-core/src/commands/groups/invites.rs
@@ -108,18 +108,54 @@ pub async fn send_group_invite(
         eprintln!("[mls] send_group_invite: reconcile for group {group_id}: {e}");
     }
 
+    // Inviter's username + group name for the invitee's status-bar alert, so it
+    // can name who invited them and to where (issue #396). Public directory
+    // metadata — the same fields `get_pending_invites` already returns. The DS
+    // write above has already landed the invite, so this lookup is best-effort:
+    // a failure degrades the alert to a generic name, it never fails the invite.
+    let (inviter_username, group_name): (Option<String>, Option<String>) =
+        match fetch_invite_alert_names(&conn, &group_id, &inviter_id).await {
+            Ok(pair) => pair,
+            Err(e) => {
+                eprintln!("[inbox] send_group_invite: alert-name lookup failed (non-fatal): {e}");
+                (None, None)
+            }
+        };
+
     // Notify invitee via their inbox so the pending invite appears immediately.
     // `kind: "invite"` lets the frontend raise a ping/OS notification — a
     // generic membership_changed (kind: null) would only invalidate queries.
     if let Err(e) = crate::commands::livekit::publish_to_user_inbox(
         state,
         &invitee_id,
-        serde_json::json!({"type": "membership_changed", "group_id": group_id, "kind": "invite"}),
+        crate::commands::livekit_signalling::group_invite_inbox_payload(
+            &group_id,
+            inviter_username.as_deref(),
+            group_name.as_deref(),
+        ),
     ).await {
         eprintln!("[inbox] send_group_invite: notify {invitee_id} failed: {e}");
     }
 
     Ok(())
+}
+
+/// Look up the inviter's username and the group's name for a group-invite alert.
+/// Public directory metadata only. Returns `(None, None)` for either field that
+/// can't be resolved (missing user/group row).
+async fn fetch_invite_alert_names(
+    conn: &libsql::Connection,
+    group_id: &str,
+    inviter_id: &str,
+) -> Result<(Option<String>, Option<String>)> {
+    let mut rows = conn.query(
+        "SELECT u.username, g.name FROM groups g LEFT JOIN users u ON u.id = ?2 WHERE g.id = ?1",
+        libsql::params![group_id.to_string(), inviter_id.to_string()],
+    ).await?;
+    match rows.next().await? {
+        Some(row) => Ok((row.get(0)?, row.get(1)?)),
+        None => Ok((None, None)),
+    }
 }
 
 /// Get all pending invites for the given user.

--- a/pollis-core/src/commands/livekit/mod.rs
+++ b/pollis-core/src/commands/livekit/mod.rs
@@ -95,6 +95,10 @@ pub(super) fn dispatch_data(payload: &[u8], channel: &dyn crate::sink::EventSink
             {
                 let _ = channel.send(RealtimeEvent::DmCreated {
                     conversation_id: conversation_id.to_owned(),
+                    sender_username: data
+                        .get("sender_username")
+                        .and_then(|v| v.as_str())
+                        .map(str::to_owned),
                 });
             }
         }
@@ -109,6 +113,14 @@ pub(super) fn dispatch_data(payload: &[u8], channel: &dyn crate::sink::EventSink
             let _ = channel.send(RealtimeEvent::MembershipChanged {
                 conversation_id: conv_id.clone(),
                 kind,
+                inviter_username: data
+                    .get("inviter_username")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_owned),
+                group_name: data
+                    .get("group_name")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_owned),
             });
             return conv_id;
         }

--- a/pollis-core/src/commands/livekit_signalling.rs
+++ b/pollis-core/src/commands/livekit_signalling.rs
@@ -81,6 +81,41 @@ pub fn roster_changed_payload(conversation_id: &str, epoch_before: u64, epoch_af
     })
 }
 
+/// `dm_created` wake-up sent to a user's PRIVATE inbox room (`inbox-{userId}`,
+/// single-subscriber). Unlike the group-room broadcasts above, this MAY carry
+/// the creator's public username: only the recipient subscribes to their own
+/// inbox, and the username is the same public directory metadata the DM-request
+/// query already returns — naming the requester in the status-bar alert is the
+/// point (issue #396). This is deliberately NOT subject to the §5 routing-only
+/// rule that governs shared-room broadcasts.
+pub fn dm_created_inbox_payload(conversation_id: &str, sender_username: Option<&str>) -> Value {
+    json!({
+        "type": "dm_created",
+        "conversation_id": conversation_id,
+        "sender_username": sender_username,
+    })
+}
+
+/// `membership_changed` / `kind: "invite"` wake-up sent to the invitee's PRIVATE
+/// inbox room. Like [`dm_created_inbox_payload`], MAY carry the inviter's public
+/// username + group name so the invitee's alert can name who invited them and to
+/// where (issue #396) — the same fields `get_pending_invites` returns. Distinct
+/// from [`membership_changed_payload`], which is the routing-only GROUP-ROOM
+/// broadcast and must never carry identity.
+pub fn group_invite_inbox_payload(
+    group_id: &str,
+    inviter_username: Option<&str>,
+    group_name: Option<&str>,
+) -> Value {
+    json!({
+        "type": "membership_changed",
+        "group_id": group_id,
+        "kind": "invite",
+        "inviter_username": inviter_username,
+        "group_name": group_name,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -147,5 +182,34 @@ mod tests {
         assert_eq!(p["conversation_id"], "conv-1");
         assert_eq!(p["epoch_after"], 5);
         assert_no_identity(&p);
+    }
+
+    /// Private-inbox pings are the intentional exception to §5: they DO carry the
+    /// counterparty's public username so a pre-MLS-join alert (DM request / group
+    /// invite) can name them. These assertions exist so a future §5 sweep doesn't
+    /// strip the username thinking it's a leak — it isn't, the inbox room is
+    /// single-subscriber and the username is public directory metadata.
+    #[test]
+    fn dm_created_inbox_ping_carries_sender_username() {
+        let p = dm_created_inbox_payload("conv-1", Some("alice"));
+        assert_eq!(p["type"], "dm_created");
+        assert_eq!(p["conversation_id"], "conv-1");
+        assert_eq!(p["sender_username"], "alice");
+    }
+
+    #[test]
+    fn dm_created_inbox_ping_tolerates_missing_username() {
+        let p = dm_created_inbox_payload("conv-1", None);
+        assert!(p["sender_username"].is_null());
+    }
+
+    #[test]
+    fn group_invite_inbox_ping_carries_inviter_and_group() {
+        let p = group_invite_inbox_payload("group-1", Some("bob"), Some("Design"));
+        assert_eq!(p["type"], "membership_changed");
+        assert_eq!(p["group_id"], "group-1");
+        assert_eq!(p["kind"], "invite");
+        assert_eq!(p["inviter_username"], "bob");
+        assert_eq!(p["group_name"], "Design");
     }
 }

--- a/pollis-core/src/realtime.rs
+++ b/pollis-core/src/realtime.rs
@@ -23,8 +23,16 @@ pub enum RealtimeEvent {
     },
     /// Sent to a user's personal inbox room when a DM channel is created
     /// and they are a member, so they can fetch it without refreshing.
+    ///
+    /// `sender_username` is the creator's public username, carried so the
+    /// recipient's status-bar alert can name the requester (a DM request is a
+    /// pre-MLS-join event — there's no credential to re-derive the name from,
+    /// unlike `NewMessage`). Public directory metadata, already returned by the
+    /// DM-request query. Optional: null if the creator's user row is missing.
     DmCreated {
         conversation_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        sender_username: Option<String>,
     },
     /// Sent to a user's personal inbox room when they are added to a group
     /// (via invite acceptance or join-request approval), or to a group room
@@ -39,6 +47,14 @@ pub enum RealtimeEvent {
         conversation_id: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         kind: Option<String>,
+        /// Inviter's public username and the group's name, carried on the
+        /// `invite` kind so the invitee's status-bar alert can name who invited
+        /// them and to where. Public directory metadata, already returned by
+        /// `get_pending_invites`. Absent on non-invite membership changes.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        inviter_username: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        group_name: Option<String>,
     },
     /// Sent to a group room when a user joins a voice channel in that group.
     VoiceJoined {


### PR DESCRIPTION
Backend payload piece of #396 Part 1. `dm_created` and `membership_changed`/`kind:invite` inbox pings now carry the counterparty's public username (+ group name), plumbed through the Rust `RealtimeEvent` enum, IPC parser, TS type, and both handlers. DM-request alert shows the real requester instead of `New DM`; group invites now raise a named status-bar alert (`alert: true` added to `group_invite`).

Private-inbox pings are the deliberate §5 exception (single-subscriber `inbox-{userId}`, public directory metadata already returned by `get_pending_invites`) — the two payload builders live in `livekit_signalling.rs` and are unit-tested next to the `assert_no_identity` tests. Metadata lookup in `send_group_invite` is best-effort (never fails the invite). Wiki updated.

Verified: `cargo check` (core + shipping crate), `tsc --noEmit`, 8 signalling unit tests (3 new). Part 2 (offline reconcile) remains as separate #396 work.