### PR TITLE
chore(release): keep only the latest 3 desktop versions in R2

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -575,12 +575,25 @@ jobs:
         run: |
           VERSION="${GITHUB_REF_NAME}"
           ENDPOINT="https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com"
-          # Use the actual artifact paths with wildcards
-          aws s3 cp $(find artifacts/pollis-macos -name "*.dmg" | head -1) "s3://pollis/releases/${VERSION}/pollis-${VERSION}-macos.dmg" --endpoint-url "${ENDPOINT}"
-          aws s3 cp $(find artifacts/pollis-windows -name "*.exe" | head -1) "s3://pollis/releases/${VERSION}/pollis-${VERSION}-windows.exe" --endpoint-url "${ENDPOINT}"
-          aws s3 cp $(find artifacts/pollis-linux -name "*.AppImage" | head -1) "s3://pollis/releases/${VERSION}/pollis-${VERSION}-linux.AppImage" --endpoint-url "${ENDPOINT}"
-          aws s3 cp $(find artifacts/pollis-linux -name "*.deb" | head -1) "s3://pollis/releases/${VERSION}/pollis-${VERSION}-linux.deb" --endpoint-url "${ENDPOINT}"
-          aws s3 cp $(find artifacts/pollis-linux -name "*.rpm" | head -1) "s3://pollis/releases/${VERSION}/pollis-${VERSION}-linux.rpm" --endpoint-url "${ENDPOINT}"
+          DMG=$(find artifacts/pollis-macos -name "*.dmg" | head -1)
+          EXE=$(find artifacts/pollis-windows -name "*.exe" | head -1)
+          APPIMAGE=$(find artifacts/pollis-linux -name "*.AppImage" | head -1)
+          DEB=$(find artifacts/pollis-linux -name "*.deb" | head -1)
+          RPM=$(find artifacts/pollis-linux -name "*.rpm" | head -1)
+          # Version-pinned, immutable copies — the canonical per-release artifacts.
+          aws s3 cp "$DMG"      "s3://pollis/releases/${VERSION}/pollis-${VERSION}-macos.dmg"      --endpoint-url "${ENDPOINT}"
+          aws s3 cp "$EXE"      "s3://pollis/releases/${VERSION}/pollis-${VERSION}-windows.exe"    --endpoint-url "${ENDPOINT}"
+          aws s3 cp "$APPIMAGE" "s3://pollis/releases/${VERSION}/pollis-${VERSION}-linux.AppImage" --endpoint-url "${ENDPOINT}"
+          aws s3 cp "$DEB"      "s3://pollis/releases/${VERSION}/pollis-${VERSION}-linux.deb"       --endpoint-url "${ENDPOINT}"
+          aws s3 cp "$RPM"      "s3://pollis/releases/${VERSION}/pollis-${VERSION}-linux.rpm"       --endpoint-url "${ENDPOINT}"
+          # Stable "latest" aliases (overwritten every release, NEVER pruned) so the
+          # website's no-JS download links resolve to the current release forever,
+          # instead of a hard-coded version that the retention prune below would 404.
+          aws s3 cp "$DMG"      "s3://pollis/releases/latest/pollis-latest-macos.dmg"      --endpoint-url "${ENDPOINT}" --cache-control "no-cache"
+          aws s3 cp "$EXE"      "s3://pollis/releases/latest/pollis-latest-windows.exe"    --endpoint-url "${ENDPOINT}" --cache-control "no-cache"
+          aws s3 cp "$APPIMAGE" "s3://pollis/releases/latest/pollis-latest-linux.AppImage" --endpoint-url "${ENDPOINT}" --cache-control "no-cache"
+          aws s3 cp "$DEB"      "s3://pollis/releases/latest/pollis-latest-linux.deb"       --endpoint-url "${ENDPOINT}" --cache-control "no-cache"
+          aws s3 cp "$RPM"      "s3://pollis/releases/latest/pollis-latest-linux.rpm"       --endpoint-url "${ENDPOINT}" --cache-control "no-cache"
         env:
           AWS_ACCESS_KEY_ID: ${{ env.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.R2_SECRET_KEY }}
