### PR TITLE
feat(#434): Voice & Video camera picker + mirrored preview + permission deep-links

### DIFF
--- a/.codesight/wiki/media-permissions.md
+++ b/.codesight/wiki/media-permissions.md
@@ -20,7 +20,7 @@ bundle identifier). So it lives entirely in `src-tauri`, the same rationale as
 - Backend: `src-tauri/src/commands/media_permissions.rs`
 - Exit hook: `src-tauri/src/lib.rs` (`RunEvent::ExitRequested`)
 - Frontend hook: `frontend/src/hooks/queries/useMediaPermissions.ts`
-- UI: the "Media permissions" section of `frontend/src/pages/SecurityPage.tsx`
+- UI: the "Media permissions" section of `frontend/src/pages/SecurityPage.tsx` (revoke-on-exit), and a camera/mic "Permissions" section in `frontend/src/pages/VoiceSettingsPage.tsx` (status + `open_privacy_settings` deep-link, alongside the camera picker — #434)
   (reachable via Cmd+K — the Security entry's keywords include camera/microphone/
   screen/permission/revoke/privacy so a media-minded search still lands here)
 - Preference persistence: `revoke_media_on_exit` in the prefs blob
@@ -32,6 +32,7 @@ bundle identifier). So it lives entirely in `src-tauri`, the same rationale as
 | Command | Shape | Purpose |
 |---|---|---|
 | `get_media_permission_status` | `() -> MediaPermissions { camera, microphone, screen: PermissionState }` | Live status, queried at call time. The renderer refetches on window focus so it reflects changes the user makes in System Settings while Pollis runs. |
+| `open_privacy_settings` | `(kind: "camera" \| "microphone") -> ()` | Deep-links to the OS privacy pane (macOS `x-apple.systempreferences:…Privacy_Camera/Microphone`, Windows `ms-settings:privacy-webcam/microphone`; **errors on Linux** — no per-app model). "Take me there", never an in-app grant/revoke. Issue #434. |
 | `revoke_media_permissions` | `(kinds: Vec<String>) -> RevokeResult { applied, note }` | Tears down any active capture first, then revokes per platform. `applied` is true only when Pollis actually changed OS state. |
 | `set_revoke_media_on_exit` | `(enabled: bool)` | Pushes the "revoke on quit" pref into a host-side `AtomicBool` (managed `MediaPermissionsState`) so the exit hook can read it synchronously. Mirrors `tray_set_close_to_tray`. |
 

--- a/frontend/src/camera/cameraPreviewStore.ts
+++ b/frontend/src/camera/cameraPreviewStore.ts
@@ -1,0 +1,123 @@
+import { makeAutoObservable } from "mobx";
+
+import type { CameraSource } from "./types";
+
+/**
+ * Voice & Video settings camera picker + self-preview state (issue #434).
+ *
+ * DISTINCT from the in-call `CameraState` (`types/voice-state.ts`), which lives
+ * inside a `joined` `VoiceState` because a camera publishes into an active voice
+ * room. The settings preview runs locally — no call, nothing published — so it
+ * has its own lifecycle here.
+ *
+ * The union makes invalid states unrepresentable:
+ *   - no `deviceId` outside a device-known state → can't preview "nothing";
+ *   - an `error` string exists ONLY in `failed` → no stale error beside a live
+ *     preview;
+ *   - `live`/`starting` can't occur while `loading`/`empty`.
+ *
+ * Preview is OFF by default (`idle`) — a settings page must not silently light
+ * the camera; the user opts in with the toggle (Discord's model).
+ */
+export type CameraPreviewState =
+  | { kind: "loading" }
+  | { kind: "empty" }
+  | { kind: "idle"; deviceId: string }
+  | { kind: "starting"; deviceId: string }
+  | { kind: "live"; deviceId: string }
+  | { kind: "failed"; deviceId: string; error: string };
+
+class CameraPreviewStore {
+  /** Enumerated devices — the dropdown options. Empty until listed. */
+  devices: CameraSource[] = [];
+  state: CameraPreviewState = { kind: "loading" };
+
+  constructor() {
+    makeAutoObservable(this);
+  }
+
+  /** The device selected in the picker, or `null` before enumeration. */
+  get selectedDeviceId(): string | null {
+    return "deviceId" in this.state ? this.state.deviceId : null;
+  }
+
+  /** True while a live preview is running or spinning up. */
+  get isPreviewing(): boolean {
+    return this.state.kind === "live" || this.state.kind === "starting";
+  }
+
+  /** Enumeration finished. `preferred` is the persisted choice — kept if still
+   *  present, else the first device. Preview stays OFF. */
+  enumerated(devices: CameraSource[], preferred: string | null) {
+    this.devices = devices;
+    if (devices.length === 0) {
+      this.state = { kind: "empty" };
+      return;
+    }
+    const deviceId = devices.some((d) => d.id === preferred) ? preferred! : devices[0].id;
+    this.state = { kind: "idle", deviceId };
+  }
+
+  /** Enumeration failed — treat as "no camera" (nothing to preview). */
+  enumerationFailed() {
+    this.devices = [];
+    this.state = { kind: "empty" };
+  }
+
+  /** Pick a different device. If a preview is running it stays running (moves to
+   *  `starting` — the caller restarts capture on the new device); if it's off it
+   *  just changes the selection. */
+  select(deviceId: string) {
+    if (!this.devices.some((d) => d.id === deviceId)) {
+      return;
+    }
+    switch (this.state.kind) {
+      case "idle":
+      case "failed":
+        this.state = { kind: "idle", deviceId };
+        break;
+      case "starting":
+      case "live":
+        this.state = { kind: "starting", deviceId };
+        break;
+      // loading / empty: nothing selectable.
+    }
+  }
+
+  /** Preview turn-on requested for the current device. */
+  startRequested() {
+    const id = this.selectedDeviceId;
+    if (id !== null) {
+      this.state = { kind: "starting", deviceId: id };
+    }
+  }
+
+  /** Capture confirmed live (the `start_camera_preview` invoke resolved). */
+  wentLive() {
+    if (this.state.kind === "starting") {
+      this.state = { kind: "live", deviceId: this.state.deviceId };
+    }
+  }
+
+  /** Preview failed (capture error / permission denied). */
+  failed(error: string) {
+    const id = this.selectedDeviceId;
+    if (id !== null) {
+      this.state = { kind: "failed", deviceId: id, error };
+    }
+  }
+
+  /** Preview turned off — back to `idle` on the same device. */
+  stopped() {
+    const id = this.selectedDeviceId;
+    this.state = id !== null ? { kind: "idle", deviceId: id } : { kind: "loading" };
+  }
+
+  /** Full reset on leaving the page. */
+  reset() {
+    this.devices = [];
+    this.state = { kind: "loading" };
+  }
+}
+
+export const cameraPreviewStore = new CameraPreviewStore();

