### PR TITLE
feat(#261 phase 2): directory index (user_groups/user_dms) + DS maintenance + group read flip

### DIFF
--- a/.codesight/wiki/database.md
+++ b/.codesight/wiki/database.md
@@ -270,6 +270,13 @@ global ordering + a UNIQUE index enforcing the per-subject invariant).
 - UNIQUE INDEX `idx_account_key_log_user_version` on `(user_id, identity_version)` — one row per version per user; a duplicate INSERT conflicts rather than silently forking the history.
 - Dual-written in lock-step with `users.account_id_pub` by `generate_account_identity` (v1 at signup) and `reset_identity` (+1 per rotation). Migration backfills the current key of every user that already has an `account_id_pub`.
 
+### user_groups / user_dms _(migration 000009 — directory index, #261 Phase 2)_
+Denormalized **per-user membership index**. Precursor to the per-conversation DB split (#261): the sidebar's "which groups / DMs am I in, with names + last-activity" read becomes one index query instead of a JOIN across `group_member`/`groups`/`channels` — the JOIN that becomes a cross-shard fan-out once each conversation gets its own DB.
+- `user_groups` — PK (`user_id`, `group_id`); `group_name`, `role`, `joined_at`, `last_activity_at`. Index `idx_user_groups_user_activity` on `(user_id, last_activity_at DESC)`.
+- `user_dms` — PK (`user_id`, `dm_channel_id`); `created_by`, `added_at`, `accepted_at`, `last_activity_at`. Index `idx_user_dms_user_activity`.
+- **Derived cache, not authoritative:** `group_member` / `dm_channel_member` remain the source of truth until the split's `primary` phase. The DS maintains the index as an **exact projection** — every write that changes membership, group/DM metadata, or produces a message calls a `pollis_delivery::directory::*` helper **inside the same transaction**, so the index can't drift. Projection-based upserts (`INSERT…SELECT FROM group_member/groups … ON CONFLICT DO UPDATE`) mean re-running a helper is always correct; deletes are explicit (FK cascade is off on the DS connection). Migration backfills from current membership.
+- Reads: `list_user_groups(_with_channels)` source membership+role here (group metadata + channels still joined pre-split). DM list reads still use the authoritative JOIN for now (its block-filter + `dc.created_at` need more index columns / cross-DB handling at the split). Equivalence guarded by the flows test `directory_index_matches_membership`.
+
 ---
 
 ## Local Database (SQLite, per-user, encrypted)

--- a/pollis-core/src/commands/groups/groups.rs
+++ b/pollis-core/src/commands/groups/groups.rs
@@ -13,14 +13,20 @@ pub async fn list_user_groups_with_channels(
 ) -> Result<Vec<GroupWithChannels>> {
     let conn = state.remote_db.conn().await?;
 
+    // Membership + role come from the directory index (`user_groups`, #261
+    // Phase 2) rather than a `group_member` JOIN — the DS keeps it an exact
+    // projection of membership, and post-split it answers "which groups am I in"
+    // without fanning out across per-group shards. Group metadata + channels are
+    // still joined from the shared DB pre-split. Order preserved (creation, then
+    // channel name) so the sidebar is unchanged.
     let mut rows = conn.query(
         "SELECT g.id, g.name, g.description, g.owner_id, g.created_at,
                 c.id, c.group_id, c.name, c.description, c.channel_type,
-                gm.role
-         FROM groups g
-         JOIN group_member gm ON gm.group_id = g.id
+                ug.role
+         FROM user_groups ug
+         JOIN groups g ON g.id = ug.group_id
          LEFT JOIN channels c ON c.group_id = g.id
-         WHERE gm.user_id = ?1
+         WHERE ug.user_id = ?1
          ORDER BY g.created_at, c.name",
         libsql::params![user_id],
     ).await?;
@@ -72,11 +78,12 @@ pub async fn list_user_groups(
 ) -> Result<Vec<Group>> {
     let conn = state.remote_db.conn().await?;
 
+    // Membership sourced from the directory index (`user_groups`, #261 Phase 2).
     let mut rows = conn.query(
         "SELECT g.id, g.name, g.description, g.owner_id, g.created_at
-         FROM groups g
-         JOIN group_member gm ON gm.group_id = g.id
-         WHERE gm.user_id = ?1",
+         FROM user_groups ug
+         JOIN groups g ON g.id = ug.group_id
+         WHERE ug.user_id = ?1",
         libsql::params![user_id],
     ).await?;
 

--- a/pollis-core/src/db/migrations/000009_directory_index.sql
+++ b/pollis-core/src/db/migrations/000009_directory_index.sql
@@ -1,0 +1,68 @@
+-- Directory index (issue #261, Phase 2 — precursor to the per-conversation DB
+-- split). Denormalized per-user membership tables in the shared directory DB, so
+-- the sidebar's "which groups / DMs am I in, most-recently-active first" read is
+-- ONE index query instead of a JOIN across group_member / groups / channels —
+-- the JOIN that becomes a cross-shard fan-out once each conversation gets its own
+-- DB. Channels themselves are NOT indexed here (they stay enumerated from the
+-- shared `channels` table pre-split, and come from the per-group replica after).
+--
+-- Additive + backward-compatible (CLAUDE.md migration rule): new tables + indexes
+-- only, no DROP / column change. `group_member` and `dm_channel_member` remain
+-- AUTHORITATIVE; these are a DS-maintained derived cache until the split reaches
+-- its `primary` phase. A previously-shipped app never reads them.
+--
+-- The tables are backfilled from current membership at the bottom of this
+-- migration so they are correct the instant the DS begins maintaining them.
+-- `last_activity_at` seeds from the newest envelope in the conversation, falling
+-- back to the group / DM creation time when there are no messages yet.
+
+CREATE TABLE IF NOT EXISTS user_groups (
+    user_id          TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    group_id         TEXT NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+    group_name       TEXT NOT NULL,
+    role             TEXT NOT NULL DEFAULT 'member',
+    joined_at        TEXT NOT NULL DEFAULT (datetime('now')),
+    last_activity_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (user_id, group_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_groups_user_activity
+    ON user_groups (user_id, last_activity_at DESC);
+
+CREATE TABLE IF NOT EXISTS user_dms (
+    user_id          TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    dm_channel_id    TEXT NOT NULL REFERENCES dm_channel(id) ON DELETE CASCADE,
+    created_by       TEXT NOT NULL,
+    added_at         TEXT NOT NULL DEFAULT (datetime('now')),
+    accepted_at      TEXT,
+    last_activity_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (user_id, dm_channel_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_dms_user_activity
+    ON user_dms (user_id, last_activity_at DESC);
+
+-- Backfill group membership. For group messages, message_envelope.conversation_id
+-- is the CHANNEL id, so last-activity resolves through channels → group_id.
+INSERT OR IGNORE INTO user_groups (user_id, group_id, group_name, role, joined_at, last_activity_at)
+SELECT gm.user_id, gm.group_id, g.name, gm.role, gm.joined_at,
+       COALESCE(
+           (SELECT MAX(me.sent_at)
+            FROM message_envelope me
+            JOIN channels c ON c.id = me.conversation_id
+            WHERE c.group_id = gm.group_id),
+           g.created_at)
+FROM group_member gm
+JOIN groups g ON g.id = gm.group_id;
+
+-- Backfill DM membership. For DMs, message_envelope.conversation_id IS the
+-- dm_channel id, so last-activity resolves directly.
+INSERT OR IGNORE INTO user_dms (user_id, dm_channel_id, created_by, added_at, accepted_at, last_activity_at)
+SELECT dcm.user_id, dcm.dm_channel_id, dc.created_by, dcm.added_at, dcm.accepted_at,
+       COALESCE(
+           (SELECT MAX(me.sent_at)
+            FROM message_envelope me
+            WHERE me.conversation_id = dcm.dm_channel_id),
+           dc.created_at)
+FROM dm_channel_member dcm
+JOIN dm_channel dc ON dc.id = dcm.dm_channel_id;

--- a/pollis-core/src/db/mod.rs
+++ b/pollis-core/src/db/mod.rs
@@ -68,6 +68,11 @@ pub const POST_BASELINE_MIGRATIONS: &[(u32, &str, &str)] = &[
         "message_envelope_sealed_sender",
         include_str!("migrations/000008_message_envelope_sealed_sender.sql"),
     ),
+    (
+        9,
+        "directory_index",
+        include_str!("migrations/000009_directory_index.sql"),
+    ),
 ];
 
 pub mod queries {

--- a/pollis-delivery/src/account.rs
+++ b/pollis-delivery/src/account.rs
@@ -660,6 +660,8 @@ pub async fn apply_reset_recover(
         libsql::params![actor.clone()],
     )
     .await?;
+    // Directory index (#261): drop the actor from every group/DM index row.
+    crate::directory::remove_user(&tx, &actor).await?;
 
     // Orphan the actor's OTHER devices; keep the current one (it re-enrolls under
     // the new identity). `None` → drop them all.
@@ -750,6 +752,9 @@ pub async fn apply_delete_account(
         libsql::params![actor.clone()],
     )
     .await?;
+    // Directory index (#261): drop the actor from every group/DM index row.
+    // Explicit (not via the user-row cascade below) so it holds with FK off.
+    crate::directory::remove_user(&tx, &actor).await?;
     // The user row last — FK ON DELETE CASCADE clears dm_channel_member,
     // group_invite, user_device, account_recovery, security_event, …
     tx.execute(
@@ -803,6 +808,8 @@ async fn handoff_group_ownership(conn: &Connection, actor: &str) -> anyhow::Resu
                 libsql::params![gid.clone()],
             )
             .await?;
+            // Directory index (#261): the group is gone.
+            crate::directory::remove_group(conn, &gid).await?;
         } else if role == "admin" {
             let other_admins: i64 = {
                 let mut rows = conn
@@ -835,9 +842,11 @@ async fn handoff_group_ownership(conn: &Connection, actor: &str) -> anyhow::Resu
                     conn.execute(
                         "UPDATE group_member SET role = 'admin' \
                          WHERE group_id = ?1 AND user_id = ?2",
-                        libsql::params![gid.clone(), new_admin],
+                        libsql::params![gid.clone(), new_admin.clone()],
                     )
                     .await?;
+                    // Directory index (#261): re-project the promoted admin's role.
+                    crate::directory::sync_group_member(conn, &gid, &new_admin).await?;
                 }
             }
         }

--- a/pollis-delivery/src/directory.rs
+++ b/pollis-delivery/src/directory.rs
@@ -1,0 +1,201 @@
+//! Directory-index maintenance (issue #261, Phase 2).
+//!
+//! Keeps the denormalized `user_groups` / `user_dms` tables — the per-user
+//! sidebar index in the directory DB — in sync with the authoritative
+//! `group_member` / `dm_channel_member` writes. The Delivery Service is the sole
+//! writer, so every write path that changes membership, group/DM metadata, or
+//! produces a message calls one of these helpers. The index can only drift if a
+//! call site is missing one, which the `directory_index_matches_membership`
+//! equivalence test guards against.
+//!
+//! The upsert helpers PROJECT from the authoritative rows
+//! (`INSERT … SELECT FROM group_member/groups … ON CONFLICT DO UPDATE`), so the
+//! index is literally a projection of membership and re-running a helper is
+//! always correct. FK cascade is deliberately NOT relied on — `foreign_keys` is
+//! OFF on the DS connection, so every delete here is explicit.
+//!
+//! All tables live in the main DB (`state.db`), so every fn takes a bare
+//! [`Connection`] and composes inside a caller's transaction (`&Transaction`
+//! derefs to `&Connection`).
+
+use libsql::Connection;
+
+// ── Groups ───────────────────────────────────────────────────────────────────
+
+/// Upsert one member's `user_groups` row by projecting from the authoritative
+/// `group_member` + `groups` rows (which must already be written). Covers member
+/// add (create / accept-invite / approve-join-request) and role change. On insert
+/// `last_activity_at` seeds from the newest channel message, falling back to the
+/// group's creation time; on a name/role update it is PRESERVED.
+pub async fn sync_group_member(
+    conn: &Connection,
+    group_id: &str,
+    user_id: &str,
+) -> anyhow::Result<()> {
+    conn.execute(
+        "INSERT INTO user_groups (user_id, group_id, group_name, role, joined_at, last_activity_at)
+         SELECT gm.user_id, gm.group_id, g.name, gm.role, gm.joined_at,
+                COALESCE(
+                    (SELECT MAX(me.sent_at) FROM message_envelope me
+                     JOIN channels c ON c.id = me.conversation_id
+                     WHERE c.group_id = g.id),
+                    g.created_at)
+         FROM group_member gm
+         JOIN groups g ON g.id = gm.group_id
+         WHERE gm.group_id = ?1 AND gm.user_id = ?2
+         ON CONFLICT(user_id, group_id) DO UPDATE SET
+             group_name = excluded.group_name,
+             role       = excluded.role",
+        libsql::params![group_id.to_string(), user_id.to_string()],
+    )
+    .await?;
+    Ok(())
+}
+
+/// Drop one member's `user_groups` row (leave / remove-member).
+pub async fn remove_group_member(
+    conn: &Connection,
+    group_id: &str,
+    user_id: &str,
+) -> anyhow::Result<()> {
+    conn.execute(
+        "DELETE FROM user_groups WHERE group_id = ?1 AND user_id = ?2",
+        libsql::params![group_id.to_string(), user_id.to_string()],
+    )
+    .await?;
+    Ok(())
+}
+
+/// Drop every `user_groups` row for a deleted group.
+pub async fn remove_group(conn: &Connection, group_id: &str) -> anyhow::Result<()> {
+    conn.execute(
+        "DELETE FROM user_groups WHERE group_id = ?1",
+        libsql::params![group_id.to_string()],
+    )
+    .await?;
+    Ok(())
+}
+
+/// Re-project the group name onto every member's row after a rename.
+pub async fn rename_group(conn: &Connection, group_id: &str) -> anyhow::Result<()> {
+    conn.execute(
+        "UPDATE user_groups
+         SET group_name = (SELECT name FROM groups WHERE id = ?1)
+         WHERE group_id = ?1",
+        libsql::params![group_id.to_string()],
+    )
+    .await?;
+    Ok(())
+}
+
+// ── DMs ──────────────────────────────────────────────────────────────────────
+
+/// Upsert one member's `user_dms` row by projecting from the authoritative
+/// `dm_channel_member` + `dm_channel` rows. Covers DM create, member add, and
+/// accept (which sets `accepted_at`). `last_activity_at` is preserved on update.
+pub async fn sync_dm_member(
+    conn: &Connection,
+    dm_channel_id: &str,
+    user_id: &str,
+) -> anyhow::Result<()> {
+    conn.execute(
+        "INSERT INTO user_dms (user_id, dm_channel_id, created_by, added_at, accepted_at, last_activity_at)
+         SELECT dcm.user_id, dcm.dm_channel_id, dc.created_by, dcm.added_at, dcm.accepted_at,
+                COALESCE(
+                    (SELECT MAX(me.sent_at) FROM message_envelope me
+                     WHERE me.conversation_id = dc.id),
+                    dc.created_at)
+         FROM dm_channel_member dcm
+         JOIN dm_channel dc ON dc.id = dcm.dm_channel_id
+         WHERE dcm.dm_channel_id = ?1 AND dcm.user_id = ?2
+         ON CONFLICT(user_id, dm_channel_id) DO UPDATE SET
+             accepted_at = excluded.accepted_at",
+        libsql::params![dm_channel_id.to_string(), user_id.to_string()],
+    )
+    .await?;
+    Ok(())
+}
+
+/// Re-project `accepted_at` for every one of a user's `user_dms` rows from the
+/// authoritative `dm_channel_member` table. Used after a bulk accepted-state
+/// change that isn't a single-row upsert — blocking a user resets `accepted_at`
+/// to NULL on all DMs shared with them.
+pub async fn resync_dm_accepted_for_user(
+    conn: &Connection,
+    user_id: &str,
+) -> anyhow::Result<()> {
+    conn.execute(
+        "UPDATE user_dms
+         SET accepted_at = (
+             SELECT dcm.accepted_at FROM dm_channel_member dcm
+             WHERE dcm.dm_channel_id = user_dms.dm_channel_id AND dcm.user_id = user_dms.user_id)
+         WHERE user_id = ?1",
+        libsql::params![user_id.to_string()],
+    )
+    .await?;
+    Ok(())
+}
+
+/// Drop one member's `user_dms` row (leave / remove).
+pub async fn remove_dm_member(
+    conn: &Connection,
+    dm_channel_id: &str,
+    user_id: &str,
+) -> anyhow::Result<()> {
+    conn.execute(
+        "DELETE FROM user_dms WHERE dm_channel_id = ?1 AND user_id = ?2",
+        libsql::params![dm_channel_id.to_string(), user_id.to_string()],
+    )
+    .await?;
+    Ok(())
+}
+
+/// Drop every `user_dms` row for a torn-down DM channel.
+pub async fn remove_dm(conn: &Connection, dm_channel_id: &str) -> anyhow::Result<()> {
+    conn.execute(
+        "DELETE FROM user_dms WHERE dm_channel_id = ?1",
+        libsql::params![dm_channel_id.to_string()],
+    )
+    .await?;
+    Ok(())
+}
+
+// ── Activity + account ───────────────────────────────────────────────────────
+
+/// Bump `last_activity_at` for whichever conversation `conversation_id` names.
+/// For a group message it is a channel id (resolved to its group); for a DM it is
+/// the dm_channel id. Both statements run — exactly one matches — so the caller
+/// doesn't need to know which kind it is.
+pub async fn bump_activity(
+    conn: &Connection,
+    conversation_id: &str,
+    sent_at: &str,
+) -> anyhow::Result<()> {
+    conn.execute(
+        "UPDATE user_groups SET last_activity_at = ?2
+         WHERE group_id = (SELECT group_id FROM channels WHERE id = ?1)",
+        libsql::params![conversation_id.to_string(), sent_at.to_string()],
+    )
+    .await?;
+    conn.execute(
+        "UPDATE user_dms SET last_activity_at = ?2 WHERE dm_channel_id = ?1",
+        libsql::params![conversation_id.to_string(), sent_at.to_string()],
+    )
+    .await?;
+    Ok(())
+}
+
+/// Remove a user from the whole index (account deletion).
+pub async fn remove_user(conn: &Connection, user_id: &str) -> anyhow::Result<()> {
+    conn.execute(
+        "DELETE FROM user_groups WHERE user_id = ?1",
+        libsql::params![user_id.to_string()],
+    )
+    .await?;
+    conn.execute(
+        "DELETE FROM user_dms WHERE user_id = ?1",
+        libsql::params![user_id.to_string()],
+    )
+    .await?;
+    Ok(())
+}

--- a/pollis-delivery/src/groups.rs
+++ b/pollis-delivery/src/groups.rs
@@ -115,6 +115,11 @@ async fn add_member_rows(conn: &Connection, group_id: &str, user_id: &str) -> an
             libsql::params![user_id.to_string(), group_id.to_string()],
         )
         .await;
+    // Directory index (#261): project this membership into `user_groups`. Runs
+    // for both add sites (accept-invite, approve-join-request) since both go
+    // through here. The group_member row was just written, so the projection
+    // reads the correct role.
+    crate::directory::sync_group_member(conn, group_id, user_id).await?;
     Ok(())
 }
 
@@ -202,6 +207,10 @@ pub async fn apply_create_group(
         )
         .await?;
     }
+    // Directory index (#261): project the creator's admin membership into
+    // `user_groups`. The group_member row above is in this tx, so the projection
+    // sees it.
+    crate::directory::sync_group_member(&tx, &body.id, &owner).await?;
     tx.commit().await?;
     Ok(WriteOutcome::Ok)
 }
@@ -259,6 +268,8 @@ pub async fn apply_update_group(
             libsql::params![n.clone(), body.group_id.clone()],
         )
         .await?;
+        // Directory index (#261): re-project the new name onto every member's row.
+        crate::directory::rename_group(conn, &body.group_id).await?;
     }
     if let Some(d) = &body.description {
         conn.execute(
@@ -323,6 +334,9 @@ pub async fn apply_delete_group(
         libsql::params![body.group_id.clone()],
     )
     .await?;
+    // Directory index (#261): drop every member's row for this group. Explicit —
+    // FK cascade is off on the DS connection.
+    crate::directory::remove_group(conn, &body.group_id).await?;
     Ok(WriteOutcome::Ok)
 }
 
@@ -376,6 +390,8 @@ pub async fn apply_leave_group(
         libsql::params![body.group_id.clone(), user.clone()],
     )
     .await?;
+    // Directory index (#261): drop the leaver's row.
+    crate::directory::remove_group_member(&tx, &body.group_id, &user).await?;
     let mut count_rows = tx
         .query(
             "SELECT COUNT(*) FROM group_member WHERE group_id = ?1",
@@ -393,6 +409,8 @@ pub async fn apply_leave_group(
             libsql::params![body.group_id.clone()],
         )
         .await?;
+        // Group is gone — clear any remaining index rows for it.
+        crate::directory::remove_group(&tx, &body.group_id).await?;
     }
     tx.commit().await?;
     Ok(WriteOutcome::Ok)
@@ -644,6 +662,8 @@ pub async fn apply_remove_member(
         libsql::params![body.group_id.clone(), body.user_id.clone()],
     )
     .await?;
+    // Directory index (#261): drop the removed member's row.
+    crate::directory::remove_group_member(conn, &body.group_id, &body.user_id).await?;
     Ok(WriteOutcome::Ok)
 }
 
