### PR TITLE
perf(frontend): lazy-load the terminal (#431)

### DIFF
--- a/frontend/src/components/Layout/AppShell.tsx
+++ b/frontend/src/components/Layout/AppShell.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useMemo, useCallback } from "react";
+import React, { useEffect, useState, useMemo, useCallback, lazy, Suspense } from "react";
 import { Outlet, useRouter, useRouterState } from "@tanstack/react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { invoke, getCurrentWindow, hideWindow } from "../../bridge";
@@ -14,7 +14,10 @@ import { screenShareSession } from "../../screenshare/screenShareSession";
 import { cameraSession } from "../../camera/cameraSession";
 import { LoadingSpinner } from "../ui/LoaderSpinner";
 import { SearchPanel } from "../SearchPanel";
-import { TerminalView } from "../TerminalView";
+// Lazy so the ~380 KiB xterm.js + WebGL addon are split into their own chunk
+// and never parsed at cold launch — only when the terminal is first opened
+// (gated by `terminalActivated` below). Deferred bundle work, see #431.
+const TerminalView = lazy(() => import("../TerminalView"));
 import { observer } from "mobx-react-lite";
 import { appStore } from "../../stores/appStore";
 import { isDropTargetActive } from "../../stores/dropTargetStore";
@@ -570,7 +573,9 @@ export const AppShell: React.FC = observer(() => {
               minWidth: 0,
             }}
           >
-            <TerminalView visible={isTerminal} />
+            <Suspense fallback={null}>
+              <TerminalView visible={isTerminal} />
+            </Suspense>
           </div>
         )}
       </div>

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -24,7 +24,7 @@ function cssVar(name: string, fallback: string): string {
  * Rust on first mount and keeps it alive for the app's lifetime. Renders
  * with xterm.js + the WebGL addon.
  */
-export const TerminalView: React.FC<TerminalViewProps> = ({ visible }) => {
+const TerminalView: React.FC<TerminalViewProps> = ({ visible }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<Terminal | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
@@ -229,3 +229,8 @@ export const TerminalView: React.FC<TerminalViewProps> = ({ visible }) => {
     />
   );
 };
+
+// Default export so AppShell can `lazy(() => import("../TerminalView"))` —
+// this keeps the ~380 KiB xterm + WebGL addon out of the initial chunk and
+// defers its parse/eval until the terminal is first opened (#431).
+export default TerminalView;


### PR DESCRIPTION
First slice of #431 (lowest-risk). `TerminalView` statically imported xterm.js + the WebGL addon (~380 KiB), and was mounted in `AppShell` — so the full terminal emulator parsed at **every cold launch**, even for users who never open it.

Converts it to `lazy(() => import("../TerminalView"))` behind a `Suspense` boundary. The mount was already gated by `terminalActivated` (flips true on first `/terminal` visit, never resets), so the chunk now loads only when the terminal is first opened; the PTY + scrollback still survive toggles exactly as before.

**Measured (production build):**
- Terminal now its own chunk: `TerminalView.*.js` **387 KiB** (96 KiB gzip) + its CSS, loaded on demand.
- Main chunk: **1,709 → 1,340 KiB** (461 → 370 KiB gzip).

This is a Tauri app (loads from `file://`), so the payoff is **cold-launch parse/eval time**, not download size. Typecheck + build green. Voice split (#2 in the issue, ~490 KiB, has a join-latency tradeoff) will follow as a separate PR.