### PR TITLE
feat(overlay): dynamic relay pool from the signed directory (#616 client half, #455)

### DIFF
--- a/docs/relay-operations.md
+++ b/docs/relay-operations.md
@@ -259,21 +259,45 @@ you can). Mount the identity volume so a restart keeps the same pinned cert.
 
 Bake the pool into the client build (the same `option_env!` mechanism as every
 other first-party endpoint; a runtime env var of the same name overrides for local
-testing):
+testing). There are two ways to supply the pool — pick ONE:
+
+**A. Dynamic signed directory (recommended — the hydra, #616).** The client fetches
+a signed, self-updating directory of live relays and refreshes it as pool
+membership changes (Spot reclamation / self-heal node replacement), so you never
+re-ship the client when nodes rotate:
+
+- `POLLIS_OVERLAY_DIRECTORY_URL` = the stable directory URL, e.g.
+  `https://relays.pollis.com/directory.json`.
+- `POLLIS_OVERLAY_DIRECTORY_KEY` = the base64 (STANDARD) of the 32-byte Ed25519
+  directory-signing **public** key (printed by `infra/relay-hydra/scripts/mint-signing-key.sh`).
+
+The client (`crate::net::directory` → `SwappableFactory` in `net/overlay.rs`)
+fetches the envelope, verifies the Ed25519 signature over the exact payload bytes
+against the pinned key, and rejects (fail-closed → `prefer` direct / `strict`
+degrade) on bad signature, `version != 1`, expiry, malformed JSON, or empty relays
+— the §3 contract, byte-identical to `infra/relay-hydra/lib/directory-verify.mjs`.
+It refreshes near the directory's `expires_at` (and on-demand when the pool is
+exhausted), swapping the live pool with **no shim restart**. Each directory entry
+carries its own pinned cert, so per-node identities work automatically. When BOTH
+vars are set, this path supersedes `POLLIS_OVERLAY_RELAY` below.
+
+**B. Static endpoint list (v0 / operator-provisioned hosts).** For a hand-managed
+pool with stable addresses:
 
 - `POLLIS_OVERLAY_RELAY` = the **comma-separated** endpoint list, e.g.
   `relay1.pollis.com:9444,relay2.pollis.com:9444`.
 - `POLLIS_OVERLAY_RELAY_CERT` = the pinned cert from Step 1 (base64 of the DER, or
   a path to the DER file).
 
-The client (`RealRelayFactory`, `pollis-core/src/net/overlay.rs`) treats the list
-as a **pool** (design §4 above): it dials endpoints in health order and takes the
-first success; a failed dial marks that endpoint dead for a 30 s cooldown and the
-next candidate is tried; only when **every** endpoint fails does a connect error
-(so `prefer` still falls back to direct, `strict` still degrades — but never on a
-single dead relay). A rotating start index spreads load; each dial is bounded (8 s)
-so an unreachable node fails over fast. One shared `POLLIS_OVERLAY_RELAY_CERT`
-pins every endpoint (all first-party, same identity).
+Either way, the client (`RealRelayFactory`, `pollis-core/src/net/overlay.rs`) treats
+the resolved set as a **pool** (design §4 above): it dials endpoints in health order
+and takes the first success; a failed dial marks that endpoint dead for a 30 s
+cooldown and the next candidate is tried; only when **every** endpoint fails does a
+connect error (so `prefer` still falls back to direct, `strict` still degrades — but
+never on a single dead relay). A rotating start index spreads load; each dial is
+bounded (8 s) so an unreachable node fails over fast. In the static path one shared
+`POLLIS_OVERLAY_RELAY_CERT` pins every endpoint; the directory path pins each node
+against its own advertised cert.
 
 ### Step 4 — verify
 

--- a/docs/relay-overlay-design.md
+++ b/docs/relay-overlay-design.md
@@ -510,6 +510,19 @@ removes the per-call-`Client::new()` anti-pattern (connection-pool win for free)
     rate + concurrency limits (`Rejected(RateLimited)`). Operational-separation commitment written up
     in **`docs/relay-operations.md`**. Bootstrap/OTP traffic (a device with no cert yet) cannot
     cert-authenticate and stays DIRECT — documented, mirrors the DS session-vs-device split.
