### PR TITLE
fix(build): make reproducibility recipe drift a CI failure, and complete the Linux recipe

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -480,9 +480,23 @@ jobs:
       # float on @stable, or the same commit can produce different bytes.
       - uses: dtolnay/rust-toolchain@1.96.0
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: .
+      # NO build cache on the Linux path, deliberately (#795).
+      #
+      # A restored `target/` lets cargo reuse artifacts compiled under earlier
+      # conditions, so the linked output stops being a pure function of the source.
+      # That is exactly what made v1.8.3 unreproducible: a warm-cache release and a
+      # cold-cache rebuild produced `.text` sections differing by 64 bytes, with every
+      # other input identical — same pinned rustc, same runner image, same RUSTFLAGS,
+      # codegen-units=1, lto=true.
+      #
+      # The asymmetry is not fixable by caching the reproducer too: a third party
+      # starts cold BY DEFINITION, so a build that only reproduces from our cache
+      # reproduces for nobody. Reproducible builds start from a clean tree — the same
+      # choice Debian, Tails and F-Droid make. The cost is a full cold compile per
+      # release, which is the price of the claim.
+      #
+      # macOS/Windows keep their caches: they are not bit-reproducible (no rebuilder
+      # asserts them), so paying cold-compile time there would buy nothing.
 
       - name: Install PipeWire build dependencies
         run: |
@@ -548,9 +562,14 @@ jobs:
       # float on @stable, or the same commit can produce different bytes.
       - uses: dtolnay/rust-toolchain@1.96.0
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: src-tauri
+      # NO build cache here, deliberately (#795). A restored `target/` lets cargo
+      # reuse artifacts compiled under earlier conditions, so the output stops being
+      # a pure function of the source — that is what made v1.8.3 unreproducible
+      # (`.text` differing by 64 bytes with every other input identical). It cannot
+      # be fixed by caching the reproducer too: a third party starts cold BY
+      # DEFINITION, so a build that reproduces only from our cache reproduces for
+      # nobody. macOS/Windows keep their caches — they are not bit-reproducible, so
+      # cold-compiling them would buy nothing.
 
       - name: Stamp version from git tag
         run: |

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -500,9 +500,25 @@ jobs:
       # would fail to compile the helper there. We hand the finished
       # binary to the app job via an artifact; the app job's build.rs
       # detects the pre-staged file and skips rebuilding.
+      # The SAME determinism inputs the app job applies (#795). This helper is
+      # embedded in the AppImage, so it is part of the reproducible payload — but it
+      # was being built with none of them, baking absolute runner paths (/home/runner,
+      # the cargo registry) into the binary. The rebuilder DOES apply them, so the two
+      # helpers could never match and no Linux rebuild could ever reproduce, whatever
+      # else was fixed. Confirmed by diffing a real rebuild against v1.8.3: exactly two
+      # files differed, and this was one of them.
+      - name: Configure reproducible build flags (capture helper)
+        run: |
+          set -euo pipefail
+          echo "SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)" >> "$GITHUB_ENV"
+          CARGO_HOME_DIR="${CARGO_HOME:-$HOME/.cargo}"
+          echo "RUSTFLAGS=--remap-path-prefix=${HOME}=/pollis-home --remap-path-prefix=${CARGO_HOME_DIR}=/pollis-cargo --remap-path-prefix=${GITHUB_WORKSPACE}=/pollis-src" >> "$GITHUB_ENV"
+
       - name: Build and stage screen-capture helper
         run: |
-          cargo build --release --target x86_64-unknown-linux-gnu -p pollis-capture-linux
+          # --locked matches the rebuilder and the app job: a drifted Cargo.lock fails
+          # rather than silently resolving different crate versions into the payload.
+          cargo build --release --locked --target x86_64-unknown-linux-gnu -p pollis-capture-linux
           mkdir -p src-tauri/binaries
           cp target/x86_64-unknown-linux-gnu/release/pollis-capture-linux \
              src-tauri/binaries/pollis-capture-linux-x86_64-unknown-linux-gnu

--- a/.github/workflows/rebuild-verify.yml
+++ b/.github/workflows/rebuild-verify.yml
@@ -477,6 +477,20 @@ jobs:
               if [ -d /tmp/xa/squashfs-root ] && [ -d /tmp/xb/squashfs-root ]; then
                 echo "--- differing files ---"
                 diff -rq /tmp/xa/squashfs-root /tmp/xb/squashfs-root 2>&1 | head -30
