### PR TITLE
The equivocation tripwire has been passing without checking anything — make its state durable

### DIFF
--- a/.github/workflows/mls-tests.yml
+++ b/.github/workflows/mls-tests.yml
@@ -137,6 +137,14 @@ jobs:
           workspaces: |
             .
             src-tauri
+          # Only `main` WRITES the cache; PR branches still restore from it and
+          # get the same speedup. Without this every branch stored its own ~1.8 GiB
+          # copy under the same key, and this repo sat permanently over GitHub's
+          # 10 GiB per-repo budget (11.34 GiB observed, of which 7.1 GiB was four
+          # identical-keyed copies of THIS cache). Being over budget makes GitHub
+          # evict least-recently-used entries, which silently disarmed the
+          # transparency equivocation tripwire for months — see #759.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # Same recipe as the desktop-release Linux job: webkit/gtk for Tauri,
       # alsa/pulse/pipewire + libva for the media stack, meson+ninja+clang for

--- a/.github/workflows/transparency-publish.yml
+++ b/.github/workflows/transparency-publish.yml
@@ -370,17 +370,38 @@ jobs:
       #     prior run's latest STH for each tree is restored from the cache; a
       #     previously-published immutable STH that changed (or vanished) means
       #     the server rewrote attested history — fail loudly.
+      # Tripwire state lives in R2, NOT actions/cache. The cache was the original
+      # home and it silently never worked: this repo runs permanently over
+      # GitHub's 10 GiB per-repo cache budget (gigabyte Rust build caches touched
+      # on every PR), so a few-KB entry touched once a day was always the LRU
+      # eviction victim. Every publish then took the "no prior STH cached (first
+      # run)" branch and passed WITHOUT COMPARING ANYTHING — a green check mark
+      # over an unarmed check, which is the worst possible failure shape for an
+      # equivocation detector (#759).
+      #
+      # Honest limit: this state shares a trust domain with the log it guards, so
+      # it does not defend against an attacker who already controls the
+      # publishing pipeline — nothing reachable from this job could. It defends
+      # against the thing that actually happens: an unnoticed rewrite or drift.
+      # Durability is the property that matters here, and R2 has it.
       - name: Restore prior published STHs (tripwire state)
         if: steps.decide.outputs.build == 'true'
-        uses: actions/cache/restore@v4
-        with:
-          path: .sth-prev
-          # A run-id key always misses; restore-keys then pulls the most recent
-          # prior run's cache (cache entries are immutable per key, so each run
-          # writes a fresh one and reads the latest older one).
-          key: transparency-sth-${{ github.run_id }}
-          restore-keys: |
-            transparency-sth-
+        env:
+          R2_ENDPOINT: ${{ secrets.R2_TRANSPARENCY_ENDPOINT }}
+          R2_BUCKET: ${{ secrets.R2_TRANSPARENCY_BUCKET }}
+        run: |
+          set -uo pipefail
+          mkdir -p .sth-prev
+          # Absent object => genuinely the first run; `seeded` distinguishes that
+          # from "we had state and lost it", which must never pass silently.
+          if aws s3 cp "s3://${R2_BUCKET}/internal/tripwire-sths.tar" .sth-prev.tar \
+               --endpoint-url "${R2_ENDPOINT}" 2>/dev/null; then
+            tar -xf .sth-prev.tar -C .sth-prev && echo "tripwire: restored prior state from R2."
+            echo "seeded=true" >> "$GITHUB_ENV"
+          else
+            echo "tripwire: no prior state in R2 — treating this as the first seeding run."
+            echo "seeded=false" >> "$GITHUB_ENV"
+          fi
 
       - name: Build pollis-verify (auditor CLI, cargo already warm)
         if: steps.decide.outputs.build == 'true'
