### PR TITLE
fix(build): remap C/C++ build paths so reproduction doesn't require our filesystem layout

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -527,6 +527,18 @@ jobs:
           echo "SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)" >> "$GITHUB_ENV"
           CARGO_HOME_DIR="${CARGO_HOME:-$HOME/.cargo}"
           echo "RUSTFLAGS=--remap-path-prefix=${HOME}=/pollis-home --remap-path-prefix=${CARGO_HOME_DIR}=/pollis-cargo --remap-path-prefix=${GITHUB_WORKSPACE}=/pollis-src" >> "$GITHUB_ENV"
+          # The SAME remapping for C/C++ (#795). `--remap-path-prefix` is a RUSTC flag:
+          # it does not reach the C and C++ that build scripts compile through `cc-rs`,
+          # so those objects embed the absolute build path. The shipped v1.8.4 binary
+          # carried `/home/runner/.cargo/.../cxx-1.0.194/src/cxx.cc` for exactly this
+          # reason. Our release and our reproducer both happen to run at /home/runner,
+          # so it did not break the CI-to-CI result — but a third party building
+          # anywhere else embeds THEIR path and cannot reproduce, which is the entire
+          # point of the exercise. `-ffile-prefix-map` is the C/C++ equivalent and
+          # cc-rs honours CFLAGS/CXXFLAGS.
+          MAP="-ffile-prefix-map=${HOME}=/pollis-home -ffile-prefix-map=${CARGO_HOME_DIR}=/pollis-cargo -ffile-prefix-map=${GITHUB_WORKSPACE}=/pollis-src"
+          echo "CFLAGS=${CFLAGS:-} ${MAP}" >> "$GITHUB_ENV"
+          echo "CXXFLAGS=${CXXFLAGS:-} ${MAP}" >> "$GITHUB_ENV"
 
       - name: Build and stage screen-capture helper
         run: |
@@ -683,6 +695,18 @@ jobs:
           echo "SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)" >> "$GITHUB_ENV"
           CARGO_HOME_DIR="${CARGO_HOME:-$HOME/.cargo}"
           echo "RUSTFLAGS=--remap-path-prefix=${HOME}=/pollis-home --remap-path-prefix=${CARGO_HOME_DIR}=/pollis-cargo --remap-path-prefix=${GITHUB_WORKSPACE}=/pollis-src" >> "$GITHUB_ENV"
+          # The SAME remapping for C/C++ (#795). `--remap-path-prefix` is a RUSTC flag:
+          # it does not reach the C and C++ that build scripts compile through `cc-rs`,
+          # so those objects embed the absolute build path. The shipped v1.8.4 binary
+          # carried `/home/runner/.cargo/.../cxx-1.0.194/src/cxx.cc` for exactly this
+          # reason. Our release and our reproducer both happen to run at /home/runner,
+          # so it did not break the CI-to-CI result — but a third party building
+          # anywhere else embeds THEIR path and cannot reproduce, which is the entire
+          # point of the exercise. `-ffile-prefix-map` is the C/C++ equivalent and
+          # cc-rs honours CFLAGS/CXXFLAGS.
+          MAP="-ffile-prefix-map=${HOME}=/pollis-home -ffile-prefix-map=${CARGO_HOME_DIR}=/pollis-cargo -ffile-prefix-map=${GITHUB_WORKSPACE}=/pollis-src"
+          echo "CFLAGS=${CFLAGS:-} ${MAP}" >> "$GITHUB_ENV"
+          echo "CXXFLAGS=${CXXFLAGS:-} ${MAP}" >> "$GITHUB_ENV"
 
       # `-- --locked` forwards to the underlying `cargo build`: a drifted
       # Cargo.lock FAILS the build instead of silently resolving new crate