@@ -708,6 +728,8 @@ pub async fn apply_set_member_role(
         libsql::params![body.role.clone(), body.group_id.clone(), body.user_id.clone()],
     )
     .await?;
+    // Directory index (#261): re-project the new role onto the member's row.
+    crate::directory::sync_group_member(conn, &body.group_id, &body.user_id).await?;
     Ok(WriteOutcome::Ok)
 }
 

--- a/pollis-delivery/src/lib.rs
+++ b/pollis-delivery/src/lib.rs
@@ -27,6 +27,7 @@ pub mod cert;
 pub mod commit;
 pub mod db;
 pub mod devices;
+pub mod directory;
 pub mod email_change;
 pub mod error;
 pub mod groups;

--- a/pollis-delivery/src/messages.rs
+++ b/pollis-delivery/src/messages.rs
@@ -312,6 +312,9 @@ pub async fn apply_send_message(
         ],
     )
     .await?;
+    // Directory index (#261): bump the conversation's last-activity so the sidebar
+    // orders it most-recent-first. Resolves channel→group / dm internally.
+    crate::directory::bump_activity(conn, &body.conversation_id, &body.sent_at).await?;
     Ok(WriteOutcome::Ok)
 }
 

--- a/pollis-delivery/src/profile.rs
+++ b/pollis-delivery/src/profile.rs
@@ -246,9 +246,12 @@ pub async fn apply_block_user(
             AND dm_channel_id IN ( \
                 SELECT dm_channel_id FROM dm_channel_member WHERE user_id = ?2 \
             )",
-        libsql::params![blocker, body.blocked_id.clone()],
+        libsql::params![blocker.clone(), body.blocked_id.clone()],
     )
     .await?;
