### PR TITLE
fix(attest): read the .rpm with bsdtar instead of an rpm2cpio|cpio pipeline

### DIFF
--- a/.github/workflows/attest-release.yml
+++ b/.github/workflows/attest-release.yml
@@ -57,12 +57,12 @@ jobs:
       # Must match desktop-release.yml's attest-and-log tooling: this workflow
       # deliberately duplicates that job, so a tool added there must be added
       # here too or the backfill path breaks while the release path works.
-      # 7z reads the dmg/NSIS payloads; rpm/cpio unpack the .rpm to reach
-      # `usr/bin/pollis` for its `exe` leaf (the .deb uses dpkg-deb, preinstalled).
+      # 7z reads the dmg/NSIS payloads; bsdtar (libarchive-tools) unpacks the .rpm to
+      # reach `usr/bin/pollis` for its `exe` leaf (the .deb uses dpkg-deb, preinstalled).
       - name: Install extraction tooling
         run: |
           sudo apt-get update
-          sudo apt-get install -y p7zip-full jq rpm cpio
+          sudo apt-get install -y p7zip-full jq libarchive-tools
 
       - name: Compute BinaryRecord leaves for this tag
         env:

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1037,12 +1037,12 @@ jobs:
 
       # 7z reads the HFS payload inside the .dmg and the NSIS installer's file
       # tree on this Linux runner; jq builds and merges the records JSON.
-      # rpm/cpio unpack the .rpm to reach `usr/bin/pollis` for its `exe` leaf
-      # (the .deb uses dpkg-deb, already present on the runner).
+      # bsdtar (libarchive-tools) unpacks the .rpm to reach `usr/bin/pollis` for
+      # its `exe` leaf (the .deb uses dpkg-deb, already present on the runner).
       - name: Install extraction tooling
         run: |
           sudo apt-get update
-          sudo apt-get install -y p7zip-full jq rpm cpio
+          sudo apt-get install -y p7zip-full jq libarchive-tools
 
       - name: Compute BinaryRecord leaves for this tag
         env:

--- a/scripts/attest-binaries.sh
+++ b/scripts/attest-binaries.sh
@@ -212,14 +212,14 @@ if [ -n "${rpm:-}" ]; then
   name="pollis-${RELEASE_TAG}-linux.rpm"
   sha="$(sha_file "$rpm")"
   emit linux x86_64 rpm "$name" payload "$sha" "$sha" "ubuntu-22.04"
-  # Same for rpm; rpm2cpio + cpio are installed by the attest job. cpio only
-  # unpacks into the cwd, so resolve the package to an absolute path before the
-  # subshell cd (ARTIFACTS_DIR — and therefore `find_one` — is relative).
-  need rpm2cpio "unpack the .rpm to reach its installed executable"
-  need cpio "unpack the .rpm to reach its installed executable"
+  # bsdtar (libarchive) reads the .rpm directly. The obvious `rpm2cpio | cpio`
+  # was tried first and failed in CI with a bare exit 1 and no diagnostic: cpio
+  # was run `--quiet`, and the two-process pipeline under `set -o pipefail` gives
+  # no indication of which half died or why. One tool, no pipeline, no cwd
+  # juggling, and it handles whatever payload compression the rpm uses.
+  need bsdtar "unpack the .rpm to reach its installed executable"
   ex="$work/rpm"; mkdir -p "$ex"
-  rpm_abs="$(cd "$(dirname "$rpm")" && pwd)/$(basename "$rpm")"
-  (cd "$ex" && rpm2cpio "$rpm_abs" | cpio -idm --quiet)
+  bsdtar -xf "$rpm" -C "$ex"
   emit_exe linux x86_64 rpm "$name" "$sha" "ubuntu-22.04" "$(find_installed_bin "$ex")"
 fi
 


### PR DESCRIPTION
Third attest failure on v1.5.3 — but the first one the log could explain, thanks to the progress trail added in #602:

```
attest: darwin/dmg payload/signed/exe   ✓
attest: windows/nsis payload/signed/exe ✓
attest: linux/appimage payload          ✓
attest: linux/deb payload/exe           ✓
attest: linux/rpm payload               ✓
##[error]Process completed with exit code 1
```

Everything works except the **rpm `exe`** step. The `need` guards passed, so `rpm2cpio` and `cpio` are installed — the pipeline itself fails, and `cpio --quiet` plus `set -o pipefail` across two processes means neither half reports which died or why.

Replaced with a single `bsdtar -xf` (libarchive reads `.rpm` natively, including whatever payload compression it uses). No pipeline, no `--quiet` swallowing diagnostics, no absolute-path juggling for a subshell `cd`.

**Verified against the actual shipped v1.5.3 rpm** before pushing:

```
bsdtar -xf Pollis-1.5.3-1.x86_64.rpm  → usr/bin/pollis
sha256 e45d0cfa5613ace07262ef68ffb13a479b632d9afa36f5a8b7b0f2114dfe400b
```

Corroborating evidence that the rest of the path is right: the CI log's `linux/deb exe artifact=5d928109f5a0…` matches the hash computed locally from the same shipped `.deb`, bit for bit.

Tooling updated in **both** workflows (`rpm cpio` → `libarchive-tools`), since they install independently.

---

**This path has now failed three times** — tar member prefixes, tool availability, and this — always on environment/packaging assumptions, never on the log design. Its only exercise is a real release, which is why each fix costs a release cycle. Worth a fixture-based test over saved package samples; happy to open that separately.
