### PR TITLE
website-verify failed because the text was found — remove the SIGPIPE trap

### DIFF
--- a/.github/workflows/website-verify.yml
+++ b/.github/workflows/website-verify.yml
@@ -37,6 +37,13 @@ permissions:
 jobs:
   verify:
     runs-on: ubuntu-latest
+    # `[[ ... == *glob* ]]` below is bash, and it replaces a `printf | grep -q`
+    # pattern that was a SIGPIPE trap under `pipefail`: grep exits on the first
+    # match, printf dies with 141, and the pipeline reports FAILURE because the
+    # text was found. It failed on this workflow's very first real run.
+    defaults:
+      run:
+        shell: bash
     env:
       SITE: https://pollis.com
     steps:
@@ -55,7 +62,7 @@ jobs:
             exit 1
           fi
           live_js="$(curl -fsSL -m 30 "$SITE/artifacts.js")"
-          if printf '%s' "$live_js" | grep -q "$repo_key"; then
+          if [[ "$live_js" == *"$repo_key"* ]]; then
             echo "✓ deployed artifacts.js pins the same key as pollis-core (${repo_key:0:16}…)"
           else
             echo "::error::pollis.com/artifacts.js does NOT pin the key pollis-core compiles in."
@@ -71,7 +78,7 @@ jobs:
           set -euo pipefail
           served="$(curl -fsSL -m 30 https://verify.pollis.com/v1/public_key.json | jq -r '.public_key')"
           live_js="$(curl -fsSL -m 30 "$SITE/artifacts.js")"
-          if printf '%s' "$live_js" | grep -q "$served"; then
+          if [[ "$live_js" == *"$served"* ]]; then
             echo "✓ deployed pin matches the served log key (${served:0:16}…)"
           else
             echo "::error::the deployed artifacts.js pin does not match the key verify.pollis.com serves."
@@ -97,13 +104,13 @@ jobs:
             echo "::error::/learn returned an empty body — check the redirect (curl needs -L)."
             exit 1
           fi
-          if printf '%s' "$page" | grep -q "$wrong kinds of loss are expected"; then
+          if [[ "$page" == *"$wrong kinds of loss are expected"* ]]; then
             echo "::error::/learn still says '$wrong kinds of loss are expected' but CLAUDE.md says $want."
             echo "::error::  A user-facing promise that stopped being true is worse than an awkward"
             echo "::error::  paragraph. Deploy the site, or fix the page."
             exit 1
           fi
-          if ! printf '%s' "$page" | grep -q "$want kinds of loss are expected"; then
+          if [[ "$page" != *"$want kinds of loss are expected"* ]]; then
             echo "::error::/learn does not state the accepted-loss count at all — the section moved or broke."
             exit 1
           fi


### PR DESCRIPTION
Fixes a bug in the workflow #768 added, caught on its **first real run**.

## The bug

Every content check used `printf '%s' "$page" | grep -q "…"` under `set -euo pipefail`. `grep -q` exits the moment it matches, `printf` then dies with SIGPIPE (141), and `pipefail` propagates that — so the pipeline reports **failure precisely because the text was present**.

The run failed with:

```
::error::/learn does not state the accepted-loss count at all — the section moved or broke.
…: printf: write error: Broken pipe
```

`/learn` states it correctly. The check was inverted by its own plumbing.

## Worse than it looks: it is a race, not a constant

Reproducing locally, the old pattern returns **0** — whether `printf` is killed before it finishes writing depends on buffering and how early in the input the match lands. So it is nondeterministically flaky, which is more dangerous than reliably broken: checks 1 and 2 passed in the same CI run using the identical pattern, purely because their match sits further into the file.

That also means these checks could have gone green for months and then failed on an unrelated content edit that moved a string earlier in the page.

## The fix

Bash substring matching — `[[ "$page" == *"$needle"* ]]` — with `defaults.run.shell: bash`. No pipe, no second process, no signal, and the result does not depend on where the match falls.

## Verified

Extracted all four steps from the workflow YAML and ran them against production:

```
✓ deployed artifacts.js pins the same key as pollis-core (56ab128f3f101073…)
✓ deployed pin matches the served log key (56ab128f3f101073…)
✓ /learn states Three accepted losses, matching CLAUDE.md
✓ deployed artifacts.js is byte-identical to main
```

The failing check now passes for the right reason, and the two that passed for the wrong reason are no longer relying on luck.