### PR TITLE
feat(infra): hydra alarm notifications + node self-heal (#616)

### DIFF
--- a/infra/relay-hydra/main.tf
+++ b/infra/relay-hydra/main.tf
@@ -63,6 +63,8 @@ module "reconciler" {
   health_port = var.health_port
   node_floor  = var.node_floor
   node_max    = var.node_max
+
+  alarm_email_addresses = var.alarm_email_addresses
 }
 
 # ── Guardrail: AWS Budgets alert at the §0 hard cap ─────────────────────────

--- a/infra/relay-hydra/modules/reconciler/main.tf
+++ b/infra/relay-hydra/modules/reconciler/main.tf
@@ -58,10 +58,11 @@ data "aws_iam_policy_document" "reconciler" {
     resources = ["*"]
   }
 
-  # Scale only pollis-relay ASGs.
+  # Scale only pollis-relay ASGs; SetInstanceHealth lets the reconciler flag a
+  # dead-container node so the ASG replaces it (self-heal).
   statement {
     sid       = "ScaleAsg"
-    actions   = ["autoscaling:UpdateAutoScalingGroup", "autoscaling:SetDesiredCapacity"]
+    actions   = ["autoscaling:UpdateAutoScalingGroup", "autoscaling:SetDesiredCapacity", "autoscaling:SetInstanceHealth"]
     resources = ["*"]
     condition {
       test     = "StringEquals"
@@ -183,7 +184,49 @@ resource "aws_lambda_permission" "events" {
   source_arn    = aws_cloudwatch_event_rule.schedule.arn
 }
 
+# ── Alarm notifications: SNS topic + email subscriptions ────────────────────
+# The alarms below all route to this topic. Email subscriptions require a one-time
+# confirmation click in the mail AWS sends (Terraform can't auto-confirm — the
+# subscription sits "pending confirmation" until then).
+
+resource "aws_sns_topic" "alarms" {
+  name = "${local.function_name}-alarms"
+  tags = { app = "pollis-relay" }
+}
+
+resource "aws_sns_topic_subscription" "alarm_emails" {
+  for_each  = toset(var.alarm_email_addresses)
+  topic_arn = aws_sns_topic.alarms.arn
+  protocol  = "email"
+  endpoint  = each.value
+}
+
+# Let CloudWatch alarms publish to the topic.
+data "aws_iam_policy_document" "alarms_topic" {
+  statement {
+    sid       = "AllowCloudWatchAlarmsPublish"
+    actions   = ["sns:Publish"]
+    resources = [aws_sns_topic.alarms.arn]
+    principals {
+      type        = "Service"
+      identifiers = ["cloudwatch.amazonaws.com"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+  }
+}
+
+resource "aws_sns_topic_policy" "alarms" {
+  arn    = aws_sns_topic.alarms.arn
+  policy = data.aws_iam_policy_document.alarms_topic.json
+}
+
 # ── Alarms (a handful; $0.10 each) ──────────────────────────────────────────
+# Each fires AND recovers to the SNS topic (alarm_actions + ok_actions) so a
+# resolved issue sends an all-clear, not silence.
 
 resource "aws_cloudwatch_metric_alarm" "reconcile_failures" {
   alarm_name          = "${local.function_name}-reconcile-failures"
@@ -195,6 +238,8 @@ resource "aws_cloudwatch_metric_alarm" "reconcile_failures" {
   statistic           = "Maximum"
   threshold           = 0
   treat_missing_data  = "notBreaching"
+  alarm_actions       = [aws_sns_topic.alarms.arn]
+  ok_actions          = [aws_sns_topic.alarms.arn]
   tags                = { app = "pollis-relay" }
 }
 
@@ -209,6 +254,8 @@ resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
   threshold           = 0
   treat_missing_data  = "notBreaching"
   dimensions          = { FunctionName = aws_lambda_function.reconciler.function_name }
+  alarm_actions       = [aws_sns_topic.alarms.arn]
+  ok_actions          = [aws_sns_topic.alarms.arn]
   tags                = { app = "pollis-relay" }
 }
 
@@ -227,5 +274,7 @@ resource "aws_cloudwatch_metric_alarm" "healthy_nodes" {
   threshold           = 1
   treat_missing_data  = "breaching"
   dimensions          = { Region = each.key }
+  alarm_actions       = [aws_sns_topic.alarms.arn]
+  ok_actions          = [aws_sns_topic.alarms.arn]
   tags                = { app = "pollis-relay" }
 }

--- a/infra/relay-hydra/modules/reconciler/variables.tf
+++ b/infra/relay-hydra/modules/reconciler/variables.tf
@@ -63,3 +63,9 @@ variable "node_floor" {
 variable "node_max" {
   type = number
 }
+
+variable "alarm_email_addresses" {
+  description = "Emails subscribed to the SNS topic the CloudWatch alarms notify. Each address must confirm the subscription via the email AWS sends. Empty = the topic still exists and alarms still fire to it, but nobody is subscribed."
+  type        = list(string)
+  default     = []
+}

--- a/infra/relay-hydra/modules/relay-region/main.tf
+++ b/infra/relay-hydra/modules/relay-region/main.tf
@@ -230,6 +230,13 @@ resource "aws_autoscaling_group" "relay" {
   vpc_zone_identifier = [for s in aws_subnet.public : s.id]
   health_check_type   = "EC2"
 
+  # The reconciler marks a node Unhealthy (via SetInstanceHealth) when its relay
+  # container is dead but the instance is still EC2-reachable. This grace period is
+  # the window, measured from launch, in which that flag is ignored so a node still
+  # running user-data (dnf install docker + image pull, ~2-3 min) isn't reaped
+  # mid-boot. 10 min leaves comfortable headroom over a cold image pull.
+  health_check_grace_period = 600
+
   mixed_instances_policy {
     instances_distribution {
       # Guarantee `node_floor` on-demand nodes; everything above is Spot. Spot

--- a/infra/relay-hydra/reconciler/index.mjs
+++ b/infra/relay-hydra/reconciler/index.mjs
@@ -68,8 +68,16 @@ export const handler = async () => {
       // Unhealthy so the ASG terminates + relaunches it. ShouldRespectGracePeriod
       // shields nodes still pulling the image on first boot (see the ASG's
       // health_check_grace_period).
-      if (unhealthy.length > 0) {
+      //
+      // Guard: only self-heal when at least one node in the region is healthy. If
+      // EVERY node is failing it's almost certainly systemic (a bad image push, bad
+      // config, an SSM/identity problem) — replacing them all just churns instances
+      // into the same failure and bills for it. Leave them for the alarms (healthy-
+      // nodes floor + reconcile failures, both now paging) to surface instead.
+      if (unhealthy.length > 0 && healthy.length > 0) {
         await markUnhealthy(region, unhealthy);
+      } else if (unhealthy.length > 0) {
+        console.error(`${region}: all ${unhealthy.length} node(s) unhealthy — NOT self-healing (looks systemic, not per-node); leaving for the alarms`);
       }
 
       for (const { ip } of healthy) {

--- a/infra/relay-hydra/reconciler/index.mjs
+++ b/infra/relay-hydra/reconciler/index.mjs
@@ -19,7 +19,7 @@
 // bytes the client base64-decodes and verifies (see scripts/verify-directory.mjs
 // and test/directory-contract.test.mjs, which run the client's verification path).
 
-import { AutoScalingClient, DescribeAutoScalingGroupsCommand, UpdateAutoScalingGroupCommand } from "@aws-sdk/client-auto-scaling";
+import { AutoScalingClient, DescribeAutoScalingGroupsCommand, UpdateAutoScalingGroupCommand, SetInstanceHealthCommand } from "@aws-sdk/client-auto-scaling";
 import { EC2Client, DescribeInstancesCommand } from "@aws-sdk/client-ec2";
 import { SSMClient, GetParameterCommand } from "@aws-sdk/client-ssm";
 import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
@@ -59,10 +59,20 @@ export const handler = async () => {
       await setDesiredCapacity(region, asgName, target);
 
       const nodes = await discoverInServiceNodes(region, asgName);
-      const healthy = await healthCheck(nodes);
+      const { healthy, unhealthy } = await healthCheck(nodes);
       perRegionHealthy[region] = healthy.length;
 
-      for (const ip of healthy) {
+      // Self-heal: an instance that's InService (EC2-reachable) but whose relay
+      // container is dead answers no /version, so the ASG's EC2 health check would
+      // never replace it — it would linger and bill while serving nothing. Mark it
+      // Unhealthy so the ASG terminates + relaunches it. ShouldRespectGracePeriod
+      // shields nodes still pulling the image on first boot (see the ASG's
+      // health_check_grace_period).
+      if (unhealthy.length > 0) {
+        await markUnhealthy(region, unhealthy);
+      }
+
+      for (const { ip } of healthy) {
         relays.push({ addr: `${ip}:${RELAY_PORT}`, region, cert_b64: certB64 });
       }
     } catch (err) {
@@ -156,34 +166,59 @@ async function discoverInServiceNodes(region, asgName) {
   }
 
   const desc = await ec2.send(new DescribeInstancesCommand({ InstanceIds: instanceIds }));
-  const ips = [];
+  const nodes = [];
   for (const reservation of desc.Reservations ?? []) {
     for (const inst of reservation.Instances ?? []) {
+      // A node with no public IP yet is still wiring up its ENI — skip it this
+      // cycle rather than treat it as a dead relay (it isn't advertised, and the
+      // grace period covers it if it's genuinely mid-boot).
       if (inst.PublicIpAddress) {
-        ips.push(inst.PublicIpAddress);
+        nodes.push({ instanceId: inst.InstanceId, ip: inst.PublicIpAddress });
       }
     }
   }
-  return ips;
+  return nodes;
+}
+
+// Flag failed nodes as Unhealthy so the ASG replaces them. Scoped to the app=
+// pollis-relay ASGs by the reconciler's IAM policy. ShouldRespectGracePeriod keeps
+// a freshly-launched node (still pulling the image) from being killed mid-boot.
+async function markUnhealthy(region, unhealthyNodes) {
+  const asg = new AutoScalingClient({ region });
+  for (const { instanceId } of unhealthyNodes) {
+    try {
+      await asg.send(new SetInstanceHealthCommand({
+        InstanceId: instanceId,
+        HealthStatus: "Unhealthy",
+        ShouldRespectGracePeriod: true,
+      }));
+      console.log(`${region}: marked ${instanceId} Unhealthy (no /version) — ASG will replace it`);
+    } catch (err) {
+      console.error(`${region}: failed to mark ${instanceId} unhealthy:`, err);
+    }
+  }
 }
 
 // --- Health check ------------------------------------------------------------
 
-async function healthCheck(ips) {
-  const results = await Promise.all(ips.map(async (ip) => {
+async function healthCheck(nodes) {
+  const results = await Promise.all(nodes.map(async (node) => {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), HEALTH_TIMEOUT_MS);
     try {
       // Treat any 200 as healthy; parse the JSON only if we want the SHA.
-      const res = await fetch(`http://${ip}:${HEALTH_PORT}/version`, { signal: controller.signal });
-      return res.ok ? ip : null;
+      const res = await fetch(`http://${node.ip}:${HEALTH_PORT}/version`, { signal: controller.signal });
+      return { node, ok: res.ok };
     } catch {
-      return null;
+      return { node, ok: false };
     } finally {
       clearTimeout(timer);
     }
   }));
-  return results.filter(Boolean);
+  return {
+    healthy: results.filter((r) => r.ok).map((r) => r.node),
+    unhealthy: results.filter((r) => !r.ok).map((r) => r.node),
+  };
 }
 
 // --- Metrics -----------------------------------------------------------------

--- a/infra/relay-hydra/terraform.tfvars.example
+++ b/infra/relay-hydra/terraform.tfvars.example
@@ -19,3 +19,7 @@ relay_allowlist = "prod-actuallydan.aws-us-east-1.turso.io,api.pollis.com,4bd9ab
 # $20/mo hard cap alert. Add emails to get notified.
 monthly_budget_usd  = 20
 budget_alert_emails = []
+
+# CloudWatch alarms (reconcile failures, Lambda errors, healthy-node floor) → SNS →
+# email. Each address must confirm the subscription email AWS sends.
+alarm_email_addresses = []

--- a/infra/relay-hydra/variables.tf
+++ b/infra/relay-hydra/variables.tf
@@ -132,3 +132,9 @@ variable "budget_alert_emails" {
   type        = list(string)
   default     = []
 }
+
+variable "alarm_email_addresses" {
+  description = "Emails subscribed to the SNS topic the CloudWatch alarms (reconcile failures, Lambda errors, healthy-node floor) notify. Each address must confirm the AWS subscription email. Empty = alarms fire to the topic but nobody is subscribed."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
Two follow-ups on the live #616 pool. **Already applied to us-west-2** (verified: alarms show 1 action each, ASG grace=600, reconciler run `{published:true,healthy:{us-west-2:3},reconcileFailures:0}`).

## SNS-backed alarm notifications
The three CloudWatch alarms had no `alarm_actions` — they'd fire to nobody. Added an SNS topic with an email subscription (`alarm_email_addresses` tfvar) and wired `alarm_actions` + `ok_actions` on all three. **The email subscription is `PendingConfirmation` until dankral01@gmail.com clicks the AWS confirmation link** — AWS blocks auto-confirming email endpoints.

## ASG self-heal for dead-container nodes
`health_check_type = "EC2"` meant a node whose relay *container* died (but instance stayed reachable) lingered and billed forever — the reconciler pruned it from the directory but nothing replaced it. The reconciler now marks such nodes `Unhealthy` via `SetInstanceHealth` so the ASG terminates + relaunches them. `ShouldRespectGracePeriod` + `health_check_grace_period=600` shield nodes still pulling the image on first boot.

Plan was 3 add / 6 change / 0 destroy — no replacements. Contract test 8/8.