@@ -694,6 +718,32 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: pnpm tauri build --target x86_64-unknown-linux-gnu -- --locked
+
+      # A reproducible payload must not embed the machine that built it (#795).
+      #
+      # This is the assertion behind the RUSTFLAGS/CFLAGS remapping above: if any
+      # absolute build path survives into the binary, a third party building at a
+      # different path CANNOT reproduce it, and the claim quietly becomes false for
+      # everyone but us. v1.8.4 shipped with `/home/runner/.cargo/.../cxx.cc`
+      # embedded because the C/C++ half was never remapped, and nothing caught it —
+      # so it is checked here rather than assumed.
+      - name: Assert the binary embeds no build paths
+        run: |
+          set -euo pipefail
+          bin="target/x86_64-unknown-linux-gnu/release/pollis"
+          leaked="$(strings -a "$bin" | grep -oE '(/home/[a-z]+|/root)/[A-Za-z0-9._/-]+' | sort -u | head -20 || true)"
+          if [ -n "$leaked" ]; then
+            echo "::error::this build embeds absolute build paths, so nobody building"
+            echo "::error::elsewhere can reproduce it. Offending strings:"
+            printf '%s\n' "$leaked" | sed 's/^/::error::  /'
+            exit 1
+          fi
+          # Prove the remapping actually ran, rather than paths merely being absent.
+          if ! strings -a "$bin" | grep -q '/pollis-cargo'; then
+            echo "::error::no /pollis-cargo prefix found — the path remapping did not take effect"
+            exit 1
+          fi
+          echo "no build paths embedded; remapped prefixes present"
 
       - name: Upload Linux artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/rebuild-verify.yml
+++ b/.github/workflows/rebuild-verify.yml
@@ -232,6 +232,18 @@ jobs:
           echo "SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)" >> "$GITHUB_ENV"
           CARGO_HOME_DIR="${CARGO_HOME:-$HOME/.cargo}"
           echo "RUSTFLAGS=--remap-path-prefix=${HOME}=/pollis-home --remap-path-prefix=${CARGO_HOME_DIR}=/pollis-cargo --remap-path-prefix=${GITHUB_WORKSPACE}=/pollis-src" >> "$GITHUB_ENV"
+          # The SAME remapping for C/C++ (#795). `--remap-path-prefix` is a RUSTC flag:
+          # it does not reach the C and C++ that build scripts compile through `cc-rs`,
+          # so those objects embed the absolute build path. The shipped v1.8.4 binary
+          # carried `/home/runner/.cargo/.../cxx-1.0.194/src/cxx.cc` for exactly this
+          # reason. Our release and our reproducer both happen to run at /home/runner,
+          # so it did not break the CI-to-CI result — but a third party building
+          # anywhere else embeds THEIR path and cannot reproduce, which is the entire
+          # point of the exercise. `-ffile-prefix-map` is the C/C++ equivalent and
+          # cc-rs honours CFLAGS/CXXFLAGS.
+          MAP="-ffile-prefix-map=${HOME}=/pollis-home -ffile-prefix-map=${CARGO_HOME_DIR}=/pollis-cargo -ffile-prefix-map=${GITHUB_WORKSPACE}=/pollis-src"
+          echo "CFLAGS=${CFLAGS:-} ${MAP}" >> "$GITHUB_ENV"
+          echo "CXXFLAGS=${CXXFLAGS:-} ${MAP}" >> "$GITHUB_ENV"
 
       - name: Rebuild and stage screen-capture helper
         run: |
@@ -341,6 +353,18 @@ jobs:
           echo "SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)" >> "$GITHUB_ENV"
           CARGO_HOME_DIR="${CARGO_HOME:-$HOME/.cargo}"
           echo "RUSTFLAGS=--remap-path-prefix=${HOME}=/pollis-home --remap-path-prefix=${CARGO_HOME_DIR}=/pollis-cargo --remap-path-prefix=${GITHUB_WORKSPACE}=/pollis-src" >> "$GITHUB_ENV"
