### PR TITLE
ci(verifier-release): cross-compile macos x86_64 from macos-15

### DIFF
--- a/.github/workflows/verifier-release.yml
+++ b/.github/workflows/verifier-release.yml
@@ -38,7 +38,11 @@ jobs:
           - os: macos-14
             target: aarch64-apple-darwin
             asset: pollis-verify-macos-arm64
-          - os: macos-13
+          # macos-13 (the last free x86_64 runner image) is deprecated and its
+          # pool drains for hours; cross-compile the x86_64 slice from an
+          # Apple-Silicon runner instead — the toolchain step installs the
+          # matrix target, so only the host image changes.
+          - os: macos-15
             target: x86_64-apple-darwin
             asset: pollis-verify-macos-x86_64
     steps:


### PR DESCRIPTION
The macos-13 runner pool is deprecated and the x86_64 verifier build sat queued for 40+ min (same reason v0.1.0 shipped without the macos-x86_64 asset). Build it on macos-15 with --target x86_64-apple-darwin instead.