+
+                # diffoscope is the standard tool for exactly this question and names the
+                # cause where a hash comparison only says "different" — an embedded path,
+                # a build id, a differing debug section, reordered symbols. Installed only
+                # on the failure path so a passing run stays fast.
+                echo "--- diffoscope on the differing binaries ---"
+                sudo apt-get update -qq >/dev/null 2>&1
+                sudo apt-get install -y -qq diffoscope >/dev/null 2>&1
+                diff -rq /tmp/xa/squashfs-root /tmp/xb/squashfs-root 2>/dev/null \
+                  | sed -n 's/^Files \(.*\) and \(.*\) differ$/\1|\2/p' \
+                  | while IFS='|' read -r f1 f2; do
+                      echo "### $(basename "$f1")"
+                      diffoscope --max-report-size 40000 --text - "$f1" "$f2" 2>/dev/null | head -60
+                    done
               else
                 echo "extraction unavailable (no FUSE / not self-extracting here);"
                 echo "the byte offsets above are still the actionable signal."

--- a/.github/workflows/rebuild-verify.yml
+++ b/.github/workflows/rebuild-verify.yml
@@ -315,11 +315,20 @@ jobs:
           R2_PUBLIC_URL: ${{ vars.R2_PUBLIC_URL }}
           LIVEKIT_URL: ${{ vars.LIVEKIT_URL }}
           POLLIS_DELIVERY_URL: ${{ vars.POLLIS_DELIVERY_URL }}
+          # The signed relay directory's URL and its VERIFICATION key. Both are
+          # public by construction — the key is the public half, and the private
+          # half never leaves the minting script — so they belong in a published
+          # recipe rather than in secrets. They were baked into the release and
+          # omitted here, which is why no rebuild could match while the directory
+          # was live; scripts/check-build-recipe.py now fails CI on that drift.
+          POLLIS_OVERLAY_DIRECTORY_URL: ${{ vars.POLLIS_OVERLAY_DIRECTORY_URL }}
+          POLLIS_OVERLAY_DIRECTORY_KEY: ${{ vars.POLLIS_OVERLAY_DIRECTORY_KEY }}
         run: |
           set -euo pipefail
           for key in TURSO_URL TURSO_TOKEN LOG_DB_URL LOG_DB_TOKEN \
                      R2_S3_ENDPOINT R2_PUBLIC_URL LIVEKIT_URL \
-                     POLLIS_DELIVERY_URL; do
+                     POLLIS_DELIVERY_URL \
+                     POLLIS_OVERLAY_DIRECTORY_URL POLLIS_OVERLAY_DIRECTORY_KEY; do
             if [ -n "${!key}" ]; then
               echo "${key}=${!key}" >> "$GITHUB_ENV"
             fi

--- a/.github/workflows/rebuild-verify.yml
+++ b/.github/workflows/rebuild-verify.yml
@@ -347,11 +347,34 @@ jobs:
       # in the binary (tauri-utils codegen tokenizes create_updater_artifacts
       # as Default::default() unconditionally), and the AppImage itself is
       # bundled identically either way.
+      # Build with the SAME tauri config the release used, rather than asserting a
+      # config override is harmless (#795).
+      #
+      # The release sets createUpdaterArtifacts:true and signs the updater bundle with
+      # a Pollis secret a reproducer can never hold, so this used to pass
+      # `--config '{"bundle":{"createUpdaterArtifacts":false}}'` and rely on a comment
+      # claiming that cannot change the compiled bytes. That claim was never tested,
+      # and a real rebuild of v1.8.3 showed `usr/bin/pollis` differing — so it is
+      # exactly the kind of assumption worth deleting instead of defending.
+      #
+      # A throwaway minisign key removes the difference entirely: the config now
+      # matches the release, and the only thing the ephemeral key touches is the
+      # detached updater `.sig`, which is outside the reproducible unit
+      # (docs/reproducible-builds-residuals.md §1).
+      - name: Mint a throwaway updater signing key
+        run: |
+          set -euo pipefail
+          pnpm tauri signer generate -p "" -w /tmp/rebuild-updater.key
+          {
+            echo "TAURI_SIGNING_PRIVATE_KEY<<__EOF__"
+            cat /tmp/rebuild-updater.key
+            echo "__EOF__"
+          } >> "$GITHUB_ENV"
+          echo "TAURI_SIGNING_PRIVATE_KEY_PASSWORD=" >> "$GITHUB_ENV"
+
       - name: Rebuild Linux AppImage payload
         run: |
-          pnpm tauri build --target x86_64-unknown-linux-gnu \
-            --config '{"bundle":{"createUpdaterArtifacts":false}}' \
-            -- --locked
+          pnpm tauri build --target x86_64-unknown-linux-gnu -- --locked
 
       # Recompute payload_sha256 with the IDENTICAL method the release attest job
       # uses — scripts/lib/payload-hash.sh, sourced by both, so the reproducer

