### PR TITLE
mobile(#185): iOS keystore-at-rest — Keychain-held master key + iOS CI gate

### DIFF
--- a/.github/workflows/mobile-core-check.yml
+++ b/.github/workflows/mobile-core-check.yml
@@ -1,19 +1,20 @@
-# Mobile cross-compile gate: does `pollis-core` still build for Android?
+# Mobile cross-compile gate: does `pollis-core` still build for Android + iOS?
 #
 # The mobile app consumes pollis-core via uniffi. Everything desktop-only
 # (terminal, host audio/voice, the Rust LiveKit/libwebrtc engine) is gated out
 # on mobile with `cfg(not(any(target_os = "ios", target_os = "android")))` and
 # `#[path]`-swapped stubs. A desktop-only `cargo check` cannot catch a broken
-# gate — the mobile build only fails on a real cross-compile. This job runs that
-# cross-compile so mobile `#[cfg]` rot becomes red CI, not a latent defect
+# gate — the mobile build only fails on a real cross-compile. These jobs run
+# that cross-compile so mobile `#[cfg]` rot becomes red CI, not a latent defect
 # discovered on the next `ubrn build` (issue #185 cross-cutting).
 #
 # Mobile builds with `--no-default-features` (drops `media` -> no webrtc-sys, and
-# `os-keystore` -> file/Android-keystore path), matching the ubrn build.
-# aarch64 alone covers every `target_os = "android"` gate (gating is per-OS, not
-# per-ABI). iOS is a separate `target_os` branch and needs a macOS runner — a
-# follow-up once iOS native builds are back in reach (see mobile/CLAUDE.md).
-name: Mobile core (android cross-compile)
+# `os-keystore` -> the keystore-encrypted file path), matching the ubrn build.
+# One aarch64 target per OS covers every `target_os = "android"` / `"ios"` gate
+# (gating is per-OS, not per-ABI). The iOS job needs a macOS runner for the
+# Apple SDK; it gates the `ios_kek` Keychain path the same way the android job
+# gates the JNI path.
+name: Mobile core (cross-compile)
 
 on:
   pull_request:
@@ -59,3 +60,21 @@ jobs:
           export AR_aarch64_linux_android="$TC/llvm-ar"
           export RANLIB_aarch64_linux_android="$TC/llvm-ranlib"
           cargo check -p pollis-core --no-default-features --target aarch64-linux-android
+
+  ios-check:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Add ios rust target
+        run: rustup target add aarch64-apple-ios
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ios-aarch64
+
+      # The macOS runner ships Xcode + the iPhoneOS SDK; cargo/cc pick them up
+      # via xcrun with no extra env. Gates the `target_os = "ios"` branches
+      # (ios_kek Keychain seal, mobile stubs) exactly like the android job.
+      - name: Cross-compile pollis-core for ios
+        run: cargo check -p pollis-core --no-default-features --target aarch64-apple-ios

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6388,6 +6388,7 @@ dependencies = [
  "reqwest 0.12.28",
  "rodio",
  "rusqlite",
+ "security-framework 3.7.0",
  "serde",
  "serde_json",
  "sha2",

--- a/mobile/CLAUDE.md
+++ b/mobile/CLAUDE.md
@@ -240,15 +240,26 @@ Current state:
   (`EXPO_PUBLIC_POLLIS_DELIVERY_URL`, dev → api-dev.pollis.com) — required, since
   OTP bootstrap + all remote writes go through the DS, not direct Turso. Full
   sign-in verified end-to-end on an Android emulator against the live dev DS.
-- **Keystore-at-rest (Android):** the file-backed keystore (used in place of
+- **Keystore-at-rest (Android + iOS):** the file-backed keystore (used in place of
   desktop's OS keychain when built `--no-default-features`, i.e. no `os-keystore`)
   envelope-encrypts its contents with an AES-256-GCM master key held in the
-  **AndroidKeyStore** — see the `android_kek` module in `pollis-core/src/keystore.rs`
-  (JNI-from-Rust: `JNI_OnLoad` captures the `JavaVM`; system `KeyStore`/`KeyGenerator`/
-  `Cipher`, alias `pollis_keystore_kek`). On-disk `dev-keystore.json` is `iv(12)||gcm-ct`,
-  not plaintext. Identity keypair + session survive a cold process kill and decrypt
-  behind the device PIN. (`accounts.json` beside it is a public-metadata index only —
-  no secrets.)
+  platform secure store — same on-disk blob (`iv(12)||gcm-ct`, `dev-keystore.json`)
+  on both platforms:
+  - **Android** — `android_kek` in `pollis-core/src/keystore.rs`: non-exportable
+    key in the **AndroidKeyStore** (JNI-from-Rust: `JNI_OnLoad` captures the
+    `JavaVM`; system `KeyStore`/`KeyGenerator`/`Cipher`, alias `pollis_keystore_kek`).
+    Runtime-verified on an emulator (full sign-in, cold-relaunch unlock).
+  - **iOS** — `ios_kek` in the same file: 32-byte master key as a Keychain
+    generic-password item (service `pollis`, account `pollis_keystore_kek`,
+    `AccessibleAfterFirstUnlockThisDeviceOnly` → excluded from all backups),
+    AES-GCM done in Rust (`kek_envelope`, host-unit-tested). Works in the
+    simulator (Secure-Enclave-resident keys deliberately not used — no simulator
+    support; possible later hardening). **On-device/simulator verification
+    pending** (needs the Tahoe/Xcode-26 machine — see iOS dev loop above).
+  Identity keypair + session survive a cold process kill and decrypt behind the
+  device PIN. (`accounts.json` beside it is a public-metadata index only — no
+  secrets.) Both `#[cfg]` branches are CI-gated by `mobile-core-check.yml`
+  (android + ios cross-compile jobs).
 - **Media:** `get_media_path` decrypts an R2 object to a sandbox `file://` for
   `expo-image` — mobile can't run desktop's loopback media server. See `lib/media/`.
 - **Foreground realtime (scaffold):** mobile joins the same SFU rooms as desktop

--- a/pollis-core/Cargo.toml
+++ b/pollis-core/Cargo.toml
@@ -160,6 +160,13 @@ webrtc-audio-processing = { version = "2", features = ["bundled"], optional = tr
 [target.'cfg(any(target_os = "ios", target_os = "android"))'.dependencies]
 rusqlite = { version = "0.31", features = ["bundled-sqlcipher-vendored-openssl"] }
 
+# iOS-only: Keychain Services so the file-backed keystore's master key lives in
+# the iOS Keychain (SEP-encrypted at rest, ThisDeviceOnly → excluded from
+# backups), mirroring the Android Keystore path below (issue #185 Section A).
+# Version 3.x is already in the workspace lock via desktop transitives.
+[target.'cfg(target_os = "ios")'.dependencies]
+security-framework = "3"
+
 # Android-only: JNI to the Android Keystore so the file-backed keystore's bytes
 # are encrypted at rest under a hardware-backed AES key (issue #185 Section A).
 # Only reaches the JVM (no app classes) so it needs no Context / classloader.

--- a/pollis-core/src/keystore.rs
+++ b/pollis-core/src/keystore.rs
@@ -1,4 +1,4 @@
-use crate::error::{Error, Result};
+use crate::error::Result;
 use async_trait::async_trait;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -226,6 +226,136 @@ mod android_kek {
     }
 }
 
+// ── iOS: encrypt the keystore file at rest under a Keychain-held key ─────────
+//
+// Mirror of `android_kek` for iOS (issue #185 Section A): the file-backed
+// store's bytes are AES-256-GCM-encrypted under a 32-byte master key held in
+// the iOS **Keychain** (a generic-password item). Keychain items are encrypted
+// at rest by the OS under Secure-Enclave-protected class keys;
+// `AccessibleAfterFirstUnlockThisDeviceOnly` keeps the key out of ALL backups
+// (iCloud + local) and available across relaunches — so identity + session
+// survive a relaunch while the on-disk ciphertext is useless off-device.
+// Same blob layout as Android: iv(12) || gcm-ciphertext(+16 tag).
+//
+// Unlike AndroidKeyStore, the DEK crosses into process memory (Keychain
+// generic-password items are readable by the owning app). That matches the
+// threat model both platforms defend against here — off-device file theft via
+// backups or sandbox reads — since on either platform an on-device attacker
+// with app privileges can simply call unseal. Secure-Enclave-resident,
+// non-extractable keys (ECIES) are a possible hardening later; they don't work
+// in the iOS simulator, which is what the dev loop runs on.
+//
+// The AES envelope itself is platform-neutral Rust (`kek_envelope` below) so
+// the seal/unseal round-trip and blob layout are unit-tested on every host.
+#[cfg(target_os = "ios")]
+mod ios_kek {
+    use super::kek_envelope;
+    use crate::error::{Error, Result};
+    use security_framework::access_control::{ProtectionMode, SecAccessControl};
+    use security_framework::passwords::{get_generic_password, set_generic_password_options};
+    use security_framework::passwords_options::PasswordOptions;
+    use std::sync::Mutex;
+
+    const SERVICE: &str = "pollis";
+    const ACCOUNT: &str = "pollis_keystore_kek";
+    /// `errSecItemNotFound` — Security.framework's "no such keychain item".
+    const ERR_SEC_ITEM_NOT_FOUND: i32 = -25300;
+
+    /// Process-local cache of the master key. Also serializes get-or-create so
+    /// two concurrent first writes can't each mint a different key (the second
+    /// `SecItemAdd` silently *updates* on duplicate, which would orphan the
+    /// first writer's ciphertext).
+    static MASTER: Mutex<Option<[u8; 32]>> = Mutex::new(None);
+
+    fn keychain_err(ctx: &str, err: security_framework::base::Error) -> Error {
+        Error::Keystore(format!("ios keychain {ctx}: {err}"))
+    }
+
+    /// Get-or-create the 32-byte master key in the iOS Keychain.
+    fn master_key() -> Result<[u8; 32]> {
+        let mut guard = MASTER
+            .lock()
+            .map_err(|_| Error::Keystore("ios kek mutex poisoned".into()))?;
+        if let Some(k) = *guard {
+            return Ok(k);
+        }
+
+        let key: [u8; 32] = match get_generic_password(SERVICE, ACCOUNT) {
+            Ok(bytes) => bytes.try_into().map_err(|_| {
+                // A wrong-sized item means the entry was tampered with or
+                // written by something else. Refuse — regenerating would orphan
+                // every sealed byte on disk (identity keys included).
+                Error::Keystore("ios keychain kek has unexpected size; refusing to overwrite".into())
+            })?,
+            Err(e) if e.code() == ERR_SEC_ITEM_NOT_FOUND => {
+                let mut fresh = [0u8; 32];
+                rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut fresh);
+                let mut opts = PasswordOptions::new_generic_password(SERVICE, ACCOUNT);
+                let protection = SecAccessControl::create_with_protection(
+                    Some(ProtectionMode::AccessibleAfterFirstUnlockThisDeviceOnly),
+                    0,
+                )
+                .map_err(|x| keychain_err("access control", x))?;
+                opts.set_access_control(protection);
+                set_generic_password_options(&fresh, opts)
+                    .map_err(|x| keychain_err("store kek", x))?;
+                fresh
+            }
+            Err(e) => return Err(keychain_err("read kek", e)),
+        };
+
+        *guard = Some(key);
+        Ok(key)
+    }
+
+    /// Encrypt: returns iv(12) || gcm-ciphertext(+16 tag).
+    pub fn seal(plaintext: &[u8]) -> Result<Vec<u8>> {
+        kek_envelope::seal_with(&master_key()?, plaintext)
+    }
+
+    /// Decrypt a blob produced by [`seal`].
+    pub fn unseal(blob: &[u8]) -> Result<Vec<u8>> {
+        kek_envelope::unseal_with(&master_key()?, blob)
+    }
+}
+
+// AES-256-GCM envelope shared by the iOS path. Platform-neutral on purpose:
+// compiled (and unit-tested) on every target so the blob layout — iv(12) ||
+// ciphertext(+16 tag), byte-compatible with `android_kek`'s Java output — is
+// pinned by host tests instead of only exercised on a device.
+#[cfg(any(target_os = "ios", test))]
+mod kek_envelope {
+    use crate::error::{Error, Result};
+    use aes_gcm::aead::{Aead, KeyInit};
+    use aes_gcm::{Aes256Gcm, Key, Nonce};
+
+    const IV_LEN: usize = 12;
+
+    pub fn seal_with(key: &[u8; 32], plaintext: &[u8]) -> Result<Vec<u8>> {
+        let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(key));
+        let mut iv = [0u8; IV_LEN];
+        rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut iv);
+        let ct = cipher
+            .encrypt(Nonce::from_slice(&iv), plaintext)
+            .map_err(|_| Error::Keystore("keystore seal failed".into()))?;
+        let mut blob = Vec::with_capacity(IV_LEN + ct.len());
+        blob.extend_from_slice(&iv);
+        blob.extend_from_slice(&ct);
+        Ok(blob)
+    }
+
+    pub fn unseal_with(key: &[u8; 32], blob: &[u8]) -> Result<Vec<u8>> {
+        if blob.len() < IV_LEN {
+            return Err(Error::Keystore("keystore blob too short".into()));
+        }
+        let (iv, ct) = blob.split_at(IV_LEN);
+        let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(key));
+        cipher
+            .decrypt(Nonce::from_slice(iv), ct)
+            .map_err(|_| Error::Keystore("keystore unseal failed (wrong key or tampered blob)".into()))
+    }
+}
+
 // ── File-backed keystore: plain JSON file (no keychain, no OS prompts) ──────
 //
 // Selected for debug builds (no OS prompts during dev/test) AND whenever the