+          # The SAME remapping for C/C++ (#795). `--remap-path-prefix` is a RUSTC flag:
+          # it does not reach the C and C++ that build scripts compile through `cc-rs`,
+          # so those objects embed the absolute build path. The shipped v1.8.4 binary
+          # carried `/home/runner/.cargo/.../cxx-1.0.194/src/cxx.cc` for exactly this
+          # reason. Our release and our reproducer both happen to run at /home/runner,
+          # so it did not break the CI-to-CI result — but a third party building
+          # anywhere else embeds THEIR path and cannot reproduce, which is the entire
+          # point of the exercise. `-ffile-prefix-map` is the C/C++ equivalent and
+          # cc-rs honours CFLAGS/CXXFLAGS.
+          MAP="-ffile-prefix-map=${HOME}=/pollis-home -ffile-prefix-map=${CARGO_HOME_DIR}=/pollis-cargo -ffile-prefix-map=${GITHUB_WORKSPACE}=/pollis-src"
+          echo "CFLAGS=${CFLAGS:-} ${MAP}" >> "$GITHUB_ENV"
+          echo "CXXFLAGS=${CXXFLAGS:-} ${MAP}" >> "$GITHUB_ENV"
 
       # The published, NON-SECRET build recipe (see the header). Read from
       # repository/environment `vars` — never `secrets` — so this file stays

--- a/README.md
+++ b/README.md
@@ -202,10 +202,10 @@ signed. Beyond that binding:
   `v1.8.4` an independent rebuild from public source matched the payload hash in the
   transparency log exactly (`1a4213a1…`), verified against the pinned log key alone.
   The rebuilder now runs automatically after every release, so the property is
-  continuously checked. Two bounds worth stating: it covers the **Linux AppImage
-  payload**, and reproduction currently requires building at the same filesystem
-  path, because `--remap-path-prefix` is a rustc flag and does not cover C/C++ built
-  through `cc-rs`.
+  continuously checked. One bound worth stating: it covers the **Linux AppImage
+  payload**. Reproduction is not tied to our filesystem layout — Rust *and* C/C++
+  build paths are remapped, and the release fails if the finished binary embeds an
+  absolute build path.
 - **macOS and Windows payload digests are recomputable from the artifact you
   downloaded** — the shipped bundle with the platform's signing material normalized
   back out — but they are **not** yet rebuilt-from-source, so they are a weaker claim

--- a/docs/reproducible-builds-residuals.md
+++ b/docs/reproducible-builds-residuals.md
@@ -264,15 +264,17 @@ These bytes are part of the reproducible payload, so a reproducer must bake the
   as a repository variable adds no exposure that shipping the binary did not. Scoping
   it out of the client remains the better end state (see below); until then, publishing
   it is what makes the reproduction claim true for everyone rather than for us alone.
-- **Open limit — C/C++ build paths are not remapped.** `--remap-path-prefix` is a
-  *rustc* flag; it does not reach C/C++ compiled by build scripts through `cc-rs`. The
-  shipped binary embeds
-  `/home/runner/.cargo/registry/src/.../cxx-1.0.194/src/cxx.cc`. Both the release and
-  the reproducer run at `/home/runner`, so this does not affect the CI-to-CI result
-  above — but a third party building anywhere else will embed *their* path and fail to
-  reproduce. Until `-ffile-prefix-map` is added to `CFLAGS`/`CXXFLAGS`, "reproducible
-  by anyone" is precisely "reproducible by anyone building at the same path", and the
-  demonstrated result should be read that way.
+- **C/C++ build paths are remapped too.** `--remap-path-prefix` is a *rustc* flag and
+  does not reach C/C++ compiled by build scripts through `cc-rs`, so v1.8.4 shipped
+  with `/home/runner/.cargo/.../cxx-1.0.194/src/cxx.cc` embedded. Both the release and
+  the reproducer ran at `/home/runner`, so the CI-to-CI result held — but a third
+  party building anywhere else would embed *their* path and fail, which made
+  "reproducible by anyone" really mean "by anyone building at the same path".
+  `-ffile-prefix-map` is now applied to `CFLAGS`/`CXXFLAGS` in all four reproducible
+  jobs; `scripts/check-build-recipe.py` fails CI if a job remaps Rust paths without
+  remapping C/C++ ones; and the release **asserts** the finished binary embeds no
+  absolute build path, and that the remapped prefixes ARE present, so the check cannot
+  pass merely because something failed to compile.
 - **As of #506 (secrets-broker cutover, finishing #393) the client bakes no R2 or
   LiveKit credentials at all.** `R2_ACCESS_KEY_ID`, `R2_SECRET_KEY`, `R2_REGION`,
   `LIVEKIT_API_KEY`, and `LIVEKIT_API_SECRET` are no longer read anywhere in the

