### PR TITLE
fix(voice): listen-only join when mic is unavailable + Linux window resize edges

### DIFF
--- a/.codesight/wiki/audio-processing.md
+++ b/.codesight/wiki/audio-processing.md
@@ -46,6 +46,29 @@ the previous per-track-stream model. AEC needs *one* point at which the
 about-to-play signal is observed; otherwise the render reference is out of
 sync with what actually comes out of the speaker.
 
+## Listen-only join (no mic)
+
+The mic is **best-effort**. If `start_mic_stream` fails at join — no capture
+device, ALSA `snd_pcm_hw_params` "No such file or directory", a busy device —
+`join_voice_channel` does **not** abort. It joins *listen-only*: connected to
+the room, receiving remote audio/video, just not publishing a mic track. On
+that path the whole capture side is skipped (no `NativeAudioSource`, no
+`publish_track`, no `frame_task`, no APM, no denoiser); playback is unaffected.
+`voice.local_track` / `audio_source` / `input_stream` / `frame_task` are all
+`None`.
+
+The backend emits `VoiceEvent::MicAvailability { available: false }` once at
+join. The renderer mirrors it onto `voiceState.joined.micAvailable` and swaps
+the mute toggle for a non-interactive "listening only" indicator
+(`voice-bar-listen-only` / `voice-tray-listen-only`).
+
+Test seam: `POLLIS_DISABLE_MIC=1` forces `start_mic_stream` to fail so the
+listen-only path can be exercised without unplugging a device. Covered by
+`e2e/voice-channel-no-mic.js` (S-NOMIC). Upgrading a listen-only session to
+speaking (plug a mic in mid-call) currently requires a rejoin —
+`set_voice_input_device` only re-opens a stream when `audio_source` is already
+`Some`.
+
 ## Source files
 
 - `pollis-core/src/commands/voice_apm.rs` — `ApmStage`, `ApmConfig`, helpers (`run_capture`, `analyze_render`).

--- a/.codesight/wiki/ui.md
+++ b/.codesight/wiki/ui.md
@@ -18,6 +18,7 @@
 - **SidebarActions** — props: isCollapsed, onCreateGroup, onSearchGroup, onHomeClick — `frontend/src/components/Layout/SidebarActions.tsx`
 - **SidebarHeader** — props: isCollapsed, onHomeClick — `frontend/src/components/Layout/SidebarHeader.tsx`
 - **TitleBar** — `frontend/src/components/Layout/TitleBar.tsx`
+- **WindowResizeEdges** — Linux-only invisible resize handles for the frameless window — `frontend/src/components/Layout/WindowResizeEdges.tsx`
 - **TreeView** — props: data, className, selectedId, onNodeClick, onNodeAction, getNodeIcon, defaultExpandedIds — `frontend/src/components/Layout/TreeView.tsx`
 - **LastMessagePreview** — props: channelId, conversationId — `frontend/src/components/Message/LastMessagePreview.tsx`
 - **MessageItem** — props: message, allMessages, authorUsername, isAuthorAdmin, onReply, onEdit, onDelete, onScrollToReply — `frontend/src/components/Message/MessageItem.tsx`
@@ -74,6 +75,22 @@
 - **VoiceSettingsPage** — `frontend/src/pages/VoiceSettingsPage.tsx`
 
 ---
+
+## Window chrome (frameless)
+
+The window ships `decorations: false` (`src-tauri/tauri.conf.json`). macOS
+re-adds `NSResizableWindowMask` and Windows uses the DWM frame (`src-tauri/src/lib.rs`),
+so both get native title-bar drag + a comfortable resize border. The custom
+**TitleBar** provides the drag region (`startDragging`) and window controls.
+
+Linux/Wayland gives an undecorated toplevel **no** server-side resize edge, so
+**WindowResizeEdges** overlays eight invisible strips (four edges + four
+corners) that call `startResizeDragging(direction)` via the window bridge —
+widening the grab area from the ~1px compositor edge to a comfortable 6px
+edge / 12px corner. Gated to Tauri + Linux (`navigator.userAgent` match);
+elsewhere the native frame already handles resize. Needs the
+`core:window:allow-start-resize-dragging` capability
+(`src-tauri/capabilities/default.json`).
 
 ## Theming & skins
 