@@ -268,9 +398,10 @@ mod backend {
                 PathBuf::from(appdata).join("pollis")
             }
         };
-        // Mobile uses the OS secure store for real (iOS Keychain / Android
-        // Keystore — issue #185). This file-backed path is a compile-complete
-        // fallback; the bridge passes POLLIS_DATA_DIR (app sandbox) when wired.
+        // Mobile: this file IS the store, but its bytes are AES-GCM ciphertext
+        // under an OS-secured master key (AndroidKeyStore / iOS Keychain — see
+        // `android_kek` / `ios_kek`, issue #185 Section A). The bridge passes
+        // POLLIS_DATA_DIR (app sandbox).
         #[cfg(any(target_os = "ios", target_os = "android"))]
         let base = {
             if let Ok(dir) = std::env::var("POLLIS_DATA_DIR") {
@@ -282,15 +413,21 @@ mod backend {
         base.join("dev-keystore.json")
     }
 
-    // On Android the file holds AES-GCM ciphertext (see `super::android_kek`);
-    // everywhere else it's plaintext JSON. These convert between the on-disk
-    // bytes and the JSON string.
+    // On mobile the file holds AES-GCM ciphertext (see `super::android_kek` /
+    // `super::ios_kek`); on desktop it's plaintext JSON (debug builds only —
+    // release desktop uses the OS keychain backend below). These convert
+    // between the on-disk bytes and the JSON string.
     #[cfg(target_os = "android")]
     fn decode_file(raw: &[u8]) -> Result<String> {
         let plain = super::android_kek::unseal(raw)?;
         String::from_utf8(plain).map_err(|e| Error::Keystore(format!("keystore utf8: {e}")))
     }
-    #[cfg(not(target_os = "android"))]
+    #[cfg(target_os = "ios")]
+    fn decode_file(raw: &[u8]) -> Result<String> {
+        let plain = super::ios_kek::unseal(raw)?;
+        String::from_utf8(plain).map_err(|e| Error::Keystore(format!("keystore utf8: {e}")))
+    }
+    #[cfg(not(any(target_os = "android", target_os = "ios")))]
     fn decode_file(raw: &[u8]) -> Result<String> {
         String::from_utf8(raw.to_vec()).map_err(|e| Error::Keystore(format!("keystore utf8: {e}")))
     }
@@ -298,7 +435,11 @@ mod backend {
     fn encode_file(json: &str) -> Result<Vec<u8>> {
         super::android_kek::seal(json.as_bytes())
     }
-    #[cfg(not(target_os = "android"))]
+    #[cfg(target_os = "ios")]
+    fn encode_file(json: &str) -> Result<Vec<u8>> {
+        super::ios_kek::seal(json.as_bytes())
+    }
+    #[cfg(not(any(target_os = "android", target_os = "ios")))]
     fn encode_file(json: &str) -> Result<Vec<u8>> {
         Ok(json.as_bytes().to_vec())
     }
@@ -582,5 +723,44 @@ mod tests {
         ks.store_for_user("session", "bob", b"b").await.unwrap();
         assert_eq!(ks.load_for_user("session", "alice").await.unwrap().as_deref(), Some(&b"a"[..]));
         assert_eq!(ks.load_for_user("session", "bob").await.unwrap().as_deref(), Some(&b"b"[..]));
+    }
+
+    // ── kek_envelope (the iOS at-rest cipher) — host-testable on purpose ────
+
+    #[test]
+    fn kek_envelope_roundtrip() {
+        let key = [7u8; 32];
+        let blob = kek_envelope::seal_with(&key, b"identity keys + session").unwrap();
+        assert_eq!(
+            kek_envelope::unseal_with(&key, &blob).unwrap(),
+            b"identity keys + session"
+        );
+    }
+
+    #[test]
+    fn kek_envelope_blob_layout_is_iv12_ct_tag16() {
+        // Pins the on-disk layout shared with android_kek: iv(12) || ct || tag(16).
+        let key = [1u8; 32];
+        let pt = b"0123456789";
+        let blob = kek_envelope::seal_with(&key, pt).unwrap();
+        assert_eq!(blob.len(), 12 + pt.len() + 16);
+        // Fresh random IV per seal — two seals of the same plaintext differ.
+        let blob2 = kek_envelope::seal_with(&key, pt).unwrap();
+        assert_ne!(blob[..12], blob2[..12], "IV must be random per seal");
+    }
+
+    #[test]
+    fn kek_envelope_rejects_wrong_key_and_tamper() {
+        let key = [2u8; 32];
+        let blob = kek_envelope::seal_with(&key, b"secret").unwrap();
+        // Wrong key.
+        assert!(kek_envelope::unseal_with(&[3u8; 32], &blob).is_err());
+        // Bit-flip in the ciphertext body → GCM auth failure.
+        let mut tampered = blob.clone();
+        let last = tampered.len() - 1;
+        tampered[last] ^= 1;
+        assert!(kek_envelope::unseal_with(&key, &tampered).is_err());
+        // Truncated below the IV → structured error, not a panic.
+        assert!(kek_envelope::unseal_with(&key, &blob[..8]).is_err());
     }
 }


### PR DESCRIPTION
iOS counterpart of #525 (issue #185 Section A): the file-backed keystore is now encrypted at rest on iOS too.

- **`ios_kek`** (`keystore.rs`): master key = 32 random bytes in the iOS **Keychain** (generic password, `AccessibleAfterFirstUnlockThisDeviceOnly` → survives relaunch, excluded from all backups, simulator-compatible). Envelope AES-256-GCM in Rust; on-disk blob byte-identical to Android (`iv(12) || gcm-ct`).
- **`kek_envelope`** is platform-neutral so the round-trip, blob layout, and tamper/wrong-key/truncation rejection are **host-unit-tested** (unlike Android's in-Java crypto).
- Get-or-create is mutex-serialized (SecItemAdd updates-on-duplicate → a racing writer could orphan ciphertext); wrong-sized existing item = hard error, never regenerate.
- **CI**: `ios-check` job (macOS runner, `aarch64-apple-ios`) added to `mobile-core-check.yml` — the follow-up its header already named. `security-framework = "3"` as an iOS-only target dep (already in the lock).
- Deliberately Keychain-DEK rather than Secure Enclave ECIES (no SE in the simulator = the whole dev loop); SE noted as later hardening in the module docs.

Verified: real `aarch64-apple-ios` cross-compile clean (local Xcode/iPhoneOS SDK), keystore tests 5/5, desktop + headless checks clean. **Runtime verification in the simulator pending** — needs the Tahoe/Xcode-26 machine (documented in mobile/CLAUDE.md).