--- a/.github/workflows/rebuild-verify.yml
+++ b/.github/workflows/rebuild-verify.yml
@@ -385,6 +385,9 @@ jobs:
       # the hash we independently reproduced is present in the log as the Linux
       # AppImage payload for this tag. Absent/mismatched → loud failure.
       - name: Assert reproduced hash is the logged Linux payload
+        env:
+          # `gh release download` in the failure diagnostic needs a token; contents:read suffices.
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           HASH="${{ steps.rehash.outputs.hash }}"
@@ -406,5 +409,52 @@ jobs:
             echo "::error::from this source. Logged Linux payload hashes for the tag:"
             jq -r '.artifacts[] | select(.platform=="linux" and .layer=="payload")
                    | "  \(.bundle): \(.payload_sha256)"' release-report.json || true
+            echo "::error::"
+            echo "::error::A tag with NO logged linux payload above means the release is not"
+            echo "::error::in the transparency tree yet (it is built by the daily"
+            echo "::error::transparency-publish cron, not at release time) — that is a"
+            echo "::error::DIFFERENT condition from a byte divergence, so do not read it as one."
+
+            # Name the differing files rather than leaving a bare hash mismatch.
+            #
+            # "the hashes differ" is the least actionable possible output for the one
+            # tool whose entire job is telling a stranger whether our binary matches our
+            # source. Without this, every investigation starts by rebuilding locally and
+            # guessing. With it, the job says which paths diverged and by how much, which
+            # is usually enough to name the cause on sight (an embedded timestamp, a
+            # differing sidecar helper, a non-deterministic asset bundle).
+            echo "::group::What actually differs"
+            set +e
+            released_url="$(jq -r '.artifacts[]
+                                   | select(.platform=="linux" and .bundle=="appimage")
+                                   | .artifact_name' release-report.json | head -1)"
+            gh release download "${{ inputs.tag }}" --repo "$GITHUB_REPOSITORY" \
+               --pattern '*.AppImage' --dir /tmp/shipped 2>/dev/null
+            shipped="$(find /tmp/shipped -name '*.AppImage' | head -1)"
+            rebuilt="$(find target/x86_64-unknown-linux-gnu/release/bundle/appimage -name '*.AppImage' | head -1)"
+            if [ -n "$shipped" ] && [ -n "$rebuilt" ]; then
+              echo "shipped:  $shipped  ($(stat -c%s "$shipped") bytes)"
+              echo "rebuilt:  $rebuilt  ($(stat -c%s "$rebuilt") bytes)"
+              chmod +x "$shipped" "$rebuilt"
+              ( cd /tmp && mkdir -p a b )
+              ( cd /tmp/a && "$OLDPWD/$shipped" --appimage-extract >/dev/null 2>&1 || \
+                             "$shipped" --appimage-extract >/dev/null 2>&1 )
+              ( cd /tmp/b && "$rebuilt" --appimage-extract >/dev/null 2>&1 )
+              if [ -d /tmp/a/squashfs-root ] && [ -d /tmp/b/squashfs-root ]; then
+                diff -rq /tmp/a/squashfs-root /tmp/b/squashfs-root 2>&1 | head -40
+                echo "--- per-file sizes for differing paths ---"
+                diff -rq /tmp/a/squashfs-root /tmp/b/squashfs-root 2>/dev/null \
+                  | sed -n 's/^Files \(.*\) and \(.*\) differ$/\1 \2/p' \
+                  | while read -r f1 f2; do
+                      printf '  %10s vs %10s  %s\n' "$(stat -c%s "$f1")" "$(stat -c%s "$f2")" "${f1#/tmp/a/squashfs-root/}"
+                    done | head -30
+              else
+                echo "could not extract one or both AppImages for comparison"
+              fi
+            else
+              echo "shipped=${shipped:-<none>} rebuilt=${rebuilt:-<none>} — nothing to diff"
+            fi
+            set -e
+            echo "::endgroup::"
             exit 1
           fi

--- a/.github/workflows/rebuild-verify.yml
+++ b/.github/workflows/rebuild-verify.yml
@@ -425,31 +425,34 @@ jobs:
             # differing sidecar helper, a non-deterministic asset bundle).
             echo "::group::What actually differs"
             set +e
-            released_url="$(jq -r '.artifacts[]
-                                   | select(.platform=="linux" and .bundle=="appimage")
-                                   | .artifact_name' release-report.json | head -1)"
             gh release download "${{ inputs.tag }}" --repo "$GITHUB_REPOSITORY" \
                --pattern '*.AppImage' --dir /tmp/shipped 2>/dev/null
             shipped="$(find /tmp/shipped -name '*.AppImage' | head -1)"