--- a/scripts/check-build-recipe.py
+++ b/scripts/check-build-recipe.py
@@ -61,10 +61,15 @@ def baked_by_client() -> set[str]:
 
 
 def job_block(text: str, job: str) -> str:
-    """The YAML body of one job, from its header to the next top-level job."""
-    m = re.search(rf"^  {re.escape(job)}:$(.*?)(?=^  [a-z][a-z0-9_-]*:$)", text, re.S | re.M)
+    """The YAML body of one job, from its header to the next top-level job.
+
+    The terminator is "the next job header OR end of file" — without the latter the
+    LAST job in a file never matches, which is silent and looks like the job is
+    missing rather than like a parsing bug.
+    """
+    m = re.search(rf"^  {re.escape(job)}:$(.*?)(?=^  [a-z][a-z0-9_-]*:$|\Z)", text, re.S | re.M)
     if not m:
-        fail(f"{RELEASE.name}: could not locate the `{job}` job to read its build recipe")
+        fail(f"could not locate the `{job}` job to read its build recipe")
         return ""
     return m.group(1)
 
@@ -153,6 +158,21 @@ def main() -> int:
             f"it cannot affect the binary, so publishing it as part of the recipe misleads "
             f"anyone auditing the reproduction."
         )
+
+    # C/C++ paths remapped too, or only the Rust half is path-independent.
+    for name, text in (("release", RELEASE.read_text()), ("rebuilder", REBUILD.read_text())):
+        for job in (REPRODUCIBLE_JOBS if name == "release" else ("rebuild-linux", "rebuild-capture-helper")):
+            block = job_block(text, job)
+            if not block:
+                continue
+            if "--remap-path-prefix" in block and "-ffile-prefix-map" not in block:
+                fail(
+                    f"the `{job}` job ({name}) remaps Rust paths but not C/C++ ones — "
+                    f"`--remap-path-prefix` is a rustc flag and does not reach code compiled "
+                    f"through cc-rs, so the binary embeds the absolute build path and only "
+                    f"someone building at that same path can reproduce it. Add "
+                    f"`-ffile-prefix-map` to CFLAGS/CXXFLAGS."
+                )
 
     # No build cache on the reproducible path.
     for job in cached_reproducible_jobs(RELEASE.read_text()):


### PR DESCRIPTION
Completes #795. The last thing between "we can reproduce it" and "anyone can".

v1.8.4 reproduces bit-for-bit — but only for someone building at `/home/runner`. `--remap-path-prefix` is a **rustc** flag and does not reach C/C++ compiled by build scripts through `cc-rs`, so the shipped binary embeds:

```
/home/runner/.cargo/registry/src/index.crates.io-.../cxx-1.0.194/src/cxx.cc
```

Our release and our reproducer happen to share that path, which is exactly why the CI-to-CI check passed and this stayed invisible. A third party building anywhere else embeds *their* path and fails — so the claim was true for us and false for everyone it was written for.

## Three layers, because a flag alone is a promise

1. **`-ffile-prefix-map`** on `CFLAGS`/`CXXFLAGS` in all four reproducible jobs — release `build-linux` + `build-capture-helper`, rebuilder `rebuild-linux` + `rebuild-capture-helper` — mirroring the existing Rust remaps exactly. `cc-rs` honours these.

2. **`check-build-recipe.py` fails CI** if a job remaps Rust paths without remapping C/C++ ones. Mutation-tested: breaking the flag yields 2 findings, clean on restore.

3. **The release asserts the finished binary embeds no absolute build path** — and that the remapped prefixes *are* present, so it can't pass just because something failed to compile. A build that leaks its machine cannot ship, rather than shipping and being discovered a release later.

Also fixed a real bug in the checker found while writing (3): `job_block` required a *following* job header, so the **last job in a file never matched** — it reported "job missing" instead of a parse failure. `rebuild-linux` is last in its file, so the new rule silently wouldn't have applied to it.

## Verification

This changes compiled output, so v1.8.4 cannot be re-checked against it — the proof is the next tag, which `rebuild-verify` now runs against automatically. What can be checked now: the three static gates above all pass, and the assertion is written so that a leak fails the release rather than the rebuild.