### PR TITLE
fix(release): stop Git bash mangling signtool's /pa and /v flags

### DIFF
--- a/scripts/test-attest-helpers.sh
+++ b/scripts/test-attest-helpers.sh
@@ -491,6 +491,50 @@ case "$out" in
   *) bad "windows error does not name the missing installer: $out" ;;
 esac
 
+# windows: the flags must reach signtool LITERALLY.
+#
+# Git-for-Windows bash rewrites Unix-looking arguments before calling a native binary,
+# which turned `/pa` into `C:/Program Files/Git/pa` and `/v` into `V:/` and failed a
+# real release for a correctly signed installer. MSYS2_ARG_CONV_EXCL suppresses that.
+#
+# This box is Linux, where no such rewriting happens, so the argv assertion alone would
+# pass with or without the fix and protect nothing. The load-bearing assertion is the
+# second one: that signtool is invoked with the exclusion actually set. Remove the env
+# var and that fails here, on Linux, instead of on the next release.
+stub="$work/signtool-stub.sh"
+cat > "$stub" <<'STUB'
+#!/usr/bin/env bash
+printf 'argv:%s\n' "$*"
+printf 'excl:%s\n' "${MSYS2_ARG_CONV_EXCL:-<unset>}"
+STUB
+chmod +x "$stub"
+printf 'pe' > "$work/signed.exe"
+out="$( "$sscript" windows "$work/signed.exe" "$stub" 2>&1 )"
+case "$out" in
+  *"argv:verify /pa /v $work/signed.exe"*) ok "signtool receives verify /pa /v <exe>" ;;
+  *) bad "unexpected signtool argv: $out" ;;
+esac
+case "$out" in
+  *"excl:"*"/pa"*) ok "the /pa flag is excluded from MSYS path conversion" ;;
+  *) bad "MSYS2_ARG_CONV_EXCL does not cover /pa — Git bash will mangle it: $out" ;;
+esac
+case "$out" in
+  *"excl:"*"/v"*) ok "the /v flag is excluded from MSYS path conversion" ;;
+  *) bad "MSYS2_ARG_CONV_EXCL does not cover /v — Git bash will mangle it: $out" ;;
+esac
+
+# windows: a non-zero signtool exit is a hard failure — an unsigned artifact must never
+# reach the upload.
+failstub="$work/signtool-fail.sh"
+printf '#!/usr/bin/env bash\nexit 1\n' > "$failstub"
+chmod +x "$failstub"
+out="$( "$sscript" windows "$work/signed.exe" "$failstub" 2>&1 )"; rc=$?
+check "windows fails when signtool rejects the signature" "$rc" "1"
+case "$out" in
+  *"not"*"validly Authenticode-signed"*) ok "rejection explains the consequence" ;;
+  *) bad "signtool rejection error is unclear: $out" ;;
+esac
+
 # windows: with a real .exe present but no signtool resolvable, the signtool guard
 # fires (rather than a confusing failure deep in an invocation).
 printf 'pe' > "$work/present.exe"

--- a/scripts/verify-signed-artifact.sh
+++ b/scripts/verify-signed-artifact.sh
@@ -138,7 +138,25 @@ case "$mode" in
     # signtool verify /pa: validate under the default Authenticode policy a normal
     # machine uses — the signature chains to a trusted root and the RFC-3161
     # timestamp is valid. /v for a verbose chain in the log.
-    if ! "$signtool" verify /pa /v "$exe"; then
+    #
+    # MSYS2_ARG_CONV_EXCL is LOAD-BEARING, not a precaution. This runs under
+    # Git-for-Windows bash, whose MSYS2 runtime rewrites any argument that looks like
+    # a Unix absolute path before handing it to a native Windows binary. `/pa` became
+    # `C:/Program Files/Git/pa` and `/v` became `V:/`, so signtool tried to verify two
+    # nonexistent files AND — having lost `/pa` — fell back to the stricter default
+    # policy for the real one, which an Azure Trusted Signing certificate does not
+    # satisfy. The result was three errors and a failed release for a correctly signed
+    # installer:
+    #
+    #   SignTool Error: File not found: C:/Program Files/Git/pa
+    #   SignTool Error: File not found: V:/
+    #   SignTool Error: A certificate chain processed, but terminated in a root ...
+    #
+    # The variable is a semicolon-separated list of argument PREFIXES to leave alone,
+    # so the flags pass through literally while `$exe` is still converted normally.
+    # Do not replace it with MSYS_NO_PATHCONV=1, which would disable conversion for
+    # the path argument too.
+    if ! MSYS2_ARG_CONV_EXCL='/pa;/v' "$signtool" verify /pa /v "$exe"; then
       echo "::error::WS3: signtool verify /pa FAILED for ${exe} — the shipped installer is not"
       echo "::error::  validly Authenticode-signed. An unsigned artifact must not be published (#704)."
       exit 1


### PR DESCRIPTION
Closes #787.

The Authenticode gate ran for the first time on release run 31241184241 — #783 removed the two-build gate that had been failing earlier in the job and masking it — and it rejected a correctly signed installer:

```
SignTool Error: File not found: C:/Program Files/Git/pa
SignTool Error: File not found: V:/
SignTool Error: A certificate chain processed, but terminated in a root ...
```

Git-for-Windows bash rewrites Unix-looking arguments before calling a native binary, so `/pa` arrived as `C:/Program Files/Git/pa` and `/v` as `V:/`. signtool verified two nonexistent files and, having lost `/pa`, fell back to the stricter default policy for the real one — which an Azure Trusted Signing certificate does not satisfy.

`MSYS2_ARG_CONV_EXCL='/pa;/v'` leaves those two arguments alone while the path argument is still converted normally. Deliberately not `MSYS_NO_PATHCONV=1`, which would disable conversion for the path too.

### Testing

78 tests in `scripts/test-attest-helpers.sh` (was 73), gated by `scripts-check`.

This box is Linux, where no mangling happens, so an argv assertion alone would pass with or without the fix. The load-bearing test asserts signtool is invoked with the exclusion actually **set** — mutation-tested by reverting the fix, which fails exactly those two assertions (76/78) and passes again when restored. Also added a test that a signtool rejection is a hard failure, which nothing covered.

### Honest limit

`signtool` exists only on a Windows runner, so this is verified by a stubbed argv contract, not by a real signature check. The real proof is the next release run.