-            rebuilt="$(find target/x86_64-unknown-linux-gnu/release/bundle/appimage -name '*.AppImage' | head -1)"
+            rebuilt="$(find "$GITHUB_WORKSPACE/target/x86_64-unknown-linux-gnu/release/bundle/appimage" -name '*.AppImage' | head -1)"
             if [ -n "$shipped" ] && [ -n "$rebuilt" ]; then
-              echo "shipped:  $shipped  ($(stat -c%s "$shipped") bytes)"
-              echo "rebuilt:  $rebuilt  ($(stat -c%s "$rebuilt") bytes)"
-              chmod +x "$shipped" "$rebuilt"
-              ( cd /tmp && mkdir -p a b )
-              ( cd /tmp/a && "$OLDPWD/$shipped" --appimage-extract >/dev/null 2>&1 || \
-                             "$shipped" --appimage-extract >/dev/null 2>&1 )
-              ( cd /tmp/b && "$rebuilt" --appimage-extract >/dev/null 2>&1 )
-              if [ -d /tmp/a/squashfs-root ] && [ -d /tmp/b/squashfs-root ]; then
-                diff -rq /tmp/a/squashfs-root /tmp/b/squashfs-root 2>&1 | head -40
-                echo "--- per-file sizes for differing paths ---"
-                diff -rq /tmp/a/squashfs-root /tmp/b/squashfs-root 2>/dev/null \
-                  | sed -n 's/^Files \(.*\) and \(.*\) differ$/\1 \2/p' \
-                  | while read -r f1 f2; do
-                      printf '  %10s vs %10s  %s\n' "$(stat -c%s "$f1")" "$(stat -c%s "$f2")" "${f1#/tmp/a/squashfs-root/}"
-                    done | head -30
+              echo "shipped: $(stat -c%s "$shipped") bytes  $shipped"
+              echo "rebuilt: $(stat -c%s "$rebuilt") bytes  $rebuilt"
+
+              # Byte-level first: identical sizes with a handful of differing bytes is a
+              # completely different diagnosis (an embedded stamp or build id) from a
+              # wholesale content change, and it costs one command to tell them apart.
+              ndiff="$(cmp -l "$shipped" "$rebuilt" 2>/dev/null | wc -l)"
+              echo "differing bytes: ${ndiff}"
+              echo "first differing offsets (byte, shipped-octal, rebuilt-octal):"
+              cmp -l "$shipped" "$rebuilt" 2>/dev/null | head -20
+
+              # Then the file-level view, so a differing byte can be attributed to a path.
+              mkdir -p /tmp/xa /tmp/xb
+              cp "$shipped" /tmp/xa/app.AppImage; cp "$rebuilt" /tmp/xb/app.AppImage
+              chmod +x /tmp/xa/app.AppImage /tmp/xb/app.AppImage
+              ( cd /tmp/xa && ./app.AppImage --appimage-extract >/dev/null 2>&1 )
+              ( cd /tmp/xb && ./app.AppImage --appimage-extract >/dev/null 2>&1 )
+              if [ -d /tmp/xa/squashfs-root ] && [ -d /tmp/xb/squashfs-root ]; then
+                echo "--- differing files ---"
+                diff -rq /tmp/xa/squashfs-root /tmp/xb/squashfs-root 2>&1 | head -30
               else
-                echo "could not extract one or both AppImages for comparison"
+                echo "extraction unavailable (no FUSE / not self-extracting here);"
+                echo "the byte offsets above are still the actionable signal."
               fi
             else
               echo "shipped=${shipped:-<none>} rebuilt=${rebuilt:-<none>} — nothing to diff"

--- a/.github/workflows/rebuild-verify.yml
+++ b/.github/workflows/rebuild-verify.yml
@@ -323,17 +323,12 @@ jobs:
           # was live; scripts/check-build-recipe.py now fails CI on that drift.
           POLLIS_OVERLAY_DIRECTORY_URL: ${{ vars.POLLIS_OVERLAY_DIRECTORY_URL }}
           POLLIS_OVERLAY_DIRECTORY_KEY: ${{ vars.POLLIS_OVERLAY_DIRECTORY_KEY }}
-          # TEMPORARY DIAGNOSTIC (#795) — do not merge. Isolates whether the baked
-          # LOG_DB_TOKEN is the remaining byte delta, without publishing it as a
-          # world-readable variable on a public repo.
-          LOG_DB_TOKEN: ${{ secrets.LOG_DB_TOKEN }}
         run: |
           set -euo pipefail
           for key in TURSO_URL TURSO_TOKEN LOG_DB_URL LOG_DB_TOKEN \
                      R2_S3_ENDPOINT R2_PUBLIC_URL LIVEKIT_URL \
                      POLLIS_DELIVERY_URL \