--- a/.github/workflows/e2e-voice-channel-no-mic.yml
+++ b/.github/workflows/e2e-voice-channel-no-mic.yml
@@ -1,0 +1,86 @@
+# On-demand single-client LISTEN-ONLY voice join E2E — regression cover for the
+# no-mic join bug (Wayland/Linux with no capture device used to hard-fail
+# `join_voice_channel` on `build mic stream`). Forces the listen-only path with
+# POLLIS_DISABLE_MIC=1 and asserts the join succeeds anyway + the tray shows the
+# "listening only" indicator instead of a live mute toggle.
+#
+# One client is enough (a solo group is its own MLS group, so the voice E2EE key
+# derives fine). Still needs LiveKit + backend fixtures; virtual audio is kept so
+# the speaker path (playback) is exercised — the mic is force-disabled in-app,
+# mirroring "has speakers, no mic".
+#
+# Pipeline mirrors e2e-two-client-voice-channel.yml. Manual trigger only.
+name: E2E voice channel no-mic (listen-only)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  voice-channel-no-mic:
+    # ubuntu-24.04: src-tauri/build.rs compiles pollis-capture-linux, whose
+    # libspa 0.9 bindgen needs PipeWire >= 1.0 headers (24.04 ships them).
+    runs-on: ubuntu-24.04
+    env:
+      CARGO_PROFILE_DEV_DEBUG: "0"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            .
+            src-tauri
+
+      - name: Install system dependencies
+        run: bash e2e/scripts/install-system-deps.sh
+
+      - name: Install meson (newer than apt)
+        run: |
+          python3 -m pip install --user 'meson>=1.3'
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Install tauri-driver
+        run: cargo install tauri-driver --locked
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build pollis + pollis-delivery (debug)
+        run: cargo build -p pollis -p pollis-delivery
+
+      # Virtual audio provides the speaker (playback) device; the mic is
+      # force-disabled in-app via POLLIS_DISABLE_MIC, so this proves listen-only.
+      - name: Start virtual audio
+        run: bash e2e/scripts/start-audio.sh
+
+      - name: Start LiveKit
+        run: bash e2e/scripts/start-livekit.sh
+
+      - name: Start backend fixtures
+        run: bash e2e/scripts/start-backend.sh
+
+      - name: Run voice-channel no-mic e2e (voice-channel-no-mic.js)
+        uses: ./.github/actions/desktop-e2e
+        with:
+          command: pnpm voice-channel-no-mic
+          working-directory: e2e
+          artifact-name: e2e-voice-channel-no-mic-failure
+          artifacts-path: |
+            e2e/artifacts/*.png
+            e2e/artifacts/*.html
+
+      - name: Stop backend fixtures
+        if: always()
+        run: bash e2e/scripts/stop-backend.sh

--- a/e2e/SCENARIOS.md
+++ b/e2e/SCENARIOS.md
@@ -43,6 +43,7 @@ makes me that the flow already works. Status: ✅ covered by an existing script,
 | S-GRP | Create a group | 3 | 3 | ⬜ | Covered as a step of M-CH. |
 | S-TXTCH | Create a text channel | 3 | 3 | ⬜ | Covered as a step of M-CH. |
 | S-VOXCH | Create a voice channel (toggle type switch) | 3 | 3 | ⬜ | Covered as a step of M-VC. |
+| S-NOMIC | Voice join with no capture device → joins listen-only (not blocked), tray shows "listening only" | 5 | 3 | ✅ | voice-channel-no-mic.js. Forces the path with POLLIS_DISABLE_MIC=1. |
 | S-RENAME | Rename a channel / group | 2 | 3 | ⬜ | |
 | S-DELCH | Delete a channel | 2 | 3 | ⬜ | |
 | S-SIGNUP | Full signup: email→OTP→secret key→PIN→app-ready | 5 | 4 | ✅ | e2e.js |

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -13,6 +13,7 @@
     "two-client-channel": "node ./two-client-channel.js",
     "two-client-dm-reply": "node ./two-client-dm-reply.js",
     "two-client-voice-channel": "node ./two-client-voice-channel.js",
+    "voice-channel-no-mic": "node ./voice-channel-no-mic.js",
     "two-client-call": "node ./two-client-call.js",
     "two-client-camera": "node ./two-client-camera.js",
     "two-client-screenshare": "node ./two-client-screenshare.js"

--- a/e2e/voice-channel-no-mic.js
+++ b/e2e/voice-channel-no-mic.js
@@ -1,0 +1,250 @@
+#!/usr/bin/env node
+/*
+ * Single-client LISTEN-ONLY voice join E2E.
+ *
+ * Regression cover for the no-mic join bug: on Wayland/Linux with no capture
+ * device, `join_voice_channel` used to hard-fail on `build mic stream` (ALSA
+ * "No such file or directory"), so you couldn't even listen in. The mic is now
+ * best-effort — a failed capture device joins the room *listen-only* (connected,
+ * receiving, not publishing) instead of aborting the whole join.
+ *
+ * We force that path deterministically with POLLIS_DISABLE_MIC=1 (the same seam
+ * the backend uses to skip cpal capture) rather than trying to unplug a virtual
+ * device mid-run.
+ *
+ * Choreography (one client is enough — a solo group is its own MLS group, so the
+ * voice E2EE key derives fine and the join is self-contained):
+ *   1. A signs up.
+ *   2. A creates a group + a VOICE channel.
+ *   3. A opens the voice channel and clicks Join — with the mic force-disabled.
+ *   4. ASSERT: the join SUCCEEDS anyway (voice-channel-view mounts), and the
+ *      tray shows the "listening only" indicator (voice-tray-listen-only)
+ *      instead of a live mute toggle (voice-tray-mute).
+ *   5. A leaves; the join CTA reappears.
+ *
+ * On failure, dumps A-FAIL.* into e2e/artifacts/.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const h = require("./lib/harness");
+
+const ARTIFACTS = path.join(__dirname, "artifacts");
+const shot = h.makeShot(ARTIFACTS);
+
+const PIN = "1357";
+const GROUP_VISIBLE_TIMEOUT_MS = 90_000;
+const JOIN_TIMEOUT_MS = 60_000;
+
+function appEnvFor(devEnv, turso, deliveryUrl, dataDir) {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  fs.mkdirSync(dataDir, { recursive: true });
+  return {
+    ...devEnv, ...process.env,
+    TURSO_URL: turso.TURSO_URL, TURSO_TOKEN: turso.TURSO_TOKEN,
+    POLLIS_DELIVERY_URL: deliveryUrl,
+    POLLIS_DATA_DIR: dataDir,
+    LOG_DB_URL: "", LOG_DB_TOKEN: "", LOG_DB_ADMIN_TOKEN: "",
+    WEBKIT_DISABLE_COMPOSITING_MODE: "1", GDK_BACKEND: "x11",
+    // The whole point of this test: force the listen-only path.
+    POLLIS_DISABLE_MIC: "1",
+  };
+}
+
+async function signUp(browser, email, tag) {
+  console.log(`[no-mic] ${tag}: signing up ${email}`);
+  await h.waitTestId(browser, "auth-screen", 30000);
+  await h.setTestIdValue(browser, "email-input", email);
+  await h.clickTestId(browser, "send-otp-button");
+  await h.waitTestId(browser, "otp-form-container", 20000);
+  await h.typeCode(browser, "000000");
+  await h.waitTestId(browser, "save-secret-key-warning-screen", 45000);
+  await h.clickTestId(browser, "save-secret-key-acknowledge-button");
+  await h.waitTestId(browser, "save-secret-key-screen");
+  const secretKey = (await (await browser.$('[data-testid="secret-key-display"]')).getText()).trim();
+  if (!secretKey) {
+    throw new Error(`${tag}: secret key display was empty`);
+  }
+  await h.clickTestId(browser, "secret-key-saved-button");
+  await h.waitTestId(browser, "save-secret-key-confirm-screen");
+  await h.setTestIdValue(browser, "secret-key-confirm-input", secretKey);
+  await h.clickTestId(browser, "confirm-secret-key-button");
+  await h.waitTestId(browser, "pin-create-screen");
+  await h.typeCode(browser, PIN);
+  await h.typeCode(browser, PIN);
+  await h.waitTestId(browser, "app-ready", 60000);
+  console.log(`[no-mic] ${tag}: reached app-ready`);
+}
+
+async function clickByPrefixText(browser, prefix, text) {
+  const ok = await browser.execute((pfx, needle) => {
+    for (const el of document.querySelectorAll(`[data-testid^="${pfx}"]`)) {
+      if ((el.textContent || "").includes(needle)) { el.click(); return true; }
+    }
+    return false;
+  }, prefix, text);
+  if (!ok) {
+    throw new Error(`clickByPrefixText: no ${prefix}* containing "${text}"`);
+  }
+}
+
+async function prefixTextPresent(browser, prefix, text) {
+  return browser.execute((pfx, needle) => {
+    for (const el of document.querySelectorAll(`[data-testid^="${pfx}"]`)) {
+      if ((el.textContent || "").includes(needle)) { return true; }
+    }
+    return false;
+  }, prefix, text);
+}
+
+async function goHome(browser) {
+  const clicked = await browser.execute(() => {
+    const trail = document.querySelector('[data-testid="breadcrumb-trail"]');
+    const btn = trail && trail.querySelector("button");
+    if (btn) { btn.click(); return true; }
+    return false;
+  });
+  if (clicked) {
+    await h.waitTestId(browser, "menu-item-groups", 15000);
+  }
+}
+
+async function createGroup(browser, groupName) {
+  await h.clickTestId(browser, "menu-item-groups");
+  await h.clickTestId(browser, "menu-item-create-group");
+  await h.waitTestId(browser, "create-group-page", 20000);
+  await h.setSelectorValue(browser, "#create-group-name", groupName);
+  await h.clickTestId(browser, "create-group-submit-button");
+  await h.waitTestId(browser, "menu-item-create-channel", 30000);
+}
+
+// Create a VOICE channel: toggle the type switch (#create-channel-type, default
+// "text") to voice before submitting. A voice channel returns to the group page.
+async function createVoiceChannel(browser, channelName) {
+  await h.clickTestId(browser, "menu-item-create-channel");
+  await h.waitTestId(browser, "create-channel-page", 20000);
+  await h.setSelectorValue(browser, "#create-channel-name", channelName);
+  await h.clickSelector(browser, "#create-channel-type");
+  await h.clickTestId(browser, "create-channel-submit-button");
+  await h.waitTestId(browser, "menu-item-create-channel", 30000);
+}
+
+async function openVoiceChannel(browser, groupName, channelName, groupTimeoutMs) {
+  const end = Date.now() + groupTimeoutMs;
+  while (Date.now() < end) {
+    await goHome(browser);
+    await h.clickTestId(browser, "menu-item-groups");
+    await h.waitTestId(browser, "menu-item-create-group", 15000);
+    if (await prefixTextPresent(browser, "group-option-", groupName)) {
+      await clickByPrefixText(browser, "group-option-", groupName);
+      await h.waitSelector(browser, '[data-testid^="channel-option-"]', 20000, "a channel row");
+      await clickByPrefixText(browser, "channel-option-", channelName);
+      await h.waitTestId(browser, "voice-join-cta", 20000);
+      return;
+    }
+    console.log(`[no-mic] group "${groupName}" not visible yet, waiting…`);
+    await h.sleep(6000);
+  }
+  throw new Error(`group "${groupName}" never appeared`);
+}
+
+async function main() {
+  h.reap();
+  const devEnv = h.readEnvFile(".env.development");
+  const turso = h.tursoEnv();
+  const deliveryUrl = process.env.POLLIS_DELIVERY_URL;
+  if (!deliveryUrl) {
+    throw new Error("POLLIS_DELIVERY_URL is not set — run e2e/scripts/start-backend.sh first.");
+  }
+  if (!process.env.LIVEKIT_URL) {
+    throw new Error("LIVEKIT_URL is not set — run e2e/scripts/start-livekit.sh first.");
+  }
+
+  const children = [];
+  const clients = [];
+  const stop = (c) => { try { c && c.kill("SIGKILL"); } catch (_) {} };
+
+  const vite = h.spawnVite(devEnv);
+  children.push(vite);
+
+  const stamp = Date.now();
+  const emailA = `e2e_nomic_a_${stamp}@pollis.test`;
+  const groupName = `nomicgrp${stamp}`;
+  const channelName = `nomicchan${stamp}`;
+
+  let code = 1;
+  let A;
+  try {
+    await h.waitViteReady();
+    console.log(`[no-mic] delivery ${deliveryUrl}, livekit ${process.env.LIVEKIT_URL}`);
+
+    A = await h.startClient({
+      index: 0, label: "A",
+      appEnv: appEnvFor(devEnv, turso, deliveryUrl, path.join(__dirname, ".tmp-data-nomic-a")),
+    });
+    clients.push(A);
+
+    await signUp(A.browser, emailA, "A");
+
+    console.log(`[no-mic] A: creating group "${groupName}"`);
+    await createGroup(A.browser, groupName);
+    console.log(`[no-mic] A: creating voice channel "${channelName}"`);
+    await createVoiceChannel(A.browser, channelName);
+
+    console.log("[no-mic] A: opening + joining the voice channel (mic disabled)");
+    await openVoiceChannel(A.browser, groupName, channelName, GROUP_VISIBLE_TIMEOUT_MS);
+    await h.clickTestId(A.browser, "voice-join-cta");
+
+    // ASSERT 1: the join succeeds despite no mic — the joined stage mounts.
+    await h.waitTestId(A.browser, "voice-channel-view", JOIN_TIMEOUT_MS);
+    console.log("[no-mic] A: joined the voice channel (listen-only)");
+    await shot(A.browser, "no-mic-joined.png");
+
+    // ASSERT 2: the tray shows the listen-only indicator, NOT a live mute
+    // toggle. The MicAvailability event lands just after join, so wait for it.
+    await h.waitTestId(A.browser, "voice-tray-listen-only", 15000);
+    const hasMute = await h.presentSelector(A.browser, '[data-testid="voice-tray-mute"]');
+    if (hasMute) {
+      throw new Error("expected listen-only indicator, but a live mute toggle is present");
+    }
+    console.log("[no-mic] A: listen-only indicator present, no mute toggle");
+    await shot(A.browser, "no-mic-listen-only.png");
+
+    // A leaves; the join CTA reappears.
+    console.log("[no-mic] A: leaving the voice channel");
+    await h.clickTestId(A.browser, "voice-tray-leave");
+    await h.waitTestId(A.browser, "voice-join-cta", 30000);
+    console.log("[no-mic] SUCCESS: listen-only join + leave round-tripped");
+    code = 0;
+  } catch (err) {
+    console.error("[no-mic] FAILED:", err.message);
+    if (A && A.browser) {
+      await dumpClient(A.browser, "A");
+    }
+  } finally {
+    for (const c of clients) {
+      if (c && c.browser) {
+        await c.browser.deleteSession().catch(() => {});
+      }
+    }
+    for (const c of clients) {
+      stop(c && c.tauriDriver);
+    }
+    for (const c of children) {
+      stop(c);
+    }
+    h.reap();
+  }
+  process.exit(code);
+}
+
+async function dumpClient(browser, tag) {
+  await shot(browser, `${tag}-FAIL.png`).catch(() => {});
+  const src = await browser.getPageSource().catch(() => "");
+  fs.mkdirSync(ARTIFACTS, { recursive: true });
+  fs.writeFileSync(path.join(ARTIFACTS, `${tag}-FAIL.html`), src);
+  const ids = [...src.matchAll(/data-testid="([^"]+)"/g)].map((m) => m[1]);
+  console.error(`[no-mic] ${tag} on-screen testids:`, [...new Set(ids)].join(", "));
+}
+
+main().catch((e) => { console.error("[no-mic] fatal:", e); h.reap(); process.exit(1); });

--- a/frontend/src/bridge/window.ts
+++ b/frontend/src/bridge/window.ts
@@ -41,6 +41,18 @@ export class LogicalPosition {
 type SizeArg = { width: number; height: number } | LogicalSize;
 type PositionArg = { x: number; y: number } | LogicalPosition;
 
+/** Mirrors Tauri's `ResizeDirection`. The eight window edges/corners a
+ *  frameless-window resize handle can drag. */
+export type ResizeDirection =
+  | "North"
+  | "NorthEast"
+  | "East"
+  | "SouthEast"
+  | "South"
+  | "SouthWest"
+  | "West"
+  | "NorthWest";
+
 export interface PollisImage {
   // Used by `setIcon`; under Electron we pass the raw PNG bytes to
   // windowSetBadgeIcon. Under Tauri this is the real `Image` from
@@ -74,6 +86,9 @@ export interface WindowProxy {
   // on the title bar does the work). Kept so the Tauri-era handler in
   // TitleBar.tsx survives without branching.
   startDragging: () => Promise<void>;
+  // Edge/corner resize for the frameless window. Tauri drives the native
+  // compositor resize; under Electron the OS frame handles it, so no-op.
+  startResizeDragging: (direction: ResizeDirection) => Promise<void>;
 }
 
 function electronWindow(): WindowProxy {
@@ -176,6 +191,9 @@ function electronWindow(): WindowProxy {
     startDragging: async () => {
       /* no-op: handled by CSS -webkit-app-region under Electron */
     },
+    startResizeDragging: async () => {
+      /* no-op: Electron windows keep the native OS frame, which resizes */
+    },
   };
 }
 
@@ -220,6 +238,8 @@ async function tauriWindow(): Promise<WindowProxy> {
     hide: () => real.hide(),
     show: () => real.show(),
     startDragging: () => real.startDragging(),
+    startResizeDragging: (direction) =>
+      real.startResizeDragging(direction as unknown as Parameters<typeof real.startResizeDragging>[0]),
   };
   return tauriWindowProxy;
 }
