### PR TITLE
fix(voice): render camera + screenshare as two tiles per participant (#394)

### DIFF
--- a/.codesight/wiki/capture-split.md
+++ b/.codesight/wiki/capture-split.md
@@ -299,8 +299,11 @@ default; the driver adjusts and we publish whatever it gives. Verified at
   screenshare]`); `StageTile.media` is a `audio | camera | screenshare`
   discriminated union so a tile carries exactly one surface (the old
   "camera-as-tile-face, dropped when screensharing" state is unrepresentable).
-  Only screenshare tiles drive the spotlight/filmstrip and carry the res·fps
-  stats badge; camera tiles are plain grid tiles.
+  Camera and screenshare tiles are treated identically at the container level —
+  both spotlightable, fullscreenable, and carrying the res·fps badge; the
+  container doesn't care where the pixels come from. The `:cam`/`:screen` tile
+  key suffix (not the badge) is what tells the two apart. When both a camera and
+  a screenshare are present, the screenshare takes the default spotlight.
 - **Frontend**: `camera/cameraSession.ts` (event subscription + lifecycle,
   reuses `screenShareSession`'s frame router), `camera/cameraActions.ts`
   (`toggleCamera`), `components/Voice/CameraPicker.tsx` (in-app picker, bar

--- a/.codesight/wiki/capture-split.md
+++ b/.codesight/wiki/capture-split.md
@@ -288,14 +288,24 @@ default; the driver adjusts and we publish whatever it gives. Verified at
   `on_remote_video_subscribed` drain + frame WS. The voice room loop reads
   the publication's `TrackSource` and tags `ScreenShareEvent::RemoteStarted`
   with a `source` (`screen` | `camera`); the renderer routes the track_key
-  to a participant's camera tile (the tile face) vs a screenshare spotlight
-  streamer. The Tauri renderer has no JS LiveKit client, so this tag is the
-  only thing that distinguishes them.
+  to the participant's camera axis (`appStore.cameraRemotes`) vs its
+  screenshare axis (`participant.video`). The Tauri renderer has no JS LiveKit
+  client, so this tag is the only thing that distinguishes them.
+- **Two tiles, not one (#394)**: camera and screenshare are independent axes
+  that coexist, so a participant publishing both renders as **two separate
+  tiles** — a camera tile and a screenshare tile. `VoiceStage`'s `tilesFor`
+  expands each participant into up to two `StageTileModel`s
+  (`none→[audio] / camera→[camera] / screen→[screenshare] / both→[camera,
+  screenshare]`); `StageTile.media` is a `audio | camera | screenshare`
+  discriminated union so a tile carries exactly one surface (the old
+  "camera-as-tile-face, dropped when screensharing" state is unrepresentable).
+  Only screenshare tiles drive the spotlight/filmstrip and carry the res·fps
+  stats badge; camera tiles are plain grid tiles.
 - **Frontend**: `camera/cameraSession.ts` (event subscription + lifecycle,
   reuses `screenShareSession`'s frame router), `camera/cameraActions.ts`
   (`toggleCamera`), `components/Voice/CameraPicker.tsx` (in-app picker, bar
-  pattern), camera toggle in `VoiceBar` + the stage tray, and camera-as-
-  tile-face in `StageTile`. MobX `CameraState` union mirrors `ShareState`.
+  pattern), camera toggle in `VoiceBar` + the stage tray, and the camera tile
+  in `StageTile`/`VoiceStage`. MobX `CameraState` union mirrors `ShareState`.
 
 ## Parent-side pipeline (unchanged, shared by all paths)
 

--- a/e2e/two-client-camera.js
+++ b/e2e/two-client-camera.js
@@ -5,6 +5,12 @@
  * end: one client turns its webcam on in a live call, the OTHER client sees
  * the remote camera video tile render.
  *
+ * Then (#394) A ALSO starts a screen share, and B must see A as TWO tiles — a
+ * camera tile AND a screenshare tile — proving simultaneous camera+screen
+ * render as two tiles instead of the screenshare replacing (dropping) the
+ * camera. The Xvfb display + LiveKit this camera fixture already stands up also
+ * support X11 screenshare, so no extra fixture is needed.
+ *
  * Builds on the M3a call test (two-client-call.js): the signup + DM-establish +
  * place/accept-call choreography is reused verbatim (copied, matching how M3a
  * itself copied from two-client.js — these e2e flow helpers are duplicated per
@@ -312,6 +318,74 @@ async function waitForRemoteCamera(browser, tag, timeoutMs) {
   );
 }
 
+// A: start a screen share ALONGSIDE the camera. Linux/X11 enumerates empty, so
+// the toggle starts capture directly with no picker (same as
+// two-client-screenshare.js). Bar pill first, stage tray as fallback.
+async function startScreenShare(browser, tag) {
+  if (await h.present(browser, "voice-bar-screenshare-button")) {
+    await h.clickTestId(browser, "voice-bar-screenshare-button");
+    return;
+  }
+  if (await h.present(browser, "voice-tray-screenshare")) {
+    await h.clickTestId(browser, "voice-tray-screenshare");
+    return;
+  }
+  throw new Error(`${tag}: no screenshare toggle (voice-bar-screenshare-button / voice-tray-screenshare) on screen`);
+}
+
+// Which KINDS of remote video tile this client currently renders. A remote tile
+// (`voice-tile-voice-<id>` root with a nested non-local `remote-video-tile-`)
+// is a screenshare if it carries the res·fps stats badge, else a camera. #394:
+// a participant publishing both must show up as BOTH kinds — two distinct tiles.
+async function remoteVideoTileKinds(browser) {
+  return browser.execute((localKeys) => {
+    let camera = false;
+    let screenshare = false;
+    for (const tile of document.querySelectorAll('[data-testid^="voice-tile-voice-"]')) {
+      if (!tile.classList.contains("vs-tile")) {
+        continue;
+      }
+      let hasRemoteVideo = false;
+      for (const v of tile.querySelectorAll('[data-testid^="remote-video-tile-"]')) {
+        const key = (v.getAttribute("data-testid") || "").slice("remote-video-tile-".length);
+        if (!localKeys.includes(key)) {
+          hasRemoteVideo = true;
+        }
+      }
+      if (!hasRemoteVideo) {
+        continue;
+      }
+      if (tile.querySelector('[data-testid^="voice-tile-stream-stats-"]')) {
+        screenshare = true;
+      } else {
+        camera = true;
+      }
+    }
+    return { camera, screenshare };
+  }, [LOCAL_CAMERA_PREVIEW_KEY, LOCAL_PREVIEW_KEY]);
+}
+
+// B: poll until it renders BOTH a remote camera tile AND a remote screenshare
+// tile — i.e. A's simultaneous camera+screen surfaces as two tiles (#394). This
+// is the regression guard for the old bug where a screenshare REPLACED the
+// camera tile and the camera was silently dropped.
+async function waitForBothRemoteVideo(browser, tag, timeoutMs) {
+  const end = Date.now() + timeoutMs;
+  let last = { camera: false, screenshare: false };
+  while (Date.now() < end) {
+    last = await remoteVideoTileKinds(browser).catch(() => ({ camera: false, screenshare: false }));
+    if (last.camera && last.screenshare) {
+      return;
+    }
+    await h.sleep(2000);
+  }
+  throw new Error(
+    `${tag}: expected BOTH a remote camera tile and a screenshare tile for the ` +
+      `participant sharing both (got camera=${last.camera}, screenshare=${last.screenshare}). ` +
+      "A participant publishing camera + screen must render two tiles (#394)."
+  );
+}
+
 async function main() {
   h.reap();
   const devEnv = h.readEnvFile(".env.development");
@@ -411,6 +485,16 @@ async function main() {
     await waitForRemoteCamera(B.browser, "B", REMOTE_CAMERA_TIMEOUT_MS);
     await shot(B.browser, "two-client-camera-B-sees-camera.png");
     console.log("[two-client-camera] SUCCESS: B sees A's remote camera tile");
+
+    // ── #394: A ALSO shares its screen — camera + screenshare must render as
+    // TWO tiles for A on B. Before the fix, the screenshare took over A's tile
+    // and the camera was dropped; now each source gets its own tile. ──
+    console.log("[two-client-camera] A: starting a screen share alongside the camera");
+    await startScreenShare(A.browser, "A");
+    console.log("[two-client-camera] B: waiting for BOTH A's camera tile AND screenshare tile…");
+    await waitForBothRemoteVideo(B.browser, "B", REMOTE_CAMERA_TIMEOUT_MS);
+    await shot(B.browser, "two-client-camera-B-sees-both.png");
+    console.log("[two-client-camera] SUCCESS: B sees A's camera AND screenshare as two tiles");
 
     // Turn the camera off + hang up (best-effort — the run already succeeded).
     await clickCameraToggle(A.browser, "A").catch(() => {});

--- a/e2e/two-client-camera.js
+++ b/e2e/two-client-camera.js
@@ -267,10 +267,12 @@ async function waitForLocalCameraPreview(browser, tag, timeoutMs) {
 }
 
 // Remote CAMERA tiles visible on this client: `remote-video-tile-<trackKey>`
-// elements nested inside a participant tile (`voice-tile-voice-<id>` root,
-// class `vs-tile`), excluding the local-preview keys and excluding screenshare
-// feeds (a screenshare tile also carries a `voice-tile-stream-stats-` badge; a
-// camera face never does). Returns the owning tiles' identities + track keys.
+// elements nested inside a participant CAMERA tile — a `voice-tile-voice-<id>`
+// root (class `vs-tile`) whose key ends in `:cam` (a screenshare tile ends in
+// `:screen`). Camera and screenshare tiles are otherwise identical (both carry
+// the res·fps badge, both spotlightable), so the `:cam`/`:screen` suffix — not
+// the badge — is what tells them apart. Excludes the local-preview keys.
+// Returns the owning tiles' identities + track keys.
 async function remoteCameraTiles(browser) {
   return browser.execute((localKeys) => {
     const out = [];
@@ -280,9 +282,7 @@ async function remoteCameraTiles(browser) {
         continue;
       }
       const tileTestId = tile.getAttribute("data-testid") || "";
-      // A screenshare feed in this tile shows a res·fps badge; a camera doesn't.
-      const isScreenshare = !!tile.querySelector('[data-testid^="voice-tile-stream-stats-"]');
-      if (isScreenshare) {
+      if (!tileTestId.endsWith(":cam")) {
         continue;
       }
       for (const v of tile.querySelectorAll('[data-testid^="remote-video-tile-"]')) {
@@ -334,8 +334,8 @@ async function startScreenShare(browser, tag) {
 }
 
 // Which KINDS of remote video tile this client currently renders. A remote tile
-// (`voice-tile-voice-<id>` root with a nested non-local `remote-video-tile-`)
-// is a screenshare if it carries the res·fps stats badge, else a camera. #394:
+// (`voice-tile-voice-<id>` root with a nested non-local `remote-video-tile-`) is
+// a camera when its key ends `:cam`, a screenshare when it ends `:screen`. #394:
 // a participant publishing both must show up as BOTH kinds — two distinct tiles.
 async function remoteVideoTileKinds(browser) {
   return browser.execute((localKeys) => {
@@ -345,6 +345,7 @@ async function remoteVideoTileKinds(browser) {
       if (!tile.classList.contains("vs-tile")) {
         continue;
       }
+      const tileTestId = tile.getAttribute("data-testid") || "";
       let hasRemoteVideo = false;
       for (const v of tile.querySelectorAll('[data-testid^="remote-video-tile-"]')) {
         const key = (v.getAttribute("data-testid") || "").slice("remote-video-tile-".length);
@@ -355,9 +356,9 @@ async function remoteVideoTileKinds(browser) {
       if (!hasRemoteVideo) {
         continue;
       }
-      if (tile.querySelector('[data-testid^="voice-tile-stream-stats-"]')) {
+      if (tileTestId.endsWith(":screen")) {
         screenshare = true;
-      } else {
+      } else if (tileTestId.endsWith(":cam")) {
         camera = true;
       }
     }

--- a/e2e/two-client-screenshare.js
+++ b/e2e/two-client-screenshare.js
@@ -355,13 +355,14 @@ async function waitForLocalSharePreview(browser, tag, timeoutMs) {
   );
 }
 
-// Remote SCREENSHARE tiles visible on this client: a participant tile
-// (`voice-tile-voice-<id>` root, class `vs-tile`) that BOTH carries a
-// `voice-tile-stream-stats-` res·fps badge (screenshare-specific — a camera tile
-// never has it) AND contains a non-local `remote-video-tile-<trackKey>`. Returns
-// the owning tiles' identities + track keys. This is the mirror-INVERSE of the
-// M3b camera assertion (two-client-camera.js `remoteCameraTiles`, which EXCLUDES
-// tiles with that badge).
+// Remote SCREENSHARE tiles visible on this client: a participant SCREENSHARE
+// tile — a `voice-tile-voice-<id>` root (class `vs-tile`) whose key ends in
+// `:screen` (a camera tile ends `:cam`) — that contains a non-local
+// `remote-video-tile-<trackKey>`. Camera and screenshare tiles are otherwise
+// identical (both carry the res·fps badge, both spotlightable), so the
+// `:screen`/`:cam` key suffix — not the badge — distinguishes them. Returns the
+// owning tiles' identities + track keys. Mirror of the M3b camera assertion
+// (two-client-camera.js `remoteCameraTiles`, which matches `:cam`).
 async function remoteScreenshareTiles(browser) {
   return browser.execute((localKeys) => {
     const out = [];
@@ -371,9 +372,7 @@ async function remoteScreenshareTiles(browser) {
         continue;
       }
       const tileTestId = tile.getAttribute("data-testid") || "";
-      // A SCREENSHARE feed in this tile shows a res·fps badge; a camera doesn't.
-      const isScreenshare = !!tile.querySelector('[data-testid^="voice-tile-stream-stats-"]');
-      if (!isScreenshare) {
+      if (!tileTestId.endsWith(":screen")) {
         continue;
       }
       for (const v of tile.querySelectorAll('[data-testid^="remote-video-tile-"]')) {

--- a/frontend/src/components/Voice/stage/StageTile.tsx
+++ b/frontend/src/components/Voice/stage/StageTile.tsx
@@ -61,7 +61,23 @@ const LiveWaveform: React.FC<{ identity: string }> = ({ identity }) => {
 
 export type TileMode = "grid" | "film" | "big" | "preview";
 
-export interface StageParticipant {
+/** The single media surface a tile renders. A tile shows EXACTLY one of these —
+ *  camera and screenshare are separate tiles, never crammed into one slot, so
+ *  the old "both track keys set, one silently dropped" state is unrepresentable.
+ *  A participant publishing camera + screenshare at once (#394) yields two tiles
+ *  (`{kind:'camera'}` + `{kind:'screenshare'}`); see `tilesFor` in VoiceStage. */
+export type TileMedia =
+  | { kind: "audio" }
+  | { kind: "camera"; trackKey: string; width?: number; height?: number }
+  | { kind: "screenshare"; trackKey: string; width?: number; height?: number };
+
+export interface StageTileModel {
+  /** Unique per tile: `${identity}` (audio), `${identity}:cam`, or
+   *  `${identity}:screen`. Distinct from `identity` because one participant can
+   *  own two tiles. */
+  tileKey: string;
+  /** Owning participant — drives name, mute/speaking, per-user volume. Shared by
+   *  a participant's camera and screenshare tiles. */
   identity: string;
   name: string;
   avatarKey: string | null;
@@ -69,23 +85,13 @@ export interface StageParticipant {
   isLocal: boolean;
   isSpeaking: boolean;
   connectionQuality?: VoiceConnectionQuality;
-  /** Track key + hint dimensions of this participant's active screen
-   *  share (local preview or remote). Undefined ⇒ audio-only layout. */
-  streamTrackKey?: string;
-  streamWidth?: number;
-  streamHeight?: number;
-  /** Track key + hint dimensions of this participant's active webcam (local
-   *  preview or remote). Renders as the tile's face — the avatar's slot —
-   *  when present and there's no screen share occupying the tile. */
-  cameraTrackKey?: string;
-  cameraWidth?: number;
-  cameraHeight?: number;
   /** Local user only, while the voice session is still negotiating. */
   isConnecting?: boolean;
+  media: TileMedia;
 }
 
 interface Props {
-  participant: StageParticipant;
+  participant: StageTileModel;
   mode: TileMode;
   /** Keyboard focus from the enclosing NavigableGrid — reveals the volume
    *  strip and highlights the border, mirroring mouse hover. */
@@ -118,24 +124,24 @@ export const StageTile: React.FC<Props> = ({
 }) => {
   const big = mode === "big";
   const preview = mode === "preview";
+  const media = p.media;
 
-  const hasFeed = p.streamTrackKey !== undefined;
-  // Camera shows as the tile face only when a screen share isn't already
-  // occupying it — a participant doing both surfaces the screen here and
-  // their camera follows the spotlight/screenshare; the tile face stays the
-  // screen. Camera never drives the spotlight (that's screen-share only).
-  const hasCamera = !hasFeed && p.cameraTrackKey !== undefined;
+  // Only a screenshare tile carries the LIVE/stats/fullscreen/spotlight chrome
+  // and can be spotlit. A camera tile is a plain video surface (never drives the
+  // spotlight — #394); an audio tile shows the avatar + meter.
+  const isScreen = media.kind === "screenshare";
   // A streaming tile in the filmstrip is clickable to spotlight it; the
   // big tile is already focused, the preview state isn't a live call.
-  const focusable = hasFeed && !big && !preview;
+  const focusable = isScreen && !big && !preview;
+  const screenTrackKey = isScreen ? media.trackKey : null;
 
-  const stats = useScreenShareStats(p.streamTrackKey ?? null);
+  const stats = useScreenShareStats(screenTrackKey);
   const statsLabel = (() => {
-    if (!hasFeed) {
+    if (media.kind !== "screenshare") {
       return null;
     }
-    const w = stats.dimensions?.width ?? p.streamWidth;
-    const h = stats.dimensions?.height ?? p.streamHeight;
+    const w = stats.dimensions?.width ?? media.width;
+    const h = stats.dimensions?.height ?? media.height;
     if (!w || !h) {
       return null;
     }
@@ -156,22 +162,15 @@ export const StageTile: React.FC<Props> = ({
   return (
     <div
       className={cls}
-      data-testid={`voice-tile-${p.identity}`}
-      onClick={focusable ? () => onFocus?.(p.identity) : undefined}
+      data-testid={`voice-tile-${p.tileKey}`}
+      onClick={focusable ? () => onFocus?.(p.tileKey) : undefined}
     >
       <div className="vs-tile-stage">
-        {hasFeed ? (
+        {media.kind === "screenshare" || media.kind === "camera" ? (
           <RemoteVideoTile
-            trackKey={p.streamTrackKey!}
-            initialWidth={p.streamWidth}
-            initialHeight={p.streamHeight}
-            preview={!big}
-          />
-        ) : hasCamera ? (
-          <RemoteVideoTile
-            trackKey={p.cameraTrackKey!}
-            initialWidth={p.cameraWidth}
-            initialHeight={p.cameraHeight}
+            trackKey={media.trackKey}
+            initialWidth={media.width}
+            initialHeight={media.height}
             preview={!big}
           />
         ) : (
@@ -180,7 +179,7 @@ export const StageTile: React.FC<Props> = ({
               avatarKey={p.avatarKey}
               size={big ? 92 : 60}
               alt={p.name}
-              testId={`voice-tile-avatar-${p.identity}`}
+              testId={`voice-tile-avatar-${p.tileKey}`}
             />
             {!preview && <LiveWaveform identity={p.identity} />}
           </div>
@@ -203,7 +202,7 @@ export const StageTile: React.FC<Props> = ({
       <div className="vs-tr">
         {p.isConnecting ? (
           <span
-            data-testid={`voice-tile-connecting-${p.identity}`}
+            data-testid={`voice-tile-connecting-${p.tileKey}`}
             className="flex items-center leading-none"
             title="Connecting…"
             aria-label="Connecting"
@@ -213,7 +212,7 @@ export const StageTile: React.FC<Props> = ({
         ) : (
           <span
             className="vs-tag vs-pad6"
-            data-testid={`voice-tile-quality-${p.identity}`}
+            data-testid={`voice-tile-quality-${p.tileKey}`}
             title={`Connection: ${p.connectionQuality ?? "excellent"}`}
           >
             <span className={"vs-sig " + signalClass(p.connectionQuality)}>
@@ -225,33 +224,35 @@ export const StageTile: React.FC<Props> = ({
 
       {/* LIVE badge: only useful before you join — once you're in the
           channel the stream itself makes it obvious who's streaming. */}
-      {hasFeed && preview && (
+      {isScreen && preview && (
         <div className="vs-bl"><span className="vs-tag live">LIVE</span></div>
       )}
 
-      {/* res · fps badge stays on the in-call tiles. */}
-      {hasFeed && !preview && statsLabel && (
+      {/* res · fps badge stays on the in-call screenshare tiles — and is the
+          marker the e2e suite uses to tell a screenshare tile from a camera
+          tile (a camera tile never renders it). */}
+      {isScreen && !preview && statsLabel && (
         <div className="vs-br">
           {/* Machine-facing metric (res · fps) — stays monospace in BOTH
               skins. Without font-machine the refined skin would swap the
               stage's inherited font-mono to sans (index.css §refined). */}
           <span
             className="vs-tag res font-machine"
-            data-testid={`voice-tile-stream-stats-${p.identity}`}
+            data-testid={`voice-tile-stream-stats-${p.tileKey}`}
           >
             {statsLabel}
           </span>
         </div>
       )}
 
-      {/* hover controls — streaming tiles in-call only */}
-      {hasFeed && !preview && (
+      {/* hover controls — screenshare tiles in-call only */}
+      {isScreen && !preview && screenTrackKey && (
         <div className="vs-hover">
           <button
             className="vs-hbtn"
             title="fullscreen"
             aria-label="Open fullscreen"
-            onClick={(e) => { e.stopPropagation(); onView?.(p.streamTrackKey!); }}
+            onClick={(e) => { e.stopPropagation(); onView?.(screenTrackKey); }}
           >
             <Maximize size={17} />
           </button>
@@ -260,7 +261,7 @@ export const StageTile: React.FC<Props> = ({
               className="vs-hbtn"
               title="spotlight"
               aria-label="Spotlight this stream"
-              onClick={(e) => { e.stopPropagation(); onFocus?.(p.identity); }}
+              onClick={(e) => { e.stopPropagation(); onFocus?.(p.tileKey); }}
             >
               <Pin size={17} />
             </button>
@@ -271,11 +272,12 @@ export const StageTile: React.FC<Props> = ({
       {/* volume — remote only, and in-call only. While previewing the channel
           (not joined) you're not listening to anyone, so a per-user output
           volume control is meaningless; it appears on hover/focus once you've
-          joined. */}
+          joined. Keyed by identity (per-user output gain), so a participant's
+          camera and screenshare tiles both control the same volume. */}
       {!p.isLocal && !preview && (
         <div
           className="vs-vol"
-          data-testid={`voice-tile-volume-${p.identity}`}
+          data-testid={`voice-tile-volume-${p.tileKey}`}
           onClick={(e) => e.stopPropagation()}
         >
           <RemoteUserVolumeSlider identity={p.identity} participantName={p.name} />

--- a/frontend/src/components/Voice/stage/StageTile.tsx
+++ b/frontend/src/components/Voice/stage/StageTile.tsx
@@ -126,22 +126,27 @@ export const StageTile: React.FC<Props> = ({
   const preview = mode === "preview";
   const media = p.media;
 
-  // Only a screenshare tile carries the LIVE/stats/fullscreen/spotlight chrome
-  // and can be spotlit. A camera tile is a plain video surface (never drives the
-  // spotlight — #394); an audio tile shows the avatar + meter.
-  const isScreen = media.kind === "screenshare";
-  // A streaming tile in the filmstrip is clickable to spotlight it; the
-  // big tile is already focused, the preview state isn't a live call.
-  const focusable = isScreen && !big && !preview;
-  const screenTrackKey = isScreen ? media.trackKey : null;
+  // A tile carries video when its media is a camera OR a screenshare — the two
+  // are treated identically at the container level (#394): both are
+  // spotlightable, fullscreenable, and carry the LIVE + res·fps chrome. The
+  // pixels' source makes no difference to the container. An audio tile shows the
+  // avatar + meter.
+  const videoTrack =
+    media.kind === "camera" || media.kind === "screenshare"
+      ? { trackKey: media.trackKey, width: media.width, height: media.height }
+      : null;
+  const isVideo = videoTrack !== null;
+  // A video tile in the filmstrip/grid is clickable to spotlight it; the big
+  // tile is already focused, the preview state isn't a live call.
+  const focusable = isVideo && !big && !preview;
 
-  const stats = useScreenShareStats(screenTrackKey);
+  const stats = useScreenShareStats(videoTrack?.trackKey ?? null);
   const statsLabel = (() => {
-    if (media.kind !== "screenshare") {
+    if (!videoTrack) {
       return null;
     }
-    const w = stats.dimensions?.width ?? media.width;
-    const h = stats.dimensions?.height ?? media.height;
+    const w = stats.dimensions?.width ?? videoTrack.width;
+    const h = stats.dimensions?.height ?? videoTrack.height;
     if (!w || !h) {
       return null;
     }
@@ -223,15 +228,15 @@ export const StageTile: React.FC<Props> = ({
       </div>
 
       {/* LIVE badge: only useful before you join — once you're in the
-          channel the stream itself makes it obvious who's streaming. */}
-      {isScreen && preview && (
+          channel the video itself makes it obvious who's streaming. */}
+      {isVideo && preview && (
         <div className="vs-bl"><span className="vs-tag live">LIVE</span></div>
       )}
 
-      {/* res · fps badge stays on the in-call screenshare tiles — and is the
-          marker the e2e suite uses to tell a screenshare tile from a camera
-          tile (a camera tile never renders it). */}
-      {isScreen && !preview && statsLabel && (
+      {/* res · fps badge on any in-call video tile (camera or screenshare). The
+          e2e suite tells camera from screenshare by the tile's `:cam`/`:screen`
+          key suffix, not this badge. */}
+      {isVideo && !preview && statsLabel && (
         <div className="vs-br">
           {/* Machine-facing metric (res · fps) — stays monospace in BOTH
               skins. Without font-machine the refined skin would swap the
@@ -245,14 +250,15 @@ export const StageTile: React.FC<Props> = ({
         </div>
       )}
 
-      {/* hover controls — screenshare tiles in-call only */}
-      {isScreen && !preview && screenTrackKey && (
+      {/* hover controls — any video tile in-call (camera or screenshare) is
+          fullscreenable and spotlightable. */}
+      {isVideo && !preview && videoTrack && (
         <div className="vs-hover">
           <button
             className="vs-hbtn"
             title="fullscreen"
             aria-label="Open fullscreen"
-            onClick={(e) => { e.stopPropagation(); onView?.(screenTrackKey); }}
+            onClick={(e) => { e.stopPropagation(); onView?.(videoTrack.trackKey); }}
           >
             <Maximize size={17} />
           </button>
@@ -260,7 +266,7 @@ export const StageTile: React.FC<Props> = ({
             <button
               className="vs-hbtn"
               title="spotlight"
-              aria-label="Spotlight this stream"
+              aria-label="Spotlight this video"
               onClick={(e) => { e.stopPropagation(); onFocus?.(p.tileKey); }}
             >
               <Pin size={17} />

--- a/frontend/src/components/Voice/stage/VoiceStage.tsx
+++ b/frontend/src/components/Voice/stage/VoiceStage.tsx
@@ -36,7 +36,7 @@ import { Button } from "../../ui/Button";
 import { NavigableGrid } from "../../ui/NavigableGrid";
 import { ScreenSharePicker } from "../ScreenSharePicker";
 import { CameraPicker } from "../CameraPicker";
-import { StageTile, type StageParticipant } from "./StageTile";
+import { StageTile, type StageTileModel } from "./StageTile";
 import "./voice-stage.css";
 
 interface VoiceStageProps {
@@ -143,42 +143,37 @@ export const VoiceStage: React.FC<VoiceStageProps> = observer(
 
     const displayNames = disambiguateVoiceNames(mergedParticipants);
 
-    // Map a live VoiceParticipant onto the tile's view model, resolving
-    // whichever screenshare track (local preview or remote) it's publishing.
-    const resolve = (p: VoiceParticipant): StageParticipant => {
-      let streamTrackKey: string | undefined;
-      let streamWidth: number | undefined;
-      let streamHeight: number | undefined;
-      let cameraTrackKey: string | undefined;
-      let cameraWidth: number | undefined;
-      let cameraHeight: number | undefined;
+    // Expand a live VoiceParticipant into its stage tiles. A participant can
+    // publish a screenshare AND a webcam at the same time (#394), so this
+    // returns UP TO TWO tiles — one per active video source — rather than one
+    // tile that has to pick a single surface. Ordering (camera first, then
+    // screenshare) keeps a person's face next to their screen in the grid.
+    //   none   → [audio]
+    //   camera → [camera]
+    //   screen → [screenshare]
+    //   both   → [camera, screenshare]
+    const tilesFor = (p: VoiceParticipant): StageTileModel[] => {
+      let screen: { trackKey: string; width?: number; height?: number } | null = null;
+      let cam: { trackKey: string; width?: number; height?: number } | null = null;
       if (p.isLocal) {
         if (shareActive) {
-          streamTrackKey = LOCAL_PREVIEW_KEY;
-          streamWidth = shareLocalDims?.width;
-          streamHeight = shareLocalDims?.height;
+          screen = { trackKey: LOCAL_PREVIEW_KEY, width: shareLocalDims?.width, height: shareLocalDims?.height };
         }
         if (cameraActive) {
-          cameraTrackKey = LOCAL_CAMERA_PREVIEW_KEY;
-          cameraWidth = cameraLocalDims?.width;
-          cameraHeight = cameraLocalDims?.height;
+          cam = { trackKey: LOCAL_CAMERA_PREVIEW_KEY, width: cameraLocalDims?.width, height: cameraLocalDims?.height };
         }
       } else {
         const remote = screenshareOf(p.video);
         if (remote) {
-          streamTrackKey = remote.trackKey;
-          streamWidth = remote.width;
-          streamHeight = remote.height;
+          screen = { trackKey: remote.trackKey, width: remote.width, height: remote.height };
         }
-        const cam =
-          cameraRemotes[p.identity] ?? cameraRemotes[voiceUserKey(p.identity)];
-        if (cam) {
-          cameraTrackKey = cam.trackKey;
-          cameraWidth = cam.width;
-          cameraHeight = cam.height;
+        const c = cameraRemotes[p.identity] ?? cameraRemotes[voiceUserKey(p.identity)];
+        if (c) {
+          cam = { trackKey: c.trackKey, width: c.width, height: c.height };
         }
       }
-      return {
+
+      const base = {
         identity: p.identity,
         name: displayNames.get(p.identity) ?? p.name,
         avatarKey: p.avatarKey ?? null,
@@ -186,25 +181,33 @@ export const VoiceStage: React.FC<VoiceStageProps> = observer(
         isLocal: p.isLocal,
         isSpeaking: speakingUsers.has(userIdFromVoiceIdentity(p.identity)) && !isMuted(p.audio),
         connectionQuality: p.connectionQuality,
-        streamTrackKey,
-        streamWidth,
-        streamHeight,
-        cameraTrackKey,
-        cameraWidth,
-        cameraHeight,
         isConnecting: p.isLocal && isJoining,
       };
+
+      const tiles: StageTileModel[] = [];
+      if (cam) {
+        tiles.push({ ...base, tileKey: `${p.identity}:cam`, media: { kind: "camera", ...cam } });
+      }
+      if (screen) {
+        tiles.push({ ...base, tileKey: `${p.identity}:screen`, media: { kind: "screenshare", ...screen } });
+      }
+      // No video → a single audio/avatar tile keyed by the bare identity (so a
+      // plain voice participant's testid stays `voice-tile-<identity>`).
+      if (tiles.length === 0) {
+        tiles.push({ ...base, tileKey: p.identity, media: { kind: "audio" } });
+      }
+      return tiles;
     };
 
-    const people = mergedParticipants.map(resolve);
-    const streamers = people.filter((p) => p.streamTrackKey !== undefined);
+    const people = mergedParticipants.flatMap(tilesFor);
+    const streamers = people.filter((p) => p.media.kind === "screenshare");
     // A call is always "in" its room (it auto-joins and rings), so it never
     // shows the group pre-join preview and its stage goes live immediately.
     const stageLive = isInCall || callMode;
     const previewState = !stageLive;
     const spotlight = stageLive && streamers.length > 0;
     const focused =
-      streamers.find((p) => p.identity === focusId) ?? streamers[0] ?? null;
+      streamers.find((p) => p.tileKey === focusId) ?? streamers[0] ?? null;
 
     // Ringing/connecting caption — call-only, shown above the (self-only) grid
     // until the counterparty joins. Replaces the group "Join Voice" preview.
@@ -216,13 +219,15 @@ export const VoiceStage: React.FC<VoiceStageProps> = observer(
           : "Ringing…"
         : null;
 
-    const previewPeople: StageParticipant[] = observerParticipants.map((p) => ({
+    const previewPeople: StageTileModel[] = observerParticipants.map((p) => ({
+      tileKey: p.identity,
       identity: p.identity,
       name: p.name,
       avatarKey: p.avatarKey ?? null,
       isMuted: false,
       isLocal: false,
       isSpeaking: false,
+      media: { kind: "audio" },
     }));
 
     const onView = (trackKey: string) => setViewingScreenShareTrackKey(trackKey);
@@ -288,9 +293,9 @@ export const VoiceStage: React.FC<VoiceStageProps> = observer(
               ) : (
                 // Populated: roster, then the CTA pinned below the users.
                 <>
-                  <NavigableGrid<StageParticipant>
+                  <NavigableGrid<StageTileModel>
                     items={previewPeople}
-                    getKey={(p) => p.identity}
+                    getKey={(p) => p.tileKey}
                     autoFocus={false}
                     minCellWidth={180}
                     maxCellWidth={240}
@@ -317,9 +322,9 @@ export const VoiceStage: React.FC<VoiceStageProps> = observer(
               </div>
               <div className="vs-film">
                 {people
-                  .filter((p) => !focused || p.identity !== focused.identity)
+                  .filter((p) => !focused || p.tileKey !== focused.tileKey)
                   .map((p) => (
-                    <div key={p.identity} className="vs-film-cell">
+                    <div key={p.tileKey} className="vs-film-cell">
                       <StageTile participant={p} mode="film" onFocus={setFocusId} onView={onView} />
                     </div>
                   ))}
@@ -332,9 +337,9 @@ export const VoiceStage: React.FC<VoiceStageProps> = observer(
                   {ringStatus}
                 </div>
               )}
-              <NavigableGrid<StageParticipant>
+              <NavigableGrid<StageTileModel>
                 items={people}
-                getKey={(p) => p.identity}
+                getKey={(p) => p.tileKey}
                 testId="voice-channel-view"
                 emptyLabel={callMode ? "Calling…" : "Connecting…"}
                 autoFocus={false}

--- a/frontend/src/components/Voice/stage/VoiceStage.tsx
+++ b/frontend/src/components/Voice/stage/VoiceStage.tsx
@@ -9,8 +9,8 @@
 //   - preview   (not joined): a "who's here" roster (NavigableGrid, same
 //                sizing as before) with persistent per-user volume + a
 //                solid Join Voice CTA.
-//   - spotlight (joined, someone streaming): the focused screenshare fills
-//                the body with a clickable filmstrip below.
+//   - spotlight (joined, someone sharing video): the focused video — camera or
+//                screenshare — fills the body with a clickable filmstrip below.
 //   - grid      (joined, no stream): a reflowing equal grid of tiles.
 //
 // Reads live data straight off appStore (MobX observer) rather than being a
@@ -200,14 +200,25 @@ export const VoiceStage: React.FC<VoiceStageProps> = observer(
     };
 
     const people = mergedParticipants.flatMap(tilesFor);
-    const streamers = people.filter((p) => p.media.kind === "screenshare");
+    // Any video tile — camera OR screenshare — can be spotlit and shows in the
+    // spotlight/filmstrip. The two are treated identically at the stage level
+    // (#394); the container doesn't care where the pixels come from.
+    const streamers = people.filter(
+      (p) => p.media.kind === "screenshare" || p.media.kind === "camera",
+    );
     // A call is always "in" its room (it auto-joins and rings), so it never
     // shows the group pre-join preview and its stage goes live immediately.
     const stageLive = isInCall || callMode;
     const previewState = !stageLive;
     const spotlight = stageLive && streamers.length > 0;
+    // Default the big view to a screenshare when one exists (the natural focal
+    // point of "watch my screen"), otherwise the first video — but an explicit
+    // user pick (focusId) always wins.
     const focused =
-      streamers.find((p) => p.tileKey === focusId) ?? streamers[0] ?? null;
+      streamers.find((p) => p.tileKey === focusId) ??
+      streamers.find((p) => p.media.kind === "screenshare") ??
+      streamers[0] ??
+      null;
 
     // Ringing/connecting caption — call-only, shown above the (self-only) grid
     // until the counterparty joins. Replaces the group "Join Voice" preview.


### PR DESCRIPTION
Since webcam support landed, a participant can publish a camera **and** a screenshare at the same time. The stage collapsed both into one tile and **silently dropped the camera** whenever a screenshare was present (`StageTile: hasCamera = !hasFeed && …`).

## Fix — the render view-model becomes a discriminated union
The data model was already correct (screenshare on `participant.video`, camera in `cameraRemotes` — two coexisting axes). The invalid state lived only in the render layer.

- **`StageTile`**: each tile's surface is now `media: { kind:'audio' } | { kind:'camera'; … } | { kind:'screenshare'; … }` — exactly one surface per tile, so "two videos, one dropped" is unrepresentable.
- **`VoiceStage.tilesFor`**: expands each participant into **1–2 tiles** — `none→[audio]`, `camera→[camera]`, `screen→[screenshare]`, `both→[camera, screenshare]`.
- Screenshare still drives spotlight/filmstrip and carries the res·fps stats badge; camera is a plain grid tile (unchanged UX, just no longer hidden).
- Per-source tile keys (`:cam` / `:screen`) keep the `voice-tile-voice-` prefix and the stats-badge disambiguation the e2e depend on; the participant-count slice takes everything before the first colon, so it's suffix-agnostic.

## Tests
`two-client-camera.js` gains a phase: A starts a screenshare alongside its camera, and B must see **both** a camera tile (no stats badge) and a screenshare tile (stats badge) for A — the direct regression guard. Reuses the camera fixture (Xvfb + LiveKit also cover X11 screenshare), so no new workflow/fixtures.

Verified: frontend `tsc` clean; existing camera/screenshare e2e stay valid under the new keys. Store's two-axis model left as-is (already correct); DU work is in the render view-model. Docs: `capture-split.md`.

Note: the WebKitGTK camera e2e is Linux-only (can't run on macOS) — it runs post-merge via `e2e-two-client-camera.yml` dispatch.