### PR TITLE
fix(attest): backfill parity — rpm tooling, annotated-tag commit sha, diagnosable failures

### DIFF
--- a/.github/workflows/attest-release.yml
+++ b/.github/workflows/attest-release.yml
@@ -34,7 +34,12 @@ jobs:
           set -euo pipefail
           git fetch --depth 1 origin tag "${{ inputs.tag }}"
           echo "epoch=$(git log -1 --format=%ct "${{ inputs.tag }}")" >> "$GITHUB_OUTPUT"
-          echo "sha=$(git rev-parse "${{ inputs.tag }}")" >> "$GITHUB_OUTPUT"
+          # `^{commit}` is load-bearing: release tags are ANNOTATED, and a bare
+          # `git rev-parse v1.5.3` resolves to the tag OBJECT's sha, not the
+          # commit's. That sha was being stamped into every backfilled leaf's
+          # `commit` field, which is documented as the exact source revision —
+          # so backfilled leaves pointed at an object that is not a commit.
+          echo "sha=$(git rev-parse "${{ inputs.tag }}^{commit}")" >> "$GITHUB_OUTPUT"
 
       # The shipped installers, pulled from the GitHub release for the tag (same
       # bytes published to cdn.pollis.com). attest-binaries.sh finds each by glob.
@@ -49,10 +54,15 @@ jobs:
             --pattern '*.deb' --pattern '*.rpm'
           ls -la artifacts
 
+      # Must match desktop-release.yml's attest-and-log tooling: this workflow
+      # deliberately duplicates that job, so a tool added there must be added
+      # here too or the backfill path breaks while the release path works.
+      # 7z reads the dmg/NSIS payloads; rpm/cpio unpack the .rpm to reach
+      # `usr/bin/pollis` for its `exe` leaf (the .deb uses dpkg-deb, preinstalled).
       - name: Install extraction tooling
         run: |
           sudo apt-get update
-          sudo apt-get install -y p7zip-full jq
+          sudo apt-get install -y p7zip-full jq rpm cpio
 
       - name: Compute BinaryRecord leaves for this tag
         env:

--- a/scripts/attest-binaries.sh
+++ b/scripts/attest-binaries.sh
@@ -82,7 +82,30 @@ emit() {
                  source_date_epoch:$source_date_epoch},
       provenance_uri:$provenance_uri}')"
   records="$(jq -c ". + [${rec}]" <<<"$records")"
+  # One line per leaf. This script runs under `set -e` in a release-critical job,
+  # so an unexpected non-zero exit anywhere kills it; without a progress trail the
+  # only evidence is "exit code 1" with no indication of which bundle was being
+  # processed. Cheap breadcrumbs beat re-running with `bash -x`.
+  echo "attest: ${1}/${3} ${5} payload=${6:0:12}… artifact=${7:0:12}…"
 }
+
+# Fail with a clear message when a tool this script shells out to is absent.
+# Missing tooling otherwise surfaces as an opaque non-zero exit (a subshell
+# pipeline under `set -o pipefail` can swallow the diagnostic entirely), which is
+# exactly what made the first v1.5.3 attest failure undiagnosable from its log.
+need() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "::error::attest: required tool '${1}' is not installed — needed to ${2}."
+    echo "::error::  Install it in the workflow calling this script. NOTE: both"
+    echo "::error::  desktop-release.yml (attest-and-log) and attest-release.yml"
+    echo "::error::  run this script and each installs its own tooling."
+    exit 1
+  }
+}
+
+need jq "build the BinaryRecord leaves"
+need tar "hash directory-tree payloads"
+need sha256sum "hash payloads and artifacts"
 
 find_one() { find "$ARTIFACTS_DIR" -type f -name "$1" 2>/dev/null | head -1; }
 
@@ -128,6 +151,7 @@ dmg="$(find_one '*.dmg' || true)"
 if [ -n "${dmg:-}" ]; then
   name="pollis-${RELEASE_TAG}-macos.dmg"
   art_sha="$(sha_file "$dmg")"
