### PR TITLE
fix(delivery): make an unwired DS config value a CI failure, not a silent no-op

### DIFF
--- a/.github/workflows/scripts-check.yml
+++ b/.github/workflows/scripts-check.yml
@@ -19,10 +19,22 @@ on:
     paths:
       - "scripts/**"
       - ".github/workflows/scripts-check.yml"
+      - "pollis-delivery/worker/**"
+      - "pollis-delivery/wrangler.dev.jsonc"
+      - "pollis-delivery/wrangler.prod.jsonc"
+      - "pollis-delivery/ds-config-manifest.json"
+      - "pollis-delivery/src/**"
+      - ".github/scripts/sync-ds-secrets.sh"
   push:
     branches: [main]
     paths:
       - "scripts/**"
+      - "pollis-delivery/worker/**"
+      - "pollis-delivery/wrangler.dev.jsonc"
+      - "pollis-delivery/wrangler.prod.jsonc"
+      - "pollis-delivery/ds-config-manifest.json"
+      - "pollis-delivery/src/**"
+      - ".github/scripts/sync-ds-secrets.sh"
 
 permissions:
   contents: read
@@ -39,6 +51,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      # #760: prove every DS config value actually traverses all five links to the
+      # running container. Three of five were silently missing for
+      # POLLIS_DS_METRICS_TOKEN and it took three PRs to notice — a deploy goes
+      # green and the value simply has no effect. Cheap, so it gates every change
+      # to any link, not just to scripts/.
+      - name: DS config chain (#760)
+        run: python3 ./scripts/check-ds-config-chain.py
 
       - name: Attest helper + payload-hash tests
         run: ./scripts/test-attest-helpers.sh

--- a/pollis-delivery/ds-config-manifest.json
+++ b/pollis-delivery/ds-config-manifest.json
@@ -1,0 +1,81 @@
+{
+  "$comment": [
+    "THE declaration of every configuration value the Delivery Service reads (#760).",
+    "",
+    "A config value has to traverse five links to affect the running DS, and each is a",
+    "separate hand-maintained list: Doppler -> KEYS in .github/scripts/sync-ds-secrets.sh",
+    "-> the wrangler config -> worker/index.ts -> the DS reading the OS env var. Three of",
+    "the five were silently missing for POLLIS_DS_METRICS_TOKEN, and it took three PRs to",
+    "notice, because each broken link hid the next.",
+    "",
+    "Link 4 is the trap: a wrangler `var` binds to the WORKER, not to the container, and a",
+    "Secrets Store binding reaches the container only if worker/index.ts forwards it. So",
+    "config can be correct in Doppler, in the Secrets Store and in wrangler.jsonc, deploy",
+    "green, and still never reach the DS.",
+    "",
+    "scripts/check-ds-config-chain.py verifies this file against every link, in BOTH",
+    "directions: a declared key missing from a link fails, and an env var the DS reads that",
+    "is not declared here fails. Adding config without wiring it end to end is therefore a",
+    "CI failure rather than a silent no-op discovered months later."
+  ],
+
+  "secrets": {
+    "$comment": "Secrets Store -> container. Must appear in the sync script's KEYS, in each listed environment's `secrets_store_secrets`, and in SECRET_KEYS in worker/index.ts.",
+    "both": [
+      "TURSO_URL",
+      "TURSO_TOKEN",
+      "LOG_DB_URL",
+      "LOG_DB_ADMIN_TOKEN",
+      "RESEND_API_KEY",
+      "LIVEKIT_API_KEY",
+      "LIVEKIT_API_SECRET",
+      "LIVEKIT_URL",
+      "R2_S3_ENDPOINT",
+      "R2_ACCESS_KEY_ID",
+      "R2_SECRET_KEY",
+      "R2_BUCKET",
+      "TURSO_PLATFORM_TOKEN",
+      "TURSO_ORG",
+      "TURSO_DB",
+      "POLLIS_DS_METRICS_TOKEN"
+    ],
+    "dev_only": ["DEV_OTP"]
+  },
+
+  "container_vars": {
+    "$comment": "Non-secret config that must reach the CONTAINER. Must appear in both wrangler configs' `vars` AND be forwarded through `envVars` in worker/index.ts. Forgetting the forward is the #720 bug.",
+    "keys": ["PORT", "POLLIS_DS_REQUIRE_AUTH", "POLLIS_DS_WATERMARK_STALE_MONTHS"]
+  },
+
+  "worker_vars": {
+    "$comment": "Read by the WORKER itself and deliberately NOT forwarded to the container. Declared so the checker does not demand a forward that would be meaningless.",
+    "keys": ["DS_SINGLETON_NAME"]
+  },
+
+  "aliases": {
+    "$comment": "Alternate names the DS accepts, each falling back to a delivered key (broker.rs). Never delivered under this name; nothing to wire.",
+    "keys": {
+      "R2_ENDPOINT": "R2_S3_ENDPOINT",
+      "R2_SECRET_ACCESS_KEY": "R2_SECRET_KEY"
+    }
+  },
+
+  "code_default_only": {
+    "$comment": [
+      "Read by the DS with a compiled-in default and NOT settable in any environment — there",
+      "is no wrangler var and no forward, so setting one would require a code change.",
+      "",
+      "Listed explicitly rather than fixed because the default IS the policy in each case, and",
+      "silently adding operator knobs is how #720 happened in reverse. If one of these ever",
+      "needs to be tunable, promote it to container_vars and wire all the links — the checker",
+      "will refuse a half-done job."
+    ],
+    "keys": [
+      "OTP_TTL_SECS",
+      "POLLIS_DS_GC_SWEEP_SECS",
+      "POLLIS_DS_SECURITY_EVENT_RETENTION_DAYS",
+      "POLLIS_DS_PUSH_TOKEN_RETENTION_DAYS",
+      "R2_REGION"
+    ]
+  }
+}

--- a/scripts/check-ds-config-chain.py
+++ b/scripts/check-ds-config-chain.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""check-ds-config-chain.py — prove DS config actually reaches the container (#760).
+
+A config value must traverse five links to affect the running Delivery Service:
+
+    1. Doppler                                      (source of truth)
+    2. KEYS in .github/scripts/sync-ds-secrets.sh   (what is pushed to the Secrets Store)
+    3. secrets_store_secrets / vars in wrangler.*   (what the WORKER can see)
+    4. SECRET_KEYS / envVars in worker/index.ts     (what the CONTAINER is given)
+    5. the DS reads the OS env var                  (effect)
+
+Each link is a separate hand-maintained list. Three of the five were missing for
+POLLIS_DS_METRICS_TOKEN and it took three PRs to notice, because a broken link is
+invisible until the one before it is fixed: the deploy goes green, the sync log says
+the secret was created, and the value simply has no effect.
+
+Link 4 is the trap — a wrangler `var` binds to the WORKER, not the container, and a
+Secrets Store binding reaches the container only if worker/index.ts forwards it.
+
+This checks links 2-5 against pollis-delivery/ds-config-manifest.json, in BOTH
+directions. A declared key missing from a link fails; an env var the DS reads that
+nothing declares also fails. Link 1 (Doppler) cannot be checked without a token —
+the deploy's own sync step is what surfaces that one.
+
+Exit 0 = every declared key is wired end to end. Exit 1 = a report of what is broken.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+MANIFEST = ROOT / "pollis-delivery" / "ds-config-manifest.json"
+SYNC = ROOT / ".github" / "scripts" / "sync-ds-secrets.sh"
+WORKER = ROOT / "pollis-delivery" / "worker" / "index.ts"
+WRANGLER = {
+    "dev": ROOT / "pollis-delivery" / "wrangler.dev.jsonc",
+    "prod": ROOT / "pollis-delivery" / "wrangler.prod.jsonc",
+}
+DS_SRC = ROOT / "pollis-delivery" / "src"
+
+failures: list[str] = []
+
+
+def fail(msg: str) -> None:
+    failures.append(msg)
+
+
+def strip_jsonc(text: str) -> str:
+    """Drop //-comments. Only ever applied to our own wrangler configs, whose string
+    values contain no `//` (the image ref uses no scheme), so a line-oriented strip is
+    sufficient and avoids depending on a JSON5 parser."""
+    return re.sub(r"^\s*//.*$", "", text, flags=re.MULTILINE)
+
+
+def load_manifest() -> dict:
+    return json.loads(strip_jsonc(MANIFEST.read_text()))
+
+
+def sync_keys() -> set[str]:
+    """KEYS=( ... ) plus the conditional DEV_OTP append (link 2)."""
+    text = SYNC.read_text()
+    m = re.search(r"^KEYS=\((.*?)\)", text, re.DOTALL | re.MULTILINE)
+    if not m:
+        fail(f"{SYNC.name}: could not find a `KEYS=( ... )` block to read")
+        return set()
+    keys = set(m.group(1).split())
+    keys |= set(re.findall(r"KEYS\+=\(([A-Z_0-9 ]+)\)", text)[0].split()) if re.findall(
+        r"KEYS\+=\(([A-Z_0-9 ]+)\)", text
+    ) else set()
+    return keys
+
+
+def wrangler_bindings(env: str) -> tuple[set[str], set[str]]:
+    """(secrets_store binding names, vars names) for one environment (link 3)."""
+    cfg = json.loads(strip_jsonc(WRANGLER[env].read_text()))
+    secrets = {b["binding"] for b in cfg.get("secrets_store_secrets", [])}
+    variables = {k for k in cfg.get("vars", {}) if not k.startswith("$")}
+    return secrets, variables
+
+
+def worker_secret_keys() -> set[str]:
+    """SECRET_KEYS = [ ... ] as const (link 4, secrets half)."""
+    m = re.search(r"const SECRET_KEYS = \[(.*?)\] as const", WORKER.read_text(), re.DOTALL)
+    if not m:
+        fail(f"{WORKER.name}: could not find `const SECRET_KEYS = [ ... ] as const`")
+        return set()
+    return set(re.findall(r'"([A-Z_0-9]+)"', m.group(1)))
+
+
+def worker_forwarded_vars() -> set[str]:
+    """Names the worker copies into the container's `envVars` (link 4, vars half).
+
+    Matches both the plain `KEY: this.env.KEY ?? ...` form and the conditional-spread
+    form used for optional values. Keyed on what appears as a PROPERTY of envVars, since
+    merely reading `this.env.X` in the worker does not deliver X to the container — that
+    distinction is the entire #720 bug."""
+    text = WORKER.read_text()
+    m = re.search(r"envVars = \{(.*?)\n  \};", text, re.DOTALL)
+    if not m:
+        fail(f"{WORKER.name}: could not find the `envVars = {{ ... }};` block")
+        return set()
+    body = m.group(1)
+    return set(re.findall(r"^\s*([A-Z_0-9]+):", body, re.MULTILINE)) | set(
+        re.findall(r"\{\s*([A-Z_0-9]+):\s*this\.env\.", body)
+    )
+
+
+def ds_read_vars() -> set[str]:
+    """Every env var the DS actually reads (link 5)."""
+    found: set[str] = set()
+    for rs in DS_SRC.rglob("*.rs"):
+        found |= set(re.findall(r'(?:env::)?var\("([A-Z_0-9]+)"\)', rs.read_text()))
+    return found
+
+
+def main() -> int:
+    man = load_manifest()
+    sec_both = set(man["secrets"]["both"])
+    sec_dev = set(man["secrets"]["dev_only"])
+    all_secrets = sec_both | sec_dev
+    container_vars = set(man["container_vars"]["keys"])
+    worker_vars = set(man["worker_vars"]["keys"])
+    aliases = man["aliases"]["keys"]
+    code_defaults = set(man["code_default_only"]["keys"])
+
+    declared = all_secrets | container_vars | worker_vars | set(aliases) | code_defaults
+
+    # ── Link 2: the sync script pushes every declared secret ────────────────
+    sk = sync_keys()
+    for k in sorted(all_secrets - sk):
+        fail(f"link 2: {k} is declared a secret but is NOT in KEYS in {SYNC.name} — it will never be pushed to the Secrets Store")
+    for k in sorted(sk - all_secrets):
+        fail(f"link 2: {SYNC.name} pushes {k}, which the manifest does not declare — add it to the manifest or stop syncing it")
+
+    # ── Link 3: each environment binds what it should ───────────────────────
+    for env in ("dev", "prod"):
+        bound, variables = wrangler_bindings(env)
+        expected = sec_both | (sec_dev if env == "dev" else set())
+        for k in sorted(expected - bound):
+            fail(f"link 3 [{env}]: {k} has no `secrets_store_secrets` binding in wrangler.{env}.jsonc — the Worker cannot see it")
+        for k in sorted(bound - expected):
+            fail(f"link 3 [{env}]: wrangler.{env}.jsonc binds {k}, which the manifest does not expect in {env}")
+        for k in sorted(container_vars - variables):
+            fail(f"link 3 [{env}]: container var {k} is missing from `vars` in wrangler.{env}.jsonc")
+        for k in sorted(worker_vars - variables):
+            fail(f"link 3 [{env}]: worker var {k} is missing from `vars` in wrangler.{env}.jsonc")
+        undeclared = variables - container_vars - worker_vars
+        for k in sorted(undeclared):
+            fail(f"link 3 [{env}]: wrangler.{env}.jsonc sets var {k}, which the manifest does not declare")
+
+    # ── Link 4: the worker hands them to the container ──────────────────────
+    wsk = worker_secret_keys()
+    for k in sorted(all_secrets - wsk):
+        fail(f"link 4: {k} is not in SECRET_KEYS in {WORKER.name} — it is bound to the Worker but NEVER injected into the container")
+    for k in sorted(wsk - all_secrets):
+        fail(f"link 4: {WORKER.name} lists {k} in SECRET_KEYS, which the manifest does not declare")
+
+    fwd = worker_forwarded_vars()
+    for k in sorted(container_vars - fwd):
+        fail(f"link 4: container var {k} is set in wrangler `vars` but NOT forwarded via envVars in {WORKER.name} — a var binds to the WORKER, so the DS will silently use its compiled-in default (this is the #720 bug)")
+    for k in sorted(worker_vars & fwd):
+        fail(f"link 4: {k} is declared worker-only but IS forwarded to the container in {WORKER.name} — declare it a container var or stop forwarding it")
+
+    # ── Link 5: the DS reads what we deliver, and we declare what it reads ──
+    read = ds_read_vars()
+    for k in sorted(read - declared):
+        fail(f"link 5: the DS reads {k} but nothing declares it — add it to ds-config-manifest.json (as a container var if it must be settable, or code_default_only if the default is the policy)")
+    for k in sorted(declared - read - worker_vars):
+        fail(f"link 5: {k} is declared and delivered but the DS never reads it — dead config; remove it or start reading it")
+
+    for alias, target in sorted(aliases.items()):
+        if target not in read:
+            fail(f"link 5: alias {alias} falls back to {target}, which the DS does not read")
+
+    if failures:
+        print("DS config chain BROKEN — a value can be correct in Doppler and still never reach the container:\n", file=sys.stderr)
+        for f in failures:
+            print(f"  ✗ {f}", file=sys.stderr)
+        print(f"\n{len(failures)} problem(s). See pollis-delivery/ds-config-manifest.json.", file=sys.stderr)
+        return 1
+
+    print(
+        f"DS config chain OK — {len(all_secrets)} secret(s), {len(container_vars)} container var(s), "
+        f"{len(worker_vars)} worker var(s), {len(code_defaults)} code-default-only, "
+        f"{len(aliases)} alias(es) verified across links 2-5."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #760.

## The problem

A config value must traverse **five** links to affect the running DS:

| # | link | where |
|---|---|---|
| 1 | Doppler | source of truth |
| 2 | `KEYS` | `.github/scripts/sync-ds-secrets.sh` |
| 3 | `secrets_store_secrets` / `vars` | `wrangler.{dev,prod}.jsonc` — what the **Worker** sees |
| 4 | `SECRET_KEYS` / `envVars` | `worker/index.ts` — what the **container** is given |
| 5 | the DS reads the env var | effect |

Nothing checked that it did. Three of five were missing for `POLLIS_DS_METRICS_TOKEN`, and it took three PRs to notice — because a broken link is **invisible until the one before it is fixed**. The deploy goes green, the sync log says the secret was created, and the value simply has no effect.

Link 4 is the trap: a wrangler `var` binds to the **Worker**, not the container, and a Secrets Store binding reaches the container only if `worker/index.ts` forwards it.

## The fix

`pollis-delivery/ds-config-manifest.json` becomes the single declaration; `scripts/check-ds-config-chain.py` verifies links 2-5 against it **in both directions**:

- a declared key missing from any link → fail
- an env var the DS reads that nothing declares → fail
- a key declared and delivered but never read → fail (dead config)

So config cannot be added half-way, and cannot rot out of the manifest. Link 1 (Doppler) needs a token and stays with the deploy's own sync step.

## Mutation-tested against the real bugs

Not "it passes today" — each historical failure was replayed and must produce exactly the right finding:

| break | result |
|---|---|
| **#720 replayed** — metrics token bound but absent from `SECRET_KEYS` | ✗ link 4, names the container-injection gap |
| **#758 replayed** — staleness var set in `vars` but never forwarded | ✗ link 4, explains that a var binds to the Worker |
| secret dropped from a wrangler binding | ✗ link 3 [dev] |
| secret dropped from the sync script | ✗ link 2 |
| DS starts reading an undeclared var | ✗ link 5 |
| restored | ✓ clean |

## What it found immediately

Five values the DS reads with a compiled-in default that **cannot be set in any environment** — no wrangler var, no forward: `OTP_TTL_SECS`, `POLLIS_DS_GC_SWEEP_SECS`, `POLLIS_DS_SECURITY_EVENT_RETENTION_DAYS`, `POLLIS_DS_PUSH_TOKEN_RETENTION_DAYS`, `R2_REGION`. The documented knobs are fiction.

Declared as `code_default_only` rather than quietly wired: the default **is** the policy in each case, and silently adding operator knobs is the same class of mistake in reverse. Promoting one now means wiring every link, and the checker refuses a half-done job.

Also confirmed benign and declared as such: `R2_ENDPOINT` and `R2_SECRET_ACCESS_KEY` are deliberate alias fallbacks in `broker.rs`, never delivered under those names.

## CI

Runs on any change to any link — worker, either wrangler config, the manifest, `pollis-delivery/src/**`, or the sync script — not just `scripts/**`. A wrangler or worker edit is exactly when it must fire. The check is instant.