### PR TITLE
Learn: in-browser Ed25519 verifier for the live STH (Topic 11)

### DIFF
--- a/website/learn.html
+++ b/website/learn.html
@@ -272,6 +272,67 @@
       line-height: 1.6;
     }
 
+    /* ── In-browser Ed25519 check of the live signed tree head (Topic 11) ── */
+    .ln-verifier {
+      margin: 1.25rem 0;
+      padding: 0.9rem 1rem;
+      border: 1px solid var(--c-border);
+      border-left: 3px solid var(--c-accent);
+      border-radius: 6px;
+      background: rgba(255, 255, 255, 0.02);
+    }
+
+    .ln-verifier-head {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.6rem;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 0.7rem;
+    }
+
+    .ln-verifier-title {
+      font-size: 0.72rem;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      color: var(--c-text-muted);
+    }
+
+    .ln-verifier-badge {
+      font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', monospace;
+      font-size: 0.72rem;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      padding: 0.2rem 0.55rem;
+      border-radius: 4px;
+      border: 1px solid var(--c-border);
+    }
+
+    .ln-verifier-badge--pass {
+      color: var(--ln-ok);
+      border-color: var(--ln-ok);
+    }
+
+    .ln-verifier-badge--fail {
+      color: var(--ln-bad);
+      border-color: var(--ln-bad);
+    }
+
+    .ln-verifier-bad {
+      color: var(--ln-bad) !important;
+    }
+
+    .ln-verifier-actions {
+      margin-top: 0.7rem;
+    }
+
+    .ln-verifier-note {
+      font-size: 0.75rem;
+      color: var(--c-text-muted);
+      margin-top: 0.7rem;
+      line-height: 1.6;
+    }
+
     /* ── The honest-limit callout — load-bearing, per the epic ── */
     .ln-limit {
       border: 1px solid var(--c-border);
@@ -1901,7 +1962,39 @@ A valid signature on a tampered app, the three levels a release is recorded at, 
             rules the log enforces. It is the same checking code the app uses, not a
             separate version that might happen to agree by accident.
           </p>
-          <p>Four commands, four questions. Arguments come in this order:</p>
+          <p>
+            You can watch the first and most important part of that, the signature
+            check, happen right here. Your browser fetched the signed statement
+            above; below it has rebuilt the exact bytes the log signs and checked
+            the signature against a key printed on this page, using nothing but its
+            built-in cryptography. No terminal, no download.
+          </p>
+
+          <!-- In-browser Ed25519 verify of the live STH. Progressive enhancement:
+               ships hidden and reveals only once a genuine head verifies, so a
+               reader on a browser without Ed25519 (or with the fetch blocked) keeps
+               the curl + CLI, which teach the same thing. -->
+          <div class="ln-verifier" data-verifier hidden>
+            <div class="ln-verifier-head">
+              <span class="ln-verifier-title">Signature checked in your browser</span>
+              <span class="ln-verifier-badge" data-verifier-badge>&#8230;</span>
+            </div>
+            <div class="ln-live-row"><span>pinned key</span><b data-verifier-key>&#8230;</b></div>
+            <div class="ln-live-row"><span>tree_size</span><b data-verifier-size>&#8230;</b></div>
+            <div class="ln-live-row"><span>root</span><b data-verifier-root>&#8230;</b></div>
+            <div class="ln-live-row"><span>timestamp</span><b data-verifier-ts>&#8230;</b></div>
+            <div class="ln-live-row"><span>signature</span><b data-verifier-sig>&#8230;</b></div>
+            <div class="ln-verifier-actions">
+              <button type="button" class="ln-proof-btn ln-proof-btn--ghost" data-verifier-tamper>Flip one character of the root</button>
+            </div>
+            <div class="ln-verifier-note" data-verifier-note></div>
+          </div>
+          <p>
+            That is the signature only. It does not, on its own, rebuild the tree or
+            check that any particular entry is inside it, which is the rest of what
+            the verifier below does. Arguments come in this order:
+          </p>
+          <p>Four commands, four questions:</p>
           <pre class="ln-pre"><code># is the whole log consistent and append-only?
 pollis-verify remote  https://verify.pollis.com
 

--- a/website/learn.js
+++ b/website/learn.js
@@ -402,6 +402,138 @@
       .catch(function () { /* stay hidden — the page reads fine without it */ });
   }
 
