### PR TITLE
The nightly transparency publish has failed every night since #766 — errexit killed the first-run path

### DIFF
--- a/.github/workflows/transparency-publish.yml
+++ b/.github/workflows/transparency-publish.yml
@@ -399,9 +399,18 @@ jobs:
           # let the tripwire pass without comparing anything — then the save step
           # would re-seed and erase the evidence. Keep stderr; it is the only
           # thing that can tell those two apart.
+          #
+          # `|| rc=$?` is load-bearing, not style. GitHub invokes every step as
+          # `bash -e {0}`, and `set -uo pipefail` does NOT clear that errexit.
+          # Without the `||`, a failing command substitution aborts the step ON
+          # THE ASSIGNMENT, so the classification below never runs. That made the
+          # first-seeding path unreachable and broke the nightly publish the
+          # moment it shipped — on the very first run there is no object yet, by
+          # definition. Guarding the assignment makes the failure *tested*, which
+          # is what stops errexit firing.
+          rc=0
           err="$(aws s3 cp "s3://${R2_BUCKET}/internal/tripwire-sths.tar" .sth-prev.tar \
-                   --endpoint-url "${R2_ENDPOINT}" 2>&1)"
-          rc=$?
+                   --endpoint-url "${R2_ENDPOINT}" 2>&1)" || rc=$?
           if [ "${rc}" -eq 0 ]; then
             tar -xf .sth-prev.tar -C .sth-prev
             echo "tripwire: restored prior state from R2."


### PR DESCRIPTION
Regression I introduced in #766 (hardened further in #771). The scheduled publish has failed on every run since, and would have kept failing indefinitely.

## What broke

GitHub invokes every step as `bash -e {0}`. `set -uo pipefail` at the top of a step does **not** clear that errexit. So this:

```bash
err="$(aws s3 cp "s3://…/internal/tripwire-sths.tar" … 2>&1)"
rc=$?
if [ "${rc}" -eq 0 ]; then … elif …404|NoSuchKey… then … fi
```

aborts the step **on the assignment** the moment `aws` exits non-zero. `rc=$?` is never reached, and neither is the classification underneath it.

That makes the *first-seeding* path unreachable by construction: on the first run there is no object yet, by definition, so the fetch fails, so the step dies. #766 shipped a check whose very first step could not succeed.

Run [30993015731](https://github.com/actuallydan/pollis/actions/runs/30993015731): `Restore prior published STHs (tripwire state)` failed; the self-audit and state-save were skipped. The R2 sync had already completed, so the log itself is fine — but the equivocation check never armed and no baseline was ever written, so every subsequent night hit the identical wall.

## The fix

```bash
rc=0
err="$(aws s3 cp … 2>&1)" || rc=$?
```

The `|| rc=$?` makes the failure *tested*, which is precisely what suppresses errexit. One line, plus a comment saying why it is load-bearing rather than stylistic — this is exactly the kind of thing a later tidy-up removes.

## Tested

Extracted the step from the workflow YAML and ran it under `bash -e` with a stubbed `aws` covering all three outcomes:

| case | exit | `seeded` | restored |
|---|---|---|---|
| object present | 0 | `true` | 1 file |
| object absent (404) | 0 | `false` | 0 |
| credentials broken | 1 | — | 0 |

And the counterfactual, on the same harness: the **pre-fix** code exits **1** on the absent-object case — the nightly failure, reproduced — while the fixed code exits 0.

Worth noting the first version of my harness gave a false failure on the "present" case because the stub wrote to `$3` (the source) instead of `$4` (the destination). The test was wrong, not the workflow; fixed before drawing any conclusion.

## Scope

Checked every other command substitution in this workflow — the rest already carry `|| echo ""` / `|| echo 0` fallbacks, so this was the only unguarded one.