### PR TITLE
ci: add fast frontend typecheck gate on PRs to main

### DIFF
--- a/.github/workflows/frontend-check.yml
+++ b/.github/workflows/frontend-check.yml
@@ -1,0 +1,44 @@
+name: Frontend check
+
+# Fast typecheck gate for the renderer (frontend/, React + TS + Vite). Until
+# now nothing gated frontend code on PRs — a tsc break could merge to main and
+# only surface at release time (documented gap in docs/deployments.md). This
+# job is deliberately minimal so it stays fast: a filtered pnpm install of the
+# frontend package only, then plain `tsc` (the tsconfig sets noEmit, so it's a
+# pure typecheck) — NO vite build, no artifacts.
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: frontend-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      # cache: "pnpm" caches the pnpm content-addressable store keyed on
+      # pnpm-lock.yaml, so warm runs skip nearly all downloads.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      # --filter ./frontend... installs only the frontend package (+ workspace
+      # deps) instead of the whole workspace — skips e2e and pollis-delivery.
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile --filter ./frontend...
+
+      # Pure typecheck: frontend/tsconfig.json has noEmit, so `tsc` emits
+      # nothing and just fails on type errors (~3s).
+      - name: Typecheck
+        run: pnpm --filter frontend exec tsc


### PR DESCRIPTION
Adds `.github/workflows/frontend-check.yml`: a standalone gate on every PR targeting main that typechecks `frontend/` — closing the documented gap in docs/deployments.md where a tsc break could merge unchecked.
Filtered install (`pnpm install --frozen-lockfile --filter ./frontend...`) + plain `tsc` (tsconfig has noEmit, so pure typecheck — no vite build), with pnpm store caching via setup-node.
Verified locally in the workspace: install and typecheck both exit 0; typecheck runs in ~3s.