@@ -687,6 +700,62 @@ jobs:
           ENDPOINT="https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com"
           echo "{\"version\":\"${VERSION}\",\"macos\":\"https://cdn.pollis.com/releases/${VERSION}/pollis-${VERSION}-macos.dmg\",\"windows\":\"https://cdn.pollis.com/releases/${VERSION}/pollis-${VERSION}-windows.exe\",\"linux\":\"https://cdn.pollis.com/releases/${VERSION}/pollis-${VERSION}-linux.AppImage\",\"linux_deb\":\"https://cdn.pollis.com/releases/${VERSION}/pollis-${VERSION}-linux.deb\",\"linux_rpm\":\"https://cdn.pollis.com/releases/${VERSION}/pollis-${VERSION}-linux.rpm\"}" > latest.json
           aws s3 cp latest.json "s3://pollis/releases/latest.json" --endpoint-url "${ENDPOINT}" --content-type "application/json" --cache-control "no-cache"
+        env:
+          AWS_ACCESS_KEY_ID: ${{ env.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ env.R2_SECRET_KEY }}
+          AWS_DEFAULT_REGION: auto
+
+      # Retention: keep only the newest KEEP version directories under
+      # `releases/`. This is COUNT-based and runs only when a release ships — a
+      # deliberate choice over an R2 lifecycle (age) rule, which would delete the
+      # CURRENT release if the project went a while between releases. GitHub
+      # Releases remain the permanent archive of every version's installers; R2
+      # keeps a small rolling window because the auto-updater / install.sh / AUR /
+      # website only ever reference the latest (plus a couple for rollback
+      # headroom). Best-effort: a prune failure must never fail an otherwise-good
+      # release, so errors are warnings, not fatal. Only `releases/v<semver>/`
+      # prefixes are candidates — top-level files (install.sh, latest.json,
+      # update-*.json), the `latest/` alias, and `cli/` never match.
+      - name: Prune old release versions from R2 (keep latest 3)
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          ENDPOINT="https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com"
+          KEEP=3
+          CURRENT="${GITHUB_REF_NAME}"
+
+          # Version "directories" directly under releases/. `aws s3 ls` prints
+          # `  PRE v1.5.1/` for each common prefix; keep only version-tag-shaped
+          # ones (v + digit) so nothing else is ever a deletion candidate.
+          VERSIONS=()
+          while IFS= read -r v; do
+            [ -n "$v" ] && VERSIONS+=("$v")
+          done < <(
+            aws s3 ls "s3://pollis/releases/" --endpoint-url "${ENDPOINT}" \
+              | awk '/ PRE v[0-9]/ { print $2 }' \
+              | sed 's#/$##' \
+              | sort -Vr
+          )
+
+          echo "Found ${#VERSIONS[@]} version prefix(es): ${VERSIONS[*]:-<none>}"
+          if [ "${#VERSIONS[@]}" -le "$KEEP" ]; then
+            echo "At or below keep threshold ($KEEP) — nothing to prune."
+            exit 0
+          fi
+
+          # Keep the newest $KEEP, and ALWAYS keep the version we just published
+          # (latest.json / update-*.json point at it; also guards any version-sort
+          # edge case around prerelease tags).
+          KEEP_SET=$(printf '%s\n' "${VERSIONS[@]:0:$KEEP}" "$CURRENT" | sort -u)
+          echo "Keeping:"; echo "$KEEP_SET" | sed 's/^/  /'
+
+          for v in "${VERSIONS[@]}"; do
+            if ! grep -qxF "$v" <<< "$KEEP_SET"; then
+              echo "Pruning s3://pollis/releases/$v/"
+              aws s3 rm "s3://pollis/releases/$v/" --recursive --endpoint-url "${ENDPOINT}" \
+                || echo "::warning::failed to prune $v — leaving it in place"
+            fi
+          done
         env:
           AWS_ACCESS_KEY_ID: ${{ env.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.R2_SECRET_KEY }}

--- a/docs/deployments.md
+++ b/docs/deployments.md
@@ -40,6 +40,7 @@ There are **4 shipped executables/sites**, **3 running backend services**, and
 - **From:** `src-tauri/` + `frontend/` + `pollis-core/` + `pollis-capture-*`
 - **Pipeline:** `.github/workflows/desktop-release.yml` — triggered by a `git tag v*` push (the whole ceremony: version stamp, signed macOS DMG/ZIP, Windows via Azure Trusted Signing, Linux .deb/.rpm/.AppImage + AUR, R2 upload, GitHub release, `latest.json` + Tauri updater manifests, and `apply-migrations` to prod Turso).
 - **Ships to:** `cdn.pollis.com/releases/<version>/…` + auto-update manifests. Install: the download cards / `curl … cdn.pollis.com/releases/install.sh | bash` on the site.