@@ -407,7 +428,17 @@ jobs:
           check_tree() {
             name="$1"; prev="$2"; sth_base="$3"; latest_url="$4"
             if [ ! -f "${prev}" ]; then
-              echo "${name}: no prior STH cached (first run) — seeding tripwire."
+              # Distinguish "never seeded" from "we HAD state and lost it". The
+              # second is how this check silently disarmed itself for months
+              # (#759): a missing file read as "first run" and passed. After the
+              # first successful seed it must never recur, so it is a failure.
+              if [ "${seeded:-false}" = "true" ]; then
+                echo "::error::${name}: tripwire state exists but this tree's prior STH is MISSING."
+                echo "::error::  Not a first run — prior state was restored. Refusing to pass an"
+                echo "::error::  unarmed equivocation check; investigate before republishing."
+                return 1
+              fi
+              echo "${name}: no prior STH (first seeding run) — recording baseline."
               return 0
             fi
             old_size="$(jq -r '.tree_size' "${prev}")"
@@ -484,7 +515,15 @@ jobs:
 
       - name: Save published STHs for next run's tripwire
         if: steps.decide.outputs.build == 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: .sth-prev
-          key: transparency-sth-${{ github.run_id }}
+        env:
+          R2_ENDPOINT: ${{ secrets.R2_TRANSPARENCY_ENDPOINT }}
+          R2_BUCKET: ${{ secrets.R2_TRANSPARENCY_BUCKET }}
+        run: |
+          set -euo pipefail
+          # `internal/` is never synced into the served tree (see the pass-1/2
+          # --exclude lists and internal/binary-records.json, which already lives
+          # here) — this is build state, not a published artifact.
+          tar -cf .sth-prev.tar -C .sth-prev .
+          aws s3 cp .sth-prev.tar "s3://${R2_BUCKET}/internal/tripwire-sths.tar" \
+            --endpoint-url "${R2_ENDPOINT}" --only-show-errors
+          echo "tripwire: state persisted to R2 for the next run."


### PR DESCRIPTION
Closes #759.

## The bug

The tripwire stored the previous run's STHs in `actions/cache`. That cache was being **evicted on essentially every run**, so each publish took the `no prior STH cached (first run)` branch and **returned success without comparing anything**.

Measured:

```
active_caches: 33   size: 11.34 GiB     (GitHub per-repo limit: 10 GiB)
```

Permanently over budget, so GitHub evicts least-recently-used. The tripwire entry is a few KB touched once a day; the Rust build caches are gigabytes touched on every PR. The small one always loses. Confirmed directly: the `Save published STHs` step reported **success**, and minutes later `gh cache list | grep transparency-sth` returned **0**.

This is the worst failure shape for a detector — a green check mark over an unarmed check. The tripwire is the only thing that detects the log serving one signed history to auditors and a different one to a target.

## Fix, in two parts

**1. State moves to R2** (`internal/tripwire-sths.tar`), alongside the `internal/binary-records.json` the publish job already keeps there. `internal/` is excluded from both sync passes, so it is build state and never a served artifact. Durable, not evictable, no new credentials — the job already holds R2 creds.

*Honest limit, stated in the workflow comment:* this state shares a trust domain with the log it guards, so it does not defend against an attacker who already controls the publishing pipeline. Nothing reachable from this job could. It defends against what actually happens — an unnoticed rewrite or drift. I considered a git orphan branch (separate trust domain, auditable history) and rejected it: it would require granting `contents: write` to the one workflow that holds the signing key, which buys less than it costs.

**2. A lost prior state is now a failure, not a shrug.** `check_tree` could not tell "never seeded" from "we had state and lost it" — both hit the same silent pass, which is exactly how this stayed hidden. The restore step now records whether state was found, and a missing per-tree STH *after* a successful restore fails loudly. Both branches verified.

## Also: the cache bloat that caused it

`mls-tests.yml` now only **writes** its cache on `main` (`save-if`); PR branches still restore and get the same speedup. Four identical-keyed copies of that one cache accounted for 7.1 GiB of the 11.34 GiB overrun — on its own enough to push the repo over the limit and start the evictions.

Other workflows still use `rust-cache` defaults. That is worth a sweep, but this is the one that was actually breaking things, and I would rather not retune caching across eight workflows in a fix whose point is the tripwire.

## Verification note

This cannot be fully proven until two publishes have run: the first seeds R2, the second is the first to actually compare. The next scheduled run seeds; the one after is the real test. I have not manufactured a fake seed to shortcut that.