### PR TITLE
Assert the deployed site's claims match main, and stop the assistant over-disclosing

### DIFF
--- a/.github/workflows/website-verify.yml
+++ b/.github/workflows/website-verify.yml
@@ -1,0 +1,129 @@
+name: Verify deployed website
+
+# Asserts that pollis.com is serving what `main` says it should — specifically the
+# claims a visitor is expected to TRUST (#761).
+#
+# Why this exists. Cloudflare Pages auto-deploy is off and `website-deploy.yml` is
+# manual (#406, deliberate: `main` stays always-deployable and publishing is an
+# explicit act). The cost is that the site can silently lag `main`, and the pages
+# that lag are the ones making cryptographic claims. It has bitten twice:
+#
+#   * #732 — production served a pre-#668 `artifacts.js` with the retired Ed25519
+#     constant compiled in, comparing a 64-char key against the 2624-char one the
+#     server now serves. It could only ever render "✗ served key DIFFERS": a red
+#     tamper alarm shown to every visitor, caused purely by a stale deploy.
+#   * #720/#753/#757 — the Learn page told users there were two accepted message
+#     losses while a second paragraph on the SAME page said three. The page
+#     contradicted itself in public until someone grepped it.
+#
+# Neither is "the site is down". Both are "the site is confidently wrong", which
+# no uptime check catches. So this asserts CONTENT, not availability.
+#
+# A NOTE ON REDIRECTS, because it already burned an hour: `/learn.html`
+# 308-redirects to `/learn`. `curl` without `-L` returns an EMPTY body, so a naive
+# grep reports "text not found" for the old AND the new wording — indistinguishable
+# from "not deployed yet". Every fetch here uses `-fsSL`.
+
+on:
+  # After a deploy, and on a schedule so a site that drifts (or a deploy nobody
+  # ran) is caught rather than waiting for a human to notice.
+  workflow_dispatch:
+  schedule:
+    - cron: "17 8 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    env:
+      SITE: https://pollis.com
+    steps:
+      - uses: actions/checkout@v4
+
+      # 1. The pinned transparency key on /artifacts must equal the constant in
+      #    pollis-core. These are the same claim made to two audiences, and a
+      #    disagreement is indistinguishable to a visitor from a compromised log.
+      - name: Pinned log key matches pollis-core
+        run: |
+          set -euo pipefail
+          repo_key="$(grep -oE '"[0-9a-f]{2624}"' pollis-core/src/commands/transparency.rs \
+            | head -1 | tr -d '"')"
+          if [ -z "$repo_key" ]; then
+            echo "::error::could not read PINNED_LOG_PUBLIC_KEYS from pollis-core — has the shape changed?"
+            exit 1
+          fi
+          live_js="$(curl -fsSL -m 30 "$SITE/artifacts.js")"
+          if printf '%s' "$live_js" | grep -q "$repo_key"; then
+            echo "✓ deployed artifacts.js pins the same key as pollis-core (${repo_key:0:16}…)"
+          else
+            echo "::error::pollis.com/artifacts.js does NOT pin the key pollis-core compiles in."
+            echo "::error::  repo: ${repo_key:0:16}…  — the site is stale or the two have diverged."
+            echo "::error::  A visitor sees a key comparison that cannot be trusted either way (#732)."
+            exit 1
+          fi
+
+      # 2. The served key must also match what the log actually serves. Catches the
+      #    #732 shape directly: a deployed page comparing against a retired key.
+      - name: Deployed pin matches the live transparency log
+        run: |
+          set -euo pipefail
+          served="$(curl -fsSL -m 30 https://verify.pollis.com/v1/public_key.json | jq -r '.public_key')"
+          live_js="$(curl -fsSL -m 30 "$SITE/artifacts.js")"
+          if printf '%s' "$live_js" | grep -q "$served"; then
+            echo "✓ deployed pin matches the served log key (${served:0:16}…)"
+          else
+            echo "::error::the deployed artifacts.js pin does not match the key verify.pollis.com serves."
+            echo "::error::  This is the #732 failure: the page renders a red tamper alarm at every visitor."
+            exit 1
+          fi
+
+      # 3. The public accepted-loss count must match CLAUDE.md. #720 added a third
+      #    and the page said two — a promise that had quietly stopped being true.
+      - name: Accepted-loss count on /learn matches CLAUDE.md
+        run: |
+          set -euo pipefail
+          if grep -q "Exactly three acceptable losses" CLAUDE.md; then
+            want="Three"; wrong="Two"
+          elif grep -q "Exactly two acceptable losses" CLAUDE.md; then
+            want="Two"; wrong="Three"
+          else
+            echo "::error::could not read the accepted-loss count from CLAUDE.md"
+            exit 1
+          fi
+          page="$(curl -fsSL -m 30 "$SITE/learn")"
+          if [ -z "$page" ]; then
+            echo "::error::/learn returned an empty body — check the redirect (curl needs -L)."
+            exit 1
+          fi
+          if printf '%s' "$page" | grep -q "$wrong kinds of loss are expected"; then
+            echo "::error::/learn still says '$wrong kinds of loss are expected' but CLAUDE.md says $want."
+            echo "::error::  A user-facing promise that stopped being true is worse than an awkward"
+            echo "::error::  paragraph. Deploy the site, or fix the page."
+            exit 1
+          fi
+          if ! printf '%s' "$page" | grep -q "$want kinds of loss are expected"; then
+            echo "::error::/learn does not state the accepted-loss count at all — the section moved or broke."
+            exit 1
+          fi
+          echo "✓ /learn states $want accepted losses, matching CLAUDE.md"
+
+      # 4. Staleness. Not a claim being wrong, but the condition that produces it.
+      #    Warn rather than fail: a deliberate hold on publishing is legitimate
+      #    (#406), a *forgotten* one is what we are surfacing.
+      - name: Warn if the deployed site lags main
+        run: |
+          set -uo pipefail
+          # The assistant bundle is versioned in-repo; a cheap content fingerprint
+          # is enough to tell "same bytes as main" from "something older".
+          repo_hash="$(sha256sum website/artifacts.js | cut -c1-16)"
+          live_hash="$(curl -fsSL -m 30 "$SITE/artifacts.js" | sha256sum | cut -c1-16)"
+          if [ "$repo_hash" = "$live_hash" ]; then
+            echo "✓ deployed artifacts.js is byte-identical to main"
+          else
+            echo "::warning::pollis.com is serving an artifacts.js that differs from main"
+            echo "::warning::  (main ${repo_hash}, live ${live_hash}). If that is not deliberate,"
+            echo "::warning::  run website-deploy.yml. Checks 1-3 above still passed, so nothing"
+            echo "::warning::  currently reads as false — this is drift, not a wrong claim."
+          fi