+  // ── Topic 11: verify the STH's Ed25519 signature in the browser ──────────
+  // The same signature check `pollis-verify` runs (minus the tree rebuild):
+  // fetch the signed head, reconstruct the exact bytes the log signs, and verify
+  // them against a key hardcoded on this page. That key matches the one compiled
+  // into the app (pollis-core PINNED_LOG_PUBLIC_KEY) — the point is that the
+  // reader trusts the pinned key, never a key the server hands them. Ships
+  // hidden; reveals only once a genuine head verifies, so a browser without
+  // Ed25519 (or a blocked fetch) just keeps the curl + CLI above.
+  var VERIFIER_KEY = "175ebfef98fc6b20c67c4cba9d4a36a4f85f05afa4e31f707e7d7e3c02227148";
+  // Domain-separation context for the binaries tree (verifiable-log/src/sth.rs).
+  var VERIFIER_CTX = "pollis-verifiable-log:sth:v1:binaries";
+
+  function hexToBytes(hex) {
+    var out = new Uint8Array(hex.length / 2);
+    for (var i = 0; i < out.length; i++) {
+      out[i] = parseInt(hex.substr(i * 2, 2), 16);
+    }
+    return out;
+  }
+
+  // Signed fields are u64 big-endian. tree_size and millisecond timestamps both
+  // stay under 2^53, so exact division beats bitwise ops (which truncate to 32).
+  function u64be(n) {
+    var a = new Uint8Array(8);
+    for (var i = 7; i >= 0; i--) {
+      a[i] = n % 256;
+      n = Math.floor(n / 256);
+    }
+    return a;
+  }
+
+  // CONTEXT || tree_size(u64 BE) || root_hash(32) || timestamp(u64 BE).
+  function sthMessage(ctx, treeSize, rootHex, timestamp) {
+    var c = new TextEncoder().encode(ctx);
+    var root = hexToBytes(rootHex);
+    var m = new Uint8Array(c.length + 8 + root.length + 8);
+    m.set(c, 0);
+    m.set(u64be(treeSize), c.length);
+    m.set(root, c.length + 8);
+    m.set(u64be(timestamp), c.length + 8 + root.length);
+    return m;
+  }
+
+  function sthVerifier() {
+    var w = document.querySelector("[data-verifier]");
+    if (!w || !subtle || typeof fetch !== "function" ||
+        typeof TextEncoder === "undefined") {
+      return;
+    }
+    var alg = { name: "Ed25519" };
+    var keyP;
+    // importKey rejects (or throws) on browsers without Ed25519 — either way,
+    // treat it as "cannot run here" and leave the block hidden.
+    try {
+      keyP = subtle.importKey("raw", hexToBytes(VERIFIER_KEY), alg, false, ["verify"]);
+    } catch (e) {
+      return;
+    }
+
+    keyP
+      .then(function (key) {
+        return fetch(STH_URL, { mode: "cors" })
+          .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
+          .then(function (sth) {
+            if (!sth || !sth.root_hash || !sth.signature) { return; }
+            var sig = hexToBytes(sth.signature);
+            var genuineRoot = sth.root_hash;
+            var badge = w.querySelector("[data-verifier-badge]");
+            var note = w.querySelector("[data-verifier-note]");
+            var rootEl = w.querySelector("[data-verifier-root]");
+            var tamperBtn = w.querySelector("[data-verifier-tamper]");
+            w.querySelector("[data-verifier-key]").textContent = VERIFIER_KEY;
+            w.querySelector("[data-verifier-size]").textContent = String(sth.tree_size);
+            w.querySelector("[data-verifier-ts]").textContent = String(sth.timestamp);
+            w.querySelector("[data-verifier-sig]").textContent = sth.signature;
+            var tampered = false;
+
+            // Flip the first hex nibble: still valid length, wrong value.
+            function tamper(hex) {
+              return (hex.charAt(0) === "0" ? "1" : "0") + hex.slice(1);
+            }
+
+            function run() {
+              var rootHex = tampered ? tamper(genuineRoot) : genuineRoot;
+              rootEl.textContent = rootHex;
+              if (tampered) {
+                rootEl.classList.add("ln-verifier-bad");
+              } else {
+                rootEl.classList.remove("ln-verifier-bad");
+              }
+              var msg = sthMessage(VERIFIER_CTX, sth.tree_size, rootHex, sth.timestamp);
+              return subtle.verify(alg, key, sig, msg).then(function (ok) {
+                badge.textContent = ok ? "SIGNATURE VALID" : "SIGNATURE INVALID";
+                badge.className = "ln-verifier-badge " +
+                  (ok ? "ln-verifier-badge--pass" : "ln-verifier-badge--fail");
+                if (!tampered && ok) {
+                  note.textContent = "Your browser rebuilt the exact bytes the log " +
+                    "signs (context, size, root, timestamp) and checked the signature " +
+                    "against the pinned key above. Nothing was taken on trust. That key " +
+                    "matches the one compiled into the app; for real assurance you would " +
+                    "compare it against a key you obtained independently, which is what " +
+                    "the command-line verifier does.";
+                } else if (tampered && !ok) {
+                  note.textContent = "One character of the root now differs, so the " +
+                    "signed bytes no longer match and the check fails. This is why an " +
+                    "edited history cannot keep a valid signature: the signature is over " +
+                    "the root, not merely attached to it.";
+                } else {
+                  note.textContent = "Unexpected result. Do not read this as verified.";
+                }
+                return ok;
+              });
+            }
+
+            // Reveal only after the genuine head verifies, so a reader never sees
+            // a false failure.
+            run().then(function (ok) {
+              if (!ok) { return; }
+              tamperBtn.addEventListener("click", function () {
+                tampered = !tampered;
+                tamperBtn.textContent = tampered
+                  ? "Restore the genuine root"
+                  : "Flip one character of the root";
+                run();
+              });
+              w.hidden = false;
+            });
+          });
+      })
+      .catch(function () { /* stay hidden — the curl + CLI still teach it */ });
+  }
+
   // ── Topic 2: a live SHA-256 of whatever the reader types ────────────────
   // The point of the widget is the avalanche: change one character, the whole
   // fingerprint changes. Ships `hidden`, revealed only if crypto.subtle exists.
@@ -539,6 +671,7 @@
 
   function init() {
     liveSth();
+    sthVerifier();
     hashWidget();
     cipherWidget();
     Array.prototype.forEach.call(


### PR DESCRIPTION
Adds a progressive-enhancement widget to Topic 11 that runs the STH signature check in the reader's browser, against a key pinned on the page (matches pollis-core `PINNED_LOG_PUBLIC_KEY`), using WebCrypto Ed25519.

- Fetches the live binaries STH, reconstructs the exact signed preimage (`context || tree_size(u64 BE) || root(32) || timestamp(u64 BE)`, context `pollis-verifiable-log:sth:v1:binaries`), verifies the signature.
- "Flip one character of the root" button demonstrates the signature binds the root: genuine PASS, tampered FAIL, restore PASS.
- Ships `hidden`; reveals only after a genuine head verifies, so browsers without Ed25519 or with the fetch blocked keep the existing curl + CLI. Honest framing preserved: the pinned key is a convenience, real assurance compares a key obtained independently.

Verified in a real browser against the live log (tree_size 60): VALID → INVALID → VALID, no console errors. Part of #655.