### PR TITLE
feat(infra): env-namespaced hydra — stand up a throwaway test pool beside prod (#616)

### DIFF
--- a/infra/relay-hydra/README.md
+++ b/infra/relay-hydra/README.md
@@ -160,11 +160,53 @@ scripts/mint-relay-identity.sh us-west-2   # overwrites the SSM identity key + c
 #   in the next directory automatically.
 ```
 
+### Stand up a throwaway TEST env (`env=test`)
+
+Exercise the REAL infra end to end — a dev-enrolled client through real AWS
+Graviton relays to your dev services — without touching prod and without a prod
+login. `env` namespaces every named resource (S3 bucket, SSM params, Lambda, ASG,
+IAM roles, SG, alarms, budget), so a second isolated pool coexists in the SAME
+account+region. `env=prod` (the default) reproduces the original names exactly, so
+prod is never affected. Cost is a few cents for a short session (see Cost below).
+
+```bash
+# From a SEPARATE working dir so the test state never touches prod state.
+cd infra/relay-hydra          # (a fresh checkout / worktree — its own terraform.tfstate)
+
+# Mint TEST signing key + identity into the test SSM prefix (note the param names):
+scripts/mint-signing-key.sh   us-west-2 /pollis/relay-hydra-test/signing-key
+scripts/mint-relay-identity.sh us-west-2   # writes /pollis/relay-hydra-test/* if you pass the test names
+
+# Point the pool at your DEV hosts and keep it to one node.
+cat > test.tfvars <<'EOF'
+env                   = "test"
+directory_domain      = ""          # raw *.cloudfront.net — skips ACM/DNS/CAA
+relay_allowlist       = "*.turso.io,*.pollis.com,*.cloudflarestorage.com"
+region_node_counts    = { "us-west-2" = 1 }
+node_floor            = 1
+node_max              = 1
+alarm_email_addresses = []
+EOF
+terraform init
+terraform apply -var-file=test.tfvars
+
+# Hand the two outputs to a DEV client build (raw CloudFront URL, no DNS):
+terraform output -raw POLLIS_OVERLAY_DIRECTORY_URL   # https://<id>.cloudfront.net/directory.json
+# POLLIS_OVERLAY_DIRECTORY_KEY = the public key printed by mint-signing-key.sh above
+
+# ...run the client (DEV_EMAIL auto-login) in Strict mode against those, then:
+terraform destroy -var-file=test.tfvars
+aws ssm delete-parameters --region us-west-2 --names \
+  /pollis/relay-hydra-test/signing-key /pollis/relay-hydra-test/identity-key \
+  /pollis/relay-hydra-test/identity-cert /pollis/relay-hydra-test/desired-state
+```
+
 ### Tear it all down
 ```bash
-terraform destroy
+terraform destroy                 # add -var-file=test.tfvars for a test env
 # The signing/identity SSM SecureStrings are NOT Terraform-managed (their plaintext
-# must never touch TF state) — delete them explicitly:
+# must never touch TF state) — delete them explicitly (swap the -test prefix for a
+# test env):
 aws ssm delete-parameters --region us-west-2 --names \
   /pollis/relay-hydra/signing-key /pollis/relay-hydra/identity-key \
   /pollis/relay-hydra/identity-cert /pollis/relay-hydra/desired-state

--- a/infra/relay-hydra/main.tf
+++ b/infra/relay-hydra/main.tf
@@ -1,3 +1,15 @@
+# ── Naming (env-namespaced) ─────────────────────────────────────────────────
+# env="prod" reproduces the ORIGINAL names byte-for-byte (so a prod re-apply is a
+# no-op); any other env prefixes every named resource so a second isolated pool
+# can coexist in the same account+region. Threaded into every module + ssm.tf.
+locals {
+  is_prod          = var.env == "prod"
+  name_prefix      = local.is_prod ? "pollis-relay-hydra" : "pollis-relay-hydra-${var.env}"
+  node_name_prefix = local.is_prod ? "pollis-relay" : "pollis-relay-${var.env}"
+  # CloudWatch metric namespace: PascalCase, per-env so alarms never cross wires.
+  metric_namespace = local.is_prod ? "PollisRelayHydra" : "PollisRelayHydra${title(var.env)}"
+}
+
 # ── Relay nodes: one module instance per allowed region ─────────────────────
 #
 # for_each over the jurisdiction-filtered region set. All allowed regions must
@@ -10,6 +22,7 @@ module "relay_region" {
   source   = "./modules/relay-region"
   for_each = toset(local.allowed_regions)
 
+  name_prefix     = local.node_name_prefix
   region          = each.value
   node_floor      = var.node_floor
   node_max        = var.node_max
@@ -35,7 +48,7 @@ module "directory" {
     aws.us_east_1 = aws.us_east_1
   }
 
-  name_prefix          = "pollis-relay-hydra"
+  name_prefix          = local.name_prefix
   directory_domain     = var.directory_domain
   directory_object_key = var.directory_object_key
 }
@@ -64,12 +77,15 @@ module "reconciler" {
   node_floor  = var.node_floor
   node_max    = var.node_max
 
+  name_prefix      = local.name_prefix
+  metric_namespace = local.metric_namespace
+
   alarm_email_addresses = var.alarm_email_addresses
 }
 
 # ── Guardrail: AWS Budgets alert at the §0 hard cap ─────────────────────────
 resource "aws_budgets_budget" "monthly_cap" {
-  name         = "pollis-relay-hydra"
+  name         = local.name_prefix
   budget_type  = "COST"
   limit_amount = tostring(var.monthly_budget_usd)
   limit_unit   = "USD"

--- a/infra/relay-hydra/modules/reconciler/main.tf
+++ b/infra/relay-hydra/modules/reconciler/main.tf
@@ -13,8 +13,8 @@ terraform {
 data "aws_caller_identity" "current" {}
 
 locals {
-  function_name = "pollis-relay-hydra-reconciler"
-  metric_ns     = "PollisRelayHydra"
+  function_name = "${var.name_prefix}-reconciler"
+  metric_ns     = var.metric_namespace
 }
 
 # ── Package (zero deps: SDK v3 + node:crypto are in the runtime) ─────────────

--- a/infra/relay-hydra/modules/reconciler/variables.tf
+++ b/infra/relay-hydra/modules/reconciler/variables.tf
@@ -1,3 +1,13 @@
+variable "name_prefix" {
+  description = "Env-namespaced resource-name prefix (e.g. pollis-relay-hydra or pollis-relay-hydra-test). Names the Lambda, IAM role, SNS topic, event rule, and alarms."
+  type        = string
+}
+
+variable "metric_namespace" {
+  description = "CloudWatch metric namespace the reconciler emits into and the alarms read from. Per-env so two pools never cross wires."
+  type        = string
+}
+
 variable "primary_region" {
   type = string
 }

--- a/infra/relay-hydra/modules/relay-region/main.tf
+++ b/infra/relay-hydra/modules/relay-region/main.tf
@@ -19,7 +19,7 @@ data "aws_availability_zones" "available" {
 
 locals {
   azs         = slice(data.aws_availability_zones.available.names, 0, var.az_count)
-  name        = "pollis-relay-${var.region}"
+  name        = "${var.name_prefix}-${var.region}"
   vpc_cidr    = "10.20.0.0/16"
   subnet_bits = 8
 }

--- a/infra/relay-hydra/modules/relay-region/variables.tf
+++ b/infra/relay-hydra/modules/relay-region/variables.tf
@@ -1,3 +1,8 @@
+variable "name_prefix" {
+  description = "Env-namespaced prefix for this shard's resource names (VPC/SG/IAM/ASG/launch-template), e.g. pollis-relay or pollis-relay-test. Region is appended."
+  type        = string
+}
+
 variable "region" {
   description = "AWS region this pool shard runs in (must already be jurisdiction-approved by the root)."
   type        = string

--- a/infra/relay-hydra/ssm.tf
+++ b/infra/relay-hydra/ssm.tf
@@ -12,7 +12,10 @@
 data "aws_caller_identity" "current" {}
 
 locals {
-  param_prefix = "/pollis/relay-hydra"
+  # env-namespaced (see the `name_prefix`/`is_prod` locals in main.tf): prod keeps
+  # "/pollis/relay-hydra", a test env gets "/pollis/relay-hydra-test", so the mint
+  # scripts + Terraform for the two envs never share secrets.
+  param_prefix = local.is_prod ? "/pollis/relay-hydra" : "/pollis/relay-hydra-${var.env}"
 
   signing_key_param   = "${local.param_prefix}/signing-key"   # SecureString: Ed25519 private PKCS8 PEM
   identity_key_param  = "${local.param_prefix}/identity-key"  # SecureString: base64(raw) QUIC identity key

--- a/infra/relay-hydra/variables.tf
+++ b/infra/relay-hydra/variables.tf
@@ -1,3 +1,19 @@
+# ── Environment ─────────────────────────────────────────────────────────────
+
+variable "env" {
+  description = <<-EOT
+    Deployment environment. "prod" (the default) reproduces the ORIGINAL resource
+    names exactly, so re-applying prod is a no-op. Any other value (e.g. "test")
+    namespaces every named resource — S3 bucket, SSM params, Lambda, ASG, IAM
+    roles, SG, alarms, budget — so a second isolated pool can stand up in the SAME
+    account+region without colliding. Point a non-prod env at your dev/test hosts
+    (relay_allowlist) + a throwaway signing key to exercise the real AWS infra end
+    to end, then `terraform destroy` it.
+  EOT
+  type        = string
+  default     = "prod"
+}
+
 # ── Pool sizing & placement ─────────────────────────────────────────────────
 
 variable "primary_region" {


### PR DESCRIPTION
Adds an `env` variable to the hydra so a second, isolated relay pool can stand up in the SAME AWS account+region without colliding with prod.

## Why
To exercise the **real** relay path end-to-end — a dev-enrolled client through real AWS Graviton relays to your dev Turso/DS — without touching prod and without a prod login. Used exactly this to prove the #649 client: a Strict-mode client read a real Turso row through a real `env=test` relay node (then destroyed it; cost ~$0.01).

## What
- `env` (default **"prod"**) reproduces the ORIGINAL resource names byte-for-byte, so a prod re-apply is a no-op. Verified the derived names match the deployed ones exactly.
- Any other value namespaces every named resource — S3 bucket, SSM params, Lambda, ASG, IAM roles, SG, alarms, budget, and the CloudWatch metric namespace — threaded through all three modules + ssm.tf.
- README documents the throwaway-test-env flow (`directory_domain=""` uses raw CloudFront → no ACM/DNS/CAA; `node_floor=1`; dev allowlist; destroy after).

## Safety
- Prod pool untouched — the test env ran from a separate state dir with distinct names; `terraform destroy` removed all 36 test resources, prod stayed at 3 InService nodes.
- `env=prod` is the default, so nothing changes for existing usage.