### PR TITLE
test(e2e): expand two-client suite + fix local fixture leaks

### DIFF
--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,8 +1,6 @@
 artifacts/
-.tmp-data/
-.tmp-data-smoke/
-.tmp-data-invalid-otp/
-.tmp-data-call-a/
-.tmp-data-call-b/
-.tmp-data-camera-a/
-.tmp-data-camera-b/
+# Per-run scratch: local SQLite + MLS state + keystore for each client instance.
+.tmp-data*/
+# Backend fixture state (start-backend.sh: DS log/pid) + captured fixture env.
+.backend/
+.e2e-env.sh

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -13,6 +13,9 @@ plumbing:
 | `e2e.js` | full signup: email → OTP → secret key → PIN → app-ready | yes | yes (writable) |
 | `invalid-otp.js` | a wrong OTP code is rejected with an inline error, doesn't advance | yes | yes (writable) |
 | `two-client.js` | two isolated app instances; a message from A converges into B's UI | yes | yes (writable) |
+| `two-client-dm-reply.js` | bidirectional 1:1 DM — B replies and A sees it (reverse leg of two-client) | yes | yes (writable) |
+| `two-client-channel.js` | A creates a group + text channel, invites B, B accepts, A posts, B receives | yes | yes (writable) |
+| `two-client-voice-channel.js` | A + B join a group voice channel, both see 2 participants, A leaves, B sees the drop | yes | yes (writable) + LiveKit + audio |
 | `two-client-call.js` | two instances place + accept a real 1:1 call; each sees the other in the call | yes | yes (writable) + LiveKit + audio |
 | `two-client-camera.js` | two instances in a call; A turns its webcam on, B sees A's remote camera tile | yes | yes (writable) + LiveKit + audio + virtual camera |
 | `two-client-screenshare.js` | two instances in a call; A shares its screen (X11/Xvfb capture), B sees A's remote screenshare tile | yes | yes (writable) + LiveKit + audio |
@@ -22,6 +25,9 @@ pnpm --filter @pollis/e2e smoke        # or: node e2e/smoke.js       (fast, no d
 pnpm --filter @pollis/e2e test         # or: node e2e/e2e.js         (full signup flow)
 pnpm --filter @pollis/e2e invalid-otp  # or: node e2e/invalid-otp.js
 pnpm --filter @pollis/e2e two-client   # or: node e2e/two-client.js  (needs backend up first)
+pnpm --filter @pollis/e2e two-client-dm-reply       # bidirectional DM (needs backend)
+pnpm --filter @pollis/e2e two-client-channel        # group text-channel convergence (needs backend)
+pnpm --filter @pollis/e2e two-client-voice-channel  # group voice join/leave (needs backend + LiveKit + audio)
 pnpm --filter @pollis/e2e two-client-call  # or: node e2e/two-client-call.js  (needs backend + LiveKit + audio up first)
 pnpm --filter @pollis/e2e two-client-camera  # or: node e2e/two-client-camera.js  (needs backend + LiveKit + audio + virtual camera up first)
 pnpm --filter @pollis/e2e two-client-screenshare  # or: node e2e/two-client-screenshare.js  (needs backend + LiveKit + audio up first)
@@ -452,6 +458,21 @@ CI via `.github/workflows/e2e-full.yml` (below). `smoke.js` remains the fast,
 backend-free launch check.
 
 ## Gotchas encoded in these scripts (learned the hard way)
+
+- **`.env.development` must not override the local fixture (local-only bug).**
+  `appEnvFor` builds the app's env as `{ ...devEnv, ...process.env, <explicit
+  overrides> }`. It **must** be that order (fixture wins) and it explicitly
+  clears `LOG_DB_*`. `.env.development` sets `LIVEKIT_URL=wss://rtc.pollis.com`
+  and a prod `LOG_DB_URL`; if those leak into the app it dials **prod** LiveKit
+  (401 → realtime dead → the membership hint that triggers the Welcome poll never
+  arrives) and reads Welcomes from the **prod** log DB (empty) — so nothing
+  converges. This never bites CI (no `.env.development` there), which is why the
+  two-client suite passed in CI but hung locally. If you add a new two-client
+  script, copy `appEnvFor` verbatim.
+- **The DS shares one libsql DB here** (`LOG_DB_*` unset → single-DB fallback),
+  so `start-backend.sh` also applies `migrations-log/` (via
+  `apply-log-migrations.py`) — without it the DS's Welcome upsert fails on a
+  missing `ON CONFLICT` target and Welcomes silently never persist.
 
 - **Clicks**: WebKitWebDriver's native `element.click()` doesn't reliably fire
   React handlers/form submits here; `clickTestId()` dispatches a DOM click via