+- **R2 retention:** the release job keeps only the **latest 3** `releases/v*/` version directories on R2, pruning older ones **at release time** (count-based, not an R2 lifecycle/age rule — an age rule would delete the *current* release if releases went quiet). It never prunes the version it just published, the top-level `install.sh`/`latest.json`/`update-*.json`, the `releases/latest/` alias, or `cli/`. **GitHub Releases remain the permanent archive** of every version's installers, and the transparency log retains every binary hash — so R2 only needs a small rolling window (the updater/install.sh/AUR/website reference only the latest, plus a couple for rollback headroom). The no-JS website download links point at the stable `releases/latest/pollis-latest-*` alias (overwritten each release, never pruned).
 
 ### 2. CLI / terminal client (`pollis`)
 - **From:** `pollis-tui/` + `pollis-core/` (headless, no Tauri)

--- a/website/index.html
+++ b/website/index.html
@@ -71,7 +71,7 @@
     <section id="download" class="download-section">
       <h2 class="download-heading">Download Pollis</h2>
       <div class="download-grid">
-        <a class="download-card" href="https://cdn.pollis.com/releases/v1.0.41/pollis-v1.0.41-macos.dmg"
+        <a class="download-card" href="https://cdn.pollis.com/releases/latest/pollis-latest-macos.dmg"
           data-platform="macos">
           <svg class="download-icon" viewBox="-1.5 0 20 20" fill="currentColor" width="32" height="32"
             aria-hidden="true">
@@ -85,7 +85,7 @@
           <span class="download-platform">macOS</span>
           <span class="download-detail">Apple Silicon</span>
         </a>
-        <a class="download-card" href="https://cdn.pollis.com/releases/v1.0.41/pollis-v1.0.41-windows.exe"
+        <a class="download-card" href="https://cdn.pollis.com/releases/latest/pollis-latest-windows.exe"
           data-platform="windows">
           <svg class="download-icon" viewBox="0 0 20 20" fill="currentColor" width="32" height="32" aria-hidden="true">
             <g transform="translate(-60,-7439)">
@@ -105,11 +105,11 @@
           </svg>
           <span class="download-platform">Linux</span>
           <div class="linux-formats">
-            <a class="linux-format-link" href="https://cdn.pollis.com/releases/v1.0.41/pollis-v1.0.41-linux.deb"
+            <a class="linux-format-link" href="https://cdn.pollis.com/releases/latest/pollis-latest-linux.deb"
               data-platform="linux_deb">.deb</a>
-            <a class="linux-format-link" href="https://cdn.pollis.com/releases/v1.0.41/pollis-v1.0.41-linux.rpm"
+            <a class="linux-format-link" href="https://cdn.pollis.com/releases/latest/pollis-latest-linux.rpm"
               data-platform="linux_rpm">.rpm</a>
-            <a class="linux-format-link" href="https://cdn.pollis.com/releases/v1.0.41/pollis-v1.0.41-linux.AppImage"
+            <a class="linux-format-link" href="https://cdn.pollis.com/releases/latest/pollis-latest-linux.AppImage"
               data-platform="linux">.AppImage</a>
           </div>
           <span class="download-detail">Arch Linux: <a href="https://aur.archlinux.org/packages/pollis" class="aur-link" target="_blank" rel="noopener noreferrer">AUR</a></span>


### PR DESCRIPTION
Bounds R2 release storage to a small rolling window without risking the current release.

## What
- **Count-based prune** in `desktop-release.yml`: at release time, keep the newest 3 `releases/v*/` directories, prune older ones. Best-effort (`continue-on-error`) so it never fails an otherwise-good release. **Always keeps the just-published version** (belt-and-braces against prerelease version-sort edge cases); only `v<semver>/` prefixes are candidates, so `install.sh`/`latest.json`/`update-*.json`/`latest/`/`cli/` are never touched.
- **Stable `releases/latest/pollis-latest-*` aliases** (overwritten each release, never pruned) + repoint the website's no-JS download fallback at them — replaces hard-coded `v1.0.41` links that the prune would otherwise 404.

## Why count-based, not an R2 lifecycle rule
An age-based lifecycle rule would delete the **current** release if releases went quiet for a while. A prune that runs *on release* and keeps a fixed count can't strand the live version.

## Safe because
- **GitHub Releases** remain the permanent archive of every version's installers.
- The **transparency log** retains every binary hash regardless.
- The auto-updater / `install.sh` / AUR / website only reference the latest (plus a couple kept for rollback headroom).

Prune selection logic tested locally against simulated `aws s3 ls` output (normal, prerelease-current, and ≤3-versions cases). Docs updated in `deployments.md`.

Note: old versions' SLSA provenance (`.intoto.jsonl`) lives under the version prefix and prunes with it; re-generatable via `attest-release.yml`, and the log keeps the hashes.