+    // Directory index (#261): re-project the blocker's accepted_at across all
+    // their DMs (the UPDATE above reset it on those shared with the blocked user).
+    crate::directory::resync_dm_accepted_for_user(&tx, &blocker).await?;
     tx.commit().await?;
     Ok(WriteOutcome::Ok)
 }
@@ -404,6 +407,10 @@ pub async fn apply_create_dm(
         )
         .await?;
     }
+    // Directory index (#261): project every member's DM membership.
+    for member in std::iter::once(&creator).chain(others.iter()) {
+        crate::directory::sync_dm_member(&tx, &body.id, member).await?;
+    }
     tx.commit().await?;
     Ok(WriteOutcome::Ok)
 }
@@ -457,9 +464,11 @@ pub async fn apply_accept_dm(
           WHERE dm_channel_id = ?1 \
             AND user_id = ?2 \
             AND accepted_at IS NULL",
-        libsql::params![body.dm_channel_id.clone(), user, body.accepted_at.clone()],
+        libsql::params![body.dm_channel_id.clone(), user.clone(), body.accepted_at.clone()],
     )
     .await?;
+    // Directory index (#261): re-project the accepter's accepted_at.
+    crate::directory::sync_dm_member(conn, &body.dm_channel_id, &user).await?;
     Ok(WriteOutcome::Ok)
 }
 