--- a/e2e/SCENARIOS.md
+++ b/e2e/SCENARIOS.md
@@ -1,0 +1,81 @@
+# E2E happy-path scenario inventory (1 & 2 users)
+
+Sorted by **value × (1 − confidence)** — highest-value, least-confident (most
+worth an automated test) first. "Confidence" = how sure static code analysis
+makes me that the flow already works. Status: ✅ covered by an existing script,
+🟡 new script added here, ⬜ not yet automated.
+
+## Legend
+- **V** = product value if it breaks (5 = core promise, 1 = cosmetic)
+- **C** = static-analysis confidence it works today (5 = certain, 1 = unknown)
+- **Priority** = V high, C low → test first
+
+## Two-user scenarios
+
+| # | Scenario | V | C | Status | Notes |
+|---|----------|---|---|--------|-------|
+| M-CH | Group + text-channel convergence: A creates group+channel, invites B, B accepts, A posts, B receives | 5 | 2 | 🟡 | Core Slack model; entirely untested cross-client. Invite path is MLS-synchronous (reliable). |
+| M-VC | Voice channel: A joins, B joins same channel, both see 2 participants, A leaves, B sees drop | 5 | 2 | 🟡 | Explicitly requested. Needs LiveKit + audio + group membership (MLS voice key). |
+| M-OFF | Offline convergence: A sends while B's app closed, B relaunches → receives (bounded history) | 5 | 2 | ⬜ | "Messages must work" invariant. |
+| M-DM2 | DM bidirectional: B replies to A, A sees B's message | 4 | 3 | 🟡 | Reverse direction never asserted (existing test is A→B only). |
+| M-JR | Join-request path: B searches group by slug, requests, A approves, B becomes member | 4 | 2 | ⬜ | Alt to invite; relies on async realtime membership_changed → welcome poll. |
+| M-EDIT | Edit convergence: A edits a message, B sees new text + (edited) | 3 | 2 | ⬜ | |
+| M-DEL | Delete convergence: A deletes, B sees `[deleted]` | 3 | 2 | ⬜ | Content tombstoned, row stays. |
+| M-ORD | Ordering: A sends 3 messages, B receives all 3 in order | 4 | 3 | ⬜ | |
+| M-PRES | Presence: A sees B come online / go offline | 3 | 2 | ⬜ | LiveKit realtime dependent. |
+| M-CALL | 1:1 call place + accept, both see each other | 5 | 3 | ✅ | two-client-call.js |
+| M-CAM | Call + camera: A camera on, B sees remote tile | 4 | 3 | ✅ | two-client-camera.js |
+| M-SS | Call + screenshare: A shares, B sees remote tile | 4 | 3 | ✅ | two-client-screenshare.js |
+| M-DECL | Call decline: A calls, B declines, A sees ended | 3 | 2 | ⬜ | |
+| M-HANG | Call hangup convergence: A hangs up, B sees end | 3 | 3 | ⬜ | |
+| M-KICK | A kicks B from group, B loses access | 3 | 2 | ⬜ | |
+| M-LEAVE | B leaves group, A sees membership drop | 2 | 2 | ⬜ | |
+| M-CONV | DM request → accept → message (base) | 5 | 4 | ✅ | two-client.js |
+
+## Single-user scenarios
+
+| # | Scenario | V | C | Status | Notes |
+|---|----------|---|---|--------|-------|
+| S-RESTART | Restart persistence: sign up, kill app, relaunch same data dir → data/session survives | 5 | 2 | 🟡 | "Same device keeps data" invariant. Reveals real cold-start behaviour. |
+| S-RELOGIN | Logout (keep data) → re-login (email+OTP+PIN) → app-ready | 4 | 3 | ⬜ | Confirmed: always re-auth, never PIN-only. |
+| S-EDIT | Send → edit own message (Enter to save) → shows (edited) | 3 | 3 | ⬜ | No submit testid; save via Enter keydown. |
+| S-DEL | Send → delete own message → `[deleted]` | 3 | 3 | ⬜ | |
+| S-GRP | Create a group | 3 | 3 | ⬜ | Covered as a step of M-CH. |
+| S-TXTCH | Create a text channel | 3 | 3 | ⬜ | Covered as a step of M-CH. |
+| S-VOXCH | Create a voice channel (toggle type switch) | 3 | 3 | ⬜ | Covered as a step of M-VC. |
+| S-RENAME | Rename a channel / group | 2 | 3 | ⬜ | |
+| S-DELCH | Delete a channel | 2 | 3 | ⬜ | |
+| S-SIGNUP | Full signup: email→OTP→secret key→PIN→app-ready | 5 | 4 | ✅ | e2e.js |
+| S-BADOTP | Wrong OTP rejected inline | 4 | 4 | ✅ | invalid-otp.js |
+| S-SMOKE | App launches, login screen renders | 5 | 5 | ✅ | smoke.js |
+
+## Fixture bugs found while getting the suite green locally
+Two blockers stopped **every** two-client script from passing on a local dev box
+(they only ever passed in CI, where `.env.development` is absent). Both fixed on
+this branch:
+
+1. **Missing commit-log migrations.** `start-backend.sh` runs the DS in single-DB
+   fallback (`LOG_DB_*` unset) so the MLS control-plane tables share the one
+   libsql DB, but only `migrations/` was applied — never `migrations-log/`. The
+   `mls_welcome` UNIQUE dedupe index (#430) and `mls_commit_since` table (#539)
+   were missing, so the DS's idempotent Welcome upsert failed with "ON CONFLICT
+   clause does not match any PRIMARY KEY or UNIQUE constraint" and Welcomes never
+   persisted → no cross-client MLS delivery. Fix: `apply-log-migrations.py`,
+   invoked from `start-backend.sh`.
+
+2. **`.env.development` leaked prod URLs into the app.** `appEnvFor` merged
+   `{...process.env, ...devEnv}`, so `.env.development`'s
+   `LIVEKIT_URL="wss://rtc.pollis.com"` overrode the local fixture's
+   `ws://127.0.0.1:7880`. The app dialed **production** LiveKit, which rejected
+   the locally-minted devkey token (401 "invalid authorization token") → realtime
+   dead → the `membership_changed` hint that triggers `poll_mls_welcomes` never
+   arrived → nothing converged. Fix: flip the merge to `{...devEnv,
+   ...process.env}` so the fixture wins (CI unaffected — no `.env.development`
+   there).
+
+## Not testable as-is
+- **Reactions** (add/remove, convergence): `MessageReactions` is commented out in
+  both skins of `MessageItem.tsx` — the `reaction-*` testids don't exist in the
+  running app. Would need the component re-enabled first.
+</content>
+</invoke>

--- a/e2e/e2e.js
+++ b/e2e/e2e.js
@@ -60,7 +60,7 @@ async function main() {
   // broken on this setup and causes rendering stalls / hung screenshot
   // commands without them. R2 placeholders (present but never dialed during
   // signup) come from process.env in CI or .env.development locally.
-  const appEnv = { ...process.env, ...devEnv, TURSO_URL, TURSO_TOKEN,
+  const appEnv = { ...devEnv, ...process.env, TURSO_URL, TURSO_TOKEN,
     POLLIS_DELIVERY_URL: deliveryUrl, POLLIS_DATA_DIR: path.join(__dirname, ".tmp-data"),
     WEBKIT_DISABLE_COMPOSITING_MODE: "1", GDK_BACKEND: "x11" };
   fs.rmSync(appEnv.POLLIS_DATA_DIR, { recursive: true, force: true });

--- a/e2e/invalid-otp.js
+++ b/e2e/invalid-otp.js
@@ -47,7 +47,7 @@ async function main() {
     console.log(`[invalid-otp] using external delivery service at ${deliveryUrl}`);
   }
 
-  const appEnv = { ...process.env, ...devEnv, TURSO_URL, TURSO_TOKEN,
+  const appEnv = { ...devEnv, ...process.env, TURSO_URL, TURSO_TOKEN,
     POLLIS_DELIVERY_URL: deliveryUrl, POLLIS_DATA_DIR: path.join(__dirname, ".tmp-data-invalid-otp"),
     WEBKIT_DISABLE_COMPOSITING_MODE: "1", GDK_BACKEND: "x11" };
   fs.rmSync(appEnv.POLLIS_DATA_DIR, { recursive: true, force: true });

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -9,6 +9,9 @@
     "smoke": "node ./smoke.js",
     "invalid-otp": "node ./invalid-otp.js",
     "two-client": "node ./two-client.js",
+    "two-client-channel": "node ./two-client-channel.js",
+    "two-client-dm-reply": "node ./two-client-dm-reply.js",
+    "two-client-voice-channel": "node ./two-client-voice-channel.js",
     "two-client-call": "node ./two-client-call.js",
     "two-client-camera": "node ./two-client-camera.js",
     "two-client-screenshare": "node ./two-client-screenshare.js"

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -8,6 +8,7 @@
     "test": "node ./e2e.js",
     "smoke": "node ./smoke.js",
     "invalid-otp": "node ./invalid-otp.js",
+    "restart-persistence": "node ./restart-persistence.js",
     "two-client": "node ./two-client.js",
     "two-client-channel": "node ./two-client-channel.js",
     "two-client-dm-reply": "node ./two-client-dm-reply.js",

--- a/e2e/restart-persistence.js
+++ b/e2e/restart-persistence.js
@@ -24,7 +24,19 @@
 
 const fs = require("fs");
 const path = require("path");
+const { spawnSync } = require("child_process");
 const h = require("./lib/harness");
+
+// Kill this client's driver/webdriver/app but SPARE the shared Vite server and
+// the external DS — the relaunch loads its UI from that same Vite server, so a
+// full h.reap() (which pkills bin/vite) would leave the relaunch on a dead port
+// ("Connection refused"). Mirrors reap() minus vite/pollis-delivery.
+function reapClientKeepVite() {
+  for (const p of ["tauri-driver", "WebKitWebDriver"]) {
+    spawnSync("pkill", ["-9", "-f", p], { stdio: "ignore" });
+  }
+  spawnSync("pkill", ["-9", "-x", "pollis"], { stdio: "ignore" });
+}
 
 const ARTIFACTS = path.join(__dirname, "artifacts");
 const shot = h.makeShot(ARTIFACTS);
@@ -164,8 +176,10 @@ async function main() {
     // 2. Tear the app down but KEEP the data dir.
     await client.browser.deleteSession().catch(() => {});
     stop(client.tauriDriver);
-    h.reap();
+    reapClientKeepVite();
     await h.sleep(3000);
+    // Re-warm Vite's lazy transforms so the relaunch's one-shot page load is warm.
+    h.warmVite();
 
     // 3. Relaunch on the SAME data dir (no wipe).
     client = await h.startClient({

--- a/e2e/restart-persistence.js
+++ b/e2e/restart-persistence.js
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+/*
+ * Single-client RESTART PERSISTENCE E2E (issue #570, single-user).
+ *
+ * Proves the "same device keeps its data" invariant: after a full app restart
+ * against the SAME POLLIS_DATA_DIR, the account is still recognised — the app
+ * does NOT fall back to a blank first-run signup. Whatever resume path the app
+ * takes (auto-resume to app-ready, PIN unlock, or re-auth with the account
+ * pre-known), the test drives it back to app-ready.
+ *
+ * Choreography:
+ *   1. Sign up (fresh account) → app-ready. The data dir now holds the local
+ *      SQLite DB + MLS state + keystore + accounts index.
+ *   2. Tear the app down (delete the WebDriver session, kill the driver) but KEEP
+ *      the data dir.
+ *   3. Relaunch a new app instance on the SAME data dir.
+ *   4. Assert persistence: the app resumes to one of app-ready / pin-entry-screen
+ *      / auth-screen-with-a-known-account — never a blank signup — and is driven
+ *      back to app-ready.
+ *
+ * Needs the backend (DS for OTP verify on the re-auth path). Run start-backend.sh
+ * first (POLLIS_DELIVERY_URL must be set).
+ */
+
+const fs = require("fs");
+const path = require("path");
+const h = require("./lib/harness");
+
+const ARTIFACTS = path.join(__dirname, "artifacts");
+const shot = h.makeShot(ARTIFACTS);
+const PIN = "1357";
+const DATA_DIR = path.join(__dirname, ".tmp-data-restart");
+
+// Env for the app. `wipe` is true only for the first (signup) launch; the
+// restart reuses the SAME dir untouched — that's the whole point.
+function appEnvFor(devEnv, turso, deliveryUrl, wipe) {
+  if (wipe) {
+    fs.rmSync(DATA_DIR, { recursive: true, force: true });
+    fs.mkdirSync(DATA_DIR, { recursive: true });
+  }
+  return {
+    ...devEnv, ...process.env,
+    TURSO_URL: turso.TURSO_URL, TURSO_TOKEN: turso.TURSO_TOKEN,
+    POLLIS_DELIVERY_URL: deliveryUrl,
+    POLLIS_DATA_DIR: DATA_DIR,
+    LOG_DB_URL: "", LOG_DB_TOKEN: "", LOG_DB_ADMIN_TOKEN: "",
+    WEBKIT_DISABLE_COMPOSITING_MODE: "1", GDK_BACKEND: "x11",
+  };
+}
+
+async function signUp(browser, email) {
+  console.log(`[restart] signing up ${email}`);
+  await h.waitTestId(browser, "auth-screen", 30000);
+  await h.setTestIdValue(browser, "email-input", email);
+  await h.clickTestId(browser, "send-otp-button");
+  await h.waitTestId(browser, "otp-form-container", 20000);
+  await h.typeCode(browser, "000000");
+  await h.waitTestId(browser, "save-secret-key-warning-screen", 45000);
+  await h.clickTestId(browser, "save-secret-key-acknowledge-button");
+  await h.waitTestId(browser, "save-secret-key-screen");
+  const secretKey = (await (await browser.$('[data-testid="secret-key-display"]')).getText()).trim();
+  if (!secretKey) {
+    throw new Error("secret key display was empty");
+  }
+  await h.clickTestId(browser, "secret-key-saved-button");
+  await h.waitTestId(browser, "save-secret-key-confirm-screen");
+  await h.setTestIdValue(browser, "secret-key-confirm-input", secretKey);
+  await h.clickTestId(browser, "confirm-secret-key-button");
+  await h.waitTestId(browser, "pin-create-screen");
+  await h.typeCode(browser, PIN);
+  await h.typeCode(browser, PIN);
+  await h.waitTestId(browser, "app-ready", 60000);
+  console.log("[restart] reached app-ready (initial signup)");
+}
+
+// After relaunch, drive whatever resume screen appears back to app-ready and
+// return a label describing the persistence path taken.
+async function resumeToAppReady(browser, email) {
+  // Wait for the app to settle on one of the known post-boot screens.
+  const screens = ["app-ready", "pin-entry-screen", "auth-screen"];
+  const end = Date.now() + 60000;
+  let landed = null;
+  while (Date.now() < end && !landed) {
+    for (const s of screens) {
+      if (await h.present(browser, s)) { landed = s; break; }
+    }
+    if (!landed) { await h.sleep(500); }
+  }
+  if (!landed) {
+    throw new Error("relaunch did not settle on a known screen");
+  }
+  console.log(`[restart] relaunch landed on: ${landed}`);
+
+  if (landed === "app-ready") {
+    return "auto-resumed";
+  }
+
+  if (landed === "pin-entry-screen") {
+    // Session/keystore persisted; just unlock with the PIN.
+    await h.typeCode(browser, PIN);
+    await h.waitTestId(browser, "app-ready", 30000);
+    return "pin-unlock";
+  }
+
+  // auth-screen: the account must still be KNOWN (a known-account chip), else
+  // persistence was lost and this is indistinguishable from a fresh install.
+  const knownAccount = await h.presentSelector(browser, '[data-testid^="known-account-chip-"]');
+  if (!knownAccount) {
+    throw new Error("relaunch showed a blank auth screen with no known account — local data was lost");
+  }
+  console.log("[restart] known-account chip present — account persisted; re-authenticating");
+  // Re-auth with the same email; existing PIN means pin-entry, not pin-create.
+  await h.setTestIdValue(browser, "email-input", email);
+  await h.clickTestId(browser, "send-otp-button");
+  await h.waitTestId(browser, "otp-form-container", 20000);
+  await h.typeCode(browser, "000000");
+  // OTP may auto-submit; if a verify button is present, click it.
+  if (await h.present(browser, "verify-otp-button")) {
+    await h.clickTestId(browser, "verify-otp-button").catch(() => {});
+  }
+  await h.waitTestId(browser, "pin-entry-screen", 45000);
+  await h.typeCode(browser, PIN);
+  await h.waitTestId(browser, "app-ready", 30000);
+  return "reauth+pin";
+}
+
+async function main() {
+  h.reap();
+  const devEnv = h.readEnvFile(".env.development");
+  const turso = h.tursoEnv();
+  const deliveryUrl = process.env.POLLIS_DELIVERY_URL;
+  if (!deliveryUrl) {
+    throw new Error("POLLIS_DELIVERY_URL is not set — run e2e/scripts/start-backend.sh first.");
+  }
+
+  const children = [];
+  const stop = (c) => { try { c && c.kill("SIGKILL"); } catch (_) {} };
+  const vite = h.spawnVite(devEnv);
+  children.push(vite);
+
+  const email = `e2e_restart_${Date.now()}@pollis.test`;
+  let code = 1;
+  let client;
+  try {
+    await h.waitViteReady();
+
+    // 1. Fresh signup (wipes + creates the data dir).
+    client = await h.startClient({
+      index: 0, label: "signup",
+      appEnv: appEnvFor(devEnv, turso, deliveryUrl, true),
+    });
+    await signUp(client.browser, email);
+    await shot(client.browser, "restart-1-signed-up.png");
+
+    // Sanity: the data dir has real state (keystore + a local DB file).
+    const files = fs.readdirSync(DATA_DIR);
+    const hasKeystore = files.some((f) => f.includes("keystore"));
+    const hasDb = files.some((f) => f.endsWith(".db"));
+    console.log(`[restart] data dir after signup: ${files.join(", ")}`);
+    if (!hasKeystore || !hasDb) {
+      throw new Error(`data dir missing keystore/db (keystore=${hasKeystore} db=${hasDb})`);
+    }
+
+    // 2. Tear the app down but KEEP the data dir.
+    await client.browser.deleteSession().catch(() => {});
+    stop(client.tauriDriver);
+    h.reap();
+    await h.sleep(3000);
+
+    // 3. Relaunch on the SAME data dir (no wipe).
+    client = await h.startClient({
+      index: 0, label: "relaunch",
+      appEnv: appEnvFor(devEnv, turso, deliveryUrl, false),
+    });
+
+    // 4. Assert persistence + drive back to app-ready.
+    const pathTaken = await resumeToAppReady(client.browser, email);
+    await shot(client.browser, "restart-2-resumed.png");
+    console.log(`[restart] SUCCESS: account persisted across restart (path: ${pathTaken})`);
+    code = 0;
+  } catch (err) {
+    console.error("[restart] FAILED:", err.message);
+    if (client && client.browser) {
+      await shot(client.browser, "restart-FAIL.png").catch(() => {});
+      const src = await client.browser.getPageSource().catch(() => "");
+      fs.writeFileSync(path.join(ARTIFACTS, "restart-FAIL.html"), src);
+      const ids = [...src.matchAll(/data-testid="([^"]+)"/g)].map((m) => m[1]);
+      console.error("[restart] on-screen testids:", [...new Set(ids)].join(", "));
+    }
+  } finally {
+    if (client && client.browser) {
+      await client.browser.deleteSession().catch(() => {});
+    }
+    stop(client && client.tauriDriver);
+    for (const c of children) {
+      stop(c);
+    }
+    h.reap();
+  }
+  process.exit(code);
+}
+
+main().catch((e) => { console.error("[restart] fatal:", e); h.reap(); process.exit(1); });

--- a/e2e/scripts/apply-log-migrations.py
+++ b/e2e/scripts/apply-log-migrations.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Apply the commit-log-DB migrations (`migrations-log/`) to the single libsql
+DB used by the e2e backend fixture.
+
+Why this exists: in production the MLS control-plane tables live on a SEPARATE
+commit-log DB (`LOG_DB_URL`, issue #420). `start-backend.sh` runs the DS in
+single-DB fallback (LOG_DB_* unset), so those tables SHARE the one libsql DB —
+but `db-apply.sh` only applies the main-DB `migrations/` dir. The incremental
+commit-log migrations (`mls_welcome` UNIQUE dedupe index #430, `mls_commit_since`
+#539) are therefore never applied, so the DS's idempotent Welcome upsert fails
+with "ON CONFLICT clause does not match any PRIMARY KEY or UNIQUE constraint" and
+Welcomes never persist — cross-client MLS delivery silently breaks.
+
+These migrations are all `CREATE ... IF NOT EXISTS` (idempotent), so they're
+applied by statement directly over the Hrana pipeline API, bypassing
+`schema_migrations` version tracking (whose versions collide with the main dir).
+"""
+import glob
+import json
+import os
+import sys
+import urllib.request
+
+TURSO_URL = os.environ.get("TURSO_URL", "http://127.0.0.1:8080").replace("libsql://", "https://")
+MIG_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "pollis-core", "src", "db", "migrations-log")
+
+
+def statements(sql: str):
+    # Strip `--` line comments, then split on `;`. The migration files are plain
+    # DDL with no `;` inside string literals, so a naive split is correct here.
+    lines = [ln for ln in sql.splitlines() if not ln.strip().startswith("--")]
+    body = "\n".join(lines)
+    for stmt in body.split(";"):
+        if stmt.strip():
+            yield stmt.strip()
+
+
+def main():
+    reqs = []
+    for path in sorted(glob.glob(os.path.join(MIG_DIR, "*.sql"))):
+        with open(path) as f:
+            for stmt in statements(f.read()):
+                reqs.append({"type": "execute", "stmt": {"sql": stmt}})
+    reqs.append({"type": "close"})
+
+    data = json.dumps({"requests": reqs}).encode()
+    req = urllib.request.Request(
+        f"{TURSO_URL}/v2/pipeline", data=data, headers={"content-type": "application/json"}
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        out = json.load(resp)
+
+    errors = [r for r in out.get("results", []) if r.get("type") == "error"]
+    if errors:
+        print(f"[apply-log-migrations] FAILED: {json.dumps(errors)}", file=sys.stderr)
+        sys.exit(1)
+    print(f"[apply-log-migrations] applied {len(reqs) - 1} statement(s) from migrations-log/", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/e2e/scripts/start-backend.sh
+++ b/e2e/scripts/start-backend.sh
@@ -90,6 +90,16 @@ log "libsql server up"
 log "applying migrations via scripts/db-apply.sh"
 TURSO_URL="$TURSO_URL" TURSO_TOKEN="$TURSO_TOKEN" bash "$ROOT/scripts/db-apply.sh" >&2
 
+# The DS runs in single-DB fallback here (LOG_DB_* unset below), so the MLS
+# control-plane tables share this one libsql DB — but db-apply.sh only applies
+# the main-DB `migrations/` dir. The incremental commit-log migrations
+# (`mls_welcome` UNIQUE dedupe #430, `mls_commit_since` #539) live in
+# `migrations-log/` and must ALSO land here, or the DS's idempotent Welcome
+# upsert fails on a missing ON CONFLICT target and cross-client MLS delivery
+# silently breaks. They are all `CREATE ... IF NOT EXISTS` (idempotent).
+log "applying commit-log migrations (migrations-log/) to the single DB"
+TURSO_URL="$TURSO_URL" python3 "$ROOT/e2e/scripts/apply-log-migrations.py" >&2
+
 # --- 3. real pollis-delivery binary -----------------------------------------
 DS_BIN="$ROOT/target/debug/pollis-delivery"
 if [ ! -x "$DS_BIN" ]; then

--- a/e2e/two-client-call.js
+++ b/e2e/two-client-call.js
@@ -68,10 +68,11 @@ function appEnvFor(devEnv, turso, deliveryUrl, dataDir) {
   fs.rmSync(dataDir, { recursive: true, force: true });
   fs.mkdirSync(dataDir, { recursive: true });
   return {
-    ...process.env, ...devEnv,
+    ...devEnv, ...process.env,
     TURSO_URL: turso.TURSO_URL, TURSO_TOKEN: turso.TURSO_TOKEN,
     POLLIS_DELIVERY_URL: deliveryUrl,
     POLLIS_DATA_DIR: dataDir,
+    LOG_DB_URL: "", LOG_DB_TOKEN: "", LOG_DB_ADMIN_TOKEN: "",
     WEBKIT_DISABLE_COMPOSITING_MODE: "1", GDK_BACKEND: "x11",
   };
 }

--- a/e2e/two-client-camera.js
+++ b/e2e/two-client-camera.js
@@ -87,10 +87,11 @@ function appEnvFor(devEnv, turso, deliveryUrl, dataDir) {
   fs.rmSync(dataDir, { recursive: true, force: true });
   fs.mkdirSync(dataDir, { recursive: true });
   return {
-    ...process.env, ...devEnv,
+    ...devEnv, ...process.env,
     TURSO_URL: turso.TURSO_URL, TURSO_TOKEN: turso.TURSO_TOKEN,
     POLLIS_DELIVERY_URL: deliveryUrl,
     POLLIS_DATA_DIR: dataDir,
+    LOG_DB_URL: "", LOG_DB_TOKEN: "", LOG_DB_ADMIN_TOKEN: "",
     WEBKIT_DISABLE_COMPOSITING_MODE: "1", GDK_BACKEND: "x11",
   };
 }

--- a/e2e/two-client-channel.js
+++ b/e2e/two-client-channel.js
@@ -1,0 +1,344 @@
+#!/usr/bin/env node
+/*
+ * Two-client GROUP + TEXT-CHANNEL convergence E2E (issue #570, extends M2).
+ *
+ * The M2 test (two-client.js) proves 1:1 DM delivery. This proves the other
+ * core conversation surface — a Slack-style GROUP text channel — converges
+ * cross-client: user A creates a group + a text channel, invites B, B accepts
+ * (which synchronously processes the MLS Welcome), A posts a message in the
+ * channel, and B's UI eventually renders it.
+ *
+ * Isolation + backend assumptions are identical to two-client.js: two isolated
+ * app instances (distinct driver ports + POLLIS_DATA_DIR), ONE shared external
+ * backend (start-backend.sh — POLLIS_DELIVERY_URL must be set), ONE Vite server.
+ *
+ * Choreography:
+ *   1. A + B sign up (reused verbatim from two-client.js).
+ *   2. A creates a group (menu-item-groups -> menu-item-create-group -> form).
+ *   3. A invites B by email (group page -> menu-item-invite-member -> form).
+ *   4. A creates a text channel in the group (stays on the channel page).
+ *   5. B accepts the invite (Root -> menu-item-invites -> accept-invite-<id>).
+ *      accept_group_invite polls MLS welcomes synchronously, so B is in the
+ *      group's MLS state before it navigates.
+ *   6. B navigates into the channel (group-option-<id> -> channel-option-<id>,
+ *      matched by visible name so default channels don't collide).
+ *   7. A sends a distinctive random-token message in the channel.
+ *   8. B polls its message list until A's token appears, re-opening the channel
+ *      each round to re-fire the 5s-debounced ingest_channel_envelopes pull.
+ *      Asserted; no fixed sleeps for correctness.
+ *
+ * On failure, dumps per-client A-FAIL.* / B-FAIL.* into e2e/artifacts/.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const h = require("./lib/harness");
+
+const ARTIFACTS = path.join(__dirname, "artifacts");
+const shot = h.makeShot(ARTIFACTS);
+
+const PIN = "1357";
+
+const INVITE_TIMEOUT_MS = 120_000;
+const GROUP_VISIBLE_TIMEOUT_MS = 90_000;
+const MESSAGE_TIMEOUT_MS = 180_000;
+
+function appEnvFor(devEnv, turso, deliveryUrl, dataDir) {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  fs.mkdirSync(dataDir, { recursive: true });
+  return {
+    ...devEnv, ...process.env,
+    TURSO_URL: turso.TURSO_URL, TURSO_TOKEN: turso.TURSO_TOKEN,
+    POLLIS_DELIVERY_URL: deliveryUrl,
+    POLLIS_DATA_DIR: dataDir,
+    LOG_DB_URL: "", LOG_DB_TOKEN: "", LOG_DB_ADMIN_TOKEN: "",
+    WEBKIT_DISABLE_COMPOSITING_MODE: "1", GDK_BACKEND: "x11",
+  };
+}
+
+// Full signup through the real UI — copied verbatim from two-client.js.
+async function signUp(browser, email, tag) {
+  console.log(`[two-client-channel] ${tag}: signing up ${email}`);
+  await h.waitTestId(browser, "auth-screen", 30000);
+  await h.setTestIdValue(browser, "email-input", email);
+  await h.clickTestId(browser, "send-otp-button");
+  await h.waitTestId(browser, "otp-form-container", 20000);
+  await h.typeCode(browser, "000000");
+  await h.waitTestId(browser, "save-secret-key-warning-screen", 45000);
+  await h.clickTestId(browser, "save-secret-key-acknowledge-button");
+  await h.waitTestId(browser, "save-secret-key-screen");
+  const secretKey = (await (await browser.$('[data-testid="secret-key-display"]')).getText()).trim();
+  if (!secretKey) {
+    throw new Error(`${tag}: secret key display was empty`);
+  }
+  await h.clickTestId(browser, "secret-key-saved-button");
+  await h.waitTestId(browser, "save-secret-key-confirm-screen");
+  await h.setTestIdValue(browser, "secret-key-confirm-input", secretKey);
+  await h.clickTestId(browser, "confirm-secret-key-button");
+  await h.waitTestId(browser, "pin-create-screen");
+  await h.typeCode(browser, PIN);
+  await h.typeCode(browser, PIN);
+  await h.waitTestId(browser, "app-ready", 60000);
+  console.log(`[two-client-channel] ${tag}: reached app-ready`);
+}
+
+// Click the first [data-testid^=prefix] whose visible text contains `text`.
+// Used for group-option-<id> / channel-option-<id> whose ids aren't known ahead
+// of time but whose label is the group/channel name.
+async function clickByPrefixText(browser, prefix, text) {
+  const ok = await browser.execute((pfx, needle) => {
+    for (const el of document.querySelectorAll(`[data-testid^="${pfx}"]`)) {
+      if ((el.textContent || "").includes(needle)) { el.click(); return true; }
+    }
+    return false;
+  }, prefix, text);
+  if (!ok) {
+    throw new Error(`clickByPrefixText: no ${prefix}* containing "${text}"`);
+  }
+}
+
+async function prefixTextPresent(browser, prefix, text) {
+  return browser.execute((pfx, needle) => {
+    for (const el of document.querySelectorAll(`[data-testid^="${pfx}"]`)) {
+      if ((el.textContent || "").includes(needle)) { return true; }
+    }
+    return false;
+  }, prefix, text);
+}
+
+// Navigate to Root ("/") via the breadcrumb Home link (the first button in the
+// breadcrumb trail; absent only when already home). Confirmed by the Root menu.
+async function goHome(browser) {
+  const clicked = await browser.execute(() => {
+    const trail = document.querySelector('[data-testid="breadcrumb-trail"]');
+    const btn = trail && trail.querySelector("button");
+    if (btn) { btn.click(); return true; }
+    return false;
+  });
+  if (clicked) {
+    await h.waitTestId(browser, "menu-item-groups", 15000);
+  }
+}
+
+// A: create a group. From app-ready (Root). Lands on the group page, marked by
+// the admin-only menu-item-create-channel.
+async function createGroup(browser, groupName) {
+  await h.clickTestId(browser, "menu-item-groups");
+  await h.clickTestId(browser, "menu-item-create-group");
+  await h.waitTestId(browser, "create-group-page", 20000);
+  await h.setSelectorValue(browser, "#create-group-name", groupName);
+  await h.clickTestId(browser, "create-group-submit-button");
+  await h.waitTestId(browser, "menu-item-create-channel", 30000);
+}
+
+// A: invite B by email from the group page, then return to the group page.
+async function inviteMember(browser, email) {
+  await h.clickTestId(browser, "menu-item-invite-member");
+  await h.waitTestId(browser, "invite-member-page", 20000);
+  await h.setSelectorValue(browser, "#invite-username", email);
+  await h.clickTestId(browser, "send-invite-button");
+  await h.waitTestId(browser, "invite-sent-confirmation", 20000);
+  // Back to the group page (breadcrumb up one level).
+  await h.clickTestId(browser, "breadcrumb-back-button");
+  await h.waitTestId(browser, "menu-item-create-channel", 20000);
+}
+
+// A: create a text channel in the group (default type = text). Lands in the
+// channel, marked by the composer.
+async function createTextChannel(browser, channelName) {
+  await h.clickTestId(browser, "menu-item-create-channel");
+  await h.waitTestId(browser, "create-channel-page", 20000);
+  await h.setSelectorValue(browser, "#create-channel-name", channelName);
+  await h.clickTestId(browser, "create-channel-submit-button");
+  await h.waitTestId(browser, "message-form", 30000);
+}
+
+// B: poll Root -> Invites until the incoming invite surfaces and accept it.
+// accept_group_invite polls MLS welcomes synchronously, so on return B is a
+// member of the group's MLS state.
+async function acceptInvite(browser, timeoutMs) {
+  const end = Date.now() + timeoutMs;
+  let attempt = 0;
+  while (Date.now() < end) {
+    attempt++;
+    await goHome(browser);
+    await h.clickTestId(browser, "menu-item-invites");
+    await h.waitTestId(browser, "invites-page", 15000);
+    if (await h.presentSelector(browser, '[data-testid^="accept-invite-"]')) {
+      await h.clickSelector(browser, '[data-testid^="accept-invite-"]');
+      // The invite row disappears; MLS welcome is polled synchronously.
+      await h.sleep(3000);
+      return;
+    }
+    const remaining = end - Date.now();
+    console.log(`[two-client-channel] B: no invite yet (attempt ${attempt}), waiting…`);
+    await h.sleep(Math.min(remaining > 0 ? remaining : 0, attempt === 1 ? 4000 : 15000));
+  }
+  throw new Error("B: group invite never appeared");
+}
+
+// Navigate into a group's channel by NAME (group-option/channel-option ids are
+// unknown ahead of time; labels are the names). Polls for the group to appear
+// (B's group list refreshes after the invite accept invalidates the query).
+async function openChannel(browser, groupName, channelName, groupTimeoutMs) {
+  const end = Date.now() + groupTimeoutMs;
+  while (Date.now() < end) {
+    await goHome(browser);
+    await h.clickTestId(browser, "menu-item-groups");
+    await h.waitTestId(browser, "menu-item-create-group", 15000);
+    if (await prefixTextPresent(browser, "group-option-", groupName)) {
+      await clickByPrefixText(browser, "group-option-", groupName);
+      // On the group page: wait for the channel row, then click it by name.
+      await h.waitSelector(browser, '[data-testid^="channel-option-"]', 20000, "a channel row");
+      await clickByPrefixText(browser, "channel-option-", channelName);
+      await h.waitTestId(browser, "message-form", 20000);
+      return;
+    }
+    console.log(`[two-client-channel] B: group "${groupName}" not visible yet, waiting…`);
+    await h.sleep(6000);
+  }
+  throw new Error(`B: group "${groupName}" never appeared in the group list`);
+}
+
+async function messageVisible(browser, token) {
+  return browser.execute((tok) => {
+    const nodes = document.querySelectorAll('[data-testid="message-content"]');
+    for (const n of nodes) {
+      if ((n.textContent || "").includes(tok)) { return true; }
+    }
+    return false;
+  }, token);
+}
+
+// B: poll the channel until A's token appears, re-opening the channel each round
+// to re-fire the 5s-debounced ingest_channel_envelopes pull (same technique as
+// two-client.js's DM waitForMessage, but for a channel).
+async function waitForChannelMessage(browser, groupName, channelName, token, timeoutMs) {
+  const end = Date.now() + timeoutMs;
+  while (Date.now() < end) {
+    if (await messageVisible(browser, token)) {
+      return;
+    }
+    // Re-open the channel to remount MainContent and re-ingest past the debounce.
+    await openChannel(browser, groupName, channelName, 30000).catch(() => {});
+    await h.sleep(6000);
+  }
+  throw new Error(`B: channel message "${token}" never converged`);
+}
+
+async function main() {
+  h.reap();
+  const devEnv = h.readEnvFile(".env.development");
+  const turso = h.tursoEnv();
+
+  const deliveryUrl = process.env.POLLIS_DELIVERY_URL;
+  if (!deliveryUrl) {
+    throw new Error(
+      "POLLIS_DELIVERY_URL is not set — run e2e/scripts/start-backend.sh first. See e2e/README.md."
+    );
+  }
+
+  const children = [];
+  const clients = [];
+  const stop = (c) => { try { c && c.kill("SIGKILL"); } catch (_) {} };
+
+  const vite = h.spawnVite(devEnv);
+  children.push(vite);
+
+  const stamp = Date.now();
+  const emailA = `e2e_ch_a_${stamp}@pollis.test`;
+  const emailB = `e2e_ch_b_${stamp}@pollis.test`;
+  const groupName = `grp${stamp}`;
+  const channelName = `chan${stamp}`;
+  const token = `chanconv-${stamp}`;
+
+  let code = 1;
+  let A;
+  let B;
+  try {
+    await h.waitViteReady();
+    console.log(`[two-client-channel] using external delivery service at ${deliveryUrl}`);
+
+    A = await h.startClient({
+      index: 0, label: "A",
+      appEnv: appEnvFor(devEnv, turso, deliveryUrl, path.join(__dirname, ".tmp-data-ch-a")),
+    });
+    clients.push(A);
+    B = await h.startClient({
+      index: 1, label: "B",
+      appEnv: appEnvFor(devEnv, turso, deliveryUrl, path.join(__dirname, ".tmp-data-ch-b")),
+    });
+    clients.push(B);
+
+    await signUp(A.browser, emailA, "A");
+    await shot(A.browser, "two-client-channel-A-ready.png");
+    await signUp(B.browser, emailB, "B");
+    await shot(B.browser, "two-client-channel-B-ready.png");
+
+    // A: create group -> invite B -> create text channel (stays in the channel).
+    console.log(`[two-client-channel] A: creating group "${groupName}"`);
+    await createGroup(A.browser, groupName);
+    console.log(`[two-client-channel] A: inviting ${emailB}`);
+    await inviteMember(A.browser, emailB);
+    console.log(`[two-client-channel] A: creating text channel "${channelName}"`);
+    await createTextChannel(A.browser, channelName);
+    await shot(A.browser, "two-client-channel-A-channel.png");
+
+    // B: accept the invite (MLS welcome processed synchronously).
+    console.log("[two-client-channel] B: waiting for the invite…");
+    await acceptInvite(B.browser, INVITE_TIMEOUT_MS);
+    console.log("[two-client-channel] B: invite accepted");
+
+    // B: navigate into the channel.
+    console.log(`[two-client-channel] B: opening channel "${channelName}"`);
+    await openChannel(B.browser, groupName, channelName, GROUP_VISIBLE_TIMEOUT_MS);
+    await shot(B.browser, "two-client-channel-B-in-channel.png");
+
+    // A: post the distinctive message; confirm it rendered locally first.
+    console.log(`[two-client-channel] A: sending channel message (token ${token})`);
+    await h.setTestIdValue(A.browser, "message-input", `hello channel ${token}`);
+    await h.clickTestId(A.browser, "message-send-button");
+    await waitForChannelMessage(A.browser, groupName, channelName, token, 30000);
+    await shot(A.browser, "two-client-channel-A-sent.png");
+
+    // B: poll until A's message converges into B's channel view.
+    console.log("[two-client-channel] B: waiting for convergence…");
+    await waitForChannelMessage(B.browser, groupName, channelName, token, MESSAGE_TIMEOUT_MS);
+    await shot(B.browser, "two-client-channel-B-received.png");
+    console.log(`[two-client-channel] SUCCESS: B received A's channel message ("${token}")`);
+    code = 0;
+  } catch (err) {
+    console.error("[two-client-channel] FAILED:", err.message);
+    if (A && A.browser) {
+      await dumpClient(A.browser, "A");
+    }
+    if (B && B.browser) {
+      await dumpClient(B.browser, "B");
+    }
+  } finally {
+    for (const c of clients) {
+      if (c && c.browser) {
+        await c.browser.deleteSession().catch(() => {});
+      }
+    }
+    for (const c of clients) {
+      stop(c && c.tauriDriver);
+    }
+    for (const c of children) {
+      stop(c);
+    }
+    h.reap();
+  }
+  process.exit(code);
+}
+
+async function dumpClient(browser, tag) {
+  await shot(browser, `${tag}-FAIL.png`).catch(() => {});
+  const src = await browser.getPageSource().catch(() => "");
+  fs.mkdirSync(ARTIFACTS, { recursive: true });
+  fs.writeFileSync(path.join(ARTIFACTS, `${tag}-FAIL.html`), src);
+  const ids = [...src.matchAll(/data-testid="([^"]+)"/g)].map((m) => m[1]);
+  console.error(`[two-client-channel] ${tag} on-screen testids:`, [...new Set(ids)].join(", "));
+}
+
+main().catch((e) => { console.error("[two-client-channel] fatal:", e); h.reap(); process.exit(1); });

--- a/e2e/two-client-dm-reply.js
+++ b/e2e/two-client-dm-reply.js
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+/*
+ * Two-client DM BIDIRECTIONAL E2E (issue #570, extends M2).
+ *
+ * two-client.js proves A -> B DM delivery. This adds the reverse leg: after the
+ * DM is established and A's message converges into B, B REPLIES and A's UI
+ * eventually renders B's message. Both directions of a 1:1 DM must work.
+ *
+ * Same isolation + backend assumptions as two-client.js (two isolated instances,
+ * one shared external backend from start-backend.sh, one Vite server).
+ *
+ * Choreography:
+ *   1. A + B sign up.
+ *   2. A DMs B by email; B accepts the request.
+ *   3. A sends msg-A; both A (local) and B (converged) render it.
+ *   4. B sends msg-B (the reply); both B (local) and A (converged) render it.
+ *
+ * On failure, dumps per-client A-FAIL.* / B-FAIL.* into e2e/artifacts/.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const h = require("./lib/harness");
+
+const ARTIFACTS = path.join(__dirname, "artifacts");
+const shot = h.makeShot(ARTIFACTS);
+
+const PIN = "1357";
+const REQUEST_TIMEOUT_MS = 120_000;
+const MESSAGE_TIMEOUT_MS = 180_000;
+
+function appEnvFor(devEnv, turso, deliveryUrl, dataDir) {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  fs.mkdirSync(dataDir, { recursive: true });
+  return {
+    ...devEnv, ...process.env,
+    TURSO_URL: turso.TURSO_URL, TURSO_TOKEN: turso.TURSO_TOKEN,
+    POLLIS_DELIVERY_URL: deliveryUrl,
+    POLLIS_DATA_DIR: dataDir,
+    LOG_DB_URL: "", LOG_DB_TOKEN: "", LOG_DB_ADMIN_TOKEN: "",
+    WEBKIT_DISABLE_COMPOSITING_MODE: "1", GDK_BACKEND: "x11",
+  };
+}
+
+async function signUp(browser, email, tag) {
+  console.log(`[dm-reply] ${tag}: signing up ${email}`);
+  await h.waitTestId(browser, "auth-screen", 30000);
+  await h.setTestIdValue(browser, "email-input", email);
+  await h.clickTestId(browser, "send-otp-button");
+  await h.waitTestId(browser, "otp-form-container", 20000);
+  await h.typeCode(browser, "000000");
+  await h.waitTestId(browser, "save-secret-key-warning-screen", 45000);
+  await h.clickTestId(browser, "save-secret-key-acknowledge-button");
+  await h.waitTestId(browser, "save-secret-key-screen");
+  const secretKey = (await (await browser.$('[data-testid="secret-key-display"]')).getText()).trim();
+  if (!secretKey) {
+    throw new Error(`${tag}: secret key display was empty`);
+  }
+  await h.clickTestId(browser, "secret-key-saved-button");
+  await h.waitTestId(browser, "save-secret-key-confirm-screen");
+  await h.setTestIdValue(browser, "secret-key-confirm-input", secretKey);
+  await h.clickTestId(browser, "confirm-secret-key-button");
+  await h.waitTestId(browser, "pin-create-screen");
+  await h.typeCode(browser, PIN);
+  await h.typeCode(browser, PIN);
+  await h.waitTestId(browser, "app-ready", 60000);
+  console.log(`[dm-reply] ${tag}: reached app-ready`);
+}
+
+async function startDmTo(browser, targetEmail) {
+  await h.clickTestId(browser, "sidebar-row-dms");
+  await h.clickTestId(browser, "menu-item-new-dm");
+  await h.waitTestId(browser, "start-dm-page", 20000);
+  await h.setSelectorValue(browser, "#dm-identifier", targetEmail);
+  await h.clickTestId(browser, "start-dm-submit-button");
+  await h.waitTestId(browser, "message-form", 30000);
+}
+
+async function acceptIncomingDm(browser, timeoutMs) {
+  const end = Date.now() + timeoutMs;
+  let attempt = 0;
+  while (Date.now() < end) {
+    attempt++;
+    await h.clickTestId(browser, "sidebar-row-account").catch(() => {});
+    await h.sleep(500);
+    await h.clickTestId(browser, "sidebar-row-dms");
+    await h.sleep(1500);
+    if (await h.presentSelector(browser, '[data-testid="menu-item-dm-requests"]')) {
+      await h.clickTestId(browser, "menu-item-dm-requests");
+      await h.waitTestId(browser, "requests-page", 15000);
+      await h.waitSelector(browser, '[data-testid^="accept-request-"]', 15000, "a DM request accept button");
+      await h.clickSelector(browser, '[data-testid^="accept-request-"]');
+      await h.waitTestId(browser, "message-form", 30000);
+      return;
+    }
+    const remaining = end - Date.now();
+    console.log(`[dm-reply] B: no DM request yet (attempt ${attempt}), waiting…`);
+    await h.sleep(Math.min(remaining > 0 ? remaining : 0, attempt === 1 ? 4000 : 32000));
+  }
+  throw new Error("B: DM request never appeared");
+}
+
+async function messageVisible(browser, token) {
+  return browser.execute((tok) => {
+    const nodes = document.querySelectorAll('[data-testid="message-content"]');
+    for (const n of nodes) {
+      if ((n.textContent || "").includes(tok)) { return true; }
+    }
+    return false;
+  }, token);
+}
+
+// Open the (only) DM conversation on this client — Home -> DMs -> first option.
+async function openDm(browser) {
+  await h.clickTestId(browser, "sidebar-row-dms").catch(() => {});
+  await h.sleep(1000);
+  if (await h.presentSelector(browser, '[data-testid^="dm-option-"]')) {
+    await h.clickSelector(browser, '[data-testid^="dm-option-"]');
+    await h.waitTestId(browser, "message-form", 15000).catch(() => {});
+  }
+}
+
+// Poll until `token` renders, re-opening the DM each round to re-fire the
+// 5s-debounced ingest_dm_envelopes pull.
+async function waitForMessage(browser, token, timeoutMs) {
+  const end = Date.now() + timeoutMs;
+  while (Date.now() < end) {
+    if (await messageVisible(browser, token)) {
+      return;
+    }
+    await openDm(browser);
+    await h.sleep(6000);
+  }
+  throw new Error(`message "${token}" never converged`);
+}
+
+async function sendMessage(browser, text) {
+  await h.setTestIdValue(browser, "message-input", text);
+  await h.clickTestId(browser, "message-send-button");
+}
+
+async function main() {
+  h.reap();
+  const devEnv = h.readEnvFile(".env.development");
+  const turso = h.tursoEnv();
+  const deliveryUrl = process.env.POLLIS_DELIVERY_URL;
+  if (!deliveryUrl) {
+    throw new Error("POLLIS_DELIVERY_URL is not set — run e2e/scripts/start-backend.sh first.");
+  }
+
+  const children = [];
+  const clients = [];
+  const stop = (c) => { try { c && c.kill("SIGKILL"); } catch (_) {} };
+
+  const vite = h.spawnVite(devEnv);
+  children.push(vite);
+
+  const stamp = Date.now();
+  const emailA = `e2e_dmr_a_${stamp}@pollis.test`;
+  const emailB = `e2e_dmr_b_${stamp}@pollis.test`;
+  const tokenA = `fromA-${stamp}`;
+  const tokenB = `fromB-${stamp}`;
+
+  let code = 1;
+  let A;
+  let B;
+  try {
+    await h.waitViteReady();
+    console.log(`[dm-reply] using external delivery service at ${deliveryUrl}`);
+
+    A = await h.startClient({
+      index: 0, label: "A",
+      appEnv: appEnvFor(devEnv, turso, deliveryUrl, path.join(__dirname, ".tmp-data-dmr-a")),
+    });
+    clients.push(A);
+    B = await h.startClient({
+      index: 1, label: "B",
+      appEnv: appEnvFor(devEnv, turso, deliveryUrl, path.join(__dirname, ".tmp-data-dmr-b")),
+    });
+    clients.push(B);
+
+    await signUp(A.browser, emailA, "A");
+    await signUp(B.browser, emailB, "B");
+
+    console.log(`[dm-reply] A: starting DM to ${emailB}`);
+    await startDmTo(A.browser, emailB);
+    console.log("[dm-reply] B: accepting the DM request…");
+    await acceptIncomingDm(B.browser, REQUEST_TIMEOUT_MS);
+
+    // Forward leg: A -> B.
+    console.log(`[dm-reply] A: sending msg-A (${tokenA})`);
+    await sendMessage(A.browser, `hi from A ${tokenA}`);
+    await waitForMessage(A.browser, tokenA, 30000);
+    await waitForMessage(B.browser, tokenA, MESSAGE_TIMEOUT_MS);
+    console.log("[dm-reply] forward leg converged (A -> B)");
+    await shot(B.browser, "dm-reply-B-got-A.png");
+
+    // Reverse leg: B -> A (the reply — the new coverage).
+    console.log(`[dm-reply] B: replying with msg-B (${tokenB})`);
+    await openDm(B.browser);
+    await sendMessage(B.browser, `reply from B ${tokenB}`);
+    await waitForMessage(B.browser, tokenB, 30000);
+    await waitForMessage(A.browser, tokenB, MESSAGE_TIMEOUT_MS);
+    console.log(`[dm-reply] SUCCESS: reverse leg converged (B -> A, "${tokenB}")`);
+    await shot(A.browser, "dm-reply-A-got-B.png");
+    code = 0;
+  } catch (err) {
+    console.error("[dm-reply] FAILED:", err.message);
+    if (A && A.browser) {
+      await dumpClient(A.browser, "A");
+    }
+    if (B && B.browser) {
+      await dumpClient(B.browser, "B");
+    }
+  } finally {
+    for (const c of clients) {
+      if (c && c.browser) {
+        await c.browser.deleteSession().catch(() => {});
+      }
+    }
+    for (const c of clients) {
+      stop(c && c.tauriDriver);
+    }
+    for (const c of children) {
+      stop(c);
+    }
+    h.reap();
+  }
+  process.exit(code);
+}
+
+async function dumpClient(browser, tag) {
+  await shot(browser, `${tag}-FAIL.png`).catch(() => {});
+  const src = await browser.getPageSource().catch(() => "");
+  fs.mkdirSync(ARTIFACTS, { recursive: true });
+  fs.writeFileSync(path.join(ARTIFACTS, `${tag}-FAIL.html`), src);
+  const ids = [...src.matchAll(/data-testid="([^"]+)"/g)].map((m) => m[1]);
+  console.error(`[dm-reply] ${tag} on-screen testids:`, [...new Set(ids)].join(", "));
+}
+
+main().catch((e) => { console.error("[dm-reply] fatal:", e); h.reap(); process.exit(1); });

--- a/e2e/two-client-screenshare.js
+++ b/e2e/two-client-screenshare.js
@@ -123,10 +123,11 @@ function appEnvFor(devEnv, turso, deliveryUrl, dataDir) {
   fs.rmSync(dataDir, { recursive: true, force: true });
   fs.mkdirSync(dataDir, { recursive: true });
   return {
-    ...process.env, ...devEnv,
+    ...devEnv, ...process.env,
     TURSO_URL: turso.TURSO_URL, TURSO_TOKEN: turso.TURSO_TOKEN,
     POLLIS_DELIVERY_URL: deliveryUrl,
     POLLIS_DATA_DIR: dataDir,
+    LOG_DB_URL: "", LOG_DB_TOKEN: "", LOG_DB_ADMIN_TOKEN: "",
     WEBKIT_DISABLE_COMPOSITING_MODE: "1", GDK_BACKEND: "x11",
     XDG_SESSION_TYPE: "x11",
   };

--- a/e2e/two-client-voice-channel.js
+++ b/e2e/two-client-voice-channel.js
@@ -1,0 +1,345 @@
+#!/usr/bin/env node
+/*
+ * Two-client VOICE CHANNEL join/leave E2E (issue #570, extends M3).
+ *
+ * The M3a call test covers 1:1 DM calls. This covers the other real-time voice
+ * surface — a Slack/Discord-style persistent GROUP voice channel: A + B are both
+ * members of a group, both JOIN the same voice channel, each sees the other as a
+ * participant, then A LEAVES and B sees the participant count drop back to one.
+ *
+ * Needs the same media stack as the call test (LiveKit + audio) PLUS group
+ * membership (join_voice_channel derives an MLS-based E2EE voice key and fails
+ * closed if the joiner isn't in the group's MLS state).
+ *
+ * Choreography:
+ *   1. A + B sign up.
+ *   2. A creates a group, invites B, B accepts (MLS welcome processed).
+ *   3. A creates a VOICE channel (toggles the create-channel type switch).
+ *   4. A opens the voice channel and clicks Join (voice-join-cta); waits until
+ *      joined (voice-channel-view present).
+ *   5. B opens the same voice channel and joins.
+ *   6. ASSERT: on the joined side, the live participant roster shows 2 distinct
+ *      users (both A and B). LiveKit presence is live, no polling of remote DB.
+ *   7. A leaves (voice-tray-leave); B's participant count drops back to 1.
+ *
+ * On failure, dumps per-client A-FAIL.* / B-FAIL.* into e2e/artifacts/.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const h = require("./lib/harness");
+
+const ARTIFACTS = path.join(__dirname, "artifacts");
+const shot = h.makeShot(ARTIFACTS);
+
+const PIN = "1357";
+const INVITE_TIMEOUT_MS = 120_000;
+const GROUP_VISIBLE_TIMEOUT_MS = 90_000;
+const JOIN_TIMEOUT_MS = 60_000;
+const CONVERGE_TIMEOUT_MS = 120_000;
+
+function appEnvFor(devEnv, turso, deliveryUrl, dataDir) {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  fs.mkdirSync(dataDir, { recursive: true });
+  return {
+    ...devEnv, ...process.env,
+    TURSO_URL: turso.TURSO_URL, TURSO_TOKEN: turso.TURSO_TOKEN,
+    POLLIS_DELIVERY_URL: deliveryUrl,
+    POLLIS_DATA_DIR: dataDir,
+    LOG_DB_URL: "", LOG_DB_TOKEN: "", LOG_DB_ADMIN_TOKEN: "",
+    WEBKIT_DISABLE_COMPOSITING_MODE: "1", GDK_BACKEND: "x11",
+  };
+}
+
+async function signUp(browser, email, tag) {
+  console.log(`[voice-channel] ${tag}: signing up ${email}`);
+  await h.waitTestId(browser, "auth-screen", 30000);
+  await h.setTestIdValue(browser, "email-input", email);
+  await h.clickTestId(browser, "send-otp-button");
+  await h.waitTestId(browser, "otp-form-container", 20000);
+  await h.typeCode(browser, "000000");
+  await h.waitTestId(browser, "save-secret-key-warning-screen", 45000);
+  await h.clickTestId(browser, "save-secret-key-acknowledge-button");
+  await h.waitTestId(browser, "save-secret-key-screen");
+  const secretKey = (await (await browser.$('[data-testid="secret-key-display"]')).getText()).trim();
+  if (!secretKey) {
+    throw new Error(`${tag}: secret key display was empty`);
+  }
+  await h.clickTestId(browser, "secret-key-saved-button");
+  await h.waitTestId(browser, "save-secret-key-confirm-screen");
+  await h.setTestIdValue(browser, "secret-key-confirm-input", secretKey);
+  await h.clickTestId(browser, "confirm-secret-key-button");
+  await h.waitTestId(browser, "pin-create-screen");
+  await h.typeCode(browser, PIN);
+  await h.typeCode(browser, PIN);
+  await h.waitTestId(browser, "app-ready", 60000);
+  console.log(`[voice-channel] ${tag}: reached app-ready`);
+}
+
+async function clickByPrefixText(browser, prefix, text) {
+  const ok = await browser.execute((pfx, needle) => {
+    for (const el of document.querySelectorAll(`[data-testid^="${pfx}"]`)) {
+      if ((el.textContent || "").includes(needle)) { el.click(); return true; }
+    }
+    return false;
+  }, prefix, text);
+  if (!ok) {
+    throw new Error(`clickByPrefixText: no ${prefix}* containing "${text}"`);
+  }
+}
+
+async function prefixTextPresent(browser, prefix, text) {
+  return browser.execute((pfx, needle) => {
+    for (const el of document.querySelectorAll(`[data-testid^="${pfx}"]`)) {
+      if ((el.textContent || "").includes(needle)) { return true; }
+    }
+    return false;
+  }, prefix, text);
+}
+
+async function goHome(browser) {
+  const clicked = await browser.execute(() => {
+    const trail = document.querySelector('[data-testid="breadcrumb-trail"]');
+    const btn = trail && trail.querySelector("button");
+    if (btn) { btn.click(); return true; }
+    return false;
+  });
+  if (clicked) {
+    await h.waitTestId(browser, "menu-item-groups", 15000);
+  }
+}
+
+async function createGroup(browser, groupName) {
+  await h.clickTestId(browser, "menu-item-groups");
+  await h.clickTestId(browser, "menu-item-create-group");
+  await h.waitTestId(browser, "create-group-page", 20000);
+  await h.setSelectorValue(browser, "#create-group-name", groupName);
+  await h.clickTestId(browser, "create-group-submit-button");
+  await h.waitTestId(browser, "menu-item-create-channel", 30000);
+}
+
+async function inviteMember(browser, email) {
+  await h.clickTestId(browser, "menu-item-invite-member");
+  await h.waitTestId(browser, "invite-member-page", 20000);
+  await h.setSelectorValue(browser, "#invite-username", email);
+  await h.clickTestId(browser, "send-invite-button");
+  await h.waitTestId(browser, "invite-sent-confirmation", 20000);
+  await h.clickTestId(browser, "breadcrumb-back-button");
+  await h.waitTestId(browser, "menu-item-create-channel", 20000);
+}
+
+// Create a VOICE channel: toggle the type switch (#create-channel-type, default
+// "text") to voice before submitting. A voice channel returns to the group page.
+async function createVoiceChannel(browser, channelName) {
+  await h.clickTestId(browser, "menu-item-create-channel");
+  await h.waitTestId(browser, "create-channel-page", 20000);
+  await h.setSelectorValue(browser, "#create-channel-name", channelName);
+  await h.clickSelector(browser, "#create-channel-type");
+  await h.clickTestId(browser, "create-channel-submit-button");
+  // Returns to the group page; the new voice channel-option should appear.
+  await h.waitTestId(browser, "menu-item-create-channel", 30000);
+}
+
+async function acceptInvite(browser, timeoutMs) {
+  const end = Date.now() + timeoutMs;
+  let attempt = 0;
+  while (Date.now() < end) {
+    attempt++;
+    await goHome(browser);
+    await h.clickTestId(browser, "menu-item-invites");
+    await h.waitTestId(browser, "invites-page", 15000);
+    if (await h.presentSelector(browser, '[data-testid^="accept-invite-"]')) {
+      await h.clickSelector(browser, '[data-testid^="accept-invite-"]');
+      await h.sleep(3000);
+      return;
+    }
+    const remaining = end - Date.now();
+    console.log(`[voice-channel] B: no invite yet (attempt ${attempt}), waiting…`);
+    await h.sleep(Math.min(remaining > 0 ? remaining : 0, attempt === 1 ? 4000 : 15000));
+  }
+  throw new Error("B: group invite never appeared");
+}
+
+// Navigate into the group and click the voice channel-option (by name), landing
+// on the not-joined VoiceStage (voice-channel-observers + voice-join-cta).
+async function openVoiceChannel(browser, groupName, channelName, groupTimeoutMs) {
+  const end = Date.now() + groupTimeoutMs;
+  while (Date.now() < end) {
+    await goHome(browser);
+    await h.clickTestId(browser, "menu-item-groups");
+    await h.waitTestId(browser, "menu-item-create-group", 15000);
+    if (await prefixTextPresent(browser, "group-option-", groupName)) {
+      await clickByPrefixText(browser, "group-option-", groupName);
+      await h.waitSelector(browser, '[data-testid^="channel-option-"]', 20000, "a channel row");
+      await clickByPrefixText(browser, "channel-option-", channelName);
+      await h.waitTestId(browser, "voice-join-cta", 20000);
+      return;
+    }
+    console.log(`[voice-channel] group "${groupName}" not visible yet, waiting…`);
+    await h.sleep(6000);
+  }
+  throw new Error(`group "${groupName}" never appeared`);
+}
+
+// Click Join and wait until joined (the joined spotlight/grid mounts).
+async function joinVoice(browser, tag) {
+  await h.clickTestId(browser, "voice-join-cta");
+  await h.waitTestId(browser, "voice-channel-view", JOIN_TIMEOUT_MS);
+  console.log(`[voice-channel] ${tag}: joined the voice channel`);
+}
+
+// Distinct participant user IDs from the live roster. Root tiles carry class
+// vs-tile and testid voice-tile-<identity> (identity = voice-{user}[:device]);
+// mirrors userIdFromVoiceIdentity. Constrain to .vs-tile so the many
+// voice-tile-<sub>-* elements don't over-match.
+async function participantUserIds(browser) {
+  return browser.execute(() => {
+    const ids = new Set();
+    for (const el of document.querySelectorAll('.vs-tile[data-testid^="voice-tile-"]')) {
+      let id = (el.getAttribute("data-testid") || "").slice("voice-tile-".length);
+      if (id.startsWith("voice-")) { id = id.slice("voice-".length); }
+      const c = id.indexOf(":");
+      ids.add(c === -1 ? id : id.slice(0, c));
+    }
+    return Array.from(ids);
+  });
+}
+
+async function waitForParticipantCount(browser, tag, n, timeoutMs) {
+  const end = Date.now() + timeoutMs;
+  let last = -1;
+  while (Date.now() < end) {
+    const ids = await participantUserIds(browser).catch(() => []);
+    if (ids.length !== last) {
+      console.log(`[voice-channel] ${tag}: sees ${ids.length} participant(s)`);
+      last = ids.length;
+    }
+    if (ids.length === n) {
+      return;
+    }
+    await h.sleep(2000);
+  }
+  throw new Error(`${tag}: participant count never reached ${n} (last ${last})`);
+}
+
+async function main() {
+  h.reap();
+  const devEnv = h.readEnvFile(".env.development");
+  const turso = h.tursoEnv();
+  const deliveryUrl = process.env.POLLIS_DELIVERY_URL;
+  if (!deliveryUrl) {
+    throw new Error("POLLIS_DELIVERY_URL is not set — run e2e/scripts/start-backend.sh first.");
+  }
+  if (!process.env.LIVEKIT_URL) {
+    throw new Error("LIVEKIT_URL is not set — run e2e/scripts/start-livekit.sh first.");
+  }
+
+  const children = [];
+  const clients = [];
+  const stop = (c) => { try { c && c.kill("SIGKILL"); } catch (_) {} };
+
+  const vite = h.spawnVite(devEnv);
+  children.push(vite);
+
+  const stamp = Date.now();
+  const emailA = `e2e_vc_a_${stamp}@pollis.test`;
+  const emailB = `e2e_vc_b_${stamp}@pollis.test`;
+  const groupName = `vcgrp${stamp}`;
+  const channelName = `vcchan${stamp}`;
+
+  let code = 1;
+  let A;
+  let B;
+  try {
+    await h.waitViteReady();
+    console.log(`[voice-channel] delivery ${deliveryUrl}, livekit ${process.env.LIVEKIT_URL}`);
+
+    A = await h.startClient({
+      index: 0, label: "A",
+      appEnv: appEnvFor(devEnv, turso, deliveryUrl, path.join(__dirname, ".tmp-data-vc-a")),
+    });
+    clients.push(A);
+    B = await h.startClient({
+      index: 1, label: "B",
+      appEnv: appEnvFor(devEnv, turso, deliveryUrl, path.join(__dirname, ".tmp-data-vc-b")),
+    });
+    clients.push(B);
+
+    await signUp(A.browser, emailA, "A");
+    await signUp(B.browser, emailB, "B");
+
+    // A: group + invite + voice channel.
+    console.log(`[voice-channel] A: creating group "${groupName}"`);
+    await createGroup(A.browser, groupName);
+    await inviteMember(A.browser, emailB);
+    console.log(`[voice-channel] A: creating voice channel "${channelName}"`);
+    await createVoiceChannel(A.browser, channelName);
+
+    // B: accept invite.
+    console.log("[voice-channel] B: accepting invite…");
+    await acceptInvite(B.browser, INVITE_TIMEOUT_MS);
+
+    // A joins the voice channel.
+    console.log("[voice-channel] A: opening + joining the voice channel");
+    await openVoiceChannel(A.browser, groupName, channelName, GROUP_VISIBLE_TIMEOUT_MS);
+    await joinVoice(A.browser, "A");
+    await shot(A.browser, "voice-channel-A-joined.png");
+
+    // B joins the same voice channel.
+    console.log("[voice-channel] B: opening + joining the voice channel");
+    await openVoiceChannel(B.browser, groupName, channelName, GROUP_VISIBLE_TIMEOUT_MS);
+    await joinVoice(B.browser, "B");
+    await shot(B.browser, "voice-channel-B-joined.png");
+
+    // ASSERT: both see 2 participants.
+    console.log("[voice-channel] waiting for both to see 2 participants…");
+    await waitForParticipantCount(A.browser, "A", 2, CONVERGE_TIMEOUT_MS);
+    await waitForParticipantCount(B.browser, "B", 2, CONVERGE_TIMEOUT_MS);
+    await shot(A.browser, "voice-channel-A-two.png");
+    await shot(B.browser, "voice-channel-B-two.png");
+    console.log("[voice-channel] both clients see 2 participants");
+
+    // A leaves; B should drop back to 1.
+    console.log("[voice-channel] A: leaving the voice channel");
+    await h.clickTestId(A.browser, "voice-tray-leave");
+    await h.waitTestId(A.browser, "voice-join-cta", 30000);
+    console.log("[voice-channel] A: left (join CTA reappeared)");
+    await waitForParticipantCount(B.browser, "B", 1, CONVERGE_TIMEOUT_MS);
+    await shot(B.browser, "voice-channel-B-one.png");
+    console.log("[voice-channel] SUCCESS: B saw A leave (back to 1 participant)");
+    code = 0;
+  } catch (err) {
+    console.error("[voice-channel] FAILED:", err.message);
+    if (A && A.browser) {
+      await dumpClient(A.browser, "A");
+    }
+    if (B && B.browser) {
+      await dumpClient(B.browser, "B");
+    }
+  } finally {
+    for (const c of clients) {
+      if (c && c.browser) {
+        await c.browser.deleteSession().catch(() => {});
+      }
+    }
+    for (const c of clients) {
+      stop(c && c.tauriDriver);
+    }
+    for (const c of children) {
+      stop(c);
+    }
+    h.reap();
+  }
+  process.exit(code);
+}
+
+async function dumpClient(browser, tag) {
+  await shot(browser, `${tag}-FAIL.png`).catch(() => {});
+  const src = await browser.getPageSource().catch(() => "");
+  fs.mkdirSync(ARTIFACTS, { recursive: true });
+  fs.writeFileSync(path.join(ARTIFACTS, `${tag}-FAIL.html`), src);
+  const ids = [...src.matchAll(/data-testid="([^"]+)"/g)].map((m) => m[1]);
+  console.error(`[voice-channel] ${tag} on-screen testids:`, [...new Set(ids)].join(", "));
+}
+
+main().catch((e) => { console.error("[voice-channel] fatal:", e); h.reap(); process.exit(1); });

--- a/e2e/two-client.js
+++ b/e2e/two-client.js
@@ -54,10 +54,11 @@ function appEnvFor(devEnv, turso, deliveryUrl, dataDir) {
   fs.rmSync(dataDir, { recursive: true, force: true });
   fs.mkdirSync(dataDir, { recursive: true });
   return {
-    ...process.env, ...devEnv,
+    ...devEnv, ...process.env,
     TURSO_URL: turso.TURSO_URL, TURSO_TOKEN: turso.TURSO_TOKEN,
     POLLIS_DELIVERY_URL: deliveryUrl,
     POLLIS_DATA_DIR: dataDir,
+    LOG_DB_URL: "", LOG_DB_TOKEN: "", LOG_DB_ADMIN_TOKEN: "",
     WEBKIT_DISABLE_COMPOSITING_MODE: "1", GDK_BACKEND: "x11",
   };
 }


### PR DESCRIPTION
Expands the two-client e2e suite and fixes three fixture leaks that prevented the existing suite from ever passing on a local dev box.

## Fixture fixes
- **Prod URL leak** — `.env.development` values (LiveKit, LOG_DB) were leaking into the app under test; the app talked to prod instead of the local fixtures. Fixed the env merge order and cleared the LOG_DB vars.
- **Missing commit-log migrations** — the single-DB backend fixture never had `migrations-log/` applied, so MLS Welcome/commit-since tables were missing. Added `apply-log-migrations.py`, wired into `start-backend.sh`.

## New tests
- `two-client-channel` — group text-channel convergence
- `two-client-dm-reply` — bidirectional DM (A→B and B→A)
- `two-client-voice-channel` — voice channel join/leave (2 participants → A leaves → B sees 1)
- `restart-persistence` — single-client: account survives a full app restart on the same data dir

## Validated on this box
All six tests pass locally. Live calling works; voice-channel join/leave works as intended.

Docs: `e2e/SCENARIOS.md` (prioritized 1/2-user happy-path inventory), `e2e/README.md` (new tests + gotchas).