+  - **Slice 2b (landed) — the signed-directory client (#616, the hydra's client half).** The pool is
+    no longer a hardcoded list: when `POLLIS_OVERLAY_DIRECTORY_URL` + `POLLIS_OVERLAY_DIRECTORY_KEY`
+    are configured, the client fetches a **signed directory** of live relays, verifies its Ed25519
+    signature over the exact payload bytes against the pinned key (`crate::net::directory`, byte-
+    identical to `infra/relay-hydra/lib/directory-verify.mjs` — the §3 frozen contract), and feeds the
+    result into the same `RealRelayFactory` pool. A `SwappableFactory` wraps the pool so a refresh loop
+    can replace membership live (near `expires_at`, and on-demand when the pool is exhausted) with no
+    shim restart or DB reconnect. Each directory entry carries its own pinned cert (per-node identities
+    for free). Fail-closed is preserved end to end: a rejected/unreachable directory yields an empty
+    pool → `prefer` direct, `strict` degrade, never a silent unverified send. The directory FETCH is
+    deliberately direct (it bootstraps the pool it cannot yet route through; integrity comes from the
+    signature, not the transport). The static `POLLIS_OVERLAY_RELAY` path (Slice 2a) remains the
+    operator/hand-provisioned fallback; the directory supersedes it when both vars are set.
 - **Slice 3 — one-hop latency measurement** against the §6.4 budget (de-risk item 3), on the real
   control plane, before any "ship v0" call.
 

--- a/pollis-core/src/bridge.rs
+++ b/pollis-core/src/bridge.rs
@@ -156,6 +156,8 @@ async fn init_pollis_inner(config_json: String) -> Result<(), BridgeError> {
                 overlay_mode: pollis_relay::OverlayMode::Off,
                 overlay_relay_url: None,
                 overlay_relay_cert: None,
+                overlay_directory_url: None,
+                overlay_directory_key: None,
             };
             let state = AppState::new(config).await?;
             Ok::<Arc<AppState>, BridgeError>(Arc::new(state))

--- a/pollis-core/src/config.rs
+++ b/pollis-core/src/config.rs
@@ -52,9 +52,30 @@ pub struct Config {
     /// endpoint). Kept separate from the endpoint so a future pool can pin one
     /// cert while listing several addresses.
     pub overlay_relay_cert: Option<String>,
+    /// URL of the signed relay **directory** (`POLLIS_OVERLAY_DIRECTORY_URL`, e.g.
+    /// `https://relays.pollis.com/directory.json`). When set (with the key below),
+    /// the overlay pool is DYNAMIC: the client fetches this directory, verifies it
+    /// (§3), and refreshes it as membership changes — superseding the static
+    /// `POLLIS_OVERLAY_RELAY` list. Absent → the static list is used (v0). See
+    /// `crate::net::directory` and issue #616.
+    pub overlay_directory_url: Option<String>,
+    /// The pinned Ed25519 directory-signing PUBLIC key
+    /// (`POLLIS_OVERLAY_DIRECTORY_KEY`): base64 (STANDARD) of the raw 32 bytes. The
+    /// client verifies every fetched directory against exactly this key, so a
+    /// rolled-back or forged directory fails closed. Required alongside the URL —
+    /// a URL without a key is treated as "directory not configured" (fail-safe).
+    pub overlay_directory_key: Option<String>,
 }
 
 impl Config {
+    /// True when BOTH the directory URL and pinned key are set — the DYNAMIC pool
+    /// path. A URL without a key (or vice versa) is deliberately NOT configured:
+    /// verifying against a key is non-negotiable, so a half-config fails safe to
+    /// the static list rather than fetching an unverifiable directory.
+    pub fn overlay_directory_configured(&self) -> bool {
+        self.overlay_directory_url.is_some() && self.overlay_directory_key.is_some()
+    }
+
     /// The configured relay endpoints, in order. `RealRelayFactory` treats them
     /// as a pool — tries them in health order and fails over to the first
     /// success. Empty when unconfigured.
@@ -112,6 +133,14 @@ impl Config {
             overlay_relay_cert: option_env!("POLLIS_OVERLAY_RELAY_CERT")
                 .map(|s| s.to_string())
                 .or_else(|| std::env::var("POLLIS_OVERLAY_RELAY_CERT").ok())
+                .filter(|s| !s.is_empty()),
+            overlay_directory_url: option_env!("POLLIS_OVERLAY_DIRECTORY_URL")
+                .map(|s| s.to_string())
+                .or_else(|| std::env::var("POLLIS_OVERLAY_DIRECTORY_URL").ok())
+                .filter(|s| !s.is_empty()),
+            overlay_directory_key: option_env!("POLLIS_OVERLAY_DIRECTORY_KEY")
+                .map(|s| s.to_string())
+                .or_else(|| std::env::var("POLLIS_OVERLAY_DIRECTORY_KEY").ok())
                 .filter(|s| !s.is_empty()),
         })
     }
@@ -172,6 +201,8 @@ impl Config {
             overlay_mode: pollis_relay::OverlayMode::Off,
             overlay_relay_url: None,
             overlay_relay_cert: None,
+            overlay_directory_url: None,
+            overlay_directory_key: None,
         })
     }
 }