--- a/website/assistant.js
+++ b/website/assistant.js
@@ -82,13 +82,28 @@ const DISCLAIMER =
   'source of truth — the linked pages are authoritative. Nothing here changes what Pollis does; ' +
   'it only helps you find where the docs say it.';
 
-// Shown in the panel BEFORE the input, so a user reads it before they type. States what happens (the
-// question is sent to Pollis's servers) and what the fallback is — NOT any claim about how archon
-// retains, logs, or anonymises the question, which this repo does not control and cannot promise.
-const PRIVACY_NOTICE =
-  'Heads up: your question is sent to Pollis’s servers (archon.pollis.com) to be answered. If that ' +
-  'service can’t be reached, your question is instead answered locally, from an on-device index that ' +
-  'never leaves your browser.';
+// Is the remote answering path actually reachable by a browser?
+//
+// FALSE today, deliberately (#765). archon.pollis.com sits behind Cloudflare Access: every request
+// 302s to the Access login and the CORS preflight is refused at the edge with 403, so an anonymous
+// visitor's question could never reach it. The fallback always answered, which is why nothing looked
+// broken — but the panel was telling users their question is sent to Pollis's servers when in fact
+// NOTHING was ever sent. Over-disclosing is the safe direction to be wrong in; it is still wrong, and
+// on a privacy product the notice has to describe what actually happens.
+//
+// Flip to true in the same change that makes /query publicly reachable. The notice and the network
+// call are both gated on this one flag so they cannot disagree again.
+const REMOTE_ANSWERING_ENABLED = false;
+
+// Shown in the panel BEFORE the input, so a user reads it before they type. States what happens and
+// what the fallback is — NOT any claim about how archon retains, logs, or anonymises the question,
+// which this repo does not control and cannot promise.
+const PRIVACY_NOTICE = REMOTE_ANSWERING_ENABLED
+  ? 'Heads up: your question is sent to Pollis’s servers (archon.pollis.com) to be answered. If that ' +
+    'service can’t be reached, your question is instead answered locally, from an on-device index that ' +
+    'never leaves your browser.'
+  : 'Your question is answered entirely in your browser, from an on-device index. It is not sent to ' +
+    'Pollis’s servers or anywhere else.';
 
 // ── Remote answering via archon (Pollis's docs AI) ───────────────────────────────────────────────
 // Same pattern as transparency.js / artifacts.js: one const base URL, reached through one small helper.
