### PR TITLE
The Worker never forwarded the metrics token or the staleness window to the container

### DIFF
--- a/pollis-delivery/worker/index.ts
+++ b/pollis-delivery/worker/index.ts
@@ -39,6 +39,10 @@ const SECRET_KEYS = [
   "TURSO_ORG",
   "TURSO_DB",
   "DEV_OTP",
+  // #720: gates GET /v1/retention/metrics. Absent here means the DS never sees
+  // it, the route stays default-closed, and the endpoint 404s however correctly
+  // the secret is set in Doppler and bound in wrangler.
+  "POLLIS_DS_METRICS_TOKEN",
 ] as const;
 
 interface SecretStoreBinding {
@@ -50,6 +54,7 @@ type Env = {
   // Static (non-secret) container config, set as wrangler `vars`.
   PORT: string;
   POLLIS_DS_REQUIRE_AUTH: string;
+  POLLIS_DS_WATERMARK_STALE_MONTHS?: string;
 } & Record<(typeof SECRET_KEYS)[number], SecretStoreBinding | undefined>;
 
 // Derived from the base method so we don't depend on the (unexported)
@@ -84,6 +89,13 @@ export class PollisDelivery extends Container<Env> {
   envVars = {
     PORT: this.env.PORT ?? "8788",
     POLLIS_DS_REQUIRE_AUTH: this.env.POLLIS_DS_REQUIRE_AUTH ?? "true",
+    // #720: the device-staleness window. Forwarded explicitly — a wrangler `var`
+    // is bound to the WORKER, not to the container, so without this line the DS
+    // silently falls back to its 6-month code default no matter what the config
+    // says. Omitted from the map when unset so that fallback stays intact.
+    ...(this.env.POLLIS_DS_WATERMARK_STALE_MONTHS
+      ? { POLLIS_DS_WATERMARK_STALE_MONTHS: this.env.POLLIS_DS_WATERMARK_STALE_MONTHS }
+      : {}),
   };
 
   // Resolve every Secrets Store binding into a plain env map. Optional/unset


### PR DESCRIPTION
Follow-up to #753 (#720). Both config values I added there were **inert in production**, and I only found out by testing the deployed endpoint rather than trusting the deploy.

## What was wrong

The DS reads its config as OS env vars inside the container. `pollis-delivery/worker/index.ts` is what puts them there, and it has two separate paths — neither of which carried these values:

- **`SECRET_KEYS`** is the allowlist of Secrets Store bindings the Worker resolves via `.get()` and injects. `POLLIS_DS_METRICS_TOKEN` was absent, so the container never saw it and `GET /v1/retention/metrics` stayed default-closed.
- **`envVars`** is the static map for non-secret config. A wrangler `var` is bound to the **Worker**, not to the container, so `POLLIS_DS_WATERMARK_STALE_MONTHS` never reached the DS either — it was silently falling back to the 6-month code default regardless of what the config said.

So the chain was five links long and #753 fixed three of them:

| link | before #753 | after #753 | now |
|---|---|---|---|
| Doppler | missing | ✅ | ✅ |
| `sync-ds-secrets.sh` `KEYS` | missing | ✅ | ✅ |
| wrangler binding / var | missing | ✅ | ✅ |
| Worker → container env | **missing** | **still missing** | ✅ |
| DS reads env var | ✅ | ✅ | ✅ |

## Verified against production, which is how this surfaced

After deploying #753 to prod, the DS came up on the right SHA and the deploy log confirmed `created DS_PROD_POLLIS_DS_METRICS_TOKEN` with the binding registered. The endpoint still returned:

```
no auth      -> 404
wrong bearer -> 404
real token   -> 404
```

404 with the *correct* token is the tell: not an auth rejection, but the route genuinely not being served — i.e. the DS never received the token at all.

## The fix

`POLLIS_DS_METRICS_TOKEN` added to `SECRET_KEYS`; `POLLIS_DS_WATERMARK_STALE_MONTHS` added to the `Env` type and spread into `envVars` **only when set**, so an unset value still falls through to the documented code default instead of forwarding an empty string.

Typechecks clean. Needs a prod + dev DS deploy to take effect, which I'll run once this merges — and I'll re-verify the endpoint with a real token rather than assume.