@@ -253,6 +273,7 @@ export function getCurrentWindow(): WindowProxy {
     hide: () => lazy().then((w) => w.hide()),
     show: () => lazy().then((w) => w.show()),
     startDragging: () => lazy().then((w) => w.startDragging()),
+    startResizeDragging: (direction) => lazy().then((w) => w.startResizeDragging(direction)),
   };
 }
 

--- a/frontend/src/components/Layout/AppShell.tsx
+++ b/frontend/src/components/Layout/AppShell.tsx
@@ -3,6 +3,7 @@ import { Outlet, useRouter, useRouterState } from "@tanstack/react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { invoke, getCurrentWindow, hideWindow } from "../../bridge";
 import { TitleBar } from "./TitleBar";
+import { WindowResizeEdges } from "./WindowResizeEdges";
 import { BreadcrumbNav } from "./BreadcrumbNav";
 import { MigrationBanner } from "../MigrationBanner";
 import { Sidebar } from "./Sidebar";
@@ -532,6 +533,9 @@ export const AppShell: React.FC = observer(() => {
         position: "relative",
       }}
     >
+      {/* Frameless-window resize handles (Linux only — see component) */}
+      <WindowResizeEdges />
+
       {/* Cmd/Ctrl+K search panel */}
       <SearchPanel isOpen={isSearchOpen} onClose={closeSearch} />
 