@@ -557,6 +566,8 @@ pub async fn apply_add_dm_member(
         libsql::params![body.dm_channel_id.clone(), body.user_id.clone()],
     )
     .await?;
+    // Directory index (#261): project the new member's DM membership.
+    crate::directory::sync_dm_member(&tx, &body.dm_channel_id, &body.user_id).await?;
     tx.commit().await?;
     Ok(WriteOutcome::Ok)
 }
@@ -632,6 +643,8 @@ pub async fn apply_remove_dm_member(
         libsql::params![body.dm_channel_id.clone(), body.user_id.clone()],
     )
     .await?;
+    // Directory index (#261): drop the removed member's DM row.
+    crate::directory::remove_dm_member(conn, &body.dm_channel_id, &body.user_id).await?;
     Ok(WriteOutcome::Ok)
 }
 
@@ -681,9 +694,11 @@ pub async fn apply_leave_dm(
     let tx = conn.transaction().await?;
     tx.execute(
         "DELETE FROM dm_channel_member WHERE dm_channel_id = ?1 AND user_id = ?2",
-        libsql::params![body.dm_channel_id.clone(), user],
+        libsql::params![body.dm_channel_id.clone(), user.clone()],
     )
     .await?;
+    // Directory index (#261): drop the leaver's DM row.
+    crate::directory::remove_dm_member(&tx, &body.dm_channel_id, &user).await?;
     // If no members remain, clean up the channel and all associated data.
     let mut rows = tx
         .query(
@@ -707,6 +722,8 @@ pub async fn apply_leave_dm(
             libsql::params![body.dm_channel_id.clone()],
         )
         .await?;
+        // Directory index (#261): DM is gone — clear any remaining index rows.
+        crate::directory::remove_dm(&tx, &body.dm_channel_id).await?;
     }
     tx.commit().await?;
     Ok(WriteOutcome::Ok)

--- a/pollis-delivery/tests/reset_session.rs
+++ b/pollis-delivery/tests/reset_session.rs
@@ -89,6 +89,24 @@ CREATE TABLE dm_channel_member (\
   accepted INTEGER NOT NULL DEFAULT 0,\
   PRIMARY KEY (dm_channel_id, user_id)\
 );\
+CREATE TABLE user_groups (\
+  user_id TEXT NOT NULL,\
+  group_id TEXT NOT NULL,\
+  group_name TEXT NOT NULL,\
+  role TEXT NOT NULL DEFAULT 'member',\
+  joined_at TEXT NOT NULL DEFAULT (datetime('now')),\
+  last_activity_at TEXT NOT NULL DEFAULT (datetime('now')),\
+  PRIMARY KEY (user_id, group_id)\
+);\
+CREATE TABLE user_dms (\
+  user_id TEXT NOT NULL,\
+  dm_channel_id TEXT NOT NULL,\
+  created_by TEXT NOT NULL,\
+  added_at TEXT NOT NULL DEFAULT (datetime('now')),\
+  accepted_at TEXT,\
+  last_activity_at TEXT NOT NULL DEFAULT (datetime('now')),\
+  PRIMARY KEY (user_id, dm_channel_id)\
+);\
 CREATE TABLE mls_key_package (\
   id INTEGER PRIMARY KEY AUTOINCREMENT,\
   user_id TEXT NOT NULL,\

--- a/src-tauri/tests/flows/groups.rs
+++ b/src-tauri/tests/flows/groups.rs
@@ -1,4 +1,4 @@
-use crate::harness::{wipe, TestClient};
+use crate::harness::{wipe, world, TestClient};
 use serde_json::json;
 use serial_test::serial;
 
@@ -264,6 +264,110 @@ async fn removed_member_loses_access() {
     assert_eq!(ids, vec![alice_profile.id.clone()]);
     assert!(!bob.list_group_ids().await.contains(&group_id));
 
+    drop(alice);
+    drop(bob);
+}
+
+// ─── #261 Phase 2: directory-index equivalence ──────────────────────────────
+
+/// After a representative membership-churn sequence, the directory index
+/// (`user_groups` / `user_dms`) is an EXACT projection of the authoritative
+/// `group_member` / `dm_channel_member` tables: every membership row is faithfully
+/// projected (matching role, group name, accepted-state) and there are no orphan
+/// index rows. This is the dual-write equivalence guard (#261 spec, acceptance D.1)
+/// — it fails loudly if any DS write path forgets to maintain the index.
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn directory_index_matches_membership() {
+    wipe().await;
+
+    let mut alice = TestClient::new().await;
+    let mut bob = TestClient::new().await;
+    let alice_profile = alice.sign_up("alice@test.local").await;
+    let bob_profile = bob.sign_up("bob@test.local").await;
+
+    // Group churn: create, invite + accept (add member), promote to admin.
+    let group_id = alice.create_group("Directory Index").await;
+    alice.invite(&group_id, &bob_profile.username).await;
+    let invite = bob.first_pending_invite().await.expect("pending invite");
+    let invite_id = invite["id"].as_str().expect("invite id").to_string();
+    bob.accept_invite(&invite_id).await;
+    alice
+        .set_member_role(&group_id, &bob_profile.id, "admin")
+        .await;
+
+    // DM churn: create a request, accept it.
+    let dm_id = alice.create_dm(&[bob_profile.id.as_str()]).await;
+    bob.accept_dm_request(&dm_id).await;
+
+    // Read raw state through the writable remote handle (sees every DS write).
+    let conn = world().await.remote.conn().await.expect("remote conn");
+    let count = |sql: &'static str| {
+        let conn = &conn;
+        async move {
+            let mut rows = conn.query(sql, ()).await.expect("query");
+            rows.next()
+                .await
+                .expect("rows")
+                .expect("count row")
+                .get::<i64>(0)
+                .expect("i64")
+        }
+    };
+
+    // Sanity: the churn actually produced index rows (no vacuous pass).
+    assert!(count("SELECT COUNT(*) FROM user_groups").await >= 2, "user_groups populated");
+    assert!(count("SELECT COUNT(*) FROM user_dms").await >= 2, "user_dms populated");
+
+    // Every group_member row is faithfully projected (role + group name).
+    assert_eq!(
+        count(
+            "SELECT COUNT(*) FROM group_member gm JOIN groups g ON g.id = gm.group_id \
+             WHERE NOT EXISTS ( \
+                 SELECT 1 FROM user_groups ug \
+                 WHERE ug.user_id = gm.user_id AND ug.group_id = gm.group_id \
+                   AND ug.role = gm.role AND ug.group_name = g.name)"
+        )
+        .await,
+        0,
+        "every group_member row must be faithfully projected into user_groups"
+    );
+    // No orphan user_groups rows.
+    assert_eq!(
+        count(
+            "SELECT COUNT(*) FROM user_groups ug WHERE NOT EXISTS ( \
+                 SELECT 1 FROM group_member gm \
+                 WHERE gm.user_id = ug.user_id AND gm.group_id = ug.group_id)"
+        )
+        .await,
+        0,
+        "no orphan user_groups rows"
+    );
+    // Every dm_channel_member row is faithfully projected (NULL-safe accepted_at).
+    assert_eq!(
+        count(
+            "SELECT COUNT(*) FROM dm_channel_member dcm WHERE NOT EXISTS ( \
+                 SELECT 1 FROM user_dms ud \
+                 WHERE ud.user_id = dcm.user_id AND ud.dm_channel_id = dcm.dm_channel_id \
+                   AND ud.accepted_at IS dcm.accepted_at)"
+        )
+        .await,
+        0,
+        "every dm_channel_member row must be faithfully projected into user_dms"
+    );
+    // No orphan user_dms rows.
+    assert_eq!(
+        count(
+            "SELECT COUNT(*) FROM user_dms ud WHERE NOT EXISTS ( \
+                 SELECT 1 FROM dm_channel_member dcm \
+                 WHERE dcm.user_id = ud.user_id AND dcm.dm_channel_id = ud.dm_channel_id)"
+        )
+        .await,
+        0,
+        "no orphan user_dms rows"
+    );
+
+    let _ = alice_profile;
     drop(alice);
     drop(bob);
 }


### PR DESCRIPTION
Phase 2 of #261 (per-conversation DB split) — the directory index that de-risks the split by removing the cross-shard sidebar fan-out before any split exists. Engine-independent; unblocked now that #515 is done. Additive + two-release-safe.

## What
- **Migration 000009** — denormalized `user_groups` / `user_dms` per-user membership index in the directory DB (+ activity indexes), backfilled from current membership.
- **DS maintenance** (`pollis-delivery/src/directory.rs`) — projection-based helpers wired into every write that changes membership, group/DM metadata, or produces a message (create/update/delete/leave group, remove/role member, accept-invite, approve-join, account delete/reset + admin handoff; DM create/accept/add/remove/leave + block-resync; message send → last-activity). Maintained **inside the same transaction** as the authoritative write, so the index is an exact projection and can't drift. `group_member`/`dm_channel_member` stay authoritative until the split's `primary` phase. Deletes are explicit (FK cascade is off on the DS connection).
- **Read flip** — `list_user_groups(_with_channels)` source membership+role from the index (group metadata + channels still joined pre-split). DM list reads stay on the JOIN for now (its block-filter + `dc.created_at` need more index columns / cross-DB handling at the split).

## Tests
- Flows equivalence test `directory_index_matches_membership` (spec acceptance D.1): after a churn sequence the index is an exact projection of the authoritative tables — no unprojected rows, no orphans, NULL-safe accepted_at.
- Full flows suite green (62 passed). DS unit tests green (added `user_groups`/`user_dms` to the reset-session harness schema). Migration applied + verified on dev and the shared test Turso; `POST_BASELINE_MIGRATIONS` updated so the headless harness seeds it.
- `database.md` documents the new tables.

Remaining #261 (separate): DM read flip, then phases 3–6 (ReplicaPool on libSQL embedded replicas per the spike, per-conv provisioning, cutover). Spike recorded in issue comments.