### PR TITLE
Finish the third-loss disclosure — I missed the recap, the narration script and the video scene

### DIFF
--- a/learn/manim/scenes/joining_leaving.py
+++ b/learn/manim/scenes/joining_leaving.py
@@ -9,6 +9,15 @@ draws the backup trade as a fork where neither path is free.
 Render (see learn/manim/render.sh):
     learn/manim/render.sh JoiningLeaving joining-leaving m
 
+STALE — NEEDS RE-RENDER (#756). #720 added a THIRD accepted loss (a device silent
+past `POLLIS_DS_WATERMARK_STALE_MONTHS`, set to 12). This scene and
+`scripts/joining-leaving.md` are updated to say three; the SHIPPED
+`website/learn/media/joining-leaving.{mp4,webm}` and its `.vtt` transcript still
+say two, because they cannot be regenerated without the render + narration
+pipeline. The video therefore currently UNDERSTATES what we lose. The prose on
+the Learn page is correct and is what most readers see, but the video needs a
+re-render before that discrepancy is acceptable long-term.
+
 Accuracy anchors:
   - .codesight/wiki/mls.md → "Multi-Device Enrollment", "GroupInfo Publishing"
   - CLAUDE.md → "Messages must work; history is bounded, not flaky" (the two
@@ -273,9 +282,9 @@ class JoiningLeaving(Scene):
         self.hold_until(160)
 
         promise = VGroup(
-            Text("Exactly two kinds of loss are acceptable:", color=FG).scale(0.44),
-            Text("Messages sent before you joined · a new device starting empty",
-                 color=MUTED).scale(0.4),
+            Text("Exactly three kinds of loss are acceptable:", color=FG).scale(0.44),
+            Text("Before you joined · a new device starts empty · every device quiet 1yr+",
+                 color=MUTED).scale(0.36),
             Text("Everything else must work. Anything else missing is a BUG.",
                  color=OK).scale(0.46),
         ).arrange(DOWN, buff=0.22).move_to([0, -2.8, 0])

--- a/learn/manim/scripts/joining-leaving.md
+++ b/learn/manim/scripts/joining-leaving.md
@@ -50,6 +50,7 @@ number.
 
 **[02:40–02:55] Scene 6 — what we do promise**
 That's the exact thing this app exists to not have. So we don't do it. What we
-*do* promise is narrow and firm. Two kinds of loss are acceptable: messages from
-before you joined, and a new device starting empty. Everything else has to
-arrive. Anything else going missing is a bug, and we treat it as one.
+*do* promise is narrow and firm. Three kinds of loss are acceptable: messages from
+before you joined, a new device starting empty, and — if every device you own goes
+quiet for over a year — mail that was still waiting only for you. Everything else
+has to arrive. Anything else going missing is a bug, and we treat it as one.

--- a/website/learn.html
+++ b/website/learn.html
@@ -1527,7 +1527,7 @@ Lockboxes left in advance, a welcome that carries only today's keys, messages fr
             <p>Removing someone is the same idea. Their line of keys is replaced, and the next message is sealed to them. What they already saw stays on their device. We cannot reach into it.</p>
             <p>Your own devices work the same way. Your phone and laptop are separate members, each with their own keys. Nothing is copied between them, because a key that travels can be stolen along the way.</p>
             <p>Which brings up one deliberate trade. A new device starts empty. There is no history backup. We could store your history on our servers behind a PIN, but that would put a copy of every conversation on our infrastructure behind a short, guessable code, which is exactly what this app exists to avoid. So we do not. If you want your history, keep your device.</p>
-            <p>What we do promise is narrow and firm. Two kinds of loss are expected: messages from before you joined, and a new device starting empty. Everything else has to arrive, and anything else going missing is a bug.</p>
+            <p>What we do promise is narrow and firm. Three kinds of loss are expected: messages from before you joined, a new device starting empty, and — if every device you own goes quiet for over a year — mail that was still waiting only for you. Everything else has to arrive, and anything else going missing is a bug.</p>
           </div>
         </details>
 


### PR DESCRIPTION
Follow-up to #753 (#720). That PR updated the main Learn paragraph but left four other places still telling users there are **two** accepted losses. Caught by grepping the deployed page rather than trusting the edit.

## Fixed here

- **`website/learn.html`** — a *second* instance further down the same page ("What we do promise is narrow and firm. Two kinds of loss are expected…"). This is the one that mattered most: it was live on pollis.com alongside the corrected paragraph, so the page contradicted itself.
- **`learn/manim/scripts/joining-leaving.md`** — the narration script the video is read from.
- **`learn/manim/scenes/joining_leaving.py`** — the on-screen card, which read *"Exactly two kinds of loss are acceptable"*. Reworded to three and the subtitle scaled down slightly so the longer line still fits the frame.

## Deliberately not fixed: the video itself

`website/learn/media/joining-leaving.{mp4,webm}` and its `.vtt` transcript still say two. Manim is not installed on this box and the narration audio would need regenerating too — video, audio and captions have to move together, so editing the `.vtt` alone would only desync the captions from what is spoken.

Tracked in **#756**, with a `STALE — NEEDS RE-RENDER` marker in the scene docstring so the next person to touch it knows. The video currently **understates** what we lose, which is the wrong direction to be wrong in; the mitigation is that the page prose is correct and is what most readers read.

## Note on how this was found

The deploy went out, I grepped the live page to confirm the new wording, and the old wording came back *too*. Worth stating because the first check I ran looked clean for the wrong reason — `/learn.html` 308-redirects to `/learn`, and curl without `-L` was reading an empty redirect body, so the page appeared to contain nothing at all. Verifying against the real URL is what surfaced both the new text and the leftover.