--- a/frontend/src/components/Layout/WindowResizeEdges.css
+++ b/frontend/src/components/Layout/WindowResizeEdges.css
@@ -1,0 +1,83 @@
+/* Invisible frameless-window resize handles. See WindowResizeEdges.tsx.
+ * The root is click-through; only the strips themselves catch the pointer,
+ * so the app UI underneath stays fully interactive. */
+
+.wre-root {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  pointer-events: none;
+}
+
+.wre-edge {
+  position: absolute;
+  pointer-events: auto;
+  background: transparent;
+}
+
+/* Grab thickness. 6px matches the forgiving edge GTK/Windows apps expose;
+ * corners get a larger square so the diagonal cursor is easy to catch. */
+:root {
+  --wre-edge: 6px;
+  --wre-corner: 12px;
+}
+
+/* ── Edges ─────────────────────────────────────────────────────────────── */
+.wre-n {
+  top: 0;
+  left: 0;
+  right: 0;
+  height: var(--wre-edge);
+  cursor: ns-resize;
+}
+.wre-s {
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: var(--wre-edge);
+  cursor: ns-resize;
+}
+.wre-w {
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: var(--wre-edge);
+  cursor: ew-resize;
+}
+.wre-e {
+  top: 0;
+  bottom: 0;
+  right: 0;
+  width: var(--wre-edge);
+  cursor: ew-resize;
+}
+
+/* ── Corners (above the edges so the diagonal cursor wins) ──────────────── */
+.wre-edge.wre-nw,
+.wre-edge.wre-ne,
+.wre-edge.wre-sw,
+.wre-edge.wre-se {
+  width: var(--wre-corner);
+  height: var(--wre-corner);
+  z-index: 1;
+}
+.wre-nw {
+  top: 0;
+  left: 0;
+  cursor: nwse-resize;
+}
+.wre-ne {
+  top: 0;
+  right: 0;
+  cursor: nesw-resize;
+}
+.wre-sw {
+  bottom: 0;
+  left: 0;
+  cursor: nesw-resize;
+}
+.wre-se {
+  bottom: 0;
+  right: 0;
+  cursor: nwse-resize;
+}

--- a/frontend/src/components/Layout/WindowResizeEdges.tsx
+++ b/frontend/src/components/Layout/WindowResizeEdges.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { getCurrentWindow, type ResizeDirection } from "../../bridge/window";
+import { hasTauri } from "../../bridge/runtime";
+import "./WindowResizeEdges.css";
+
+/**
+ * Invisible resize handles around the window perimeter.
+ *
+ * The window ships `decorations: false`. On macOS we re-add
+ * `NSResizableWindowMask` and on Windows the DWM frame provides native resize
+ * borders, so both get a comfortable grab region for free. Linux/Wayland gives
+ * an undecorated toplevel *no* server-side resize edge, and there was no
+ * client-side handle either — so the only resizable target was the literal 1px
+ * compositor edge (the "pixel-perfect" cursor Dan hit).
+ *
+ * This overlays eight thin strips (four edges + four corners) that call the
+ * compositor's interactive resize via `startResizeDragging`, matching how every
+ * other frameless GTK app widens its grab area. Corners sit above edges so the
+ * diagonal cursor wins in the shared region.
+ *
+ * Linux + Tauri only: elsewhere the native frame already handles this and an
+ * overlay would only get in the way (traffic lights, rounded corners, DWM).
+ */
+
+// WebKitGTK's user agent reports "X11; Linux x86_64" on both X11 and Wayland.
+const IS_LINUX = typeof navigator !== "undefined" && /Linux/.test(navigator.userAgent);
+
+const EDGES: Array<{ dir: ResizeDirection; cls: string }> = [
+  { dir: "North", cls: "wre-n" },
+  { dir: "South", cls: "wre-s" },
+  { dir: "East", cls: "wre-e" },
+  { dir: "West", cls: "wre-w" },
+  { dir: "NorthWest", cls: "wre-nw" },
+  { dir: "NorthEast", cls: "wre-ne" },
+  { dir: "SouthWest", cls: "wre-sw" },
+  { dir: "SouthEast", cls: "wre-se" },
+];
+
+export const WindowResizeEdges: React.FC = () => {
+  if (!hasTauri() || !IS_LINUX) {
+    return null;
+  }
+
+  const onMouseDown = (dir: ResizeDirection) => (e: React.MouseEvent) => {
+    // Primary button only — a right/middle click must not start a resize.
+    if (e.button !== 0) {
+      return;
+    }
+    e.preventDefault();
+    void getCurrentWindow().startResizeDragging(dir);
+  };
+
+  return (
+    <div className="wre-root" aria-hidden="true">
+      {EDGES.map(({ dir, cls }) => (
+        <div
+          key={dir}
+          className={`wre-edge ${cls}`}
+          data-testid={`window-resize-${dir.toLowerCase()}`}
+          onMouseDown={onMouseDown(dir)}
+        />
+      ))}
+    </div>
+  );
+};