--- a/pollis-core/src/net/directory.rs
+++ b/pollis-core/src/net/directory.rs
@@ -1,0 +1,314 @@
+//! The client's consumer of the signed relay **directory** (issue #616 §3, the
+//! frozen contract; the hydra's `infra/relay-hydra/lib/directory-verify.mjs` is
+//! the byte-for-byte reference this mirrors). The reconciler Lambda signs a
+//! directory of live relay endpoints and publishes it at a stable HTTPS URL; this
+//! module fetches it, verifies the Ed25519 signature against the client-pinned
+//! public key, and hands back the typed [`Directory`]. The overlay engine
+//! ([`crate::net::overlay`]) turns that into the live relay pool.
+//!
+//! **Byte-for-byte discipline (§3).** The envelope is
+//! `{ "payload_b64", "signature_b64" }`. We verify the signature over the EXACT
+//! bytes we base64-decode from `payload_b64`, THEN parse those bytes as the
+//! Directory. No JSON canonicalization — both sides sign/verify identical bytes.
+//!
+//! **Fail closed.** Every rejection ([`DirectoryError`]) leaves the caller with no
+//! usable relays, which in `Prefer` means direct fallback and in `Strict` a
+//! surfaced degrade — never a silent send over an unverified path. The reject set
+//! matches the reference exactly: bad signature, `version != 1`, `now >=
+//! expires_at`, malformed JSON (envelope or payload), or empty `relays`.
+//!
+//! **Bootstrap is direct, by necessity.** The fetch uses a plain (non-overlay)
+//! HTTP client: the directory is what BUILDS the relay pool, so it cannot itself
+//! route through a pool that does not exist yet. The artifact is Ed25519-signed,
+//! so its integrity does not depend on the transport — only the client's IP is
+//! exposed to the directory host during the fetch, the same unavoidable bootstrap
+//! every bridge-list design has.
+
+use std::time::Duration;
+
+use base64::Engine as _;
+use ed25519_dalek::{Signature, VerifyingKey};
+use serde::Deserialize;
+
+/// How long a single directory fetch may take before it is treated as a failure
+/// (the refresh loop retries; the pool keeps its previous membership meanwhile).
+const FETCH_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Why a directory was rejected. Every variant is fail-closed at the call site.
+#[derive(Debug, thiserror::Error)]
+pub enum DirectoryError {
+    #[error("directory fetch failed: {0}")]
+    Fetch(String),
+    #[error("malformed envelope JSON")]
+    MalformedEnvelope,
+    #[error("malformed payload JSON")]
+    MalformedPayload,
+    #[error("bad base64 in {0}")]
+    BadBase64(&'static str),
+    #[error("pinned directory key is not a 32-byte Ed25519 public key")]
+    BadPinnedKey,
+    #[error("signature is not 64 bytes")]
+    BadSignatureLen,
+    #[error("bad signature")]
+    BadSignature,
+    #[error("unsupported directory version {0}")]
+    UnsupportedVersion(u32),
+    #[error("directory expired (now {now} >= expires_at {expires_at})")]
+    Expired { now: i64, expires_at: i64 },
+    #[error("directory lists no relays")]
+    EmptyRelays,
+}
+
+/// The signed envelope as published: base64 (STANDARD) of the payload bytes plus
+/// base64 of the 64-byte Ed25519 signature over those exact bytes.
+#[derive(Deserialize)]
+struct Envelope {
+    payload_b64: String,
+    signature_b64: String,
+}
+
+/// The Directory object (the exact bytes that get base64'd into `payload_b64`).
+#[derive(Debug, Clone, Deserialize)]
+pub struct Directory {
+    pub version: u32,
+    pub issued_at: i64,
+    pub expires_at: i64,
+    pub relays: Vec<DirectoryRelay>,
+}
+
+/// One relay advertised by the directory. `cert_b64` is base64 (STANDARD) of the
+/// DER bytes of that node's pinned QUIC leaf — the client verifies the relay it
+/// dials against exactly this cert (the relay's identity *is* its cert, §7).
+#[derive(Debug, Clone, Deserialize)]
+pub struct DirectoryRelay {
+    /// Directly-dialable `public-ip-or-host:udp-port`.
+    pub addr: String,
+    /// Informational (the client may later prefer nearer regions). Defaulted so a
+    /// future directory that omits it still parses.
+    #[serde(default)]
+    pub region: String,
+    pub cert_b64: String,
+}
+
+/// Fetch the raw envelope bytes from `url` over a DIRECT (non-overlay) client.
+/// See the module docs for why the fetch cannot route through the overlay.
+pub async fn fetch_directory(url: &str) -> Result<Vec<u8>, DirectoryError> {
+    let client = reqwest::Client::builder()
+        .timeout(FETCH_TIMEOUT)
+        .build()
+        .map_err(|e| DirectoryError::Fetch(e.to_string()))?;
+    let resp = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| DirectoryError::Fetch(e.to_string()))?
+        .error_for_status()
+        .map_err(|e| DirectoryError::Fetch(e.to_string()))?;
+    let bytes = resp
+        .bytes()
+        .await
+        .map_err(|e| DirectoryError::Fetch(e.to_string()))?;
+    Ok(bytes.to_vec())
+}
+
+/// Verify a directory envelope against the pinned public key and validity window,
+/// returning the parsed [`Directory`] on success. `pinned_pubkey_b64` is base64
+/// (STANDARD) of the raw 32-byte Ed25519 public key (as
+/// `POLLIS_OVERLAY_DIRECTORY_KEY` is minted). `now_secs` is injected so tests can
+/// exercise expiry deterministically.
+///
+/// Mirrors `directory-verify.mjs` exactly: verify the signature over the decoded
+/// payload bytes FIRST, then parse and range-check.
+pub fn verify_directory(
+    envelope_bytes: &[u8],
+    pinned_pubkey_b64: &str,
+    now_secs: i64,
+) -> Result<Directory, DirectoryError> {
+    let envelope: Envelope =
+        serde_json::from_slice(envelope_bytes).map_err(|_| DirectoryError::MalformedEnvelope)?;
+
+    let payload = base64::engine::general_purpose::STANDARD
+        .decode(envelope.payload_b64.as_bytes())
+        .map_err(|_| DirectoryError::BadBase64("payload_b64"))?;
+    let signature_bytes = base64::engine::general_purpose::STANDARD
+        .decode(envelope.signature_b64.as_bytes())
+        .map_err(|_| DirectoryError::BadBase64("signature_b64"))?;
+
+    let verifying_key = verifying_key_from_b64(pinned_pubkey_b64)?;
+    let signature =
+        Signature::from_slice(&signature_bytes).map_err(|_| DirectoryError::BadSignatureLen)?;
+    verifying_key
+        .verify_strict(&payload, &signature)
+        .map_err(|_| DirectoryError::BadSignature)?;
+
+    let directory: Directory =
+        serde_json::from_slice(&payload).map_err(|_| DirectoryError::MalformedPayload)?;
+
+    if directory.version != 1 {
+        return Err(DirectoryError::UnsupportedVersion(directory.version));
+    }
+    if now_secs >= directory.expires_at {
+        return Err(DirectoryError::Expired {
+            now: now_secs,
+            expires_at: directory.expires_at,
+        });
+    }
+    if directory.relays.is_empty() {
+        return Err(DirectoryError::EmptyRelays);
+    }
+    Ok(directory)
+}
+
+/// Rebuild an Ed25519 [`VerifyingKey`] from the base64 of its raw 32 bytes.
+fn verifying_key_from_b64(pinned_pubkey_b64: &str) -> Result<VerifyingKey, DirectoryError> {
+    let raw = base64::engine::general_purpose::STANDARD
+        .decode(pinned_pubkey_b64.trim().as_bytes())
+        .map_err(|_| DirectoryError::BadBase64("pinned key"))?;
+    let raw: [u8; 32] = raw.try_into().map_err(|_| DirectoryError::BadPinnedKey)?;
+    VerifyingKey::from_bytes(&raw).map_err(|_| DirectoryError::BadPinnedKey)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::{Signer, SigningKey};
+
+    // Deterministic key so the test never touches the RNG.
+    fn signing_key() -> SigningKey {
+        SigningKey::from_bytes(&[7u8; 32])
+    }
+
+    fn pinned_b64(sk: &SigningKey) -> String {
+        base64::engine::general_purpose::STANDARD.encode(sk.verifying_key().to_bytes())
+    }
+
+    /// Build a signed envelope from a Directory JSON string (so tests can craft
+    /// exact payload bytes, including invalid ones, and sign them faithfully).
+    fn envelope_for(sk: &SigningKey, payload_json: &str) -> Vec<u8> {
+        let payload = payload_json.as_bytes();
+        let sig = sk.sign(payload);
+        let env = serde_json::json!({
+            "payload_b64": base64::engine::general_purpose::STANDARD.encode(payload),
+            "signature_b64": base64::engine::general_purpose::STANDARD.encode(sig.to_bytes()),
+        });
+        serde_json::to_vec(&env).unwrap()
+    }
+
+    fn valid_payload(expires_at: i64) -> String {
+        format!(
+            r#"{{"version":1,"issued_at":1000,"expires_at":{expires_at},"relays":[{{"addr":"203.0.113.7:9444","region":"us-west-2","cert_b64":"QUJD"}},{{"addr":"203.0.113.8:9444","region":"us-west-2","cert_b64":"REVG"}}]}}"#
+        )
+    }
+
+    #[test]
+    fn accepts_a_valid_directory_with_per_node_certs() {
+        let sk = signing_key();
+        let env = envelope_for(&sk, &valid_payload(2000));
+        let dir = verify_directory(&env, &pinned_b64(&sk), 1500).expect("valid");
+        assert_eq!(dir.version, 1);
+        assert_eq!(dir.relays.len(), 2);
+        assert_eq!(dir.relays[0].addr, "203.0.113.7:9444");
+        // Per-node certs are distinct — the format carries one per entry.
+        assert_ne!(dir.relays[0].cert_b64, dir.relays[1].cert_b64);
+    }
+
+    #[test]
+    fn rejects_a_tampered_payload() {
+        let sk = signing_key();
+        let mut env = envelope_for(&sk, &valid_payload(2000));
+        // Flip a byte in the base64 payload so the signature no longer matches.
+        let text = String::from_utf8(env).unwrap();
+        let mut v: serde_json::Value = serde_json::from_str(&text).unwrap();
+        let p = v["payload_b64"].as_str().unwrap().to_string();
+        let mut chars: Vec<char> = p.chars().collect();
+        chars[10] = if chars[10] == 'A' { 'B' } else { 'A' };
+        v["payload_b64"] = serde_json::Value::String(chars.into_iter().collect());
+        env = serde_json::to_vec(&v).unwrap();
+        assert!(matches!(
+            verify_directory(&env, &pinned_b64(&sk), 1500),
+            Err(DirectoryError::BadSignature
+                | DirectoryError::MalformedPayload
+                | DirectoryError::BadBase64(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_signature_from_the_wrong_key() {
+        let sk = signing_key();
+        let env = envelope_for(&sk, &valid_payload(2000));
+        let attacker = SigningKey::from_bytes(&[9u8; 32]);
+        assert!(matches!(
+            verify_directory(&env, &pinned_b64(&attacker), 1500),
+            Err(DirectoryError::BadSignature)
+        ));
+    }
+
+    #[test]
+    fn rejects_unsupported_version() {
+        let sk = signing_key();
+        let payload = r#"{"version":2,"issued_at":1000,"expires_at":2000,"relays":[{"addr":"x:1","cert_b64":"QUJD"}]}"#;
+        let env = envelope_for(&sk, payload);
+        assert!(matches!(
+            verify_directory(&env, &pinned_b64(&sk), 1500),
+            Err(DirectoryError::UnsupportedVersion(2))
+        ));
+    }
+
+    #[test]
+    fn rejects_an_expired_directory() {
+        let sk = signing_key();
+        let env = envelope_for(&sk, &valid_payload(2000));
+        // now == expires_at is already expired (>=, matching the reference).
+        assert!(matches!(
+            verify_directory(&env, &pinned_b64(&sk), 2000),
+            Err(DirectoryError::Expired { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_empty_relays() {
+        let sk = signing_key();
+        let payload = r#"{"version":1,"issued_at":1000,"expires_at":2000,"relays":[]}"#;
+        let env = envelope_for(&sk, payload);
+        assert!(matches!(
+            verify_directory(&env, &pinned_b64(&sk), 1500),
+            Err(DirectoryError::EmptyRelays)
+        ));
+    }
+
+    #[test]
+    fn rejects_malformed_envelope() {
+        let sk = signing_key();
+        assert!(matches!(
+            verify_directory(b"not json", &pinned_b64(&sk), 1500),
+            Err(DirectoryError::MalformedEnvelope)
+        ));
+    }
+
+    /// Cross-language interop proof: verify a REAL reconciler-signed directory
+    /// (Node `crypto.sign`) with this Rust verifier — the unit tests above only
+    /// prove dalek-signs / dalek-verifies. Ignored (needs the live pool + creds);
+    /// run locally with:
+    ///   POLLIS_OVERLAY_DIRECTORY_URL=... POLLIS_OVERLAY_DIRECTORY_KEY=... \
+    ///     cargo test -p pollis-core --no-default-features --features test-harness \
+    ///     net::directory::tests::verifies_the_live_directory -- --ignored --nocapture
+    #[tokio::test]
+    #[ignore]
+    async fn verifies_the_live_directory() {
+        let url = std::env::var("POLLIS_OVERLAY_DIRECTORY_URL").expect("set URL");
+        let key = std::env::var("POLLIS_OVERLAY_DIRECTORY_KEY").expect("set KEY");
+        let bytes = super::fetch_directory(&url).await.expect("fetch");
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        let dir = verify_directory(&bytes, &key, now).expect("live directory must verify");
+        eprintln!(
+            "live directory OK: version={} relays={} expires_at={}",
+            dir.version,
+            dir.relays.len(),
+            dir.expires_at
+        );
+        assert!(!dir.relays.is_empty());
+    }
+}

--- a/pollis-core/src/net/mod.rs
+++ b/pollis-core/src/net/mod.rs
@@ -4,4 +4,5 @@
 //! shared reqwest client seam, and the libsql SOCKS connector. All of it is
 //! INERT unless `POLLIS_OVERLAY` selects a non-off mode at runtime.
 
+pub mod directory;
 pub mod overlay;

--- a/pollis-core/src/net/overlay.rs
+++ b/pollis-core/src/net/overlay.rs
@@ -25,7 +25,10 @@ use hyper::Uri;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf};
 use tokio::net::TcpStream;
 use tokio::sync::Mutex as AsyncMutex;
+use tokio::task::JoinHandle;
 use tower_service::Service;
+
+use super::directory;
 
 use pollis_relay::circuit::{Circuit, CircuitFactory, Hop};
 use pollis_relay::client::ClientIdentity;
@@ -448,6 +451,239 @@ fn load_pinned_cert(s: &str) -> Option<CertificateDer<'static>> {
         .map(CertificateDer::from)
 }
 
+// ── Dynamic pool: the signed directory (design §14.1, issue #616) ──────────
+//
+// When `POLLIS_OVERLAY_DIRECTORY_URL` + `_KEY` are configured, the pool is not a
+// static list but a signed directory (`crate::net::directory`) the client fetches
+// + verifies and REFRESHES as the hosted pool's membership changes (nodes rotate
+// on Spot reclamation / self-heal). A `SwappableFactory` holds the live pool and
+// the refresh loop swaps it in place — no shim restart, no DB reconnect.
+
+/// Refresh the directory this long BEFORE it expires, so the pool is never serving
+/// from an expired directory. The reconciler re-signs every couple of minutes with
+/// a ~1h expiry, so at steady state this refetches roughly hourly.
+const DIRECTORY_REFRESH_SKEW: Duration = Duration::from_secs(5 * 60);
+/// Clamp the computed sleep so a pathological `expires_at` can neither tight-loop
+/// nor park refresh forever.
+const DIRECTORY_MIN_REFRESH: Duration = Duration::from_secs(30);
+const DIRECTORY_MAX_REFRESH: Duration = Duration::from_secs(55 * 60);
+/// After a failed fetch, retry on this fixed backoff — recover lazily, keep the
+/// previous pool meanwhile (mirrors `RemoteDb::with_retry`; never poll tightly).
+const DIRECTORY_RETRY_BACKOFF: Duration = Duration::from_secs(60);
+/// Floor on the interval between fetches, so an on-exhaustion notify storm during
+/// an outage can never hammer the directory host.
+const DIRECTORY_MIN_REFETCH: Duration = Duration::from_secs(15);
+
+/// Map a verified [`directory::Directory`] to the factory's endpoint pool. Each
+/// entry carries its OWN pinned cert (the format supports per-node certs; v0.5
+/// shares one across the pool, but we consume whatever is listed). Entries whose
+/// `cert_b64` is not valid base64/DER are skipped — never dial a relay we cannot
+/// pin.
+fn directory_to_endpoints(dir: &directory::Directory) -> Vec<RelayEndpoint> {
+    use base64::Engine as _;
+    dir.relays
+        .iter()
+        .filter_map(|r| {
+            let der = base64::engine::general_purpose::STANDARD
+                .decode(r.cert_b64.trim())
+                .ok()?;
+            Some(RelayEndpoint {
+                addr: r.addr.clone(),
+                cert: CertificateDer::from(der),
+            })
+        })
+        .collect()
+}
+
+/// Seconds to sleep before the next scheduled refresh, derived from the current
+/// directory's `expires_at` minus the skew, clamped to a sane window.
+fn until_refresh(expires_at: i64) -> Duration {
+    let now = now_unix_secs() as i64;
+    let secs = (expires_at - now).saturating_sub(DIRECTORY_REFRESH_SKEW.as_secs() as i64);
+    Duration::from_secs(secs.max(0) as u64).clamp(DIRECTORY_MIN_REFRESH, DIRECTORY_MAX_REFRESH)
+}
+
+/// Owns the directory refresh task and aborts it when the factory drops (overlay
+/// stopped or rebuilt) — so no orphan refresh loop outlives the pool it feeds.
+struct AbortOnDrop(JoinHandle<()>);
+impl Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
+/// A [`CircuitFactory`] whose relay pool can be swapped live, so the refresh loop
+/// replaces the pool as membership changes without restarting the shim. `connect`
+/// reads the current pool per call (a cheap `Arc` clone; the lock is never held
+/// across I/O) and, when a dial fully fails, nudges the refresh loop — the pool it
+/// holds may be stale.
+struct SwappableFactory {
+    inner: Mutex<Arc<dyn CircuitFactory>>,
+    /// Pinged when a connect exhausts the current pool: membership likely changed
+    /// under us, so refetch out of band instead of waiting for the schedule.
+    refresh_notify: tokio::sync::Notify,
+    /// Aborts the refresh task on drop. `Option` only so it can be set AFTER the
+    /// `Arc<SwappableFactory>` exists (the task holds a `Weak` back to it).
+    refresh_task: Mutex<Option<AbortOnDrop>>,
+}
+
+impl SwappableFactory {
+    fn new(initial: Arc<dyn CircuitFactory>) -> Self {
+        SwappableFactory {
+            inner: Mutex::new(initial),
+            refresh_notify: tokio::sync::Notify::new(),
+            refresh_task: Mutex::new(None),
+        }
+    }
+
+    fn current(&self) -> Arc<dyn CircuitFactory> {
+        self.inner.lock().unwrap().clone()
+    }
+
+    fn swap(&self, next: Arc<dyn CircuitFactory>) {
+        *self.inner.lock().unwrap() = next;
+    }
+}
+
+#[async_trait::async_trait]
+impl CircuitFactory for SwappableFactory {
+    async fn connect(&self, host: &str, port: u16) -> anyhow::Result<BoxedStream> {
+        let factory = self.current();
+        match factory.connect(host, port).await {
+            Ok(stream) => Ok(stream),
+            Err(e) => {
+                // Pool exhausted — likely stale membership. Nudge a refetch; the
+                // refresh loop's debounce keeps this from hammering the host.
+                self.refresh_notify.notify_one();
+                Err(e)
+            }
+        }
+    }
+}
+
+/// Fetch + verify the directory and build a fresh relay pool from it. Returns the
+/// new factory and the directory's `expires_at` (to schedule the next refresh).
+/// Fails (fail-closed) if the fetch, verification, or every listed cert fails.
+async fn fetch_and_build_pool(
+    url: &str,
+    key: &str,
+    state: &Weak<AppState>,
+    cooldown: Duration,
+    dial_timeout: Duration,
+) -> anyhow::Result<(Arc<dyn CircuitFactory>, i64)> {
+    let bytes = directory::fetch_directory(url).await?;
+    let now = now_unix_secs() as i64;
+    let dir = directory::verify_directory(&bytes, key, now)?;
+    let endpoints = directory_to_endpoints(&dir);
+    if endpoints.is_empty() {
+        anyhow::bail!("overlay: directory verified but no relay had a usable pinned cert");
+    }
+    let factory: Arc<dyn CircuitFactory> = Arc::new(RealRelayFactory::new(
+        state.clone(),
+        endpoints,
+        cooldown,
+        dial_timeout,
+    ));
+    Ok((factory, dir.expires_at))
+}
+
+/// The directory refresh loop: keep the [`SwappableFactory`]'s pool current. Wakes
+/// on either the expiry-derived schedule OR an on-exhaustion notify (debounced by
+/// [`DIRECTORY_MIN_REFETCH`]). On success it swaps the pool and schedules the next
+/// refresh near the new directory's expiry; on failure it keeps the existing pool
+/// and retries on a fixed backoff. Exits when the factory is dropped (overlay
+/// stopped) — the `Weak` upgrade fails. This is event-driven + lazy, not a
+/// keepalive poll: it sleeps on the directory's own TTL and on real dial failures.
+async fn directory_refresh_loop(
+    factory: Weak<SwappableFactory>,
+    state: Weak<AppState>,
+    url: String,
+    key: String,
+    cooldown: Duration,
+    dial_timeout: Duration,
+    mut next_sleep: Duration,
+) {
+    let mut last_fetch = Instant::now();
+    loop {
+        let sf = match factory.upgrade() {
+            Some(sf) => sf,
+            None => return,
+        };
+        tokio::select! {
+            _ = tokio::time::sleep(next_sleep) => {}
+            _ = sf.refresh_notify.notified() => {}
+        }
+        drop(sf);
+
+        // Debounce: never refetch more often than DIRECTORY_MIN_REFETCH.
+        let since = last_fetch.elapsed();
+        if since < DIRECTORY_MIN_REFETCH {
+            tokio::time::sleep(DIRECTORY_MIN_REFETCH - since).await;
+        }
+        last_fetch = Instant::now();
+
+        match fetch_and_build_pool(&url, &key, &state, cooldown, dial_timeout).await {
+            Ok((next_factory, expires_at)) => match factory.upgrade() {
+                Some(sf) => {
+                    sf.swap(next_factory);
+                    next_sleep = until_refresh(expires_at);
+                }
+                None => return,
+            },
+            Err(e) => {
+                eprintln!("[overlay] directory refresh failed, keeping current pool: {e}");
+                next_sleep = DIRECTORY_RETRY_BACKOFF;
+            }
+        }
+    }
+}
+
+/// Build the DYNAMIC (directory-backed) circuit factory: one initial fetch so the
+/// pool is usable immediately, then spawn the refresh loop that keeps it current.
+/// If the initial fetch fails the factory starts empty (fail-closed: Prefer→direct,
+/// Strict→degrade) and the refresh loop recovers it.
+async fn build_directory_factory(state: &Arc<AppState>) -> Arc<dyn CircuitFactory> {
+    // Both are Some here — start_overlay_shim only calls this when configured.
+    let url = state.config.overlay_directory_url.clone().unwrap_or_default();
+    let key = state.config.overlay_directory_key.clone().unwrap_or_default();
+    let weak_state = Arc::downgrade(state);
+
+    let (initial, next_sleep) = match fetch_and_build_pool(
+        &url,
+        &key,
+        &weak_state,
+        RELAY_DEAD_COOLDOWN,
+        RELAY_DIAL_TIMEOUT,
+    )
+    .await
+    {
+        Ok((factory, expires_at)) => (factory, until_refresh(expires_at)),
+        Err(e) => {
+            eprintln!("[overlay] initial directory fetch failed, fail-closed until refresh: {e}");
+            let empty: Arc<dyn CircuitFactory> = Arc::new(RealRelayFactory::new(
+                weak_state.clone(),
+                Vec::new(),
+                RELAY_DEAD_COOLDOWN,
+                RELAY_DIAL_TIMEOUT,
+            ));
+            (empty, DIRECTORY_RETRY_BACKOFF)
+        }
+    };
+
+    let swappable = Arc::new(SwappableFactory::new(initial));
+    let task = tokio::spawn(directory_refresh_loop(
+        Arc::downgrade(&swappable),
+        weak_state,
+        url,
+        key,
+        RELAY_DEAD_COOLDOWN,
+        RELAY_DIAL_TIMEOUT,
+        next_sleep,
+    ));
+    *swappable.refresh_task.lock().unwrap() = Some(AbortOnDrop(task));
+    swappable
+}
+
 /// Start the overlay shim for `state` under `mode` (must be non-off). Builds the
 /// routing policy + the real circuit factory and binds the loopback SOCKS5 shim.
 /// The returned handle owns the shim task (aborted on drop) and lets the caller
@@ -459,21 +695,33 @@ pub(crate) async fn start_overlay_shim(
     mode: OverlayMode,
 ) -> Result<OverlayHandle> {
     let policy = overlay_policy(&state.config, mode);
-    let endpoints = load_relay_endpoints(&state.config);
-    let factory: Arc<dyn CircuitFactory> = Arc::new(RealRelayFactory::new(
-        Arc::downgrade(state),
-        endpoints,
-        RELAY_DEAD_COOLDOWN,
-        RELAY_DIAL_TIMEOUT,
-    ));
+    // Dynamic pool (signed directory) when configured; else the static v0 list.
+    let factory: Arc<dyn CircuitFactory> = if state.config.overlay_directory_configured() {
+        build_directory_factory(state).await
+    } else {
+        Arc::new(RealRelayFactory::new(
+            Arc::downgrade(state),
+            load_relay_endpoints(&state.config),
+            RELAY_DEAD_COOLDOWN,
+            RELAY_DIAL_TIMEOUT,
+        ))
+    };
     let handle = OverlayShim::start(policy, factory)
         .await
         .map_err(|e| Error::Other(anyhow::anyhow!("overlay shim start: {e}")))?;
-    let relay = state
-        .config
-        .overlay_relay_url
-        .as_deref()
-        .unwrap_or("<none configured>");
+    let relay = if state.config.overlay_directory_configured() {
+        state
+            .config
+            .overlay_directory_url
+            .as_deref()
+            .unwrap_or("<directory>")
+    } else {
+        state
+            .config
+            .overlay_relay_url
+            .as_deref()
+            .unwrap_or("<none configured>")
+    };
     eprintln!(
         "[overlay] shim on {} (mode={mode:?}, relay={relay})",
         handle.socks_addr()
@@ -707,6 +955,8 @@ mod tests {
             overlay_mode: mode,
             overlay_relay_url: relay.map(|s| s.to_string()),
             overlay_relay_cert: None,
+            overlay_directory_url: None,
+            overlay_directory_key: None,
         }
     }
 

--- a/pollis-core/tests/overlay_live_relay.rs
+++ b/pollis-core/tests/overlay_live_relay.rs
@@ -1,0 +1,79 @@
+//! Live end-to-end: prove the directory-backed overlay actually routes real
+//! control-plane traffic through a real relay — not a mock, not a unit stub.
+//!
+//! Ignored by default (needs a dev backend + a local relay + a signed directory).
+//! Run it against the setup in the PR notes:
+//!   - a real `pollis-relay` bound on 127.0.0.1:9444 whose allowlist covers the
+//!     dev hosts;
+//!   - a signed directory served over HTTP pointing at that relay;
+//!   - dev env (`.env.development`) + `DEV_EMAIL`/`DEV_OTP` for auto-enroll +
+//!     `POLLIS_OVERLAY_DIRECTORY_URL` / `POLLIS_OVERLAY_DIRECTORY_KEY`.
+//!
+//!   set -a; . ./.env.development; set +a
+//!   DEV_EMAIL=reltest@mail.com DEV_OTP=000000 \
+//!   POLLIS_OVERLAY_DIRECTORY_URL=http://127.0.0.1:8799/directory.json \
+//!   POLLIS_OVERLAY_DIRECTORY_KEY=<pubkey> POLLIS_DATA_DIR=/tmp/relaytest/tui-data \
+//!   cargo test -p pollis-core --test overlay_live_relay -- --ignored --nocapture
+
+use std::sync::Arc;
+
+use pollis_core::commands::{auth, overlay, pin, user};
+use pollis_core::config::{Config, OverlayMode};
+use pollis_core::state::AppState;
+
+#[tokio::test]
+#[ignore]
+async fn overlay_directory_routes_real_traffic_through_a_relay() {
+    let config = Config::from_env().expect("Config::from_env");
+    assert!(
+        config.overlay_directory_configured(),
+        "set POLLIS_OVERLAY_DIRECTORY_URL + _KEY to exercise the directory path"
+    );
+    let state = Arc::new(AppState::new(config).await.expect("AppState::new"));
+
+    // 1. Log in first, with the overlay OFF — enrollment/OTP is a pre-cert
+    //    bootstrap that must go direct (it can't authenticate to a relay yet).
+    let profile = auth::get_session(&state)
+        .await
+        .expect("get_session")
+        .expect("DEV_EMAIL should auto-log-in");
+    eprintln!("[live] logged in as user {}", profile.id);
+
+    // First-device tail: set a PIN (opens the encrypted local DB + persists the
+    // account key) then initialize identity — the relay handshake needs both the
+    // account key and the device signing key, which this makes loadable. Mirrors
+    // the desktop/TUI first-device flow (set_pin -> initialize_identity).
+    pin::set_pin(&state, None, "0000".to_string())
+        .await
+        .expect("set_pin (opens local DB, persists account key)");
+    auth::initialize_identity(&state, profile.id.clone())
+        .await
+        .expect("initialize_identity");
+    eprintln!("[live] device fully provisioned (PIN set, identity initialized)");
+
+    // 2. Turn the overlay to STRICT. This fetches the signed directory, verifies
+    //    it against the pinned key, builds the relay pool, and reconnects the
+    //    remote DBs through the loopback shim. Strict = no silent direct fallback.
+    overlay::apply_overlay_mode(&state, OverlayMode::Strict)
+        .await
+        .expect("apply Strict overlay (directory fetch + pool build)");
+    let live = overlay::get_overlay_mode(&state).await.expect("get_overlay_mode");
+    assert_eq!(live, "strict", "overlay must actually be strict now");
+    eprintln!("[live] overlay is STRICT — remote DB is routed through the relay");
+
+    // 3. A real remote read: SELECT from the users table on Turso. In Strict this
+    //    can ONLY succeed by going through the relay — if the relay weren't
+    //    forwarding, this would degrade/error instead of returning the row.
+    let read = user::get_user_profile(profile.id.clone(), &state)
+        .await
+        .expect("remote profile read routed through the relay");
+    assert!(
+        read.is_some(),
+        "the users row must read back — proving the relay forwarded the Turso query"
+    );
+    eprintln!(
+        "[live] READ OK THROUGH THE RELAY: users row id={} — a real Turso query \
+         crossed the relay under Strict mode.",
+        read.unwrap().id
+    );
+}

--- a/pollis-tui/tests/common/mod.rs
+++ b/pollis-tui/tests/common/mod.rs
@@ -264,6 +264,8 @@ pub async fn spawn_world() -> World {
         overlay_mode: pollis_core::config::OverlayMode::Off,
         overlay_relay_url: None,
         overlay_relay_cert: None,
+        overlay_directory_url: None,
+        overlay_directory_key: None,
     };
 
     World {


### PR DESCRIPTION
Wires the desktop client to the live relay pool stood up in #635/#647 — the client half of #616 and the missing piece that makes the overlay actually usable against the hydra.

## What this does
When `POLLIS_OVERLAY_DIRECTORY_URL` + `POLLIS_OVERLAY_DIRECTORY_KEY` are set, the overlay pool is no longer a hardcoded list. The client fetches the hydra's **signed directory**, verifies it, and refreshes it as pool membership changes (Spot reclaim / self-heal) — no client re-ship when nodes rotate.

- **`net/directory.rs`** — fetch (direct bootstrap) + Ed25519 verify over the exact payload bytes + typed `Directory`. Full fail-closed reject set (bad sig, `version != 1`, expired, malformed, empty), **byte-identical to the §3 contract** in `infra/relay-hydra/lib/directory-verify.mjs`. Rust unit tests mirror the JS contract tests, **plus** an (ignored) live test verified against the real reconciler-signed directory: `version=1 relays=3`.
- **`net/overlay.rs`** — a `SwappableFactory` wraps the pool so a refresh loop swaps membership live (near `expires_at`, and on-demand when the pool is exhausted) with **no shim restart or DB reconnect**. Each directory entry's own pinned cert is consumed (per-node identities). The static `POLLIS_OVERLAY_RELAY` path stays as the operator/fallback; the directory supersedes it when both vars are set.
- **config** — the two knobs + `overlay_directory_configured()`.

## Invariants preserved
- **Fail-closed end to end**: a rejected/unreachable directory → empty pool → `prefer` direct, `strict` degrade, never a silent unverified send.
- **Off is byte-identical** to the pre-overlay path (directory code only runs when a non-off mode is applied AND the vars are set).
- **No periodic polling**: refresh is driven by the directory's own TTL + real dial failures, debounced — not a keepalive timer.

## Frontend
Nothing needed — the existing #455 off/prefer/strict Settings toggle is transport-agnostic and drives this as-is.

## Tests
`cargo test -p pollis-core --no-default-features --features test-harness net::` → **25 passed** (18 overlay + 7 directory). Headless `-p pollis --no-default-features` build clean (the design's Slice-1 gate).

## To actually turn it on
Bake `POLLIS_OVERLAY_DIRECTORY_URL=https://relays.pollis.com/directory.json` + `POLLIS_OVERLAY_DIRECTORY_KEY=<pubkey>` into a client build, then flip the Settings toggle to Prefer/Strict.