### PR TITLE
ci(e2e): wire new two-client tests into dispatch workflows (#570)

### DIFF
--- a/.github/workflows/e2e-restart-persistence.yml
+++ b/.github/workflows/e2e-restart-persistence.yml
@@ -1,0 +1,78 @@
+# On-demand SINGLE-client RESTART PERSISTENCE E2E (issue #570, M2): one real
+# Tauri app instance signs up, is torn down (keeping its POLLIS_DATA_DIR), then
+# relaunched on the SAME data dir — proving the account is still recognised (PIN
+# unlock / auto-resume / known-account re-auth) rather than falling back to a
+# blank first-run signup.
+#
+# Backend-only (the DS is needed for the OTP verify on the re-auth path) — same
+# fixtures + composite action as e2e-two-client.yml, one app instance.
+# Manual trigger only (workflow_dispatch).
+name: E2E restart persistence (single client)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  restart-persistence:
+    # ubuntu-24.04: src-tauri/build.rs compiles pollis-capture-linux, whose
+    # libspa 0.9 bindgen needs PipeWire >= 1.0 headers (24.04 ships them).
+    runs-on: ubuntu-24.04
+    env:
+      CARGO_PROFILE_DEV_DEBUG: "0"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            .
+            src-tauri
+
+      - name: Install system dependencies
+        run: bash e2e/scripts/install-system-deps.sh
+
+      - name: Install meson (newer than apt)
+        run: |
+          python3 -m pip install --user 'meson>=1.3'
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Install tauri-driver
+        run: cargo install tauri-driver --locked
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Clean env (no TURSO_* / POLLIS_DELIVERY_URL yet — start-backend runs
+      # LATER) so config.rs's option_env! bakes nothing in and the binary reads
+      # the runtime env the e2e scripts inject.
+      - name: Build pollis + pollis-delivery (debug)
+        run: cargo build -p pollis -p pollis-delivery
+
+      - name: Start backend fixtures
+        run: bash e2e/scripts/start-backend.sh
+
+      - name: Run restart-persistence e2e (restart-persistence.js)
+        uses: ./.github/actions/desktop-e2e
+        with:
+          command: pnpm restart-persistence
+          working-directory: e2e
+          artifact-name: e2e-restart-persistence-failure
+          artifacts-path: |
+            e2e/artifacts/*.png
+            e2e/artifacts/*.html
+
+      - name: Stop backend fixtures
+        if: always()
+        run: bash e2e/scripts/stop-backend.sh

--- a/.github/workflows/e2e-two-client-channel.yml
+++ b/.github/workflows/e2e-two-client-channel.yml
@@ -1,0 +1,76 @@
+# On-demand two-client GROUP TEXT-CHANNEL convergence E2E (issue #570, M2): two
+# isolated real Tauri app instances against ONE shared backend prove that a
+# message client A posts in a group text channel converges into client B's UI.
+#
+# Backend-only (no media) — same fixtures + composite action as e2e-two-client.yml.
+# Manual trigger only (workflow_dispatch): two WebKitGTK windows + a two-binary
+# cargo build + a libsql container is heavy.
+name: E2E two-client channel (group text convergence)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  two-client-channel:
+    # ubuntu-24.04: src-tauri/build.rs compiles pollis-capture-linux, whose
+    # libspa 0.9 bindgen needs PipeWire >= 1.0 headers (24.04 ships them).
+    runs-on: ubuntu-24.04
+    env:
+      CARGO_PROFILE_DEV_DEBUG: "0"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            .
+            src-tauri
+
+      - name: Install system dependencies
+        run: bash e2e/scripts/install-system-deps.sh
+
+      - name: Install meson (newer than apt)
+        run: |
+          python3 -m pip install --user 'meson>=1.3'
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Install tauri-driver
+        run: cargo install tauri-driver --locked
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Clean env (no TURSO_* / POLLIS_DELIVERY_URL yet — start-backend runs
+      # LATER) so config.rs's option_env! bakes nothing in and the binaries read
+      # the runtime env the e2e scripts inject.
+      - name: Build pollis + pollis-delivery (debug)
+        run: cargo build -p pollis -p pollis-delivery
+
+      - name: Start backend fixtures
+        run: bash e2e/scripts/start-backend.sh
+
+      - name: Run two-client channel e2e (two-client-channel.js)
+        uses: ./.github/actions/desktop-e2e
+        with:
+          command: pnpm two-client-channel
+          working-directory: e2e
+          artifact-name: e2e-two-client-channel-failure
+          artifacts-path: |
+            e2e/artifacts/*.png
+            e2e/artifacts/*.html
+
+      - name: Stop backend fixtures
+        if: always()
+        run: bash e2e/scripts/stop-backend.sh

--- a/.github/workflows/e2e-two-client-dm-reply.yml
+++ b/.github/workflows/e2e-two-client-dm-reply.yml
@@ -1,0 +1,76 @@
+# On-demand two-client BIDIRECTIONAL DM E2E (issue #570, M2): two isolated real
+# Tauri app instances against ONE shared backend prove a DM converges A->B AND
+# the reply converges back B->A through the real renderer + real MLS + real DS.
+#
+# Backend-only (no media) — same fixtures + composite action as e2e-two-client.yml.
+# Manual trigger only (workflow_dispatch): heavy (two WebKitGTK windows + a
+# two-binary cargo build + a libsql container).
+name: E2E two-client DM reply (bidirectional)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  two-client-dm-reply:
+    # ubuntu-24.04: src-tauri/build.rs compiles pollis-capture-linux, whose
+    # libspa 0.9 bindgen needs PipeWire >= 1.0 headers (24.04 ships them).
+    runs-on: ubuntu-24.04
+    env:
+      CARGO_PROFILE_DEV_DEBUG: "0"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            .
+            src-tauri
+
+      - name: Install system dependencies
+        run: bash e2e/scripts/install-system-deps.sh
+
+      - name: Install meson (newer than apt)
+        run: |
+          python3 -m pip install --user 'meson>=1.3'
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Install tauri-driver
+        run: cargo install tauri-driver --locked
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Clean env (no TURSO_* / POLLIS_DELIVERY_URL yet — start-backend runs
+      # LATER) so config.rs's option_env! bakes nothing in and the binaries read
+      # the runtime env the e2e scripts inject.
+      - name: Build pollis + pollis-delivery (debug)
+        run: cargo build -p pollis -p pollis-delivery
+
+      - name: Start backend fixtures
+        run: bash e2e/scripts/start-backend.sh
+
+      - name: Run two-client DM-reply e2e (two-client-dm-reply.js)
+        uses: ./.github/actions/desktop-e2e
+        with:
+          command: pnpm two-client-dm-reply
+          working-directory: e2e
+          artifact-name: e2e-two-client-dm-reply-failure
+          artifacts-path: |
+            e2e/artifacts/*.png
+            e2e/artifacts/*.html
+
+      - name: Stop backend fixtures
+        if: always()
+        run: bash e2e/scripts/stop-backend.sh

--- a/.github/workflows/e2e-two-client-voice-channel.yml
+++ b/.github/workflows/e2e-two-client-voice-channel.yml
@@ -1,0 +1,97 @@
+# On-demand two-client VOICE-CHANNEL join/leave E2E — a MEDIA slice (issue #570,
+# M3): two real Tauri app instances join a group voice channel over a real
+# LiveKit SFU and each asserts the participant roster (2 present, then A leaves
+# and B sees 1).
+#
+# Extends the M2 two-client job with the media stack: headless virtual audio (a
+# PulseAudio null-sink + virtual-source) and an ephemeral LiveKit SFU on
+# loopback — same fixtures as e2e-two-client-call.yml.
+#
+# Pipeline: install deps -> build pollis + pollis-delivery -> start-audio ->
+# start-livekit -> start-backend -> run e2e/two-client-voice-channel.js through
+# the shared desktop-e2e action -> tear everything down (always).
+# Manual trigger only (workflow_dispatch): heavy.
+name: E2E two-client voice channel (audio + LiveKit)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  two-client-voice-channel:
+    # ubuntu-24.04: src-tauri/build.rs compiles pollis-capture-linux, whose
+    # libspa 0.9 bindgen needs PipeWire >= 1.0 headers (24.04 ships them).
+    runs-on: ubuntu-24.04
+    env:
+      CARGO_PROFILE_DEV_DEBUG: "0"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            .
+            src-tauri
+
+      # Shared apt list also installs pulseaudio + pulseaudio-utils +
+      # libasound2-plugins (the ALSA->Pulse plugin) for the virtual audio.
+      - name: Install system dependencies
+        run: bash e2e/scripts/install-system-deps.sh
+
+      - name: Install meson (newer than apt)
+        run: |
+          python3 -m pip install --user 'meson>=1.3'
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Install tauri-driver
+        run: cargo install tauri-driver --locked
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Clean env (no TURSO_* / POLLIS_DELIVERY_URL / LIVEKIT_* yet — the fixtures
+      # run LATER) so config.rs's option_env! bakes nothing in and both binaries
+      # read the runtime env the fixtures inject.
+      - name: Build pollis + pollis-delivery (debug)
+        run: cargo build -p pollis -p pollis-delivery
+
+      # Virtual audio FIRST — a voice-channel join opens cpal mic/playback and
+      # fails the join if no device exists. Exports PULSE_* to $GITHUB_ENV.
+      - name: Start virtual audio
+        run: bash e2e/scripts/start-audio.sh
+
+      # Ephemeral LiveKit (dev mode, loopback). Exports LIVEKIT_URL /
+      # LIVEKIT_API_KEY / LIVEKIT_API_SECRET so the DS mints valid tokens and the
+      # app dials the right ws URL.
+      - name: Start LiveKit
+        run: bash e2e/scripts/start-livekit.sh
+
+      - name: Start backend fixtures
+        run: bash e2e/scripts/start-backend.sh
+
+      - name: Run two-client voice-channel e2e (two-client-voice-channel.js)
+        uses: ./.github/actions/desktop-e2e
+        with:
+          command: pnpm two-client-voice-channel
+          working-directory: e2e
+          artifact-name: e2e-two-client-voice-channel-failure
+          artifacts-path: |
+            e2e/artifacts/*.png
+            e2e/artifacts/*.html
+
+      # Always tear down (idempotent): the DS, the libsql + LiveKit containers,
+      # and the PulseAudio daemon.
+      - name: Stop backend fixtures
+        if: always()
+        run: bash e2e/scripts/stop-backend.sh

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -12,6 +12,7 @@ plumbing:
 | `smoke.js` | app launches, login screen renders | no | no |
 | `e2e.js` | full signup: email → OTP → secret key → PIN → app-ready | yes | yes (writable) |
 | `invalid-otp.js` | a wrong OTP code is rejected with an inline error, doesn't advance | yes | yes (writable) |
+| `restart-persistence.js` | single client; account survives a full app restart on the same data dir (no blank re-signup) | yes | yes (writable) |
 | `two-client.js` | two isolated app instances; a message from A converges into B's UI | yes | yes (writable) |
 | `two-client-dm-reply.js` | bidirectional 1:1 DM — B replies and A sees it (reverse leg of two-client) | yes | yes (writable) |
 | `two-client-channel.js` | A creates a group + text channel, invites B, B accepts, A posts, B receives | yes | yes (writable) |
@@ -24,6 +25,7 @@ plumbing:
 pnpm --filter @pollis/e2e smoke        # or: node e2e/smoke.js       (fast, no deps)
 pnpm --filter @pollis/e2e test         # or: node e2e/e2e.js         (full signup flow)
 pnpm --filter @pollis/e2e invalid-otp  # or: node e2e/invalid-otp.js
+pnpm --filter @pollis/e2e restart-persistence       # account persists across restart (needs backend)
 pnpm --filter @pollis/e2e two-client   # or: node e2e/two-client.js  (needs backend up first)
 pnpm --filter @pollis/e2e two-client-dm-reply       # bidirectional DM (needs backend)
 pnpm --filter @pollis/e2e two-client-channel        # group text-channel convergence (needs backend)
@@ -558,3 +560,23 @@ builds `pollis` **and** `pollis-delivery`, brings the backend up with
 through the same `desktop-e2e` composite action, and tears the backend down in
 an `if: always()` step. No nightly schedule (cost); trigger it from the Actions
 tab when you want the full signup path exercised end-to-end.
+
+Every two-client / single-client script has its own `workflow_dispatch`-only
+workflow, all following one of two shapes above — backend-only (mirrors
+`e2e-two-client.yml`) or media (adds `start-audio` + `start-livekit`, mirrors
+`e2e-two-client-call.yml`):
+
+| script | workflow | extra fixtures |
+|---|---|---|
+| `restart-persistence.js` | `e2e-restart-persistence.yml` | — |
+| `two-client.js` | `e2e-two-client.yml` | — |
+| `two-client-dm-reply.js` | `e2e-two-client-dm-reply.yml` | — |
+| `two-client-channel.js` | `e2e-two-client-channel.yml` | — |
+| `two-client-voice-channel.js` | `e2e-two-client-voice-channel.yml` | LiveKit + audio |
+| `two-client-call.js` | `e2e-two-client-call.yml` | LiveKit + audio |
+| `two-client-camera.js` | `e2e-two-client-camera.yml` | LiveKit + audio + virtual camera |
+| `two-client-screenshare.js` | `e2e-two-client-screenshare.yml` | LiveKit + audio (X11 capture) |
+
+None run automatically. Wiring a cheap PR tier + a nightly full tier is the
+remaining piece of #570 M4 (deferred on cost); until then, dispatch them from
+the Actions tab after touching MLS delivery, DMs, the DS, or media.


### PR DESCRIPTION
The #576 tests (channel, dm-reply, voice-channel, restart-persistence) had no CI workflow. Adds four `workflow_dispatch` workflows mirroring the existing proven patterns — backend-only (like `e2e-two-client.yml`) for channel/dm-reply/restart, and media (adds start-audio + start-livekit, like `e2e-two-client-call.yml`) for voice-channel. Updates `e2e/README.md` with the full script→workflow map and flags automated PR/nightly gating as the remaining #570 M4 piece.

Part of #570. YAML validated locally; underlying tests already pass locally.