--- a/frontend/src/components/Voice/VoiceBar.tsx
+++ b/frontend/src/components/Voice/VoiceBar.tsx
@@ -24,6 +24,9 @@ export const VoiceBar: React.FC<VoiceBarProps> = observer(({ channelId, channelN
     voiceActiveSpeakerIds,
   } = appStore;
   const voiceIsMuted = voiceState.kind === 'joined' ? voiceState.micMuted : false;
+  // Listen-only: joined without a working capture device. The mute toggle
+  // becomes a non-interactive "listening only" indicator.
+  const micAvailable = voiceState.kind === 'joined' ? voiceState.micAvailable : true;
   const share = shareOf(voiceState);
   const shareActive = share.kind === 'active';
   // Anything non-idle/non-picking means the button should become a "stop"
@@ -93,17 +96,29 @@ export const VoiceBar: React.FC<VoiceBarProps> = observer(({ channelId, channelN
         {channelName}
       </PillButton>
 
-      {/* Mute toggle */}
-      <PillButton
-        data-testid="voice-bar-mute-button"
-        accent={voiceIsMuted ? "var(--c-danger)" : "var(--c-accent)"}
-        onClick={toggleMute}
-        title={voiceIsMuted ? "Unmute microphone" : "Mute microphone"}
-        aria-label={voiceIsMuted ? "Unmute microphone" : "Mute microphone"}
-        square
-      >
-        {voiceIsMuted ? <MicOff size={12} /> : <Mic size={12} />}
-      </PillButton>
+      {/* Mute toggle — or, listen-only, a static "listening only" indicator */}
+      {micAvailable ? (
+        <PillButton
+          data-testid="voice-bar-mute-button"
+          accent={voiceIsMuted ? "var(--c-danger)" : "var(--c-accent)"}
+          onClick={toggleMute}
+          title={voiceIsMuted ? "Unmute microphone" : "Mute microphone"}
+          aria-label={voiceIsMuted ? "Unmute microphone" : "Mute microphone"}
+          square
+        >
+          {voiceIsMuted ? <MicOff size={12} /> : <Mic size={12} />}
+        </PillButton>
+      ) : (
+        <PillButton
+          data-testid="voice-bar-listen-only"
+          accent="var(--c-text-dim)"
+          title="No microphone detected — listening only"
+          aria-label="No microphone detected — listening only"
+          square
+        >
+          <MicOff size={12} />
+        </PillButton>
+      )}
 
       {/* Screen share toggle. On macOS we enumerate via SCShareableContent
           and route to our in-app picker — the system picker

--- a/frontend/src/components/Voice/stage/VoiceStage.tsx
+++ b/frontend/src/components/Voice/stage/VoiceStage.tsx
@@ -96,6 +96,9 @@ export const VoiceStage: React.FC<VoiceStageProps> = observer(
 
     const isJoining = voiceState.kind === "joining";
     const micMuted = voiceState.kind === "joined" ? voiceState.micMuted : false;
+    // Listen-only: joined without a working capture device. The mute button
+    // becomes a non-interactive "listening only" indicator.
+    const micAvailable = voiceState.kind === "joined" ? voiceState.micAvailable : true;
 
     const [focusId, setFocusId] = useState<string | null>(null);
 
@@ -359,15 +362,27 @@ export const VoiceStage: React.FC<VoiceStageProps> = observer(
             <div className="vs-foot-side">
               {isInCall || callMode ? (
                 <div className="vs-tray">
-                  <button
-                    className={"vs-tray-btn danger" + (micMuted ? " on" : "")}
-                    data-testid="voice-tray-mute"
-                    title={micMuted ? "Unmute" : "Mute"}
-                    aria-label={micMuted ? "Unmute microphone" : "Mute microphone"}
-                    onClick={() => voiceSession.toggleMute()}
-                  >
-                    {micMuted ? <MicOff size={15} /> : <Mic size={15} />}
-                  </button>
+                  {micAvailable ? (
+                    <button
+                      className={"vs-tray-btn danger" + (micMuted ? " on" : "")}
+                      data-testid="voice-tray-mute"
+                      title={micMuted ? "Unmute" : "Mute"}
+                      aria-label={micMuted ? "Unmute microphone" : "Mute microphone"}
+                      onClick={() => voiceSession.toggleMute()}
+                    >
+                      {micMuted ? <MicOff size={15} /> : <Mic size={15} />}
+                    </button>
+                  ) : (
+                    <button
+                      className="vs-tray-btn on"
+                      data-testid="voice-tray-listen-only"
+                      title="No microphone detected — listening only"
+                      aria-label="No microphone detected — listening only"
+                      disabled
+                    >
+                      <MicOff size={15} />
+                    </button>
+                  )}
                   <button
                     className={"vs-tray-btn" + (shareActive ? " on" : "")}
                     data-testid="voice-tray-screenshare"

--- a/frontend/src/stores/appStore.ts
+++ b/frontend/src/stores/appStore.ts
@@ -259,6 +259,8 @@ class AppStore implements AppState {
       channelId,
       counterpartyUserId,
       micMuted: false,
+      // Assume a mic until the backend says otherwise via `mic_availability`.
+      micAvailable: true,
       share: { kind: 'idle' },
       camera: { kind: 'idle' },
     };
@@ -294,6 +296,13 @@ class AppStore implements AppState {
       return;
     }
     this.voiceState = { ...this.voiceState, micMuted: muted };
+  }
+
+  voiceSetMicAvailable(available: boolean) {
+    if (this.voiceState.kind !== 'joined') {
+      return;
+    }
+    this.voiceState = { ...this.voiceState, micAvailable: available };
   }
 
   shareStartPicking(sources: SourceList) {

--- a/frontend/src/types/voice-state.ts
+++ b/frontend/src/types/voice-state.ts
@@ -36,6 +36,11 @@ export type VoiceState =
       channelId: string;
       counterpartyUserId: string | null;
       micMuted: boolean;
+      /** False when this session joined *listen-only* — no working capture
+       *  device, so we're connected and receiving but not publishing audio.
+       *  The UI shows a "listening only" indicator instead of a mute toggle.
+       *  Set from the backend `mic_availability` event at join. */
+      micAvailable: boolean;
       share: ShareState;
       camera: CameraState;
     }

--- a/frontend/src/voice/VoiceSessionManager.ts
+++ b/frontend/src/voice/VoiceSessionManager.ts
@@ -29,6 +29,7 @@ export type VoiceEvent =
   | { type: 'participant_left'; identity: string }
   | { type: 'muted'; identity: string }
   | { type: 'unmuted'; identity: string }
+  | { type: 'mic_availability'; identity: string; available: boolean }
   | { type: 'speaking_started'; identity: string }
   | { type: 'speaking_stopped'; identity: string }
   | { type: 'audio_bands'; identity: string; bands: number[] }
@@ -81,6 +82,10 @@ export interface VoiceSessionState {
    *  a participant's audio DU — this is the local user's toggle, not a
    *  speaking-derived value. */
   isMuted: boolean;
+  /** False when the session joined listen-only (no working capture device).
+   *  Mirrored onto the store's `joined.micAvailable`; drives the "listening
+   *  only" indicator in place of the mute toggle. */
+  micAvailable: boolean;
   /** Last error from a failed join. Cleared on the next intent change. */
   error: string | null;
 }
@@ -120,6 +125,7 @@ const INITIAL_STATE: VoiceSessionState = {
   counterpartyUserId: null,
   participants: [],
   isMuted: false,
+  micAvailable: true,
   error: null,
 };
 
@@ -452,6 +458,9 @@ class VoiceSessionManager {
       groupId: target.groupId,
       counterpartyUserId: target.counterpartyUserId ?? null,
       isMuted: false,
+      // Reset any stale listen-only state from a previous session; the
+      // backend re-asserts it via `mic_availability` on this join.
+      micAvailable: true,
       participants: [
         {
           identity: localIdentity,
@@ -673,6 +682,13 @@ class VoiceSessionManager {
         this.setState(patch);
         break;
       }
+      case 'mic_availability': {
+        // Only ever carries the local identity. False = joined listen-only.
+        if (event.identity === localIdentity) {
+          this.setState({ micAvailable: event.available });
+        }
+        break;
+      }
       case 'speaking_started':
       case 'speaking_stopped': {
         const speaking = event.type === 'speaking_started';
@@ -889,10 +905,13 @@ voiceSession.subscribe(() => {
         store.voiceStartJoining(s.channelId, s.counterpartyUserId);
         store.voiceJoined();
       }
-      // Mic-mute mirror.
+      // Mic-mute + availability mirror.
       const after = appStore.voiceState;
       if (after.kind === 'joined' && after.micMuted !== s.isMuted) {
         store.voiceSetMicMuted(s.isMuted);
+      }
+      if (after.kind === 'joined' && after.micAvailable !== s.micAvailable) {
+        store.voiceSetMicAvailable(s.micAvailable);
       }
       break;
     }

--- a/pollis-core/src/commands/voice/lifecycle.rs
+++ b/pollis-core/src/commands/voice/lifecycle.rs
@@ -344,6 +344,12 @@ pub async fn join_voice_channel(
     };
     let mic_fut = async {
         tokio::task::spawn_blocking(move || {
+            // Test seam: exercise the listen-only path without unplugging a
+            // physical mic. The e2e suite sets this to prove a join still
+            // succeeds when capture is unavailable.
+            if std::env::var("POLLIS_DISABLE_MIC").is_ok() {
+                return Err(anyhow::anyhow!("mic disabled via POLLIS_DISABLE_MIC").into());
+            }
             let host = cpal::default_host();
             let dev = get_device(&host, input_device_clone.as_deref(), true)?;
             eprintln!("[voice] mic device: {:?}", dev.name());
@@ -358,21 +364,53 @@ pub async fn join_voice_channel(
     let (connect_res, room_connect_ms) = connect_pair;
     let (room, mut events) =
         connect_res.map_err(|e| anyhow::anyhow!("LiveKit connect: {e}"))?;
-    let (mic_stream, mic_rate, mic_init_ms) = mic_res
-        .map_err(|e| anyhow::anyhow!("mic init panicked: {e}"))??;
-    eprintln!("[voice] connected to room {channel_id}, mic at {mic_rate} Hz");
+
+    // Mic is best-effort: a missing/failed capture device must not block the
+    // join. On failure we connect *listen-only* — in the room, receiving
+    // remote audio/video, just not publishing a mic track. A missing mic, an
+    // ALSA "No such file or directory", a busy device, or POLLIS_DISABLE_MIC
+    // all land here.
+    let mic = match mic_res {
+        Ok(Ok(v)) => Some(v),
+        Ok(Err(e)) => {
+            eprintln!("[voice] mic unavailable — joining listen-only: {e}");
+            None
+        }
+        Err(e) => {
+            eprintln!("[voice] mic init panicked — joining listen-only: {e}");
+            None
+        }
+    };
+    let has_mic = mic.is_some();
+    // Listen-only still needs a nominal rate for the playback/APM plumbing;
+    // 48 kHz is what everything downstream prefers.
+    let mic_rate = mic.as_ref().map(|(_, r, _)| *r).unwrap_or(48_000);
+    let mic_init_ms = mic.as_ref().map(|(_, _, ms)| *ms).unwrap_or(0);
+    let mic_stream = mic.map(|(s, _, _)| s);
+    if has_mic {
+        eprintln!("[voice] connected to room {channel_id}, mic at {mic_rate} Hz");
+    } else {
+        eprintln!("[voice] connected to room {channel_id}, listen-only (no mic)");
+    }
 
     let room = Arc::new(room);
 
     // ── Build APM at the mic's actual rate ────────────────────────────────
     // WebRTC supports 8/16/32/48 kHz. Anything else (e.g. legacy 44.1) means
     // we can't run APM for this session; we log and proceed without it.
-    let apm_stage = match voice_apm::ApmStage::new(mic_rate, audio_processing.clone()) {
-        Ok(stage) => Some(stage),
-        Err(e) => {
-            eprintln!("[voice] APM disabled: {e}");
-            None
+    // APM only touches the captured mic signal (and taps playback as its AEC
+    // render reference). With no mic there's nothing to process and no echo to
+    // cancel, so skip it entirely on the listen-only path.
+    let apm_stage = if has_mic {
+        match voice_apm::ApmStage::new(mic_rate, audio_processing.clone()) {
+            Ok(stage) => Some(stage),
+            Err(e) => {
+                eprintln!("[voice] APM disabled: {e}");
+                None
+            }
         }
+    } else {
+        None
     };
     let apm_handle = apm_stage.as_ref().map(|s| s.handle());
     let apm_frame_samples = voice_apm::frame_samples(mic_rate);
@@ -386,11 +424,11 @@ pub async fn join_voice_channel(
     });
     {
         let mut slot = denoiser_arc.lock().unwrap();
-        *slot = if audio_processing.click_suppression && mic_rate == voice_denoiser::REQUIRED_RATE_HZ {
+        *slot = if has_mic && audio_processing.click_suppression && mic_rate == voice_denoiser::REQUIRED_RATE_HZ {
             eprintln!("[voice/rnnoise] engaged @ {mic_rate} Hz");
             Some(voice_denoiser::DenoiserStage::new())
         } else {
-            if audio_processing.click_suppression {
+            if has_mic && audio_processing.click_suppression {
                 eprintln!(
                     "[voice/rnnoise] requested but mic rate is {mic_rate} Hz; \
                      RNNoise needs 48000 Hz — disabling for this session"
@@ -400,139 +438,153 @@ pub async fn join_voice_channel(
         };
     }
 
-    // Disable libwebrtc's internal AudioProcessingModule — APM is the only
-    // stage that touches the mic signal. Leaving libwebrtc's APM on would
-    // double-process and produce pumping/swirling artefacts.
-    let audio_source = NativeAudioSource::new(
-        AudioSourceOptions {
-            echo_cancellation: false,
-            noise_suppression: false,
-            auto_gain_control: false,
-        },
-        mic_rate,
-        1,
-        100,
-    );
+    // Publish the mic track and run the capture pipeline only when we have a
+    // working mic. On the listen-only path we skip all of it — no track, no
+    // APM capture loop — and simply consume remote media.
+    let mut audio_source_opt: Option<NativeAudioSource> = None;
+    let mut local_track_opt: Option<LocalAudioTrack> = None;
+    let mut frame_task_opt: Option<tokio::task::JoinHandle<()>> = None;
+    let mut first_publish_ms: u64 = 0;
 
-    let local_track = LocalAudioTrack::create_audio_track(
-        "microphone",
-        RtcAudioSource::Native(audio_source.clone()),
-    );
+    if has_mic {
+        // Disable libwebrtc's internal AudioProcessingModule — APM is the only
+        // stage that touches the mic signal. Leaving libwebrtc's APM on would
+        // double-process and produce pumping/swirling artefacts.
+        let audio_source = NativeAudioSource::new(
+            AudioSourceOptions {
+                echo_cancellation: false,
+                noise_suppression: false,
+                auto_gain_control: false,
+            },
+            mic_rate,
+            1,
+            100,
+        );
 
-    eprintln!("[voice] publishing track…");
-    // ── Phase: first_publish ───────────────────────────────────────────────
-    let publish_start = Instant::now();
-    room.local_participant()
-        .publish_track(
-            LocalTrack::Audio(local_track.clone()),
-            TrackPublishOptions::default(),
-        )
-        .await
-        .map_err(|e| anyhow::anyhow!("publish track: {e}"))?;
-    let first_publish_ms = publish_start.elapsed().as_millis() as u64;
-    eprintln!("[voice] track published");
+        let local_track = LocalAudioTrack::create_audio_track(
+            "microphone",
+            RtcAudioSource::Native(audio_source.clone()),
+        );
 
-    // ── Mic frame task: rebuffer to exact 10ms, run APM, capture_frame ────
-    // Speaking detection runs on the post-APM peak so the indicator follows
-    // the user's effective level (after AGC + NS) rather than raw input.
-    let audio_source_task = audio_source.clone();
-    let voice_arc_frame = Arc::clone(&state.voice);
-    let local_identity_for_speaking = local_identity.clone();
-    let apm_for_capture = apm_handle.clone();
-    let denoiser_for_capture = Arc::clone(&denoiser_arc);
-    let frame_task = tokio::spawn(async move {
-        let chunk_size = (mic_rate / 100) as usize;
-        let mut buf: Vec<i16> = Vec::new();
-        let mut speak_hold: u32 = 0; // counts down after speech stops (12 × 10ms = 120ms hold)
-        let mut onset_frames: u32 = 0; // consecutive above-threshold frames; 2 required to (re)trigger
-        let mut is_speaking = false;
+        eprintln!("[voice] publishing track…");
+        // ── Phase: first_publish ───────────────────────────────────────────────
+        let publish_start = Instant::now();
+        room.local_participant()
+            .publish_track(
+                LocalTrack::Audio(local_track.clone()),
+                TrackPublishOptions::default(),
+            )
+            .await
+            .map_err(|e| anyhow::anyhow!("publish track: {e}"))?;
+        first_publish_ms = publish_start.elapsed().as_millis() as u64;
+        eprintln!("[voice] track published");
 
-        // Live multi-band meter for our own tile. Sink cloned once so the
-        // per-frame emit never re-locks the shared VoiceState mutex. Emit
-        // every 5 chunks (~10 ms each) ⇒ ~20 Hz.
-        let bands_sink = voice_arc_frame.lock().await.channel.clone();
-        let mut analyzer = BandAnalyzer::new(mic_rate);
-        let mut bands_ctr: u32 = 0;
+        // ── Mic frame task: rebuffer to exact 10ms, run APM, capture_frame ────
+        // Speaking detection runs on the post-APM peak so the indicator follows
+        // the user's effective level (after AGC + NS) rather than raw input.
+        let audio_source_task = audio_source.clone();
+        let voice_arc_frame = Arc::clone(&state.voice);
+        let local_identity_for_speaking = local_identity.clone();
+        let apm_for_capture = apm_handle.clone();
+        let denoiser_for_capture = Arc::clone(&denoiser_arc);
+        let frame_task = tokio::spawn(async move {
+            let chunk_size = (mic_rate / 100) as usize;
+            let mut buf: Vec<i16> = Vec::new();
+            let mut speak_hold: u32 = 0; // counts down after speech stops (12 × 10ms = 120ms hold)
+            let mut onset_frames: u32 = 0; // consecutive above-threshold frames; 2 required to (re)trigger
+            let mut is_speaking = false;
 
-        while let Some((samples, rate)) = frame_rx.recv().await {
-            buf.extend_from_slice(&samples);
-            while buf.len() >= chunk_size {
-                let mut chunk: Vec<i16> = buf.drain(..chunk_size).collect();
+            // Live multi-band meter for our own tile. Sink cloned once so the
+            // per-frame emit never re-locks the shared VoiceState mutex. Emit
+            // every 5 chunks (~10 ms each) ⇒ ~20 Hz.
+            let bands_sink = voice_arc_frame.lock().await.channel.clone();
+            let mut analyzer = BandAnalyzer::new(mic_rate);
+            let mut bands_ctr: u32 = 0;
 
-                // RNNoise (if enabled) runs first so APM gets a cleaner signal:
-                // its NS / AGC adapt to actual voice energy instead of the
-                // typing/click noise floor. Std Mutex; the lock is held for
-                // ~0.1 ms per frame (single-writer) and never crosses an await.
-                {
-                    let mut guard = denoiser_for_capture.lock().unwrap();
-                    if let Some(d) = guard.as_mut() {
-                        d.process(&mut chunk);
-                    }
-                }
+            while let Some((samples, rate)) = frame_rx.recv().await {
+                buf.extend_from_slice(&samples);
+                while buf.len() >= chunk_size {
+                    let mut chunk: Vec<i16> = buf.drain(..chunk_size).collect();
 
-                // APM mutates the chunk in place (AGC + NS + HPF + AEC capture).
-                if let Some(apm) = &apm_for_capture {
-                    if let Err(e) = voice_apm::run_capture(apm, &mut chunk, chunk_size) {
-                        eprintln!("[voice] APM capture error (frame dropped): {e}");
-                        continue;
-                    }
-                }
-
-                let peak = chunk.iter().map(|&s| s.abs()).max().unwrap_or(0);
-
-                // Speaking detection: require 2 consecutive above-threshold frames to trigger,
-                // preventing single trailing spikes from resetting the hold counter.
-                if peak > 1000 {
-                    onset_frames += 1;
-                    if onset_frames >= 2 {
-                        speak_hold = 12;
-                    }
-                } else {
-                    onset_frames = 0;
-                    if speak_hold > 0 {
-                        speak_hold -= 1;
-                    }
-                }
-                let now_speaking = speak_hold > 0;
-                if now_speaking != is_speaking {
-                    is_speaking = now_speaking;
-                    let voice = voice_arc_frame.lock().await;
-                    if let Some(ch) = &voice.channel {
-                        if is_speaking {
-                            let _ = ch.send(VoiceEvent::SpeakingStarted { identity: local_identity_for_speaking.clone() });
-                        } else {
-                            let _ = ch.send(VoiceEvent::SpeakingStopped { identity: local_identity_for_speaking.clone() });
+                    // RNNoise (if enabled) runs first so APM gets a cleaner signal:
+                    // its NS / AGC adapt to actual voice energy instead of the
+                    // typing/click noise floor. Std Mutex; the lock is held for
+                    // ~0.1 ms per frame (single-writer) and never crosses an await.
+                    {
+                        let mut guard = denoiser_for_capture.lock().unwrap();
+                        if let Some(d) = guard.as_mut() {
+                            d.process(&mut chunk);
                         }
                     }
-                }
 
-                // Live band meter on the post-APM signal (same source as
-                // the speaking indicator, so the meter matches what others
-                // hear). Decimated to ~20 Hz.
-                analyzer.process(&chunk);
-                bands_ctr += 1;
-                if bands_ctr >= 5 {
-                    bands_ctr = 0;
-                    if let Some(ch) = &bands_sink {
-                        let _ = ch.send(VoiceEvent::AudioBands {
-                            identity: local_identity_for_speaking.clone(),
-                            bands: analyzer.levels(),
-                        });
+                    // APM mutates the chunk in place (AGC + NS + HPF + AEC capture).
+                    if let Some(apm) = &apm_for_capture {
+                        if let Err(e) = voice_apm::run_capture(apm, &mut chunk, chunk_size) {
+                            eprintln!("[voice] APM capture error (frame dropped): {e}");
+                            continue;
+                        }
+                    }
+
+                    let peak = chunk.iter().map(|&s| s.abs()).max().unwrap_or(0);
+
+                    // Speaking detection: require 2 consecutive above-threshold frames to trigger,
+                    // preventing single trailing spikes from resetting the hold counter.
+                    if peak > 1000 {
+                        onset_frames += 1;
+                        if onset_frames >= 2 {
+                            speak_hold = 12;
+                        }
+                    } else {
+                        onset_frames = 0;
+                        if speak_hold > 0 {
+                            speak_hold -= 1;
+                        }
+                    }
+                    let now_speaking = speak_hold > 0;
+                    if now_speaking != is_speaking {
+                        is_speaking = now_speaking;
+                        let voice = voice_arc_frame.lock().await;
+                        if let Some(ch) = &voice.channel {
+                            if is_speaking {
+                                let _ = ch.send(VoiceEvent::SpeakingStarted { identity: local_identity_for_speaking.clone() });
+                            } else {
+                                let _ = ch.send(VoiceEvent::SpeakingStopped { identity: local_identity_for_speaking.clone() });
+                            }
+                        }
+                    }
+
+                    // Live band meter on the post-APM signal (same source as
+                    // the speaking indicator, so the meter matches what others
+                    // hear). Decimated to ~20 Hz.
+                    analyzer.process(&chunk);
+                    bands_ctr += 1;
+                    if bands_ctr >= 5 {
+                        bands_ctr = 0;
+                        if let Some(ch) = &bands_sink {
+                            let _ = ch.send(VoiceEvent::AudioBands {
+                                identity: local_identity_for_speaking.clone(),
+                                bands: analyzer.levels(),
+                            });
+                        }
+                    }
+
+                    let frame = AudioFrame {
+                        data: chunk.into(),
+                        sample_rate: rate,
+                        num_channels: 1,
+                        samples_per_channel: chunk_size as u32,
+                    };
+                    if let Err(e) = audio_source_task.capture_frame(&frame).await {
+                        eprintln!("[voice] capture_frame error: {e:?}");
                     }
                 }
-
-                let frame = AudioFrame {
-                    data: chunk.into(),
-                    sample_rate: rate,
-                    num_channels: 1,
-                    samples_per_channel: chunk_size as u32,
-                };
-                if let Err(e) = audio_source_task.capture_frame(&frame).await {
-                    eprintln!("[voice] capture_frame error: {e:?}");
-                }
             }
-        }
-    });
+        });
+
+        audio_source_opt = Some(audio_source);
+        local_track_opt = Some(local_track);
+        frame_task_opt = Some(frame_task);
+    }
 
     // ── Open the speaker pipeline: single output stream + mixer task ──────
     // Doing this BEFORE the room event loop starts means the very first
@@ -807,10 +859,11 @@ pub async fn join_voice_channel(
     if let Some(t) = voice.room_task.take() { t.abort(); }
     if let Some(t) = voice.frame_task.take() { t.abort(); }
     voice.room = Some(room);
-    voice.local_track = Some(local_track);
-    voice.audio_source = Some(audio_source);
-    voice.input_stream = Some(mic_stream);
-    voice.frame_task = Some(frame_task);
+    // All `None` on the listen-only path (no mic captured/published).
+    voice.local_track = local_track_opt;
+    voice.audio_source = audio_source_opt;
+    voice.input_stream = mic_stream;
+    voice.frame_task = frame_task_opt;
     voice.room_task = Some(room_task);
     voice.current_input_device = input_device;
     voice.apm = apm_stage;
@@ -818,6 +871,16 @@ pub async fn join_voice_channel(
     voice.e2ee_mls_group_id = Some(voice_mls_group_id);
     voice.e2ee_epoch = voice_epoch;
     *voice.last_join_timings.lock().unwrap() = Some(timings);
+
+    // Tell the renderer whether this session can transmit, so the local tile
+    // and tray show a "listening only" state instead of a live mute toggle
+    // when there's no capture device.
+    if let Some(ch) = &voice.channel {
+        let _ = ch.send(VoiceEvent::MicAvailability {
+            identity: local_identity.clone(),
+            available: has_mic,
+        });
+    }
 
     Ok(())
 }

--- a/pollis-core/src/commands/voice/types.rs
+++ b/pollis-core/src/commands/voice/types.rs
@@ -88,6 +88,12 @@ pub enum VoiceEvent {
     ParticipantLeft { identity: String },
     Muted { identity: String },
     Unmuted { identity: String },
+    /// Whether the local session has a working capture device. Emitted once at
+    /// join: `available: false` means the mic failed to open (no device, ALSA
+    /// error, busy) and we joined *listen-only* — connected and receiving, but
+    /// not publishing audio. Lets the renderer swap the mute toggle for a
+    /// "listening only" indicator. Only ever carries the local identity.
+    MicAvailability { identity: String, available: bool },
     SpeakingStarted { identity: String },
     SpeakingStopped { identity: String },
     /// Per-source multi-band audio levels (one 0..1 value per band),

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
   "permissions": [
     "core:default",
     "core:window:allow-start-dragging",
+    "core:window:allow-start-resize-dragging",
     "core:window:allow-minimize",
     "core:window:allow-toggle-maximize",
     "core:window:allow-close",


### PR DESCRIPTION
Two fixes.

## 1. Voice: join listen-only when there's no mic
`join_voice_channel` treated mic init as fatal, so an ALSA capture error (e.g. no mic plugged in on Wayland: `snd_pcm_hw_params` "No such file or directory") aborted the whole join — you couldn't even listen in or watch video.

Mic is now best-effort. On failure it joins **listen-only**: connected, receiving remote audio/video, just not publishing. The capture side (source, publish, frame task, APM, denoiser) is skipped; playback is untouched. Backend emits `MicAvailability`, and the mute toggle becomes a non-interactive "listening only" indicator in the voice bar + stage tray.

E2E: `voice-channel-no-mic.js` (dispatch workflow + S-NOMIC) forces the path via a new `POLLIS_DISABLE_MIC=1` seam and asserts the join succeeds with the listen-only indicator shown.

## 2. Linux window resize edges
`decorations: false` gives Linux/Wayland no server-side resize border (macOS/Windows re-add native ones), so resizing meant grabbing the 1px compositor edge. Added `WindowResizeEdges` — 8 invisible strips (6px edges / 12px corners) calling `startResizeDragging`, gated to Tauri+Linux. Needed a `core:window:allow-start-resize-dragging` capability.

## Verified
`cargo check -p pollis-core --features media`, `tsc`, `vite build`. Not run end-to-end locally (voice needs LiveKit + backend fixtures — covered by the e2e workflow).