### PR TITLE
fix(infra): stand up the hydra relay pool — plan-safe subnets, arm64 image, CAA pre-flight (#616)

### DIFF
--- a/.github/workflows/relay-image.yml
+++ b/.github/workflows/relay-image.yml
@@ -70,9 +70,30 @@ jobs:
         run: cargo test -p pollis-relay -p pollis-device-cert
 
   # Build the container image and (on dispatch/push, not PRs) publish to GHCR.
+  #
+  # MULTI-ARCH (amd64 + arm64) — arm64 is REQUIRED, not a nicety: the hydra's AWS
+  # pool (infra/relay-hydra/, #616) runs Graviton `t4g.nano` nodes because the §0
+  # budget math depends on it. An amd64-only image makes every node fail at boot
+  # with `no matching manifest for linux/arm64/v8`, cloud-init aborts, and the ASG
+  # happily keeps billing for instances that never run the relay.
+  #
+  # Each platform builds on its OWN NATIVE RUNNER (free for public repos) and pushes
+  # by digest; the `manifest` job then stitches the digests into one tag. Native
+  # beats QEMU here by a wide margin — cross-emulating a release build of the Rust
+  # workspace (ring's assembly, quinn, rustls) turns minutes into tens of minutes.
   image:
     needs: test
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       # Required to push the image to GHCR with the built-in GITHUB_TOKEN.
@@ -113,14 +134,106 @@ jobs:
 
       # Build from the REPO ROOT so the whole cargo workspace resolves; bake the
       # git SHA so /version reports the running build (the DS #509 tripwire shape).
-      - name: Build + push image
+      #
+      # PR / build-only: just prove this platform still assembles. No push, so no
+      # digest to hand the manifest job.
+      - name: Build image (build-only)
+        if: steps.mode.outputs.push != 'true'
         uses: docker/build-push-action@v6
         with:
           context: .
           file: pollis-relay/Dockerfile
-          push: ${{ steps.mode.outputs.push == 'true' }}
+          platforms: ${{ matrix.platform }}
+          push: false
           build-args: |
             GIT_SHA=${{ steps.sha.outputs.sha }}
-          tags: |
-            ${{ env.IMAGE }}:${{ steps.sha.outputs.sha }}
-            ${{ env.IMAGE }}:latest
+
+      # Publish path: push an untagged, per-platform image and record its digest.
+      # Tagging happens once, in `manifest` — tagging here would have the two
+      # platforms race to overwrite `:latest` with a single-arch image, which is
+      # exactly the failure this job exists to prevent.
+      - name: Build + push by digest
+        id: build
+        if: steps.mode.outputs.push == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: pollis-relay/Dockerfile
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            GIT_SHA=${{ steps.sha.outputs.sha }}
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        if: steps.mode.outputs.push == 'true'
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: steps.mode.outputs.push == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Stitch the per-platform digests into ONE multi-arch tag. Without this the
+  # registry holds two unrelated single-arch images and no manifest list, so an
+  # arm64 node still finds no matching manifest.
+  manifest:
+    needs: image
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout ${{ inputs.ref || github.sha }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Resolve build SHA
+        id: sha
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list + push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            -t "${IMAGE}:${{ steps.sha.outputs.sha }}" \
+            -t "${IMAGE}:latest" \
+            $(printf "${IMAGE}@sha256:%s " *)
+
+      # Fail loudly if arm64 is somehow missing — that is the exact regression that
+      # silently bricks every Graviton node in the hydra pool.
+      - name: Verify both platforms are present
+        run: |
+          docker buildx imagetools inspect "${IMAGE}:latest" --raw > /tmp/manifest.json
+          cat /tmp/manifest.json
+          for arch in amd64 arm64; do
+            if ! grep -q "\"architecture\": *\"$arch\"" /tmp/manifest.json; then
+              echo "::error::manifest list is missing linux/$arch"
+              exit 1
+            fi
+          done
+          echo "manifest list contains both linux/amd64 and linux/arm64"

--- a/infra/relay-hydra/README.md
+++ b/infra/relay-hydra/README.md
@@ -71,7 +71,12 @@ scripts/mint-signing-key.sh us-west-2
 # 2. Mint the ONE shared pool QUIC identity → SSM (key + cert). Prints cert_b64.
 scripts/mint-relay-identity.sh us-west-2
 
-# 3. Custom domain: create the ACM cert first so you can add its DNS validation
+# 3. CAA PRE-FLIGHT — do this BEFORE minting the cert (see the warning below).
+dig +short CAA relays.pollis.com; dig +short CAA pollis.com
+#    → if any CAA records exist and none names an Amazon CA, add one scoped to the
+#      subdomain first:  relays.pollis.com  CAA  0 issue "amazon.com"
+
+# 4. Custom domain: create the ACM cert first so you can add its DNS validation
 #    record, then a full apply once the cert is issued.
 cp terraform.tfvars.example terraform.tfvars    # edit as needed
 terraform init
@@ -79,16 +84,36 @@ terraform apply -target=module.directory.aws_acm_certificate.directory
 #    → add the CNAME from `terraform output acm_validation_records` at pollis.com's
 #      DNS host (Cloudflare). Wait until ACM shows "Issued" (minutes).
 
-# 4. Full apply.
+# 5. Full apply.
 terraform apply
 #    → add a CNAME:  relays.pollis.com  →  <terraform output directory_cname_target>
 
-# 5. Prove the contract end to end against the live URL.
+# 6. Prove the contract end to end against the live URL.
 node scripts/verify-directory.mjs "$(terraform output -raw POLLIS_OVERLAY_DIRECTORY_URL)" "<POLLIS_OVERLAY_DIRECTORY_KEY>"
 ```
 
 > Using the raw CloudFront domain instead? Set `directory_domain = ""`, skip steps
-> 3's `-target` and the CNAMEs, and just `terraform apply`.
+> 3–4 (the CAA check, the `-target`, and the CNAMEs) and just `terraform apply`.
+
+> ### ⚠️ CAA will fail the cert if you skip step 3
+> ACM issues from Amazon Trust Services. If the domain publishes **any** CAA
+> records, at least one must name an Amazon CA (`amazon.com` is the documented
+> minimum; `amazontrust.com` / `awstrust.com` / `amazonaws.com` also count) or
+> issuance is forbidden. `pollis.com` carries a CAA allowlist (Comodo, DigiCert,
+> Let's Encrypt, Google, Sectigo, SSL.com) that **excludes Amazon**, so the first
+> attempt here failed with `FailureReason: CAA_ERROR` — with a perfectly correct
+> validation CNAME in place, which makes it look like a DNS problem when it isn't.
+>
+> A `FAILED` ACM certificate **cannot be retried** — fix the CAA record, then
+> replace the cert:
+> ```bash
+> terraform apply -replace='module.directory.aws_acm_certificate.directory[0]' \
+>                 -target=module.directory.aws_acm_certificate.directory
+> ```
+> ACM reuses the same validation token per domain+account, so the existing
+> validation CNAME stays valid across the replacement — don't re-add it. The CAA
+> record is scoped to `relays.pollis.com` on purpose: it lets Amazon issue for that
+> one name without loosening the apex policy for the rest of pollis.com.
 
 ---
 

--- a/infra/relay-hydra/README.md
+++ b/infra/relay-hydra/README.md
@@ -32,11 +32,29 @@ health/failover. Each relay is just a node with a public UDP port.
 1. **AWS auth.** `aws login` (interactive), then `aws sts get-caller-identity` must
    succeed. The account needs VPC/EC2/ASG/IAM/SSM/S3/CloudFront/Lambda/EventBridge/
    Budgets/CloudWatch.
+
+   > **Terraform can't see an `aws login` session.** That flow stores short-lived
+   > creds under `~/.aws/login/`, which the AWS CLI resolves but the Go SDK the AWS
+   > provider uses does not — `terraform plan` fails with "No valid credential
+   > sources found". Export them into the environment first, in the same shell:
+   >
+   > ```bash
+   > eval "$(aws configure export-credentials --format env)"
+   > ```
+   >
+   > These expire (check `AWS_CREDENTIAL_EXPIRATION`, typically a few hours). Re-run
+   > `aws login` + the `eval` when they do. Don't start a long apply — the CloudFront
+   > distribution alone takes several minutes — with only minutes left on the clock.
 2. **The relay image is published and pullable by the nodes.** Run
    `.github/workflows/relay-image.yml` (needs org `packages: write`) and make
    `ghcr.io/actuallydan/pollis-relay` **public** (or add a pull secret to the
    user-data). This is a prerequisite, not part of the Terraform.
 3. **Terraform ≥ 1.6** and Node ≥ 20 (for the scripts/test).
+
+   > **State is local and gitignored** (`terraform.tfstate` next to this README).
+   > Losing it orphans every resource below — they keep billing and nothing manages
+   > them. Run applies from a durable checkout, not a temp dir, and back the file up
+   > (or move to an S3 backend) before the pool grows.
 4. **Allowlist hostnames** — the defaults in `variables.tf` were pulled from
    `.env.production`; re-verify against the current file before apply.
 

--- a/infra/relay-hydra/modules/relay-region/main.tf
+++ b/infra/relay-hydra/modules/relay-region/main.tf
@@ -43,14 +43,18 @@ resource "aws_internet_gateway" "this" {
   tags   = { Name = local.name }
 }
 
+// Keyed by AZ INDEX, not AZ name: the name list comes from a data source and is
+// unknown at plan time, and for_each keys must be static. The apply-time AZ name
+// therefore goes in the value position (see the `availability_zone` attribute) —
+// which is what Terraform's "unknown values in for_each" guidance prescribes.
 resource "aws_subnet" "public" {
-  for_each = { for idx, az in local.azs : az => idx }
+  for_each = toset([for idx in range(var.az_count) : tostring(idx)])
 
   vpc_id                  = aws_vpc.this.id
-  availability_zone       = each.key
-  cidr_block              = cidrsubnet(local.vpc_cidr, local.subnet_bits, each.value)
+  availability_zone       = local.azs[tonumber(each.key)]
+  cidr_block              = cidrsubnet(local.vpc_cidr, local.subnet_bits, tonumber(each.key))
   map_public_ip_on_launch = true
-  tags                    = { Name = "${local.name}-${each.key}" }
+  tags                    = { Name = "${local.name}-${local.azs[tonumber(each.key)]}" }
 }
 
 resource "aws_route_table" "public" {

--- a/infra/relay-hydra/scripts/mint-relay-identity.sh
+++ b/infra/relay-hydra/scripts/mint-relay-identity.sh
@@ -44,8 +44,17 @@ if [ ! -s "$TMP/identity.key" ] || [ ! -s "$TMP/identity.key.crt" ]; then
   exit 1
 fi
 
-KEY_B64="$(base64 -w0 "$TMP/identity.key")"
-CERT_B64="$(base64 -w0 "$TMP/identity.key.crt")"
+# The relay runs as root in the container, so the identity it writes into the bind
+# mount is root-owned 0600 — the host user can stat it (hence the -s checks above)
+# but not read it. Stream the bytes back out THROUGH the image instead of chown'ing
+# the host copies: `cat` runs as root inside, we base64 on the host.
+KEY_B64="$(docker run --rm -v "$TMP:/id" --entrypoint cat "$IMAGE" /id/identity.key | base64 -w0)"
+CERT_B64="$(docker run --rm -v "$TMP:/id" --entrypoint cat "$IMAGE" /id/identity.key.crt | base64 -w0)"
+
+if [ -z "$KEY_B64" ] || [ -z "$CERT_B64" ]; then
+  echo "failed to read the generated identity out of the container" >&2
+  exit 1
+fi
 
 aws ssm put-parameter --region "$REGION" --name "$KEY_PARAM" --type SecureString \
   --overwrite --value "$KEY_B64" \


### PR DESCRIPTION
Deploys the #616 hydra (IaC landed in #618, never applied). Three fixes were needed to get from merged code to running infra:

- **`plan` was broken.** `aws_subnet.public` used `for_each` over AZ names from a data source — unknown at plan time. Re-keyed by AZ index. `plan` had never been run before, so this had gone unnoticed.
- **arm64 image (blocker).** `ghcr.io/actuallydan/pollis-relay` was amd64-only, so every Graviton `t4g.nano` node died at boot with `no matching manifest for linux/arm64/v8` while still billing. `relay-image.yml` now builds both arches on native runners and verifies the manifest list.
- **CAA.** `pollis.com`'s CAA set excludes Amazon, so ACM failed with `CAA_ERROR` despite a correct validation CNAME — and a FAILED cert can't be retried. Documented as a pre-flight, with the CAA record scoped to `relays.pollis.com`.

Also documents the `aws login` → Terraform credential gap and the local-state hazard, and fixes `mint-relay-identity.sh` (root-owned bind mount made the identity unreadable).

**Live:** 36 resources applied in us-west-2. `https://relays.pollis.com/directory.json` resolves and serves a valid ACM cert.

**Still blocked:** needs a `relay-image.yml` dispatch to publish the arm64 image before nodes can boot and the directory can be published.