-                     POLLIS_OVERLAY_DIRECTORY_URL POLLIS_OVERLAY_DIRECTORY_KEY \
-                     LOG_DB_TOKEN; do
+                     POLLIS_OVERLAY_DIRECTORY_URL POLLIS_OVERLAY_DIRECTORY_KEY; do
             if [ -n "${!key}" ]; then
               echo "${key}=${!key}" >> "$GITHUB_ENV"
             fi

--- a/.github/workflows/rebuild-verify.yml
+++ b/.github/workflows/rebuild-verify.yml
@@ -323,12 +323,17 @@ jobs:
           # was live; scripts/check-build-recipe.py now fails CI on that drift.
           POLLIS_OVERLAY_DIRECTORY_URL: ${{ vars.POLLIS_OVERLAY_DIRECTORY_URL }}
           POLLIS_OVERLAY_DIRECTORY_KEY: ${{ vars.POLLIS_OVERLAY_DIRECTORY_KEY }}
+          # TEMPORARY DIAGNOSTIC (#795) — do not merge. Isolates whether the baked
+          # LOG_DB_TOKEN is the remaining byte delta, without publishing it as a
+          # world-readable variable on a public repo.
+          LOG_DB_TOKEN: ${{ secrets.LOG_DB_TOKEN }}
         run: |
           set -euo pipefail
           for key in TURSO_URL TURSO_TOKEN LOG_DB_URL LOG_DB_TOKEN \
                      R2_S3_ENDPOINT R2_PUBLIC_URL LIVEKIT_URL \
                      POLLIS_DELIVERY_URL \
-                     POLLIS_OVERLAY_DIRECTORY_URL POLLIS_OVERLAY_DIRECTORY_KEY; do
+                     POLLIS_OVERLAY_DIRECTORY_URL POLLIS_OVERLAY_DIRECTORY_KEY \
+                     LOG_DB_TOKEN; do
             if [ -n "${!key}" ]; then
               echo "${key}=${!key}" >> "$GITHUB_ENV"
             fi

--- a/.github/workflows/rebuild-verify.yml
+++ b/.github/workflows/rebuild-verify.yml
@@ -365,9 +365,13 @@ jobs:
         run: |
           set -euo pipefail
           pnpm tauri signer generate -p "" -w /tmp/rebuild-updater.key
+          # `echo "$key"`, not `cat`: the key file has no trailing newline, so cat runs
+          # the value straight into the heredoc delimiter and the env write fails with
+          # "Matching delimiter not found".
+          key="$(cat /tmp/rebuild-updater.key)"
           {
             echo "TAURI_SIGNING_PRIVATE_KEY<<__EOF__"
-            cat /tmp/rebuild-updater.key
+            echo "$key"
             echo "__EOF__"
           } >> "$GITHUB_ENV"
           echo "TAURI_SIGNING_PRIVATE_KEY_PASSWORD=" >> "$GITHUB_ENV"

--- a/.github/workflows/scripts-check.yml
+++ b/.github/workflows/scripts-check.yml
@@ -25,6 +25,11 @@ on:
       - "pollis-delivery/ds-config-manifest.json"
       - "pollis-delivery/src/**"
       - ".github/scripts/sync-ds-secrets.sh"
+      # Reproducibility recipe inputs: the release build, the rebuilder, and the
+      # client's option_env! surface must stay in agreement.
+      - ".github/workflows/desktop-release.yml"
+      - ".github/workflows/rebuild-verify.yml"
+      - "pollis-core/src/config.rs"
   push:
     branches: [main]
     paths:
@@ -35,6 +40,11 @@ on:
       - "pollis-delivery/ds-config-manifest.json"
       - "pollis-delivery/src/**"
       - ".github/scripts/sync-ds-secrets.sh"
+      # Reproducibility recipe inputs: the release build, the rebuilder, and the
+      # client's option_env! surface must stay in agreement.
+      - ".github/workflows/desktop-release.yml"
+      - ".github/workflows/rebuild-verify.yml"
+      - "pollis-core/src/config.rs"
 
 permissions:
   contents: read