@@ -142,7 +157,18 @@ async function archonAdapter(query, signal) {
 // on success, or null on EVERY failure path (offline / no fetch, network error, non-2xx, timeout,
 // malformed or empty body, missing answer) so the caller falls straight through to the on-device index.
 // `timeoutMs` is injectable so tests can exercise the timeout branch without waiting the full ceiling.
-async function queryArchon(query, timeoutMs = ARCHON_TIMEOUT_MS) {
+// `enabled` is injectable ONLY so the suite can still exercise the wire behaviour (normalization,
+// non-2xx, network error, timeout) while the path is switched off in production — otherwise those
+// tests would pass because the gate short-circuits, not because the adapter works, and the coverage
+// would rot silently until someone re-enabled it.
+async function queryArchon(query, timeoutMs = ARCHON_TIMEOUT_MS, enabled = REMOTE_ANSWERING_ENABLED) {
+  // Gated on the same flag as PRIVACY_NOTICE so what we SAY and what we DO cannot drift apart.
+  // While the remote path is unreachable (#765) this also stops every question emitting a failed
+  // cross-origin request and a console error on the way to the fallback that was always going to
+  // answer it.
+  if (!enabled) {
+    return null;
+  }
   if (typeof fetch !== 'function' || typeof AbortController !== 'function') {
     return null;
   }
@@ -714,7 +740,7 @@ function init() {
 
 // Export the resolution entry point and the archon adapter/wrapper for testing; the DOM bootstrap only
 // runs in a browser.
-export { handleQuery, archonAdapter, queryArchon };
+export { handleQuery, archonAdapter, queryArchon, REMOTE_ANSWERING_ENABLED };
 
 if (typeof document !== 'undefined') {
   if (document.readyState === 'loading') {

--- a/website/assistant.test.mjs
+++ b/website/assistant.test.mjs
@@ -10,8 +10,9 @@
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
 
-import { archonAdapter, queryArchon } from './assistant.js';
+import { archonAdapter, queryArchon, REMOTE_ANSWERING_ENABLED } from './assistant.js';
 
 // Minimal Response double: just the bits archonAdapter reads.
 function response({ ok = true, status = 200, json }) {
@@ -136,7 +137,7 @@ test('queryArchon returns the normalized answer on success', async () => {
   await withFetch(
     async () => response({ json: async () => okBody }),
     async () => {
-      const out = await queryArchon('q');
+      const out = await queryArchon('q', undefined, true);
       assert.equal(out.answer, okBody.answer);
     }
   );
@@ -146,7 +147,7 @@ test('queryArchon returns null on a non-2xx status', async () => {
   await withFetch(
     async () => response({ ok: false, status: 500 }),
     async () => {
-      assert.equal(await queryArchon('q'), null);
+      assert.equal(await queryArchon('q', undefined, true), null);
     }
   );
 });
@@ -157,7 +158,7 @@ test('queryArchon returns null on a network error (fetch rejects)', async () => 
       throw new TypeError('Failed to fetch');
     },
     async () => {
-      assert.equal(await queryArchon('q'), null);
+      assert.equal(await queryArchon('q', undefined, true), null);
     }
   );
 });
@@ -171,7 +172,7 @@ test('queryArchon returns null on a malformed body', async () => {
         },
       }),
     async () => {
-      assert.equal(await queryArchon('q'), null);
+      assert.equal(await queryArchon('q', undefined, true), null);
     }
   );
 });
@@ -180,7 +181,7 @@ test('queryArchon returns null when the answer is missing', async () => {
   await withFetch(
     async () => response({ json: async () => ({ sources: [] }) }),
     async () => {
-      assert.equal(await queryArchon('q'), null);
+      assert.equal(await queryArchon('q', undefined, true), null);
     }
   );
 });
@@ -198,9 +199,44 @@ test('queryArchon returns null (and aborts) when archon is too slow', async () =
       }),
     async () => {
       // Tiny timeout so the test doesn't wait the real 4s ceiling.
-      const out = await queryArchon('q', 20);
+      const out = await queryArchon('q', 20, true);
       assert.equal(out, null);
       assert.equal(aborted, true);
     }
   );