+  need 7z "extract the .app payload from the .dmg"
   ex="$work/dmg"; mkdir -p "$ex"
   # 7z reads the HFS filesystem inside the .dmg on Linux; extract the .app.
   # The .dmg carries the standard "drag to /Applications" symlink, on which
@@ -150,6 +174,7 @@ exe="$(find_one '*.exe' || true)"
 if [ -n "${exe:-}" ]; then
   name="pollis-${RELEASE_TAG}-windows.exe"
   art_sha="$(sha_file "$exe")"
+  need 7z "extract the file tree from the NSIS installer"
   ex="$work/nsis"; mkdir -p "$ex"
   # 7z unpacks the NSIS installer's embedded file tree.
   7z x -y -o"$ex" "$exe" >/dev/null
@@ -177,6 +202,7 @@ if [ -n "${deb:-}" ]; then
   # Unpack the package filesystem to reach the installed executable — a running
   # deb install's `current_exe()` IS `/usr/bin/pollis`, so that file's hash is
   # what the app will present.
+  need dpkg-deb "unpack the .deb to reach its installed executable"
   ex="$work/deb"; mkdir -p "$ex"
   dpkg-deb --fsys-tarfile "$deb" | tar -xf - -C "$ex"
   emit_exe linux x86_64 deb "$name" "$sha" "ubuntu-22.04" "$(find_installed_bin "$ex")"
@@ -189,6 +215,8 @@ if [ -n "${rpm:-}" ]; then
   # Same for rpm; rpm2cpio + cpio are installed by the attest job. cpio only
   # unpacks into the cwd, so resolve the package to an absolute path before the
   # subshell cd (ARTIFACTS_DIR — and therefore `find_one` — is relative).
+  need rpm2cpio "unpack the .rpm to reach its installed executable"
+  need cpio "unpack the .rpm to reach its installed executable"
   ex="$work/rpm"; mkdir -p "$ex"
   rpm_abs="$(cd "$(dirname "$rpm")" && pwd)/$(basename "$rpm")"
   (cd "$ex" && rpm2cpio "$rpm_abs" | cpio -idm --quiet)


### PR DESCRIPTION
The v1.5.3 re-attest via `attest-release.yml` failed with **`exit code 1` and no output whatsoever** — no stdout, no stderr, no annotation. Three fixes, two of them real bugs in the backfill path.

### 1. Missing rpm tooling (the failure)

`attest-release.yml` installs only `p7zip-full jq`. #587 added `rpm cpio` to `desktop-release.yml`'s `attest-and-log` job but not here — and this workflow's own header says it "deliberately duplicates" that job, which is exactly the hazard that realises. Now installs the same set, with a comment saying why the two must move together.

### 2. Annotated-tag sha — backfilled leaves recorded a non-commit

```
git rev-parse v1.5.3       → 90996387…   ← tag OBJECT
git rev-list -n1 v1.5.3    → feeb7645…   ← the commit
```

Release tags are annotated, so `git rev-parse <tag>` returns the tag object's sha. That value was being stamped into every backfilled leaf's `commit` field — documented as "the exact source revision (40-hex git sha)" — so any tag attested through this path pointed at an object that is not a commit. `desktop-release.yml` is unaffected (it uses `github.sha`). Fixed with `^{commit}`.

Latent since this workflow was written; it would have silently corrupted the `commit` field of every backfilled release.

### 3. Make the script diagnosable

A release-critical script under `set -euo pipefail` that exits 1 with an empty log is not debuggable. Two additions:

- **`need <tool>` guards** — per-bundle preflight checks with a clear `::error::`, including the reminder that two workflows install tooling independently. A missing tool inside a `set -o pipefail` subshell can swallow its own diagnostic; that's what happened here.
- **One progress line per emitted leaf** — so a failure names the last bundle processed instead of leaving `exit code 1` as the only evidence.

Both earlier failures in this series (#588's tar path, this one) would have been readable from the log on the first run with these in place.
