### PR TITLE
Stop the relay pool's AZ-rebalance thrash — the alarms were reporting real churn

### DIFF
--- a/infra/relay-hydra/modules/relay-region/main.tf
+++ b/infra/relay-hydra/modules/relay-region/main.tf
@@ -242,6 +242,27 @@ resource "aws_autoscaling_group" "relay" {
   vpc_zone_identifier = [for s in aws_subnet.public : s.id]
   health_check_type   = "EC2"
 
+  # Stop the AZ-rebalance thrash loop.
+  #
+  # The group spans one subnet per AZ (three in most regions) while the pool holds
+  # two nodes. AWS's AZRebalance process continuously tries to even instances
+  # across zones, and 2 does not divide across 3 — so it launches a THIRD node
+  # ("resulting in more than desired number of instances"), then terminates one to
+  # get back to desired, then finds the zones uneven again. Forever.
+  #
+  # Observed in us-west-2: 27 rebalance events in one window of scaling history,
+  # each cascading into a replacement launch, several per minute. That churn is
+  # what was paging the owner ~6x/day — the alarms were reporting real instability,
+  # not misfiring. It also burns instance-hours and public-IPv4 allocations, which
+  # is most of the gap between ~$2 actual spend and the ~$23 forecast.
+  #
+  # Suspending AZRebalance does NOT weaken availability: the multi-AZ subnets still
+  # spread new launches, replacement still honours them, and a genuine AZ failure is
+  # still handled by the health-check path. It only stops AWS from *moving healthy
+  # nodes between zones* to satisfy an evenness constraint that a 2-node pool can
+  # never meet. Re-evaluate if the pool ever holds a multiple of the AZ count.
+  suspended_processes = ["AZRebalance"]
+
   # The reconciler marks a node Unhealthy (via SetInstanceHealth) when its relay
   # container is dead but the instance is still EC2-reachable. This grace period is
   # the window, measured from launch, in which that flag is ignored so a node still


### PR DESCRIPTION
The hydra alarms firing several times a day are **not** misconfigured alarms. They are correctly reporting a pool that is continuously launching and killing nodes.

## What is happening

Each region's ASG spans one subnet per AZ — three in `us-west-2` — while the pool holds **two** nodes. AWS's `AZRebalance` process continuously tries to even instances across zones, and 2 does not divide across 3. So it launches a **third** node ("resulting in more than desired number of instances in the group"), terminates one to return to desired, finds the zones uneven again, and repeats.

From one window of `us-west-2` scaling history:

| cause | count |
|---|---|
| `difference between desired and actual` (replacement) | 58 |
| `to balance instances in zones` (AZRebalance) | 27 |
| `EC2 health check indicating…` (Spot reclaim) | 5 |
| `user health-check` (reconciler self-heal) | 3 |

Timestamps several **per minute**. The rebalances are the engine; most of the 58 replacements are its downstream effect.

## Why it matters beyond the noise

- **Paging on a non-event.** The alarms flap because the pool genuinely flaps. Silencing them would have hidden a real fault — the churn is the bug, not the alerting.
- **Cost.** Instance-hours and public-IPv4 allocations for nodes that live minutes. Per #616's own math a public IPv4 is the dominant per-node cost, and this is most of the gap between ~$2 actual spend and the ~$23 forecast that has been tripping the budget alert.
- **Availability.** Every replacement is a node that stops serving. `mayDrain` already implements the add-before-remove the owner asked for, but it only governs *reconciler-driven* rotation — AZRebalance is ASG-driven and bypasses it entirely. That is why the surge-then-retire behaviour was not being observed.

## The change

`suspended_processes = ["AZRebalance"]` on the relay ASG, in all regions.

This does **not** weaken availability. The multi-AZ subnets still spread new launches, replacement still honours them, and a genuine AZ failure is still handled through the health-check path. It only stops AWS from relocating *healthy* nodes to satisfy an evenness constraint a 2-node pool can never meet. Worth revisiting if the pool ever holds a multiple of the AZ count.

`terraform validate` passes.

## Applying this is blocked on a prerequisite — do not apply blind

`terraform plan` against the live state shows this change alongside the pending #703 work:

```
aws_ssm_parameter.intended_image will be created
module.relay_region_*.aws_launch_template.relay will be updated in-place   (× 4 regions)
```

`terraform.tfvars` still sets no `relay_image`, and its default is `""`. The new launch-template user-data resolves the image from that SSM record and deliberately `exit 1`s when it is empty — and the parameter carries `ignore_changes = [value]`, so the seed is a one-shot. Applying as-is would seed an empty image and **every future node launch would fail to boot**, which is strictly worse than the churn.

The prerequisite (from #677): set an immutable ref in `terraform.tfvars` first — GHCR currently has `ghcr.io/actuallydan/pollis-relay:3a28f55be80cdd498b7fc9dfd0d947abbdd838fe`. `terraform.tfvars` is gitignored, so that is an operator edit, not something this PR can carry.

**Immediate relief without any apply**, reversible in one command:

```bash
aws autoscaling suspend-processes --region us-west-2 \
  --auto-scaling-group-name pollis-relay-us-west-2 \
  --scaling-processes AZRebalance
```

That stops the churn and the emails today; this PR makes it survive the next apply.