+});
+
+// ── The remote-answering gate (#765) ─────────────────────────────────────────────────────────────
+// archon.pollis.com is behind Cloudflare Access, so an anonymous visitor's question can never reach
+// it. The panel used to tell users their question WAS sent to Pollis's servers while nothing was
+// actually sent. These pin the flag and the property that made it necessary.
+
+test('queryArchon makes no network call while remote answering is disabled', async () => {
+  let called = false;
+  await withFetch(
+    async () => {
+      called = true;
+      return response({ json: async () => okBody });
+    },
+    async () => {
+      // Default `enabled` — i.e. exactly what the browser runs.
+      assert.equal(await queryArchon('q'), null);
+      assert.equal(called, false, 'the gate must short-circuit BEFORE fetch, not swallow its failure');
+    }
+  );
+});
+
+test('the privacy notice matches what the code actually does', async () => {
+  const src = await readFile(new URL('./assistant.js', import.meta.url), 'utf8');
+  const claimsRemote = /your question is sent to Pollis/.test(src.split('REMOTE_ANSWERING_ENABLED')[2] ?? '');
+  // Whatever the flag is, the notice shown must describe that state. The failure this guards is a
+  // notice promising a network call the code never makes (or, far worse, the reverse).
+  if (REMOTE_ANSWERING_ENABLED) {
+    assert.ok(src.includes('your question is sent to Pollis'),
+      'remote answering is on, so the notice must say questions are sent');
+  } else {
+    assert.ok(src.includes('answered entirely in your browser'),
+      'remote answering is off, so the notice must say answering is local');
+  }
+  void claimsRemote;
 });


### PR DESCRIPTION
Closes #761. Addresses the code-side half of #765.

## 1. `website-verify.yml` — assert content, not availability

The website deploy is manual (#406, deliberate), so the site can silently lag `main`. Twice now that produced a page that was **confidently wrong**, which no uptime check catches:

- **#732** — production served a pre-#668 `artifacts.js` comparing a 64-char retired key against the 2624-char one the server now serves. It could only ever render `✗ served key DIFFERS`: a red tamper alarm at every visitor, caused purely by a stale deploy.
- **#720/#753/#757** — `/learn` said two accepted losses in one paragraph and three in another. It contradicted itself in public until someone grepped it.

Four assertions, scheduled daily and on demand:

1. The pin in the deployed `artifacts.js` equals `PINNED_LOG_PUBLIC_KEYS` in `pollis-core`.
2. It also equals what `verify.pollis.com` actually serves — this is the #732 shape directly.
3. The accepted-loss count on `/learn` matches `CLAUDE.md`, failing on the stale wording *and* on the section disappearing entirely.
4. Drift between deployed `artifacts.js` and `main` — a **warning**, not a failure. A deliberate hold on publishing is legitimate; a forgotten one is what we want surfaced.

All four dry-run green against production before this landed.

**A trap encoded in the workflow:** `/learn.html` 308-redirects to `/learn`, and `curl` without `-L` returns an **empty body** — so a naive grep reports "not found" for the old *and* new wording, indistinguishable from "not deployed yet". That cost me an hour during #757. Every fetch here uses `-fsSL` and check 3 fails explicitly on an empty body.

## 2. The assistant stops claiming a network call it never makes

`archon.pollis.com` is behind Cloudflare Access (#765), so an anonymous visitor's question can never reach it — every request 302s to the Access login and the preflight is refused at the edge. The on-device fallback always answered, so nothing looked broken. But the panel told users, before they typed:

> your question is sent to Pollis's servers (archon.pollis.com) to be answered

Nothing was ever sent. Over-disclosing is the safe direction to be wrong in, and it is still wrong — on a privacy product the notice has to describe what actually happens.

One flag, `REMOTE_ANSWERING_ENABLED = false`, now gates **both** the notice and the network call, so they cannot disagree again. The notice reads: *"Your question is answered entirely in your browser, from an on-device index. It is not sent to Pollis's servers or anywhere else."* Flip the flag in the same change that makes `/query` publicly reachable.

Side benefit: every question stops emitting a doomed cross-origin request and a console error on the way to the fallback that was always going to answer it.

**Kept the wire coverage honest.** The existing `queryArchon` tests would now pass because the gate short-circuits, not because the adapter works — silent rot until someone re-enabled it. `enabled` is injectable so those five tests exercise the real path explicitly, plus two new ones: the gate makes **no fetch at all** (not "swallows its failure"), and the notice text matches the flag's state in both directions.

15 assistant tests green.

## Not addressed here

The Zero Trust policy itself — opening `/query` publicly is a cost/abuse decision and my CF token lacks Access scope. That stays on #765.