### PR TITLE
Self-heal a split-brain relay pool instead of waiting for natural replacement

### DIFF
--- a/docs/relay-operations.md
+++ b/docs/relay-operations.md
@@ -264,6 +264,22 @@ Open the host firewall for **`9444/udp`** (the QUIC relay) and the **health TCP
 port** (`9445`, scoped to your orchestrator/LB rather than the public internet if
 you can). Mount the identity volume so a restart keeps the same pinned cert.
 
+> **Rolling a new image does not update running nodes.** A node pulls `:latest`
+> at boot only, so pushing a new image leaves every running node on its old build
+> until something *replaces* it. After a protocol change — an ALPN bump, say —
+> that leaves the pool split-brain: clients can only use the subset on the new
+> build and fail negotiation against the rest (#677).
+>
+> In the hydra pool this now self-heals. The reconciler reads each node's build
+> SHA from `/version` and, when a region's nodes disagree, marks the one behind
+> the newest-launched node Unhealthy so the ASG relaunches it on `:latest`
+> (`staleBuildNodes` in `reconciler/placement.mjs`). It cycles at most one node
+> per region per run, so a bad `:latest` cannot empty the pool in one cycle.
+> Convergence takes a few reconcile intervals, not one.
+>
+> On a **manually provisioned** host there is no such loop — pull and recreate
+> the container yourself after an image roll.
+
 ### Step 3 — point clients at the pool
 
 Bake the pool into the client build (the same `option_env!` mechanism as every

--- a/infra/relay-hydra/reconciler/index.mjs
+++ b/infra/relay-hydra/reconciler/index.mjs
@@ -32,7 +32,7 @@ import { SSMClient, GetParameterCommand, PutParameterCommand } from "@aws-sdk/cl
 import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
 import { CloudWatchClient, PutMetricDataCommand } from "@aws-sdk/client-cloudwatch";
 import { createPrivateKey, sign } from "node:crypto";
-import { readDesiredTotal, drawPlacement, placementNeedsRedraw, placementTotal, mayDrain, clamp } from "./placement.mjs";
+import { readDesiredTotal, drawPlacement, placementNeedsRedraw, placementTotal, mayDrain, clamp, staleBuildNodes } from "./placement.mjs";
 
 // --- Config from the Lambda environment (set by Terraform) -------------------
 
@@ -89,6 +89,20 @@ export const handler = async () => {
       const { healthy, unhealthy } = await healthCheck(nodes);
       perRegionHealthy[region] = healthy.length;
       unhealthyByRegion[region] = unhealthy;
+
+      // A node running an older build than the rest of its region is cycled the
+      // same way a dead one is: marked Unhealthy so the ASG relaunches it on
+      // `:latest`. It stays advertised this cycle — it is serving fine, just on
+      // the wrong protocol version — and drops out once it is replaced.
+      const stale = staleBuildNodes(healthy);
+      if (stale.length > 0) {
+        console.log(
+          `${region}: split-brain — ${stale
+            .map((n) => `${n.instanceId}@${n.sha.slice(0, 12)}`)
+            .join(", ")} behind the newest node; cycling onto :latest`
+        );
+        reconcileFailures += await markUnhealthy(region, stale);
+      }
 
       // Every healthy node is advertised, including ones in a region that is on
       // its way out — during a handover both the old and new nodes serve.
@@ -329,7 +343,11 @@ async function instancesOf(region, group) {
       // cycle rather than treat it as a dead relay (it isn't advertised, and the
       // grace period covers it if it's genuinely mid-boot).
       if (inst.PublicIpAddress) {
-        nodes.push({ instanceId: inst.InstanceId, ip: inst.PublicIpAddress });
+        nodes.push({
+          instanceId: inst.InstanceId,
+          ip: inst.PublicIpAddress,
+          launchedAt: inst.LaunchTime ? new Date(inst.LaunchTime).getTime() : 0,
+        });
       }
     }
   }
@@ -370,9 +388,19 @@ async function healthCheck(nodes) {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), HEALTH_TIMEOUT_MS);
     try {
-      // Treat any 200 as healthy; parse the JSON only if we want the SHA.
+      // Treat any 200 as healthy. The SHA is parsed too, but only to detect a
+      // split-brain pool (see staleBuildNodes) — a node is never called
+      // unhealthy merely because the body did not parse.
       const res = await fetch(`http://${node.ip}:${HEALTH_PORT}/version`, { signal: controller.signal });
-      return { node, ok: res.ok };
+      let sha = null;
+      if (res.ok) {
+        try {
+          sha = (await res.json())?.sha ?? null;
+        } catch {
+          sha = null;
+        }
+      }
+      return { node: { ...node, sha }, ok: res.ok };
     } catch {
       return { node, ok: false };
     } finally {

--- a/infra/relay-hydra/reconciler/placement.mjs
+++ b/infra/relay-hydra/reconciler/placement.mjs
@@ -165,3 +165,32 @@ export function mayDrain({ draining, perRegionHealthy, poolTotal, nodeFloor }) {
   const required = Math.min(poolTotal, nodeFloor);
   return { ok: retainedHealthy >= required, retainedHealthy, required };
 }
+
+// --- Split-brain detection (#677) --------------------------------------------
+
+// Nodes pull `:latest` at BOOT ONLY, so pushing a new image does not update a
+// running node — it keeps serving whatever it launched with until something
+// replaces it. After an ALPN bump that leaves the pool split-brain: clients can
+// only use the subset on the current build, and the rest fail negotiation.
+//
+// Rather than trust an external notion of "the right SHA", take the build of the
+// most recently launched healthy node as the target: that node pulled `:latest`
+// most recently, so a node disagreeing with it is behind. This converges without
+// the reconciler needing registry credentials or a deploy hook.
+//
+// Deliberately conservative — a wrong guess needlessly destroys capacity:
+//   * needs at least two distinct SHAs before it does anything;
+//   * never touches the newest node itself;
+//   * cycles at most ONE node per region per run, so replacements roll in
+//     gradually and a bad `:latest` cannot empty the pool in a single cycle.
+export function staleBuildNodes(healthy) {
+  const withSha = healthy.filter((n) => typeof n.sha === "string" && n.sha.length > 0);
+  if (withSha.length < 2) {
+    return [];
+  }
+  if (new Set(withSha.map((n) => n.sha)).size < 2) {
+    return [];
+  }
+  const newest = withSha.reduce((a, b) => (b.launchedAt > a.launchedAt ? b : a));
+  return withSha.filter((n) => n.sha !== newest.sha).slice(0, 1);
+}

--- a/infra/relay-hydra/test/split-brain.test.mjs
+++ b/infra/relay-hydra/test/split-brain.test.mjs
@@ -1,0 +1,70 @@
+// Split-brain detection (#677) — reconciler/placement.mjs `staleBuildNodes`.
+// Pure function, no AWS, no network.
+//
+// Run: node --test   (from infra/relay-hydra/)
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { staleBuildNodes } from "../reconciler/placement.mjs";
+
+const NEW = "e0322e720858d14c75211ee7ea0afeaca03d3ea8";
+const OLD = "aaaa1111bbbb2222cccc3333dddd4444eeee5555";
+
+function node(id, sha, launchedAt) {
+  return { instanceId: id, ip: "203.0.113.1", sha, launchedAt };
+}
+
+test("a uniform pool is left alone", () => {
+  const pool = [node("i-1", NEW, 100), node("i-2", NEW, 200)];
+  assert.deepEqual(staleBuildNodes(pool), []);
+});
+
+test("the node behind the newest launch is cycled", () => {
+  // i-2 launched later, so its build is the one that pulled :latest most
+  // recently; i-1 is the straggler.
+  const stale = staleBuildNodes([node("i-1", OLD, 100), node("i-2", NEW, 200)]);
+  assert.equal(stale.length, 1);
+  assert.equal(stale[0].instanceId, "i-1");
+});
+
+test("launch order decides the target, not array order", () => {
+  // Same pool, newest listed first — the verdict must not change.
+  const stale = staleBuildNodes([node("i-2", NEW, 200), node("i-1", OLD, 100)]);
+  assert.equal(stale.length, 1);
+  assert.equal(stale[0].instanceId, "i-1");
+});
+
+test("the newest node is never cycled", () => {
+  const stale = staleBuildNodes([node("i-1", OLD, 100), node("i-2", NEW, 999)]);
+  assert.ok(!stale.some((n) => n.instanceId === "i-2"));
+});
+
+test("at most one node is cycled per run", () => {
+  // Three stragglers behind one new node: capacity must drain gradually, so a
+  // bad :latest cannot empty the pool in a single cycle.
+  const stale = staleBuildNodes([
+    node("i-1", OLD, 100),
+    node("i-2", OLD, 110),
+    node("i-3", OLD, 120),
+    node("i-4", NEW, 200),
+  ]);
+  assert.equal(stale.length, 1);
+});
+
+test("a single-node pool is never cycled", () => {
+  // With one node there is nothing to disagree with, and cycling it would take
+  // the pool to zero.
+  assert.deepEqual(staleBuildNodes([node("i-1", OLD, 100)]), []);
+});
+
+test("nodes with no reportable SHA are ignored, not cycled", () => {
+  // /version answered 200 but the body did not parse. That is not evidence of a
+  // stale build, and must never by itself destroy a node that is serving.
+  assert.deepEqual(staleBuildNodes([node("i-1", null, 100), node("i-2", null, 200)]), []);
+  const mixed = staleBuildNodes([node("i-1", null, 100), node("i-2", NEW, 200)]);
+  assert.deepEqual(mixed, []);
+});
+
+test("an empty pool is a no-op", () => {
+  assert.deepEqual(staleBuildNodes([]), []);
+});


### PR DESCRIPTION
Closes #677.

## The pool is already healthy — the ticket's manual step is moot

Checked before changing anything:

- **No stale nodes to terminate.** The `us-west-2` instances #677 names were terminated on 2026-07-31; that ASG is now at desired 0.
- **Current pool: 2 nodes in `us-east-1`**, both reporting `sha e0322e72` — the `#673`/#668 PQ-signatures merge, i.e. the commit that set `ALPN = "pollis-relay/3"`. Identical SHAs, so there is no split-brain today.
- **No relay code has landed since that SHA** (`git log e0322e72..main -- pollis-relay/ pollis-device-cert/` is empty), so the deployed build is current.

`us-east-1` looks alarming against #616's original Virginia/Ohio/California denylist, but that is **not** a violation: `variables.tf` documents the denylist as deliberately emptied — it was placement *hygiene*, not compliance, traded for a wider random-placement pool. Placement across all four US regions is intended.

So the split-brain healed itself via natural ASG replacement, exactly as #677 predicted it eventually would. What is left is the prevention half.

## The fix: self-heal, not a deploy hook

The ticket suggests an ASG instance refresh on image roll. That would need AWS credentials in CI — there are **no** AWS secrets and no OIDC role in the repo today, so it would mean granting Actions the ability to cycle production instances. Avoided.

Instead the reconciler does it, reusing machinery it already has (IAM, a schedule, and a `markUnhealthy` → ASG-replaces path for dead nodes):

- `healthCheck` now parses the `sha` from `/version`. It already fetched the endpoint; the code even carried a comment saying to parse the SHA "only if we want it".
- `staleBuildNodes` (`reconciler/placement.mjs`) takes the build of the **most recently launched** healthy node as the target — that node pulled `:latest` most recently — and returns nodes disagreeing with it. No registry credentials, no notion of "the right SHA" from outside.
- Those nodes are marked Unhealthy, so the ASG relaunches them on `:latest`. They stay advertised for that cycle: they are serving fine, just on the wrong protocol version.

Deliberately conservative, because a wrong guess destroys capacity:

- needs ≥2 distinct SHAs before acting;
- never touches the newest node;
- **at most one node per region per run**, so a bad `:latest` cannot empty the pool in a single cycle;
- a node whose `/version` body does not parse is ignored, never cycled — an unparseable body is not evidence of a stale build.

Logic lives in `placement.mjs` rather than `index.mjs` because that is the pure, AWS-free module the existing tests import.

## Tests

`node --test` from `infra/relay-hydra/`: 43 pass (35 existing + 8 new) — uniform pool untouched, straggler cycled, launch order beats array order, newest never cycled, one-per-run cap, single-node pool never cycled, unparseable SHA ignored, empty pool a no-op.

`docs/relay-operations.md` gains a note that a manually provisioned host has no such loop and must be recreated by hand after an image roll.