### PR TITLE
ci: least-privilege workflow token permissions + document new pollis-verify subcommands in release notes

### DIFF
--- a/.github/workflows/attest-release.yml
+++ b/.github/workflows/attest-release.yml
@@ -18,6 +18,9 @@ on:
         description: "Published release tag to attest, e.g. v1.3.4"
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   attest:
     runs-on: ubuntu-latest

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -23,6 +23,9 @@ on:
         required: false
         default: ""
 
+permissions:
+  contents: read
+
 jobs:
   # Resolve the version once so every build/publish job agrees. Uses the
   # dispatch input when given, else the [workspace.package] version in the

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -25,6 +25,12 @@ on:
     tags:
       - "v*"
 
+# Least-privilege default. Jobs that need more declare it themselves:
+# `release` has contents: write (GitHub release), `provenance` has
+# id-token/attestations. Everything else only reads the repo.
+permissions:
+  contents: read
+
 jobs:
   # This workflow builds + publishes a FULL versioned release (installers, prod DB
   # migrations, SLSA/cosign provenance, binary-transparency log) — all keyed on the

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -14,6 +14,9 @@ name: E2E smoke (login screen)
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   smoke:
     # Same rationale as mls-tests.yml: src-tauri/build.rs compiles

--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -26,6 +26,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: kani-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/mls-tests.yml
+++ b/.github/workflows/mls-tests.yml
@@ -39,6 +39,9 @@ on:
   schedule:
     - cron: "0 7 * * *"
 
+permissions:
+  contents: read
+
 concurrency:
   group: mls-tests-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/rebuild-verify.yml
+++ b/.github/workflows/rebuild-verify.yml
@@ -48,6 +48,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 # Pinned so the reproduced key can never silently change under us.
 env:
   VERIFY_BASE_URL: "https://verify.pollis.com"

--- a/.github/workflows/verifier-release.yml
+++ b/.github/workflows/verifier-release.yml
@@ -97,8 +97,14 @@ jobs:
 
             # verify one conversation's commit chain (use a conversation id, not a name)
             ./pollis-verify-<platform> group https://verify.pollis.com <CONVERSATION_ID>
+
+            # verify a user's account-key history chain (identity-key versions)
+            ./pollis-verify-<platform> account https://verify.pollis.com <USER_ID>
+
+            # verify a released version's binaries against the transparency log
+            ./pollis-verify-<platform> release https://verify.pollis.com v1.3.0
             ```
             Exit code is non-zero if any check fails. Add `--json` to
-            `group` for machine-readable output.
+            `group`, `account`, or `release` for machine-readable output.
 
             Verify the download against the matching `*.sha256` file.


### PR DESCRIPTION
Adds top-level `permissions: contents: read` to the 7 workflows that had none (attest-release, cli-release, desktop-release, e2e-smoke, kani, mls-tests, rebuild-verify) — defense-in-depth; verified no job relies on broader token perms (desktop-release's `release`/`provenance` jobs keep their job-level blocks). Also extends the verifier-release.yml release-notes Usage section with the `account` and `release` subcommands added to pollis-verify.