### PR TITLE
feat(privacy): make sealed sender unconditional and remove the opt-out flag

### DIFF
--- a/.codesight/wiki/database.md
+++ b/.codesight/wiki/database.md
@@ -97,9 +97,8 @@ decrypts and reads the credential's `{user_id}:{device_id}`, so a server-written
 additionally marks an envelope whose `sender_id` column is a non-identifying
 sentinel (the string `"sealed"`) rather than the real sender — envelope-sender
 *blinding*, so a Turso breach/subpoena of the stored table reveals nothing about
-who sent which message. Blinding is gated behind `POLLIS_SEAL_SENDER` (default
-**OFF**, dormant); the column and both code paths ship now so flipping it on later
-is a config change, not a migration. `sender_id` stays `NOT NULL` and the sentinel
+who sent which message. Blinding is **unconditional** — every send and
+redaction writes the sentinel; there is no flag and no opt-out. `sender_id` stays `NOT NULL` and the sentinel
 is a valid value, so the previously-shipped app keeps working (see migration
 000008's backward-compat note; version 000007 is deliberately skipped).
 

--- a/.codesight/wiki/mls.md
+++ b/.codesight/wiki/mls.md
@@ -332,22 +332,31 @@ deliberately *not* read for attribution. This is **always on**: because the
 sender is authenticated by MLS, a server that rewrites `sender_id` can neither
 forge authorship nor learn it from that column.
 
-On top of that, **envelope-sender blinding** can make the stored `sender_id`
-non-identifying. When `state.config.seal_sender` is set (env `POLLIS_SEAL_SENDER`,
-default **OFF**), `send_message` posts `sealed = 1` and a fixed sentinel
-(`SEALED_SENDER_SENTINEL = "sealed"`) as the envelope's `sender_id` instead of the
-real user id, so a Turso breach/subpoena of `message_envelope` reveals nothing
-about who sent which message. The local `message` row keeps the real `sender_id`
-(it's the author's own copy on a trusted device; the send path writes
-self-attribution directly rather than re-deriving from the credential). The DS
-relaxes its "send-as-yourself" equality check for sealed sends but keeps the
-membership authz unchanged — it still verifies the *authenticated* writer is a
-member (`apply_send_message` in `pollis-delivery/src/messages.rs`).
+On top of that, **envelope-sender blinding is unconditional**. `send_message`
+(and the redaction path in `edit_delete.rs`) always posts `sealed = 1` with a
+fixed sentinel (`SEALED_SENDER_SENTINEL = "sealed"`) as the envelope's
+`sender_id`, so a Turso breach or subpoena of `message_envelope` reveals nothing
+about who sent which message. There is **no flag** — `POLLIS_SEAL_SENDER` and
+`Config::seal_sender` were removed once the reader half had shipped, because a
+build-time toggle would make the envelope's privacy depend on a value the user
+can neither see nor verify. `src-tauri/tests/flows/sealed_sender.rs` carries an
+invariant test (`sealing_has_no_opt_out_for_an_ordinary_client`) that fails if an
+escape hatch is reintroduced.
 
-**Honest scope (§2.1).** This is an **at-rest** defense. The DS authenticates
-every write with an `X-Pollis-User` header and gates on membership, so a *live* DS
-operator still sees the sender in real time. Closing that axis is v1.5
-anonymous-membership (not shipped — tracked in #489). See
+The local `message` row keeps the real `sender_id` (it's the author's own copy on
+a trusted device; the send path writes self-attribution directly rather than
+re-deriving from the credential). The DS relaxes its "send-as-yourself" equality
+check for sealed sends but keeps the membership authz unchanged — it still
+verifies the *authenticated* writer is a member (`apply_send_message` in
+`pollis-delivery/src/messages.rs`), and it still accepts `sealed = 0` from
+pre-cutover clients.
+
+**Scope.** Blinding covers the **stored envelope** — the artifact a breach or
+subpoena yields. It does not cover the live request path: the DS authenticates
+every write with an `X-Pollis-User` header and gates on membership, so a DS
+operator observing traffic in real time still sees who is sending. Removing that
+requires authorizing membership without identifying the member — anonymous
+membership credentials, tracked in #489. See
 `docs/metadata-minimization-design.md` §2.
 
 ## Metadata-minimized signalling (#331 v2)

--- a/.github/workflows/attest-release.yml
+++ b/.github/workflows/attest-release.yml
@@ -57,12 +57,12 @@ jobs:
       # Must match desktop-release.yml's attest-and-log tooling: this workflow
       # deliberately duplicates that job, so a tool added there must be added
       # here too or the backfill path breaks while the release path works.
-      # 7z reads the dmg/NSIS payloads; rpm/cpio unpack the .rpm to reach
-      # `usr/bin/pollis` for its `exe` leaf (the .deb uses dpkg-deb, preinstalled).
+      # 7z reads the dmg/NSIS payloads; bsdtar (libarchive-tools) unpacks the .rpm to
+      # reach `usr/bin/pollis` for its `exe` leaf (the .deb uses dpkg-deb, preinstalled).
       - name: Install extraction tooling
         run: |
           sudo apt-get update
-          sudo apt-get install -y p7zip-full jq rpm cpio
+          sudo apt-get install -y p7zip-full jq libarchive-tools
 
       - name: Compute BinaryRecord leaves for this tag
         env:

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1037,12 +1037,12 @@ jobs:
 
       # 7z reads the HFS payload inside the .dmg and the NSIS installer's file
       # tree on this Linux runner; jq builds and merges the records JSON.
-      # rpm/cpio unpack the .rpm to reach `usr/bin/pollis` for its `exe` leaf
-      # (the .deb uses dpkg-deb, already present on the runner).
+      # bsdtar (libarchive-tools) unpacks the .rpm to reach `usr/bin/pollis` for
+      # its `exe` leaf (the .deb uses dpkg-deb, already present on the runner).
       - name: Install extraction tooling
         run: |
           sudo apt-get update
-          sudo apt-get install -y p7zip-full jq rpm cpio
+          sudo apt-get install -y p7zip-full jq libarchive-tools
 
       - name: Compute BinaryRecord leaves for this tag
         env:

--- a/.github/workflows/rebuild-verify.yml
+++ b/.github/workflows/rebuild-verify.yml
@@ -28,7 +28,7 @@ name: Rebuild & Verify (independent reproducer)
 # recipe via `option_env!` at compile time (pollis-core/src/config.rs). Since
 # the #506 secrets-broker cutover that recipe is: TURSO_URL, the READ-ONLY
 # TURSO_TOKEN, LOG_DB_URL, LOG_DB_TOKEN, R2_S3_ENDPOINT, R2_PUBLIC_URL,
-# LIVEKIT_URL, POLLIS_DELIVERY_URL, POLLIS_SEAL_SENDER — no R2 or LiveKit
+# LIVEKIT_URL, POLLIS_DELIVERY_URL — no R2 or LiveKit
 # credentials are read by the client at all anymore. Every entry is publishable
 # except the one remaining secret-shaped residual: the OPTIONAL observability
 # LOG_DB_TOKEN (see the residuals doc, item 4). Until that token is scoped out
@@ -268,8 +268,8 @@ jobs:
       # passed). Exported via $GITHUB_ENV behind an is-set guard because an
       # unset var must stay truly UNSET: a plain `env:` mapping of an undefined
       # var exports an EMPTY string, which option_env! bakes as Some("") —
-      # different bytes from a release that left the var unset (None), e.g.
-      # POLLIS_SEAL_SENDER today. Tags older than v1.3.5 predate both the
+      # different bytes from a release that left the var unset (None), e.g. the
+      # optional LOG_DB_TOKEN today. Tags older than v1.3.5 predate both the
       # determinism flags (#504) and the #506 recipe and are not
       # bit-reproducible here regardless — for those, only log inclusion
       # applies.
@@ -283,12 +283,11 @@ jobs:
           R2_PUBLIC_URL: ${{ vars.R2_PUBLIC_URL }}
           LIVEKIT_URL: ${{ vars.LIVEKIT_URL }}
           POLLIS_DELIVERY_URL: ${{ vars.POLLIS_DELIVERY_URL }}
-          POLLIS_SEAL_SENDER: ${{ vars.POLLIS_SEAL_SENDER }}
         run: |
           set -euo pipefail
           for key in TURSO_URL TURSO_TOKEN LOG_DB_URL LOG_DB_TOKEN \
                      R2_S3_ENDPOINT R2_PUBLIC_URL LIVEKIT_URL \
-                     POLLIS_DELIVERY_URL POLLIS_SEAL_SENDER; do
+                     POLLIS_DELIVERY_URL; do
             if [ -n "${!key}" ]; then
               echo "${key}=${!key}" >> "$GITHUB_ENV"
             fi

--- a/docs/reproducible-builds-residuals.md
+++ b/docs/reproducible-builds-residuals.md
@@ -65,7 +65,8 @@ non-reproducible signed-wrapper layer.
 The client bakes build-configuration values into the binary at compile time via
 `option_env!` (`pollis-core/src/config.rs`): `TURSO_URL`, the **read-only**
 `TURSO_TOKEN`, `LOG_DB_URL`, `LOG_DB_TOKEN`, `R2_S3_ENDPOINT`, `R2_PUBLIC_URL`,
-`LIVEKIT_URL`, `POLLIS_DELIVERY_URL`, and `POLLIS_SEAL_SENDER`. These bytes are
+`LIVEKIT_URL`, and `POLLIS_DELIVERY_URL`. (`POLLIS_SEAL_SENDER` was removed when
+sealed sending became unconditional — one fewer recipe input to reproduce.) These bytes are
 part of the reproducible payload, so a reproducer must bake the **identical**
 values or its hash legitimately diverges.
 

--- a/pollis-core/src/bridge.rs
+++ b/pollis-core/src/bridge.rs
@@ -123,9 +123,6 @@ struct InitConfig {
     /// Optional Delivery Service base URL. Absent → direct Turso writes.
     #[serde(default)]
     pollis_delivery_url: Option<String>,
-    /// Sealed sender (issue #331). Absent/false → real sender_id, sealed=0.
-    #[serde(default)]
-    seal_sender: bool,
 }
 
 /// Initialize the process-global `AppState`. Safe to call multiple times —
@@ -153,7 +150,6 @@ async fn init_pollis_inner(config_json: String) -> Result<(), BridgeError> {
                 r2_public_url: parsed.r2_public_url,
                 livekit_url: parsed.livekit_url,
                 pollis_delivery_url: parsed.pollis_delivery_url.filter(|s| !s.is_empty()),
-                seal_sender: parsed.seal_sender,
             };
             let state = AppState::new(config).await?;
             Ok::<Arc<AppState>, BridgeError>(Arc::new(state))

--- a/pollis-core/src/commands/messages/edit_delete.rs
+++ b/pollis-core/src/commands/messages/edit_delete.rs
@@ -383,11 +383,8 @@ async fn send_redaction_message(
     // Blind the envelope sender under sealed sender exactly like a normal send
     // (issue #331) — the true author is the MLS credential inside the ciphertext,
     // which is what the recipient's redaction-authorization check reads.
-    let (envelope_sender_id, sealed_flag): (&str, i64) = if state.config.seal_sender {
-        (super::send::SEALED_SENDER_SENTINEL, 1)
-    } else {
-        (user_id, 0)
-    };
+    let (envelope_sender_id, sealed_flag): (&str, i64) =
+        (super::send::SEALED_SENDER_SENTINEL, 1);
 
     let body = serde_json::json!({
         "id": envelope_id,

--- a/pollis-core/src/commands/messages/send.rs
+++ b/pollis-core/src/commands/messages/send.rs
@@ -178,11 +178,13 @@ pub async fn send_message(
     // apply. Sealing it would mislabel the author's own message, since the send
     // path writes attribution directly rather than re-deriving it from the
     // credential the way the ingest reader does.
-    let (envelope_sender_id, sealed_flag): (&str, i64) = if state.config.seal_sender {
-        (SEALED_SENDER_SENTINEL, 1)
-    } else {
-        (sender_id.as_str(), 0)
-    };
+    // Sealing is unconditional (#331). The reader half — attribution from the
+    // MLS credential inside the ciphertext, never from this column — shipped a
+    // release earlier, which is what the additive two-release dance required;
+    // this is that second release. There is deliberately no opt-out: a runtime
+    // flag would mean the envelope's privacy depended on a build-time value the
+    // user cannot see or verify.
+    let (envelope_sender_id, sealed_flag): (&str, i64) = (SEALED_SENDER_SENTINEL, 1);
 
     // Post to Turso for offline delivery. DS seam: route the envelope write
     // through the Delivery Service (the write API).

--- a/pollis-core/src/config.rs
+++ b/pollis-core/src/config.rs
@@ -23,16 +23,6 @@ pub struct Config {
     /// commit submission routes through the DS (serialized, race/gap-free);
     /// when `None`, commits write direct to Turso. See `commands::mls::delivery`.
     pub pollis_delivery_url: Option<String>,
-    /// Sealed sender (issue #331, `docs/metadata-minimization-design.md` §2).
-    /// When true, outbound `message_envelope` rows are written with `sealed = 1`
-    /// and a non-identifying sentinel `sender_id` instead of the real sender — so
-    /// the stored envelope no longer reveals sender-per-message (at-rest / breach
-    /// / subpoena defense). Attribution is unaffected: recipients always take the
-    /// sender from the MLS credential inside the ciphertext (release N, already
-    /// shipped). Defaults OFF: landing the sending half == release N (reader on,
-    /// sealing off); flipping `POLLIS_SEAL_SENDER` on later == release N+1. This
-    /// is the additive two-release dance CLAUDE.md prescribes.
-    pub seal_sender: bool,
 }
 
 impl Config {
@@ -62,12 +52,6 @@ impl Config {
                 .map(|s| s.to_string())
                 .or_else(|| std::env::var("POLLIS_DELIVERY_URL").ok())
                 .filter(|s| !s.is_empty()),
-            // Optional boolean, default OFF (release N: reader on, sealing off).
-            seal_sender: option_env!("POLLIS_SEAL_SENDER")
-                .map(|s| s.to_string())
-                .or_else(|| std::env::var("POLLIS_SEAL_SENDER").ok())
-                .map(|s| parse_env_bool(&s))
-                .unwrap_or(false),
         })
     }
 }
@@ -120,8 +104,6 @@ impl Config {
             // path. There is no remaining direct-write path to exercise.
             pollis_delivery_url: None,
             // Default OFF; the sealed-sender flows test flips this per-client to
-            // exercise the release-N+1 sealing path (see `TestClient::new_sealed`).
-            seal_sender: false,
         })
     }
 }

--- a/pollis-tui/tests/common/mod.rs
+++ b/pollis-tui/tests/common/mod.rs
@@ -262,7 +262,6 @@ pub async fn spawn_world() -> World {
         pollis_delivery_url: Some(delivery_url),
         // Sealed Sender off: the smoke rig exercises sync/enroll flows, not
         // envelope blinding (mirrors the flows harness default).
-        seal_sender: false,
     };
 
     World {

--- a/scripts/attest-binaries.sh
+++ b/scripts/attest-binaries.sh
@@ -212,14 +212,14 @@ if [ -n "${rpm:-}" ]; then
   name="pollis-${RELEASE_TAG}-linux.rpm"
   sha="$(sha_file "$rpm")"
   emit linux x86_64 rpm "$name" payload "$sha" "$sha" "ubuntu-22.04"
-  # Same for rpm; rpm2cpio + cpio are installed by the attest job. cpio only
-  # unpacks into the cwd, so resolve the package to an absolute path before the
-  # subshell cd (ARTIFACTS_DIR — and therefore `find_one` — is relative).
-  need rpm2cpio "unpack the .rpm to reach its installed executable"
-  need cpio "unpack the .rpm to reach its installed executable"
+  # bsdtar (libarchive) reads the .rpm directly. The obvious `rpm2cpio | cpio`
+  # was tried first and failed in CI with a bare exit 1 and no diagnostic: cpio
+  # was run `--quiet`, and the two-process pipeline under `set -o pipefail` gives
+  # no indication of which half died or why. One tool, no pipeline, no cwd
+  # juggling, and it handles whatever payload compression the rpm uses.
+  need bsdtar "unpack the .rpm to reach its installed executable"
   ex="$work/rpm"; mkdir -p "$ex"
-  rpm_abs="$(cd "$(dirname "$rpm")" && pwd)/$(basename "$rpm")"
-  (cd "$ex" && rpm2cpio "$rpm_abs" | cpio -idm --quiet)
+  bsdtar -xf "$rpm" -C "$ex"
   emit_exe linux x86_64 rpm "$name" "$sha" "ubuntu-22.04" "$(find_installed_bin "$ex")"
 fi
 

--- a/src-tauri/tests/flows/harness.rs
+++ b/src-tauri/tests/flows/harness.rs
@@ -2443,19 +2443,8 @@ impl TestClient {
         Self::new_with_config(world().await.config.clone()).await
     }
 
-    /// Build a fresh client whose Config has sealed sender enabled
-    /// (`POLLIS_SEAL_SENDER=1`, issue #331). Used by the sealed-sender flows
-    /// test to drive the release-N+1 sending path per-client while every other
-    /// client in the process stays on the default (sealing off). Does NOT sign
-    /// in — call [`sign_up`] after construction.
-    pub(crate) async fn new_sealed() -> Self {
-        let mut config = world().await.config.clone();
-        config.seal_sender = true;
-        Self::new_with_config(config).await
-    }
 
-    /// Shared constructor: build a client backed by an explicit Config (so a
-    /// test can flip per-client flags like `seal_sender`).
+    /// Shared constructor: build a client backed by an explicit Config.
     async fn new_with_config(config: Config) -> Self {
         let w = world().await;
         let keystore: Arc<dyn Keystore> = Arc::new(InMemoryKeystore::new());

--- a/src-tauri/tests/flows/sealed_sender.rs
+++ b/src-tauri/tests/flows/sealed_sender.rs
@@ -3,17 +3,19 @@
 //! The reader half — attributing every message from the MLS credential inside
 //! the ciphertext rather than the server-writable `message_envelope.sender_id`
 //! column — shipped as release N and is exercised by the whole existing flows
-//! suite. These tests cover the SENDING half (release N+1, gated behind
-//! `POLLIS_SEAL_SENDER`, default off):
+//! suite. These tests cover the SENDING half, which is now **unconditional** —
+//! `POLLIS_SEAL_SENDER` is gone, and there is no code path that writes a real
+//! `sender_id` into `message_envelope`:
 //!
-//!   - **sealed positive** — with sealing on, the stored envelope is blinded
-//!     (`sealed = 1`, sentinel `sender_id`) yet the recipient still attributes
-//!     the message to the real sender via the credential.
+//!   - **sealed positive** — the stored envelope is blinded (`sealed = 1`,
+//!     sentinel `sender_id`) yet the recipient still attributes the message to
+//!     the real sender via the credential.
 //!   - **non-member rejected** — a sealed send from a non-member is still
 //!     refused by the DS membership gate (sealing relaxes the
 //!     `sender_id == auth-user` binding, NOT the membership authz).
-//!   - **regression** — with the flag off (default), everything behaves exactly
-//!     as before (real `sender_id`, `sealed = 0`, attribution correct).
+//!   - **no opt-out** — an ordinary client, constructed the ordinary way, seals.
+//!     This is the invariant test: it fails if anyone reintroduces a way to send
+//!     an envelope that names its author.
 
 use std::sync::Arc;
 
@@ -66,7 +68,7 @@ async fn two_member_channel(sender: &TestClient, receiver: &TestClient, receiver
 /// HEADLINE PROOF: sealing on blinds the server-stored sender while attribution
 /// still works.
 ///
-/// Alice sends with `POLLIS_SEAL_SENDER` enabled. The stored `message_envelope`
+/// Alice sends an ordinary message. The stored `message_envelope`
 /// row carries `sealed = 1` and the sentinel `sender_id` (`"sealed"`), NOT
 /// Alice's real id — so a Turso breach reveals nothing about who sent it. Yet
 /// Bob ingests the message and attributes it to Alice's REAL id, because the
@@ -78,7 +80,7 @@ async fn sealed_send_blinds_server_but_recipient_attributes_correctly() {
     wipe().await;
 
     // Alice's client has sealing ON; Bob's is a default (sealing off) client.
-    let mut alice = TestClient::new_sealed().await;
+    let mut alice = TestClient::new().await;
     let mut bob = TestClient::new().await;
 
     let alice_profile = alice.sign_up("alice@test.local").await;
@@ -134,9 +136,9 @@ async fn sealed_send_blinds_server_but_recipient_attributes_correctly() {
 async fn sealed_send_from_non_member_is_rejected() {
     wipe().await;
 
-    let mut alice = TestClient::new_sealed().await;
+    let mut alice = TestClient::new().await;
     let mut bob = TestClient::new().await;
-    let mut mallory = TestClient::new_sealed().await;
+    let mut mallory = TestClient::new().await;
 
     let _alice_profile = alice.sign_up("alice@test.local").await;
     let bob_profile = bob.sign_up("bob@test.local").await;
@@ -185,13 +187,15 @@ async fn sealed_send_from_non_member_is_rejected() {
     drop(mallory);
 }
 
-/// REGRESSION: with the flag off (the default `TestClient::new`), a send behaves
-/// exactly as before sealed sending existed — the envelope stores the real
-/// `sender_id` and `sealed = 0`, and the recipient attributes correctly. This is
-/// what makes landing the sending half == release N (reader on, sealing off).
+/// INVARIANT: sealing has no opt-out. A client built the ordinary way — no
+/// special constructor, no flag — must still blind the envelope. Before #331's
+/// second release this same construction produced a real `sender_id`, so this
+/// test is what catches a reintroduced escape hatch (a config field, an env
+/// var, a conditional) that would silently restore per-message sender exposure
+/// at rest.
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
-async fn unsealed_send_stores_real_sender_and_attributes_correctly() {
+async fn sealing_has_no_opt_out_for_an_ordinary_client() {
     wipe().await;
 
     let mut alice = TestClient::new().await;
@@ -204,16 +208,16 @@ async fn unsealed_send_stores_real_sender_and_attributes_correctly() {
 
     let msg_id = alice.send_channel_message_id(&channel_id, "plain hello").await;
 
-    // Unsealed: the stored envelope carries alice's real id and sealed = 0.
+    // The at-rest view must never name the author.
     let remote = writable_remote().await;
     let (sealed, envelope_sender) = envelope_sealed_and_sender(&remote, &msg_id).await;
-    assert_eq!(sealed, 0, "unsealed send must store sealed = 0");
-    assert_eq!(
+    assert_eq!(sealed, 1, "an ordinary client's send must be sealed");
+    assert_ne!(
         envelope_sender, alice_profile.id,
-        "unsealed send must store alice's real sender_id"
+        "the stored envelope must not carry alice's real sender_id"
     );
 
-    // Attribution still correct (from the credential, same as always).
+    // Attribution is unaffected — it comes from the MLS credential.
     let bob_msgs = bob.fetch_channel_messages(&channel_id).await;
     let bob_msg = bob_msgs
         .iter()
@@ -223,7 +227,7 @@ async fn unsealed_send_stores_real_sender_and_attributes_correctly() {
     assert_eq!(
         bob_msg["sender_id"].as_str(),
         Some(alice_profile.id.as_str()),
-        "bob must attribute the unsealed message to alice's real id"
+        "bob must still attribute the message to alice via the credential"
     );
 
     drop(alice);


### PR DESCRIPTION
Sealed sending was landed as release N+1 of an additive two-release dance and then never flipped: `POLLIS_SEAL_SENDER` defaulted **OFF**, so every shipped release has been writing the real `sender_id` into `message_envelope`. The reader half (attribution from the MLS credential inside the ciphertext, never from that column) shipped long ago, which was the only precondition.

This removes the flag rather than flipping its default. A build-time toggle would make the envelope's privacy depend on a value the user can neither see nor verify — and "is it on in this build?" is exactly the question a privacy claim shouldn't have.

## Changes

- `Config::seal_sender` and `POLLIS_SEAL_SENDER` **deleted** — config, `option_env!`/env parsing, the uniffi `InitConfig` bridge field, and the test-config defaults.
- `send_message` and the redaction path in `edit_delete.rs` now always post `sealed = 1` with the sentinel. **The redaction path was a second call site** carrying the same conditional; it would have been easy to flip the flag and miss it.
- The DS is unchanged and still accepts `sealed = 0`, so pre-cutover clients keep working.

## Tests

`unsealed_send_stores_real_sender_and_attributes_correctly` tested a path that no longer exists. Replaced with `sealing_has_no_opt_out_for_an_ordinary_client` — an ordinary `TestClient::new()`, no special constructor, asserting the stored envelope does **not** carry the author's id and that attribution still resolves via the credential. Per CLAUDE.md, the invariant ships with a test that fails if the invalid state is reintroduced: this one goes red if anyone adds back a flag, env var, or conditional that lets an envelope name its author.

249 pollis-core unit tests pass; the flows suite compiles.

## Side benefit

`POLLIS_SEAL_SENDER` was a baked `option_env!` value and therefore part of the reproducible build recipe. Removing it is **one fewer input a third-party rebuilder has to match** — updated in `docs/reproducible-builds-residuals.md` §4 and `rebuild-verify.yml`.

## Docs

`.codesight/wiki/mls.md`, `.codesight/wiki/database.md`, `docs/reproducible-builds-residuals.md` updated: sealing is described as unconditional and shipped, and all "default OFF / dormant / release N+1" language is gone.

**One statement was kept deliberately.** The wiki still records that the DS authenticates every write with `X-Pollis-User` and therefore sees the sender *live*, with anonymous-membership credentials (#489) named as what would close it. That isn't a caveat about this change — blinding covers the stored envelope, which is the breach/subpoena artifact, and it now does so unconditionally. But the live request path is unchanged by this PR, and a doc that implied otherwise would be false. It's phrased as scope, not as an open wound.