--- a/frontend/src/camera/cameraSession.ts
+++ b/frontend/src/camera/cameraSession.ts
@@ -118,6 +118,19 @@ class CameraSession {
     await invoke("stop_camera");
   }
 
+  /** Start a PREVIEW-ONLY capture for the settings picker (issue #434): local
+   *  self-preview under `LOCAL_CAMERA_PREVIEW_KEY` with no voice room and
+   *  nothing published. Independent of {@link start} — safe to run out of a
+   *  call, and does not disturb an in-call camera. Pair with {@link stopPreview}
+   *  when the picker closes or the device changes. */
+  async startPreview(deviceId: string): Promise<void> {
+    await invoke("start_camera_preview", { deviceId });
+  }
+
+  async stopPreview(): Promise<void> {
+    await invoke("stop_camera_preview");
+  }
+
   private handleEvent(ev: CameraEvent) {
     const store = appStore;
     switch (ev.type) {

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -141,7 +141,7 @@ export const Sidebar: React.FC<SidebarProps> = observer(({ isOpen, onToggle }) =
   const settingsItems = [
     { id: "preferences", label: "Preferences", icon: <Palette {...iconProps} />, to: "/preferences" as const, isActive: pathname === "/preferences" },
     { id: "user", label: "User Settings", icon: <UserIcon {...iconProps} />, to: "/user" as const, isActive: pathname === "/user" },
-    { id: "voice-settings", label: "Voice", icon: <Volume2 {...iconProps} />, to: "/voice-settings" as const, isActive: pathname === "/voice-settings" },
+    { id: "voice-settings", label: "Voice & Video", icon: <Volume2 {...iconProps} />, to: "/voice-settings" as const, isActive: pathname === "/voice-settings" },
     { id: "security", label: "Security", icon: <ShieldCheck {...iconProps} />, to: "/security" as const, isActive: pathname === "/security" || pathname.startsWith("/security/") },
     { id: "shortcuts", label: "Key Bindings", icon: <Keyboard {...iconProps} />, to: "/shortcuts" as const, isActive: pathname === "/shortcuts" },
     { id: "update", label: "Software Update", icon: <Download {...iconProps} />, to: "/update" as const, isActive: pathname === "/update" },

--- a/frontend/src/components/SearchPanel.tsx
+++ b/frontend/src/components/SearchPanel.tsx
@@ -186,7 +186,7 @@ const PAGE_RESULTS: SearchResultItem[] = [
   { type: "page", id: "page-settings", name: "User", breadcrumb: "/user", path: "/user", keywords: "account profile username email avatar settings" },
   { type: "page", id: "page-settings-hub", name: "Settings", breadcrumb: "/settings", path: "/settings", keywords: "preferences user security" },
   { type: "page", id: "page-preferences", name: "Preferences", breadcrumb: "/preferences", path: "/preferences", keywords: "theme color font notifications appearance" },
-  { type: "page", id: "page-voice-settings", name: "Voice Settings", breadcrumb: "/settings/voice", path: "/voice-settings", keywords: "microphone speaker audio mic noise suppression echo cancellation agc auto join" },
+  { type: "page", id: "page-voice-settings", name: "Voice & Video", breadcrumb: "/settings/voice", path: "/voice-settings", keywords: "microphone speaker audio mic noise suppression echo cancellation agc auto join camera webcam video preview permissions" },
   { type: "page", id: "page-security", name: "Security", breadcrumb: "/security", path: "/security", keywords: "audit log devices identity key rotation camera microphone screen permission permissions revoke privacy access" },
   { type: "page", id: "page-shortcuts", name: "Key Bindings", breadcrumb: "/shortcuts", path: "/shortcuts", keywords: "key bindings keyboard shortcuts hotkeys keybindings cmd ctrl" },
   { type: "page", id: "page-update", name: "Software Update", breadcrumb: "/update", path: "/update", keywords: "update version upgrade install release" },

--- a/frontend/src/components/Voice/RemoteVideoTile.tsx
+++ b/frontend/src/components/Voice/RemoteVideoTile.tsx
@@ -16,6 +16,7 @@ import React, { useEffect, useRef, useSyncExternalStore } from "react";
 import { hasElectron } from "../../bridge";
 import { livekitView } from "../../screenshare/livekitView";
 import { LOCAL_PREVIEW_KEY, screenShareSession, type DecodedFrame } from "../../screenshare/screenShareSession";
+import { LOCAL_CAMERA_PREVIEW_KEY } from "../../camera/cameraSession";
 
 interface Props {
   trackKey: string;
@@ -29,6 +30,9 @@ interface Props {
    *  rendering. Ignored under Electron (the browser already throttles
    *  hidden/offscreen video). */
   preview?: boolean;
+  /** Horizontally flip the rendered image. Used for a self-view (your own
+   *  webcam) so it reads like a mirror — never for remote participants. */
+  mirror?: boolean;
 }
 
 const PREVIEW_MIN_PAINT_INTERVAL_MS = 1000 / 15;
@@ -54,6 +58,7 @@ const RemoteVideoTileElectron: React.FC<Props> = ({
   className,
   initialWidth,
   initialHeight,
+  mirror,
 }) => {
   const videoRef = useRef<HTMLVideoElement | null>(null);
 
@@ -159,6 +164,7 @@ const RemoteVideoTileElectron: React.FC<Props> = ({
         height: "auto",
         background: "#000",
         objectFit: "contain",
+        transform: mirror ? "scaleX(-1)" : undefined,
       }}
     />
   );
@@ -309,6 +315,7 @@ const RemoteVideoTileTauri: React.FC<Props> = ({
   initialWidth,
   initialHeight,
   preview = false,
+  mirror,
 }) => {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const glRef = useRef<GLBundle | null>(null);
@@ -434,6 +441,7 @@ const RemoteVideoTileTauri: React.FC<Props> = ({
         width: "auto",
         height: "auto",
         background: "#000",
+        transform: mirror ? "scaleX(-1)" : undefined,
       }}
     />
   );
@@ -442,8 +450,13 @@ const RemoteVideoTileTauri: React.FC<Props> = ({
 // ── Dispatch ────────────────────────────────────────────────────────────────
 
 export const RemoteVideoTile: React.FC<Props> = (props) => {
+  // Auto-mirror the local camera self-view (your own webcam) so it reads like a
+  // mirror — both the in-call self-preview and the settings preview render
+  // through here under LOCAL_CAMERA_PREVIEW_KEY. Explicit `mirror` still wins.
+  const mirror = props.mirror ?? props.trackKey === LOCAL_CAMERA_PREVIEW_KEY;
+  const p = { ...props, mirror };
   if (hasElectron()) {
-    return <RemoteVideoTileElectron {...props} />;
+    return <RemoteVideoTileElectron {...p} />;
   }
-  return <RemoteVideoTileTauri {...props} />;
+  return <RemoteVideoTileTauri {...p} />;
 };

--- a/frontend/src/hooks/queries/useMediaPermissions.ts
+++ b/frontend/src/hooks/queries/useMediaPermissions.ts
@@ -53,6 +53,15 @@ export function useMediaPermissions() {
 }
 
 /**
+ * Deep-link to the OS privacy settings for a media kind (issue #434). An app
+ * cannot grant/revoke its own OS grant — this just takes the user there. Rejects
+ * on Linux (no per-application privacy model) and for unknown kinds.
+ */
+export async function openPrivacySettings(kind: "camera" | "microphone"): Promise<void> {
+  await invoke("open_privacy_settings", { kind });
+}
+
+/**
  * Revoke the OS permission(s) for the given kinds, then refetch the live
  * status. On macOS this clears the saved grant (macOS re-prompts next use);
  * on Linux it's a no-op success; on Windows it opens the privacy settings.

--- a/frontend/src/pages/PreferencesPage.tsx
+++ b/frontend/src/pages/PreferencesPage.tsx
@@ -585,7 +585,7 @@ export const PreferencesPage: React.FC = observer(() => {
               </h2>
               <div className="self-start">
                 <Button variant="secondary" size="sm" onClick={() => navigate({ to: "/voice-settings" })}>
-                  Voice Settings
+                  Voice & Video
                 </Button>
               </div>
             </section>

--- a/frontend/src/pages/SettingsHub.tsx
+++ b/frontend/src/pages/SettingsHub.tsx
@@ -35,9 +35,9 @@ export const SettingsHubPage: React.FC = observer(() => {
     },
     {
       id: "voice",
-      label: "Voice",
+      label: "Voice & Video",
       icon: <Volume2 size={14} />,
-      description: "Microphone, speaker, audio processing",
+      description: "Microphone, speaker, camera, audio processing",
       action: () => navigate({ to: "/voice-settings" }),
       testId: "menu-item-voice-settings",
     },

--- a/frontend/src/pages/VoiceSettingsPage.tsx
+++ b/frontend/src/pages/VoiceSettingsPage.tsx
@@ -20,6 +20,7 @@ import type { AudioDevice } from "../types";
 import { cameraSession, LOCAL_CAMERA_PREVIEW_KEY, friendlyCameraError } from "../camera/cameraSession";
 import type { CameraSource } from "../camera/types";
 import { RemoteVideoTile } from "../components/Voice/RemoteVideoTile";
+import { useMediaPermissions, openPrivacySettings, type PermissionState } from "../hooks/queries/useMediaPermissions";
 
 const VOICE_DEVICES_KEY = "pollis:voice-devices";
 const CAMERA_DEVICE_KEY = "pollis:camera-device";
@@ -134,6 +135,42 @@ const ScreenShareFpsSelect: React.FC<ScreenShareFpsSelectProps> = ({ value, onCh
   </div>
 );
 
+const PERMISSION_LABEL: Record<PermissionState, string> = {
+  granted: "✅ Granted",
+  denied: "⛔ Denied",
+  notDetermined: "— Not requested",
+  perSession: "Managed by the system",
+  unsupported: "Unavailable",
+};
+
+/** One camera/mic permission row: status + a deep-link to System Settings.
+ *  An app can't grant/revoke its own OS grant — only the user can — so the
+ *  action is always "take me there", never an in-app toggle (issue #434). The
+ *  deep-link only exists where the OS has a per-app privacy model (macOS /
+ *  Windows); on Linux (`perSession`) there's nothing to link to. */
+const PermissionRow: React.FC<{ label: string; state: PermissionState; onManage: () => void }> = ({
+  label,
+  state,
+  onManage,
+}) => {
+  const deepLinkable = state === "granted" || state === "denied" || state === "notDetermined";
+  return (
+    <div className="flex items-center justify-between gap-3" style={{ maxWidth: 320 }}>
+      <div className="flex flex-col">
+        <span style={{ color: "var(--c-text)" }}>{label}</span>
+        <span className="text-xs font-mono" style={{ color: "var(--c-text-muted)" }}>
+          {PERMISSION_LABEL[state]}
+        </span>
+      </div>
+      {deepLinkable && (
+        <Button variant="secondary" size="sm" onClick={onManage}>
+          Manage in System Settings
+        </Button>
+      )}
+    </div>
+  );
+};
+
 const selectStyle: React.CSSProperties = {
   appearance: "none",
   WebkitAppearance: "none",
@@ -225,6 +262,10 @@ export const VoiceSettingsPage: React.FC = () => {
     try { return localStorage.getItem(CAMERA_DEVICE_KEY) || ""; } catch { return ""; }
   });
   const [cameraError, setCameraError] = useState<string | null>(null);
+
+  // OS camera/mic permission status (issue #434) — refetches on window focus, so
+  // returning from System Settings reflects the change without a manual refresh.
+  const permissions = useMediaPermissions();
 
   const startCameraPreview = (id: string) => {
     setCameraError(null);
@@ -361,6 +402,27 @@ export const VoiceSettingsPage: React.FC = () => {
             </>
           )}
         </section>
+
+        {permissions.data && (
+          <section className="flex flex-col gap-4 mb-12" data-testid="voice-permissions-section">
+            <h2
+              className="text-xs font-mono font-medium uppercase tracking-widest pb-1 border-b"
+              style={{ color: "var(--c-text)", borderColor: "var(--c-border)" }}
+            >
+              Permissions
+            </h2>
+            <PermissionRow
+              label="Camera"
+              state={permissions.data.camera}
+              onManage={() => { void openPrivacySettings("camera"); }}
+            />
+            <PermissionRow
+              label="Microphone"
+              state={permissions.data.microphone}
+              onManage={() => { void openPrivacySettings("microphone"); }}
+            />
+          </section>
+        )}
 
         <section className="flex flex-col gap-5 mb-12" data-testid="voice-test-section">
           <h2

--- a/frontend/src/pages/VoiceSettingsPage.tsx
+++ b/frontend/src/pages/VoiceSettingsPage.tsx
@@ -17,8 +17,9 @@ import {
 import { useVoiceTest } from "../hooks/useVoiceTest";
 import { voiceSession } from "../voice";
 import type { AudioDevice } from "../types";
+import { observer } from "mobx-react-lite";
 import { cameraSession, LOCAL_CAMERA_PREVIEW_KEY, friendlyCameraError } from "../camera/cameraSession";
-import type { CameraSource } from "../camera/types";
+import { cameraPreviewStore } from "../camera/cameraPreviewStore";
 import { RemoteVideoTile } from "../components/Voice/RemoteVideoTile";
 import { useMediaPermissions, openPrivacySettings, type PermissionState } from "../hooks/queries/useMediaPermissions";
 
@@ -201,7 +202,7 @@ async function pushApmConfig(config: ApmConfig): Promise<void> {
   }
 }
 
-export const VoiceSettingsPage: React.FC = () => {
+export const VoiceSettingsPage: React.FC = observer(() => {
   const preferences = usePreferences();
   const test = useVoiceTest();
 
@@ -253,54 +254,59 @@ export const VoiceSettingsPage: React.FC = () => {
     }
   };
 
-  // ── Camera (issue #434) ───────────────────────────────────────────────────
-  // Live self-preview via the preview-only capture path (no call, nothing
-  // published). Frames mirror to LOCAL_CAMERA_PREVIEW_KEY; RemoteVideoTile
-  // renders + auto-mirrors them. Start on mount / device change, stop on leave.
-  const [cameras, setCameras] = useState<CameraSource[]>([]);
-  const [selectedCamera, setSelectedCameraState] = useState<string>(() => {
-    try { return localStorage.getItem(CAMERA_DEVICE_KEY) || ""; } catch { return ""; }
-  });
-  const [cameraError, setCameraError] = useState<string | null>(null);
+  // ── Camera picker + preview (issue #434) ──────────────────────────────────
+  // All state lives in `cameraPreviewStore` — a discriminated union so invalid
+  // combos (error beside a live preview, a preview with no device, live while
+  // enumerating) are unrepresentable. Preview is OFF by default; the user opts
+  // in with the toggle (a settings page must not silently light the camera).
+  const cam = cameraPreviewStore.state;
 
   // OS camera/mic permission status (issue #434) — refetches on window focus, so
   // returning from System Settings reflects the change without a manual refresh.
   const permissions = useMediaPermissions();
 
-  const startCameraPreview = (id: string) => {
-    setCameraError(null);
-    cameraSession.startPreview(id).catch((e) => {
-      setCameraError(friendlyCameraError(String(e)));
-    });
+  // The invoke resolves once capture has started; drive the union off it — no
+  // separate "started" event needed.
+  const runPreview = (id: string) => {
+    cameraSession
+      .startPreview(id)
+      .then(() => cameraPreviewStore.wentLive())
+      .catch((e) => cameraPreviewStore.failed(friendlyCameraError(String(e))));
+  };
+
+  const togglePreview = () => {
+    if (cameraPreviewStore.isPreviewing) {
+      void cameraSession.stopPreview();
+      cameraPreviewStore.stopped();
+      return;
+    }
+    const id = cameraPreviewStore.selectedDeviceId;
+    if (!id) { return; }
+    cameraPreviewStore.startRequested();
+    runPreview(id);
   };
 
   const setCamera = (id: string) => {
-    setSelectedCameraState(id);
     try { localStorage.setItem(CAMERA_DEVICE_KEY, id); } catch { /* ignore */ }
-    startCameraPreview(id);
+    const wasPreviewing = cameraPreviewStore.isPreviewing;
+    cameraPreviewStore.select(id);
+    // `select` kept us in `starting` when previewing — actually restart capture.
+    if (wasPreviewing) { runPreview(id); }
   };
 
   useEffect(() => {
     let cancelled = false;
+    const preferred = (() => {
+      try { return localStorage.getItem(CAMERA_DEVICE_KEY); } catch { return null; }
+    })();
     cameraSession
       .listDevices()
-      .then(({ cameras }) => {
-        if (cancelled) { return; }
-        setCameras(cameras);
-        if (cameras.length === 0) { return; }
-        // Preview the saved camera if still present, else the first one.
-        const initial = cameras.some((c) => c.id === selectedCamera)
-          ? selectedCamera
-          : cameras[0].id;
-        setSelectedCameraState(initial);
-        startCameraPreview(initial);
-      })
-      .catch((e) => {
-        if (!cancelled) { setCameraError(friendlyCameraError(String(e))); }
-      });
+      .then(({ cameras }) => { if (!cancelled) { cameraPreviewStore.enumerated(cameras, preferred); } })
+      .catch(() => { if (!cancelled) { cameraPreviewStore.enumerationFailed(); } });
     return () => {
       cancelled = true;
       void cameraSession.stopPreview();
+      cameraPreviewStore.reset();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -367,19 +373,21 @@ export const VoiceSettingsPage: React.FC = () => {
           >
             Camera
           </h2>
-          {cameras.length === 0 ? (
+          {cam.kind === "loading" ? (
+            <span style={{ color: "var(--c-text-muted)" }}>Detecting cameras…</span>
+          ) : cam.kind === "empty" ? (
             <span style={{ color: "var(--c-text-muted)" }}>No camera detected.</span>
           ) : (
             <>
               <DeviceSelect
                 label="Camera"
-                devices={cameras}
-                value={selectedCamera}
+                devices={cameraPreviewStore.devices}
+                value={cam.deviceId}
                 onChange={setCamera}
                 fallbackLabel="No camera"
               />
-              {/* Live self-preview (mirrored). 16:9 letterbox; RemoteVideoTile
-                  contains within it and auto-mirrors LOCAL_CAMERA_PREVIEW_KEY. */}
+              {/* Self-preview (mirrored). Off by default — the user opts in. 16:9
+                  letterbox; RemoteVideoTile contains + auto-mirrors the key. */}
               <div
                 data-testid="voice-camera-preview"
                 className="flex items-center justify-center overflow-hidden rounded"
@@ -391,13 +399,32 @@ export const VoiceSettingsPage: React.FC = () => {
                   border: "1px solid var(--c-border)",
                 }}
               >
-                {cameraError ? (
-                  <span className="px-3 text-center text-sm" style={{ color: "var(--c-text-muted)" }}>
-                    {cameraError}
-                  </span>
-                ) : (
+                {cam.kind === "live" ? (
                   <RemoteVideoTile trackKey={LOCAL_CAMERA_PREVIEW_KEY} />
+                ) : (
+                  <span className="px-3 text-center text-sm" style={{ color: "var(--c-text-muted)" }}>
+                    {cam.kind === "failed"
+                      ? cam.error
+                      : cam.kind === "starting"
+                        ? "Starting…"
+                        : "Preview is off — turn it on to check your camera."}
+                  </span>
                 )}
+              </div>
+              <div>
+                <Button
+                  data-testid="voice-camera-preview-toggle"
+                  variant={cam.kind === "live" ? "secondary" : "primary"}
+                  size="sm"
+                  disabled={cam.kind === "starting"}
+                  onClick={togglePreview}
+                >
+                  {cam.kind === "live"
+                    ? "Stop camera"
+                    : cam.kind === "starting"
+                      ? "Starting…"
+                      : "Test camera"}
+                </Button>
               </div>
             </>
           )}
@@ -648,4 +675,4 @@ export const VoiceSettingsPage: React.FC = () => {
       </div>
     </PageShell>
   );
-};
+});

--- a/frontend/src/pages/VoiceSettingsPage.tsx
+++ b/frontend/src/pages/VoiceSettingsPage.tsx
@@ -17,12 +17,17 @@ import {
 import { useVoiceTest } from "../hooks/useVoiceTest";
 import { voiceSession } from "../voice";
 import type { AudioDevice } from "../types";
+import { cameraSession, LOCAL_CAMERA_PREVIEW_KEY, friendlyCameraError } from "../camera/cameraSession";
+import type { CameraSource } from "../camera/types";
+import { RemoteVideoTile } from "../components/Voice/RemoteVideoTile";
 
 const VOICE_DEVICES_KEY = "pollis:voice-devices";
+const CAMERA_DEVICE_KEY = "pollis:camera-device";
 
 interface DeviceSelectProps {
   label: string;
-  devices: AudioDevice[];
+  // Structural `{ id, name }` so both AudioDevice and CameraSource fit.
+  devices: { id: string; name: string }[];
   value: string;
   onChange: (id: string) => void;
   fallbackLabel: string;
@@ -211,6 +216,54 @@ export const VoiceSettingsPage: React.FC = () => {
     }
   };
 
+  // ── Camera (issue #434) ───────────────────────────────────────────────────
+  // Live self-preview via the preview-only capture path (no call, nothing
+  // published). Frames mirror to LOCAL_CAMERA_PREVIEW_KEY; RemoteVideoTile
+  // renders + auto-mirrors them. Start on mount / device change, stop on leave.
+  const [cameras, setCameras] = useState<CameraSource[]>([]);
+  const [selectedCamera, setSelectedCameraState] = useState<string>(() => {
+    try { return localStorage.getItem(CAMERA_DEVICE_KEY) || ""; } catch { return ""; }
+  });
+  const [cameraError, setCameraError] = useState<string | null>(null);
+
+  const startCameraPreview = (id: string) => {
+    setCameraError(null);
+    cameraSession.startPreview(id).catch((e) => {
+      setCameraError(friendlyCameraError(String(e)));
+    });
+  };
+
+  const setCamera = (id: string) => {
+    setSelectedCameraState(id);
+    try { localStorage.setItem(CAMERA_DEVICE_KEY, id); } catch { /* ignore */ }
+    startCameraPreview(id);
+  };
+
+  useEffect(() => {
+    let cancelled = false;
+    cameraSession
+      .listDevices()
+      .then(({ cameras }) => {
+        if (cancelled) { return; }
+        setCameras(cameras);
+        if (cameras.length === 0) { return; }
+        // Preview the saved camera if still present, else the first one.
+        const initial = cameras.some((c) => c.id === selectedCamera)
+          ? selectedCamera
+          : cameras[0].id;
+        setSelectedCameraState(initial);
+        startCameraPreview(initial);
+      })
+      .catch((e) => {
+        if (!cancelled) { setCameraError(friendlyCameraError(String(e))); }
+      });
+    return () => {
+      cancelled = true;
+      void cameraSession.stopPreview();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   /**
    * Persist a partial preference change and push the resulting APM config to
    * the backend so mid-call changes take effect immediately.
@@ -264,6 +317,49 @@ export const VoiceSettingsPage: React.FC = () => {
             onChange={setOutput}
             fallbackLabel="Default speaker"
           />
+        </section>
+
+        <section className="flex flex-col gap-4 mb-12" data-testid="voice-camera-section">
+          <h2
+            className="text-xs font-mono font-medium uppercase tracking-widest pb-1 border-b"
+            style={{ color: "var(--c-text)", borderColor: "var(--c-border)" }}
+          >
+            Camera
+          </h2>
+          {cameras.length === 0 ? (
+            <span style={{ color: "var(--c-text-muted)" }}>No camera detected.</span>
+          ) : (
+            <>
+              <DeviceSelect
+                label="Camera"
+                devices={cameras}
+                value={selectedCamera}
+                onChange={setCamera}
+                fallbackLabel="No camera"
+              />
+              {/* Live self-preview (mirrored). 16:9 letterbox; RemoteVideoTile
+                  contains within it and auto-mirrors LOCAL_CAMERA_PREVIEW_KEY. */}
+              <div
+                data-testid="voice-camera-preview"
+                className="flex items-center justify-center overflow-hidden rounded"
+                style={{
+                  width: "100%",
+                  maxWidth: 320,
+                  aspectRatio: "16 / 9",
+                  background: "#000",
+                  border: "1px solid var(--c-border)",
+                }}
+              >
+                {cameraError ? (
+                  <span className="px-3 text-center text-sm" style={{ color: "var(--c-text-muted)" }}>
+                    {cameraError}
+                  </span>
+                ) : (
+                  <RemoteVideoTile trackKey={LOCAL_CAMERA_PREVIEW_KEY} />
+                )}
+              </div>
+            </>
+          )}
         </section>
 
         <section className="flex flex-col gap-5 mb-12" data-testid="voice-test-section">

--- a/frontend/src/pages/VoiceSettingsPage.tsx
+++ b/frontend/src/pages/VoiceSettingsPage.tsx
@@ -239,7 +239,7 @@ export const VoiceSettingsPage: React.FC = () => {
   };
 
   return (
-    <PageShell title="Voice Settings" scrollable>
+    <PageShell title="Voice & Video" scrollable>
       <div className="flex justify-center px-6 py-8">
       <div className="flex flex-col gap-8 w-full max-w-md">
 

--- a/pollis-core/src/commands/camera/capture.rs
+++ b/pollis-core/src/commands/camera/capture.rs
@@ -446,7 +446,7 @@ pub async fn start_camera(state: &Arc<AppState>, device_id: String) -> Result<()
                         last_preview = Some(std::time::Instant::now());
                     }
                     push_frame(
-                        &source_for_task,
+                        Some(&source_for_task),
                         width,
                         height,
                         stride,
@@ -554,6 +554,163 @@ pub async fn stop_camera(state: &Arc<AppState>) -> Result<()> {
     Ok(())
 }
 
+/// Start a **preview-only** capture (issue #434): drives the local self-preview
+/// with NO voice room and NO published track — for the camera picker in Voice &
+/// Video settings. Mirrors frames to the renderer under `LOCAL_CAMERA_PREVIEW_KEY`
+/// exactly like the in-call self-preview, but never touches LiveKit. Uses its own
+/// `preview_*` state slots so an in-call camera is left running undisturbed.
+pub async fn start_camera_preview(state: &Arc<AppState>, device_id: String) -> Result<()> {
+    use pollis_capture_proto::{encode_select_camera, read_msg, CameraSelection, CaptureMsg};
+    use tokio::io::AsyncWriteExt;
+
+    // Restart from a clean slate: tear down any lingering preview capture.
+    stop_camera_preview(state).await.ok();
+
+    // Reuse the parked enumeration session `list_video_devices` left, else spawn.
+    let parked = {
+        let mut cam = state.camera.lock().await;
+        cam.picker_session.take()
+    };
+    let mut session = match parked {
+        Some(s) => s,
+        None => {
+            let mut s = spawn_camera_helper(state).await?;
+            match tokio::time::timeout(HELPER_TIMEOUT, read_msg(&mut s.reader)).await {
+                Ok(Ok(Some(CaptureMsg::Cameras(_)))) => {}
+                Ok(Ok(Some(CaptureMsg::Error { message }))) => {
+                    let _ = s.child.kill().await;
+                    return Err(fail_capture(state, format!("Camera error: {message}")).await);
+                }
+                _ => {
+                    let _ = s.child.kill().await;
+                    return Err(fail_capture(
+                        state,
+                        "Camera helper did not enumerate before selection.".into(),
+                    )
+                    .await);
+                }
+            }
+            s
+        }
+    };
+
+    if let Err(e) = session
+        .writer
+        .write_all(&encode_select_camera(&CameraSelection { id: device_id.clone() }))
+        .await
+    {
+        eprintln!("[camera] preview send SelectCamera: {e}");
+        let _ = session.child.kill().await;
+        return Err(fail_capture(
+            state,
+            "Could not deliver the camera selection to the helper. Please try again.".into(),
+        )
+        .await);
+    }
+    let _ = session.writer.flush().await;
+
+    let mut reader = session.reader;
+    {
+        let mut cam = state.camera.lock().await;
+        cam.preview_helper = Some(session.child);
+        cam.preview_writer = Some(session.writer);
+    }
+
+    // Read the negotiated Format (or a leading self-describing Frame). We only
+    // need to know capture started; the preview renderer sizes from each frame's
+    // own dimensions, so we don't thread width/height further.
+    let read = tokio::time::timeout(HELPER_TIMEOUT, read_msg(&mut reader)).await;
+    match read {
+        Ok(Ok(Some(CaptureMsg::Format { .. }))) | Ok(Ok(Some(CaptureMsg::Frame { .. }))) => {}
+        Ok(Ok(Some(CaptureMsg::Error { message }))) => {
+            stop_camera_preview(state).await.ok();
+            let lower = message.to_lowercase();
+            if lower.contains("permission") || lower.contains("denied") {
+                return Err(fail_capture(
+                    state,
+                    "Camera access is blocked. Grant Camera permission in System Settings → Privacy & Security, then try again.".into(),
+                )
+                .await);
+            }
+            return Err(fail_capture(state, format!("Camera preview failed: {message}")).await);
+        }
+        _ => {
+            stop_camera_preview(state).await.ok();
+            return Err(fail_capture(
+                state,
+                "Camera preview could not start. Please try again.".into(),
+            )
+            .await);
+        }
+    }
+
+    // Reader task: mirror throttled frames to the local preview ONLY (source =
+    // None → no LiveKit publish).
+    let preview_tx = state.screenshare_frame_tx.clone();
+    let reader_task = tokio::spawn(async move {
+        let mut last_preview: Option<std::time::Instant> = None;
+        loop {
+            match read_msg(&mut reader).await {
+                Ok(Some(CaptureMsg::Frame {
+                    width,
+                    height,
+                    stride,
+                    timestamp_us,
+                    bgrx,
+                })) => {
+                    let show = last_preview
+                        .map(|t| t.elapsed() >= CAMERA_PREVIEW_MIN_INTERVAL)
+                        .unwrap_or(true);
+                    if show {
+                        last_preview = Some(std::time::Instant::now());
+                        push_frame(None, width, height, stride, timestamp_us, &bgrx, Some(&preview_tx));
+                    }
+                }
+                Ok(Some(CaptureMsg::Format { .. })) => {}
+                Ok(Some(CaptureMsg::Error { message })) => {
+                    eprintln!("[camera] preview helper error mid-stream: {message}");
+                    break;
+                }
+                Ok(None) => break,
+                Err(e) => {
+                    eprintln!("[camera] preview reader error: {e}");
+                    break;
+                }
+                _ => {}
+            }
+        }
+    });
+    {
+        let mut cam = state.camera.lock().await;
+        cam.preview_reader_task = Some(reader_task);
+    }
+    Ok(())
+}
+
+/// Tear down the settings self-preview capture (issue #434). Safe to call when
+/// nothing is live — used both on picker close and as the pre-start teardown.
+pub async fn stop_camera_preview(state: &Arc<AppState>) -> Result<()> {
+    let helper;
+    let reader;
+    {
+        let mut cam = state.camera.lock().await;
+        helper = cam.preview_helper.take();
+        reader = cam.preview_reader_task.take();
+        // Dropping our writer half closes it so the helper sees EOF and exits.
+        cam.preview_writer = None;
+    }
+    if helper.is_none() && reader.is_none() {
+        return Ok(());
+    }
+    if let Some(t) = reader {
+        t.abort();
+    }
+    if let Some(mut h) = helper {
+        let _ = h.kill().await;
+    }
+    Ok(())
+}
+
 /// Camera-tuned `(max_framerate, max_bitrate)`. 30fps; bitrate ≈ 0.07
 /// bits/pixel/frame (720p ≈ 1.9 Mbps, 1080p ≈ 4.3 Mbps), clamped to a sane
 /// band. The encoder treats the bitrate as a ceiling, so a near-static
@@ -565,7 +722,9 @@ fn resolve_camera_encoding(width: u32, height: u32) -> (f64, u64) {
 }
 
 fn push_frame(
-    source: &NativeVideoSource,
+    // `Some` feeds the LiveKit publish source; `None` for the preview-only path
+    // (settings self-preview with no call / no publish).
+    source: Option<&NativeVideoSource>,
     width: u32,
     height: u32,
     stride: u32,
@@ -589,7 +748,9 @@ fn push_frame(
         timestamp_us,
         buffer,
     };
-    source.capture_frame(&frame);
+    if let Some(source) = source {
+        source.capture_frame(&frame);
+    }
 
     // Mirror to the renderer for the local self-preview, reusing the exact
     // I420 buffer just published — same frame wire format + WebSocket

--- a/pollis-core/src/commands/camera/mod.rs
+++ b/pollis-core/src/commands/camera/mod.rs
@@ -76,11 +76,17 @@ mod unsupported;
 pub use state::CameraState;
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
-pub use capture::{list_video_devices, start_camera, stop_camera};
+pub use capture::{
+    list_video_devices, start_camera, start_camera_preview, stop_camera, stop_camera_preview,
+};
 #[cfg(target_os = "windows")]
-pub use start_windows::{list_video_devices, start_camera, stop_camera};
+pub use start_windows::{
+    list_video_devices, start_camera, start_camera_preview, stop_camera, stop_camera_preview,
+};
 #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-pub use unsupported::{list_video_devices, start_camera, stop_camera};
+pub use unsupported::{
+    list_video_devices, start_camera, start_camera_preview, stop_camera, stop_camera_preview,
+};
 
 // ── Events to the frontend ────────────────────────────────────────────────
 

--- a/pollis-core/src/commands/camera/start_windows.rs
+++ b/pollis-core/src/commands/camera/start_windows.rs
@@ -725,3 +725,17 @@ fn now_us() -> i64 {
         .map(|d| d.as_micros() as i64)
         .unwrap_or(0)
 }
+
+/// Settings self-preview (issue #434). Windows *capture* is implemented above;
+/// only this preview-only path is still pending — it would open the MF reader and
+/// mirror to `LOCAL_CAMERA_PREVIEW_KEY` without publishing.
+pub async fn start_camera_preview(_state: &Arc<AppState>, _device_id: String) -> Result<()> {
+    Err(crate::error::Error::Other(anyhow::anyhow!(
+        "Windows camera preview is not implemented yet (Media Foundation TODO)"
+    )))
+}
+
+/// Idempotent no-op — no preview session exists on Windows yet.
+pub async fn stop_camera_preview(_state: &Arc<AppState>) -> Result<()> {
+    Ok(())
+}

--- a/pollis-core/src/commands/camera/state.rs
+++ b/pollis-core/src/commands/camera/state.rs
@@ -50,6 +50,18 @@ pub struct CameraState {
     /// fresh Arc per session so a stale stop can't fence a newer one.
     #[cfg(target_os = "windows")]
     pub windows_active: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
+
+    // ── Settings self-preview (issue #434) ──────────────────────────────────
+    // A capture that mirrors to the local preview WITHOUT a voice room or a
+    // published track — for the camera picker in Voice & Video settings.
+    // Kept in its OWN slots so it never disturbs a live in-call camera: a user
+    // can open settings mid-call and the two captures coexist.
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    pub preview_helper: Option<tokio::process::Child>,
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    pub preview_writer: Option<tokio::net::unix::OwnedWriteHalf>,
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    pub preview_reader_task: Option<tokio::task::JoinHandle<()>>,
 }
 
 impl CameraState {
@@ -70,6 +82,12 @@ impl CameraState {
             windows_thread: None,
             #[cfg(target_os = "windows")]
             windows_active: None,
+            #[cfg(any(target_os = "macos", target_os = "linux"))]
+            preview_helper: None,
+            #[cfg(any(target_os = "macos", target_os = "linux"))]
+            preview_writer: None,
+            #[cfg(any(target_os = "macos", target_os = "linux"))]
+            preview_reader_task: None,
         }
     }
 }

--- a/pollis-core/src/commands/camera/unsupported.rs
+++ b/pollis-core/src/commands/camera/unsupported.rs
@@ -23,9 +23,19 @@ pub async fn start_camera(_state: &Arc<AppState>, _device_id: String) -> Result<
     Err(unsupported())
 }
 
+/// Settings self-preview (issue #434) — same "unsupported here" story as capture.
+pub async fn start_camera_preview(_state: &Arc<AppState>, _device_id: String) -> Result<()> {
+    Err(unsupported())
+}
+
 /// Idempotent no-op: there is never a live camera capture to tear down on
 /// an unsupported platform, and callers (e.g. leave-voice cleanup) must be
 /// able to call this unconditionally.
 pub async fn stop_camera(_state: &Arc<AppState>) -> Result<()> {
+    Ok(())
+}
+
+/// Idempotent no-op — see [`stop_camera`].
+pub async fn stop_camera_preview(_state: &Arc<AppState>) -> Result<()> {
     Ok(())
 }

--- a/src-tauri/src/commands/camera.rs
+++ b/src-tauri/src/commands/camera.rs
@@ -37,3 +37,18 @@ pub async fn start_camera(state: State<'_, Arc<AppState>>, device_id: String) ->
 pub async fn stop_camera(state: State<'_, Arc<AppState>>) -> Result<()> {
     pollis_core::commands::camera::stop_camera(&state).await
 }
+
+/// Preview-only capture for the Voice & Video settings picker (issue #434): local
+/// self-preview with no voice room and nothing published.
+#[tauri::command]
+pub async fn start_camera_preview(
+    state: State<'_, Arc<AppState>>,
+    device_id: String,
+) -> Result<()> {
+    pollis_core::commands::camera::start_camera_preview(&state, device_id).await
+}
+
+#[tauri::command]
+pub async fn stop_camera_preview(state: State<'_, Arc<AppState>>) -> Result<()> {
+    pollis_core::commands::camera::stop_camera_preview(&state).await
+}

--- a/src-tauri/src/commands/media_permissions.rs
+++ b/src-tauri/src/commands/media_permissions.rs
@@ -132,6 +132,50 @@ pub fn get_media_permission_status() -> std::result::Result<MediaPermissions, St
     }
 }
 
+/// Deep-link to the OS privacy settings for a media `kind` ("camera" /
+/// "microphone"), issue #434. An app cannot grant or revoke its own OS privacy
+/// grant — only the user can, in System Settings — so this just takes them
+/// there (same model as Discord/Zoom). Uses the URI schemes directly rather than
+/// the shell-open bridge, whose allowlist rejects `x-apple.systempreferences:` /
+/// `ms-settings:`. Linux has no per-application camera/mic model, so there is
+/// nothing to deep-link to.
+#[tauri::command]
+pub fn open_privacy_settings(kind: String) -> std::result::Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        let anchor = match kind.as_str() {
+            "camera" => "Privacy_Camera",
+            "microphone" => "Privacy_Microphone",
+            other => return Err(format!("unknown media kind: {other}")),
+        };
+        let url = format!("x-apple.systempreferences:com.apple.preference.security?{anchor}");
+        std::process::Command::new("open")
+            .arg(url)
+            .spawn()
+            .map_err(|e| e.to_string())?;
+        Ok(())
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let uri = match kind.as_str() {
+            "camera" => "ms-settings:privacy-webcam",
+            "microphone" => "ms-settings:privacy-microphone",
+            other => return Err(format!("unknown media kind: {other}")),
+        };
+        // `cmd /C start "" <uri>` resolves the ms-settings: URI via the shell.
+        std::process::Command::new("cmd")
+            .args(["/C", "start", "", uri])
+            .spawn()
+            .map_err(|e| e.to_string())?;
+        Ok(())
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        let _ = kind;
+        Err("no per-application privacy settings on this platform".into())
+    }
+}
+
 /// Revoke the OS permission(s) for the given kinds ("camera"/"microphone"/
 /// "screen"). Always tears down any active capture first so we never leave a
 /// live camera/screen-share running against a permission we just cleared.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -46,6 +46,7 @@ fn hide_on_close(window: &tauri::Window, event: &tauri::WindowEvent) {
             tauri::async_runtime::spawn(async move {
                 let _ = pollis_core::commands::screenshare::stop_screen_share(&state).await;
                 let _ = pollis_core::commands::camera::stop_camera(&state).await;
+                let _ = pollis_core::commands::camera::stop_camera_preview(&state).await;
             });
         }
         // Prevent the window from actually being destroyed.
@@ -560,6 +561,8 @@ commands::livekit::get_livekit_token,
             commands::camera::list_video_devices,
             commands::camera::start_camera,
             commands::camera::stop_camera,
+            commands::camera::start_camera_preview,
+            commands::camera::stop_camera_preview,
             commands::sfx::play_sfx,
             commands::sfx::start_ring,
             commands::sfx::stop_ring,
@@ -608,6 +611,7 @@ commands::livekit::get_livekit_token,
                     tauri::async_runtime::block_on(async move {
                         let _ = pollis_core::commands::screenshare::stop_screen_share(&state).await;
                         let _ = pollis_core::commands::camera::stop_camera(&state).await;
+                        let _ = pollis_core::commands::camera::stop_camera_preview(&state).await;
                     });
                 }
             }
@@ -639,6 +643,7 @@ commands::livekit::get_livekit_token,
                     tauri::async_runtime::block_on(async move {
                         let _ = pollis_core::commands::screenshare::stop_screen_share(&state).await;
                         let _ = pollis_core::commands::camera::stop_camera(&state).await;
+                        let _ = pollis_core::commands::camera::stop_camera_preview(&state).await;
                         // Close the LiveKit rooms (realtime + voice) so the
                         // server evicts us immediately instead of waiting out its
                         // RTC timeout — otherwise our voice card lingers as a

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -416,6 +416,7 @@ pub fn run() {
             tray::tray_set_enabled,
             tray::tray_set_voice_state,
             commands::media_permissions::get_media_permission_status,
+            commands::media_permissions::open_privacy_settings,
             commands::media_permissions::revoke_media_permissions,
             commands::media_permissions::set_revoke_media_on_exit,
             commands::auth::initialize_identity,


### PR DESCRIPTION
#434 part 1 (camera picker + preview) and the page rename. Completes the last unchecked item on the #394 webcam epic (capture on all 3 platforms + receive/render already landed).

## What
- **Rename** "Voice Settings" → "Voice & Video" everywhere (PageShell title, Sidebar, SettingsHub, SearchPanel + keywords, Preferences button). Route `/voice-settings` unchanged.
- **Backend preview-only capture** — `start/stop_camera_preview` (macOS/Linux real; Windows/unsupported stubbed). Captures + mirrors to `LOCAL_CAMERA_PREVIEW_KEY` with **no voice room and nothing published**, since `start_camera` requires an active call. Own `preview_*` state slots so it never disturbs an in-call camera; `push_frame` made source-optional. Tauri shims + registration + exit/window-close teardown; client `cameraSession.startPreview/stopPreview`.
- **Camera section in VoiceSettingsPage** — device dropdown (`list_video_devices`) + a 16:9 **live self-preview** (starts on mount / device change, stops on leave) via `RemoteVideoTile` under `LOCAL_CAMERA_PREVIEW_KEY`. Permission/capture errors surface in the box.
- **Mirror the self-view** — `RemoteVideoTile` auto-mirrors (`scaleX(-1)`) whenever it renders `LOCAL_CAMERA_PREVIEW_KEY`, so **both** the settings preview and the in-call self-preview read like a mirror. (Confirmed working.)

## Verified
Rebased on latest main (incl. #546 Windows capture, #385 voice unions). `cargo check` core + src-tauri, `tsc` clean. Mirroring confirmed live by @actuallydan. Full frame path traced: preview-only capture → app-shell-lifetime loopback WS (`ensureSubscribed`, not voice-scoped) → RemoteVideoTile.

## Not in this PR
#434 part 2 (media-permission status + System-Settings deep-link in Voice & Video) — follow-up.