@@ -59,6 +69,15 @@ jobs:
       # to any link, not just to scripts/.
       - name: DS config chain (#760)
         run: python3 ./scripts/check-ds-config-chain.py
+
+      # The reproducibility counterpart to the DS config-chain gate above. A value
+      # baked into the release but missing from the rebuilder's recipe makes
+      # independent Linux reproduction impossible, and the only symptom is a hash
+      # mismatch that reads like tampering. That is not hypothetical: it is why
+      # both of rebuild-verify.yml's runs failed while the docs described
+      # independent reproduction as a working, shipped property.
+      - name: Build recipe drift (reproducibility)
+        run: python3 ./scripts/check-build-recipe.py
 
       - name: Attest helper + payload-hash tests
         run: ./scripts/test-attest-helpers.sh

--- a/docs/reproducible-builds-residuals.md
+++ b/docs/reproducible-builds-residuals.md
@@ -218,6 +218,24 @@ These bytes are part of the reproducible payload, so a reproducer must bake the
 - Most are **non-secret by design** (public URLs, the RO token)
   and can be published as a build recipe; `rebuild-verify.yml` reads them from
   non-secret repository/environment `vars`.
+- **The recipe is now CI-enforced, because it silently drifted (#697 sweep).**
+  `POLLIS_OVERLAY_DIRECTORY_URL` and `POLLIS_OVERLAY_DIRECTORY_KEY` were added to the
+  Linux release build and never to the rebuilder's recipe, so from the moment the
+  relay directory went live no independent rebuild could match — and the only symptom
+  is a hash mismatch, which reads like tampering rather than like a missing input.
+  Both of `rebuild-verify.yml`'s runs failed on exactly this while these documents
+  described independent Linux reproduction as a working, shipped property.
+  `scripts/check-build-recipe.py` now fails CI whenever the three hand-maintained
+  lists disagree — `option_env!` in `config.rs`, the release job's exports, and the
+  rebuilder's recipe — so the gap cannot silently reopen. Both directory values are
+  public by construction (the key is the *verification* half; the private half never
+  leaves the minting script), so publishing them in the recipe costs nothing.
+- **Status, stated plainly:** independent Linux reproduction has **not yet been
+  demonstrated end to end**. The mechanism exists and the recipe is now complete and
+  enforced, but the recipe `vars` must be populated in the repository before a run can
+  succeed, and no green `rebuild-verify.yml` run exists to date. Until one does, treat
+  "the Linux payload is independently reproducible" as *implemented and unverified*
+  rather than *proven*.
 - **As of #506 (secrets-broker cutover, finishing #393) the client bakes no R2 or
   LiveKit credentials at all.** `R2_ACCESS_KEY_ID`, `R2_SECRET_KEY`, `R2_REGION`,
   `LIVEKIT_API_KEY`, and `LIVEKIT_API_SECRET` are no longer read anywhere in the

--- a/scripts/check-build-recipe.py
+++ b/scripts/check-build-recipe.py
@@ -107,6 +107,27 @@ def rebuild_env_mapping() -> set[str]:
     return set(re.findall(r"^\s+([A-Z_0-9]+):", m.group(1), re.M))
 
 
+# Jobs that produce the bit-reproducible Linux payload. Both must build cold.
+REPRODUCIBLE_JOBS = ("build-linux", "build-capture-helper")
+
+
+def cached_reproducible_jobs(text: str) -> list[str]:
+    """Reproducible-payload jobs that restore a build cache.
+
+    A restored `target/` lets cargo reuse artifacts compiled under earlier conditions,
+    so the output stops being a pure function of the source. This is what made v1.8.3
+    unreproducible, and it is invisible in a diff — the job still looks correct. It
+    cannot be fixed by caching the reproducer too: a third party starts cold by
+    definition, so a build that reproduces only from our cache reproduces for nobody.
+    """
+    hits = []
+    for job in REPRODUCIBLE_JOBS:
+        block = job_block(text, job)
+        if "Swatinem/rust-cache" in block or "actions/cache" in block:
+            hits.append(job)
+    return hits
+
+
 def main() -> int:
     client = baked_by_client()
     if not client:
@@ -131,6 +152,14 @@ def main() -> int:
             f"{REBUILD.name} passes {k}, which {CONFIG.name} never reads via option_env! — "
             f"it cannot affect the binary, so publishing it as part of the recipe misleads "
             f"anyone auditing the reproduction."
+        )
+
+    # No build cache on the reproducible path.
+    for job in cached_reproducible_jobs(RELEASE.read_text()):
+        fail(
+            f"the `{job}` release job restores a build cache — a reproducible payload must "
+            f"be built from a clean tree, or its bytes depend on our cache state and no "
+            f"third party (who always starts cold) can reproduce them. Remove the cache step."
         )
 
     # The step's own two lists must agree, or the recipe silently drops an entry.

--- a/scripts/check-build-recipe.py
+++ b/scripts/check-build-recipe.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""check-build-recipe.py — keep the reproducer's recipe equal to what the release bakes.
+
+A Linux release is only bit-reproducible by a third party if the rebuilder compiles with
+EXACTLY the values the release compiled with. Every one of those values reaches the binary
+through `option_env!` in `pollis-core/src/config.rs`, which means an environment variable
+present at release time and absent at rebuild time silently changes the bytes — and the
+rebuild fails with a hash mismatch that looks like tampering.
+
+That is not hypothetical. `POLLIS_OVERLAY_DIRECTORY_URL` and `POLLIS_OVERLAY_DIRECTORY_KEY`
+were added to the release build and never to the rebuilder's recipe, so no rebuild could
+have matched while the relay directory was live. Both of the rebuilder's runs failed on
+exactly this, and the docs went on describing independent Linux reproduction as a shipped,
+working property.
+
+Three lists have to agree, and all three are hand-maintained in different files:
+
+    1. `option_env!(...)` in pollis-core/src/config.rs    what the binary can absorb
+    2. the release build's exports in desktop-release.yml what a release actually bakes
+    3. the recipe list in rebuild-verify.yml              what a reproducer compiles with
+
+The invariant this enforces is (2) ⊆ (3) ⊆ (1):
+
+  * anything the RELEASE bakes must be in the rebuilder's recipe, or reproduction is
+    impossible — this is the failure above;
+  * anything in the recipe must actually be read by the client, or the recipe is
+    advertising an input that does nothing and misleads whoever audits it.
+
+Note (3) ⊄ (2) is fine and expected: the recipe may list a var the release leaves unset
+(e.g. an optional log-DB token), because the rebuilder skips unset vars so the compile sees
+`None` either way.
+
+Exit 0 = a third party given the published recipe compiles the same inputs we did.
+Exit 1 = a report of the drift.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+CONFIG = ROOT / "pollis-core" / "src" / "config.rs"
+RELEASE = ROOT / ".github" / "workflows" / "desktop-release.yml"
+REBUILD = ROOT / ".github" / "workflows" / "rebuild-verify.yml"
+
+# The reproducible unit is the Linux AppImage, so only that job's recipe matters.
+RELEASE_JOB = "build-linux"
+
+failures: list[str] = []
+
+
+def fail(msg: str) -> None:
+    failures.append(msg)
+
+
+def baked_by_client() -> set[str]:
+    """(1) Every env var the client absorbs at compile time."""
+    return set(re.findall(r'option_env!\("([A-Z_0-9]+)"\)', CONFIG.read_text()))
+
+
+def job_block(text: str, job: str) -> str:
+    """The YAML body of one job, from its header to the next top-level job."""
+    m = re.search(rf"^  {re.escape(job)}:$(.*?)(?=^  [a-z][a-z0-9_-]*:$)", text, re.S | re.M)
+    if not m:
+        fail(f"{RELEASE.name}: could not locate the `{job}` job to read its build recipe")
+        return ""
+    return m.group(1)
+
+
+def baked_by_release() -> set[str]:
+    """(2) What the Linux release job writes into the build environment.
+
+    Matches the `echo "KEY=${{ secrets.X }}" >> $GITHUB_ENV` form the release uses. Only
+    keys the client actually reads are relevant, so the caller intersects with (1) — this
+    job also exports plenty of things that never reach the binary (signing material,
+    toolchain paths).
+    """
+    block = job_block(RELEASE.read_text(), RELEASE_JOB)
+    return set(re.findall(r'echo\s+"([A-Z_0-9]+)=', block))
+
+
+def rebuild_recipe() -> set[str]:
+    """(3) The recipe the independent rebuilder compiles with.
+
+    Read from the `for key in ... ; do` loop rather than the `env:` mapping: the loop is
+    what actually reaches `$GITHUB_ENV`, and an entry present in one but not the other is
+    precisely the kind of drift this script exists to catch. Both are checked against each
+    other below.
+    """
+    text = REBUILD.read_text()
+    m = re.search(r"for key in ([A-Z_0-9\s\\]+?);\s*do", text)
+    if not m:
+        fail(f"{REBUILD.name}: could not find the `for key in ... ; do` recipe loop")
+        return set()
+    return set(m.group(1).replace("\\", " ").split())
+
+
+def rebuild_env_mapping() -> set[str]:
+    """The `env:` keys on the rebuilder's recipe step — must equal the loop."""
+    text = REBUILD.read_text()
+    m = re.search(r"- name: Load build recipe.*?\n\s+env:\n(.*?)\n\s+run:", text, re.S)
+    if not m:
+        fail(f"{REBUILD.name}: could not find the recipe step's `env:` block")
+        return set()
+    return set(re.findall(r"^\s+([A-Z_0-9]+):", m.group(1), re.M))
+
+
+def main() -> int:
+    client = baked_by_client()
+    if not client:
+        fail(f"{CONFIG.name}: found no `option_env!` keys at all — has the recipe moved?")
+
+    release = baked_by_release() & client
+    recipe = rebuild_recipe()
+    mapping = rebuild_env_mapping()
+
+    # (2) ⊆ (3) — the one that breaks reproduction.
+    for k in sorted(release - recipe):
+        fail(
+            f"{k} is baked into the {RELEASE_JOB} release build but is NOT in the rebuilder's "
+            f"recipe — an independent rebuild compiles without it and CANNOT reproduce the "
+            f"shipped bytes. Add it to both the `env:` block and the `for key in` loop in "
+            f"{REBUILD.name}, and publish its value as a repository variable."
+        )
+
+    # (3) ⊆ (1) — a recipe entry the client never reads is a misleading input.
+    for k in sorted(recipe - client):
+        fail(
+            f"{REBUILD.name} passes {k}, which {CONFIG.name} never reads via option_env! — "
+            f"it cannot affect the binary, so publishing it as part of the recipe misleads "
+            f"anyone auditing the reproduction."
+        )
+
+    # The step's own two lists must agree, or the recipe silently drops an entry.
+    for k in sorted(mapping - recipe):
+        fail(f"{REBUILD.name}: {k} is in the recipe step's `env:` but missing from the `for key in` loop — it is never exported")
+    for k in sorted(recipe - mapping):
+        fail(f"{REBUILD.name}: {k} is in the `for key in` loop but has no `env:` entry — it is always empty")
+
+    if failures:
+        print(
+            "BUILD RECIPE DRIFT — an independent rebuild of the Linux payload cannot "
+            "reproduce the shipped bytes:\n",
+            file=sys.stderr,
+        )
+        for f in failures:
+            print(f"  ✗ {f}", file=sys.stderr)
+        print(
+            f"\n{len(failures)} problem(s). See docs/reproducible-builds-residuals.md.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"Build recipe OK — {len(release)} value(s) baked by the release are all in the "
+        f"rebuilder's recipe ({len(recipe)} entries), and every recipe entry is read by the client."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Part of #795.

The reproducibility gap from the pre-deploy sweep turned out to be worse than "two missing variables". **The independent rebuilder has never once reproduced a build** — it has run twice, in July, and failed both times on the hash assertion, while the README, whitepaper and design doc all describe it as a shipped, working property.

## What was actually broken

`POLLIS_OVERLAY_DIRECTORY_URL` and `POLLIS_OVERLAY_DIRECTORY_KEY` are baked into the Linux release build via `option_env!` and were never added to the rebuilder's recipe. From the moment the relay directory went live, no independent rebuild could match — and the only symptom is a hash mismatch, which reads like *tampering* rather than like a missing input. That is the worst possible failure mode for a verifiability mechanism: it cries wolf.

## The fix

**`scripts/check-build-recipe.py`** enforces that three hand-maintained lists agree — `option_env!` in `config.rs`, the release job's exports, and the rebuilder's recipe loop — with the invariant (release ⊆ recipe ⊆ client). Anything the release bakes but the rebuilder omits makes reproduction impossible; anything in the recipe the client never reads misleads whoever audits it. It also cross-checks the recipe step's own `env:` block against its `for key in` loop, since an entry in one but not the other silently drops.

Same shape as `check-ds-config-chain.py` (#782), which exists because that class of multi-file drift already cost three PRs to notice once.

Run against `main` before the fix, it independently reproduced the exact finding:

```
✗ POLLIS_OVERLAY_DIRECTORY_KEY is baked into the build-linux release build but is NOT in
  the rebuilder's recipe — an independent rebuild compiles without it and CANNOT reproduce
  the shipped bytes.
✗ POLLIS_OVERLAY_DIRECTORY_URL ...
```

After adding both to `rebuild-verify.yml`: `Build recipe OK — 10 value(s) baked by the release are all in the rebuilder's recipe (10 entries)`. Mutation-tested by dropping an entry back out: 2 findings, then clean on restore.

Gated in `scripts-check.yml`, with path triggers extended so a change to `desktop-release.yml`, `rebuild-verify.yml` or `config.rs` runs it — the three files that can cause the drift.

## The honest status

`reproducible-builds-residuals.md` now says independent Linux reproduction is **implemented and unverified** rather than proven. The mechanism exists and the recipe is complete and enforced, but **the recipe variables do not exist in the repository** — `gh variable list` returns only `VPS_HOST` and `VPS_USER` — so every `vars.*` resolves empty and the rebuild compiles with none of the recipe. That is cause #2 and it needs values I cannot read from secrets; the list is in #795.

This PR makes the gap impossible to reopen and stops the docs overclaiming. It does not by itself produce a green rebuild — that needs the variables set, and then one run against a recent tag.