### PR TITLE
feat(website): publish each download's SHA-256 next to the download button

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -115,6 +115,29 @@
           <span class="download-detail">Arch Linux: <a href="https://aur.archlinux.org/packages/pollis" class="aur-link" target="_blank" rel="noopener noreferrer">AUR</a></span>
         </div>
       </div>
+
+      <!-- Every release's hash is already public in the transparency log; this puts
+           it next to the download so checking is one command, not a research task. -->
+      <section class="verify-downloads" aria-labelledby="verify-downloads-heading">
+        <h3 class="verify-heading" id="verify-downloads-heading">
+          Check what you downloaded
+          <span class="verify-tag" data-verify-tag></span>
+        </h3>
+        <p class="verify-intro">
+          Pollis publishes the SHA-256 of every release into a public, append-only
+          transparency log. Hash the file you just downloaded and compare it with the
+          value below — if they match, you have exactly the bytes Pollis published,
+          and not a copy someone altered in transit or on a mirror.
+        </p>
+        <ul class="verify-list" data-verify-list>
+          <li class="verify-note">Loading published hashes…</li>
+        </ul>
+        <p class="verify-foot">
+          This compares bytes, not intent. For the full picture — inclusion proofs
+          against the signed log, and whether a build reproduces from source —
+          see <a href="/artifacts">artifacts</a>.
+        </p>
+      </section>
     </section>
 
       <div class="install-block">
@@ -253,6 +276,7 @@
     }
   </script>
   <script src="script.js"></script>
+  <script type="module" src="verify-downloads.js"></script>
 </body>
 
 </html>

--- a/website/styles.css
+++ b/website/styles.css
@@ -397,3 +397,143 @@ footer {
     grid-template-columns: 1fr;
   }
 }
+/* ── Download verification (#801) ──────────────────────────────────────────
+   Deliberately quieter than the download cards: this is for the person who
+   wants it, and it must not compete with the primary action or read as a
+   warning. Same 1px border / 8px radius / single accent as the rest of the
+   page — no new visual language for a subordinate block. */
+.verify-downloads {
+  margin-top: 2.5rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--c-border);
+}
+
+.verify-heading {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--c-text);
+  margin: 0 0 0.5rem;
+}
+
+/* The version these hashes belong to. Empty until resolved, so the heading never
+   claims a version the list has not actually been filled from. */
+.verify-tag {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.8rem;
+  font-weight: 400;
+  color: var(--c-accent);
+}
+
+.verify-intro,
+.verify-foot {
+  font-size: 0.85rem;
+  line-height: 1.6;
+  color: var(--c-text-muted);
+  margin: 0 0 1rem;
+  max-width: 62ch;
+}
+
+.verify-foot {
+  margin: 1rem 0 0;
+}
+
+.verify-intro a,
+.verify-foot a,
+.verify-note a {
+  color: var(--c-accent);
+}
+
+.verify-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.verify-row {
+  border: 1px solid var(--c-border);
+  border-radius: 8px;
+  padding: 0.75rem 0.9rem;
+}
+
+.verify-row-top {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.verify-plat {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--c-text);
+  white-space: nowrap;
+}
+
+/* The exact command to run, so nobody has to know their platform's spelling of
+   "hash this file". */
+.verify-cmd {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.75rem;
+  color: var(--c-text-muted);
+  text-align: right;
+  overflow-wrap: anywhere;
+}
+
+.verify-row-hash {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+/* Full 64 chars, wrapping rather than truncated: a hash you cannot see in full is
+   a hash you cannot compare, and truncation is where a near-miss hides. */
+.verify-hash {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.78rem;
+  line-height: 1.5;
+  color: var(--c-text);
+  overflow-wrap: anywhere;
+  flex: 1;
+  user-select: all;
+}
+
+.verify-copy {
+  flex-shrink: 0;
+  font: inherit;
+  font-size: 0.75rem;
+  padding: 0.25rem 0.6rem;
+  border: 1px solid var(--c-border);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--c-text-muted);
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.verify-copy:hover {
+  border-color: var(--c-accent);
+  color: var(--c-accent);
+}
+
+.verify-note {
+  font-size: 0.85rem;
+  color: var(--c-text-muted);
+}
+
+@media (max-width: 560px) {
+  .verify-row-top {
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .verify-cmd {
+    text-align: left;
+  }
+}

--- a/website/verify-downloads.js
+++ b/website/verify-downloads.js
@@ -1,0 +1,152 @@
+// Publish the hash of every download, next to the download (#801).
+//
+// A transparency log nobody consults proves nothing. The proof already existed —
+// every released artifact's SHA-256 is in the public binaries tree — but reaching
+// it meant knowing the log exists, finding /artifacts, and reading a proof UI. So
+// in practice the people the guarantee is FOR never used it.
+//
+// This puts the published hash where the download button is, with the exact command
+// for the platform, so checking is: run one line, compare two strings.
+//
+// WHAT IT PROVES, precisely: that the bytes you downloaded are the bytes Pollis
+// published and logged for this version. It is not a signature check and it does not
+// prove the build matches source (that is /artifacts and the reproducible-build
+// work). Understating it here is deliberate — the page must not imply more than a
+// hash comparison can carry.
+//
+// NO in-browser verification, matching artifacts.js: the browser fetches published
+// values and DISPLAYS them. Every remote value is escaped before it reaches HTML.
+
+const VERIFY_BASE = "https://verify.pollis.com";
+const CDN_BASE = "https://cdn.pollis.com";
+
+// Which log leaf corresponds to the file a person actually downloads.
+//
+// For the signed platforms that is the `signed` layer — the .dmg / .exe as shipped,
+// signature included. For Linux the shipped bytes ARE the payload (the Tauri
+// signature is detached), so `payload` is the same file. Picking the wrong layer
+// here would show a hash that never matches what a user computes, which is worse
+// than showing nothing.
+const ROWS = [
+  { label: "macOS", platform: "darwin", bundle: "dmg", layer: "signed", file: "pollis-latest-macos.dmg", cmd: (f) => `shasum -a 256 ${f}` },
+  { label: "Windows", platform: "windows", bundle: "nsis", layer: "signed", file: "pollis-latest-windows.exe", cmd: (f) => `Get-FileHash ${f}` },
+  { label: "Linux · AppImage", platform: "linux", bundle: "appimage", layer: "payload", file: "pollis-latest-linux.AppImage", cmd: (f) => `sha256sum ${f}` },
+  { label: "Linux · .deb", platform: "linux", bundle: "deb", layer: "payload", file: "pollis-latest-linux.deb", cmd: (f) => `sha256sum ${f}` },
+  { label: "Linux · .rpm", platform: "linux", bundle: "rpm", layer: "payload", file: "pollis-latest-linux.rpm", cmd: (f) => `sha256sum ${f}` },
+];
+
+function esc(s) {
+  return String(s).replace(/[&<>"']/g, (c) =>
+    ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]),
+  );
+}
+
+async function fetchJSON(url) {
+  const res = await fetch(url, { cache: "no-store" });
+  if (!res.ok) {
+    throw new Error(`${url}: HTTP ${res.status}`);
+  }
+  return res.json();
+}
+
+// Log entries arrive as hex-encoded JSON records; decode the ones we can and skip
+// anything unparseable rather than failing the whole render.
+function decodeEntries(doc) {
+  const raw = Array.isArray(doc) ? doc : doc.entries || [];
+  const out = [];
+  for (const e of raw) {
+    if (!e || typeof e.data !== "string") {
+      continue;
+    }
+    try {
+      const bytes = e.data.match(/.{2}/g).map((h) => parseInt(h, 16));
+      out.push(JSON.parse(new TextDecoder().decode(new Uint8Array(bytes))));
+    } catch {
+      // A record we cannot read is not a record we should guess at.
+    }
+  }
+  return out;
+}
+
+function render(container, tag, byKey) {
+  const rows = ROWS.map((r) => {
+    const hash = byKey.get(`${r.platform}|${r.bundle}|${r.layer}`);
+    if (!hash) {
+      return "";
+    }
+    return `
+      <li class="verify-row">
+        <div class="verify-row-top">
+          <span class="verify-plat">${esc(r.label)}</span>
+          <code class="verify-cmd">${esc(r.cmd(r.file))}</code>
+        </div>
+        <div class="verify-row-hash">
+          <code class="verify-hash">${esc(hash)}</code>
+          <button type="button" class="verify-copy" data-hash="${esc(hash)}"
+                  aria-label="Copy the SHA-256 for ${esc(r.label)}">Copy</button>
+        </div>
+      </li>`;
+  }).join("");
+
+  if (!rows.trim()) {
+    container.innerHTML =
+      `<li class="verify-note">Published hashes for ${esc(tag)} are not in the log yet. ` +
+      `They appear shortly after each release.</li>`;
+    return;
+  }
+  container.innerHTML = rows;
+}
+
+async function init() {
+  const list = document.querySelector("[data-verify-list]");
+  const tagEl = document.querySelector("[data-verify-tag]");
+  if (!list) {
+    return;
+  }
+
+  try {
+    // Key off the version the download links actually serve, NOT the newest tag in
+    // the log. Those can differ for a few minutes around a release, and showing a
+    // hash for a build nobody can download yet would look like a mismatch — the one
+    // impression this feature must never create.
+    const latest = await fetchJSON(`${CDN_BASE}/releases/latest.json`);
+    const tag = latest.version;
+    if (tagEl && tag) {
+      tagEl.textContent = tag;
+    }
+
+    const entries = decodeEntries(await fetchJSON(`${VERIFY_BASE}/v1/binaries/entries.json`));
+    const byKey = new Map();
+    for (const r of entries) {
+      if (r.release_tag === tag && r.artifact_sha256) {
+        byKey.set(`${r.platform}|${r.bundle}|${r.layer}`, r.artifact_sha256);
+      }
+    }
+    render(list, tag, byKey);
+  } catch {
+    // Degrade to silence, never to a scary state: a failed fetch here says nothing
+    // about the integrity of anyone's download, and must not imply that it does.
+    list.innerHTML =
+      `<li class="verify-note">Published hashes are temporarily unavailable. ` +
+      `They can also be read from the <a href="/artifacts">artifacts page</a>.</li>`;
+  }
+
+  list.addEventListener("click", async (ev) => {
+    const btn = ev.target.closest(".verify-copy");
+    if (!btn) {
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(btn.dataset.hash);
+      const was = btn.textContent;
+      btn.textContent = "Copied";
+      setTimeout(() => {
+        btn.textContent = was;
+      }, 1200);
+    } catch {
+      // Clipboard denied — the hash is selectable on the page regardless.
+    }
+  });
+}
+
+init();


### PR DESCRIPTION
Closes #801.

Every released artifact's SHA-256 was already public in the binaries transparency log — but reaching it meant knowing the log exists, finding `/artifacts`, and reading a proof UI. The guarantee existed and the people it was for couldn't use it.

Now it sits directly under the download cards: the published hash, the exact command for that platform, and a copy button.

```
macOS              shasum -a 256 pollis-latest-macos.dmg
9b37a585ef23d417f8c8454e…                              [Copy]

Windows            Get-FileHash pollis-latest-windows.exe
c098d4978e227836c98d8550…                              [Copy]
```

Five rows — macOS, Windows, AppImage, .deb, .rpm — matching the download options exactly.

## Verified against reality, not assumed

Picking the wrong log *layer* would show a hash that never matches what a user computes, which reads as an attack. So I downloaded the real artifacts and hashed them:

```
Windows installer, downloaded : c098d4978e227836c98d8550417bbca027e3ffa730432f432b074bfd7ff8b82b
logged `signed` layer         : c098d4978e227836c98d8550417bbca027e3ffa730432f432b074bfd7ff8b82b

Linux AppImage, downloaded    : 1a4213a162521a3bf9b3d60f34060222c64a47a083a47700e34efa0b6ead26d5
logged `payload` layer        : 1a4213a162521a3bf9b3d60f34060222c64a47a083a47700e34efa0b6ead26d5
```

Signed platforms use the `signed` layer (the .dmg/.exe as shipped, signature included); Linux uses `payload`, because the Tauri signature is detached so the shipped bytes *are* the payload. All five rows resolve against the live endpoints.

## Two design decisions worth stating

**It keys off `latest.json`, not the newest tag in the log.** Those differ for a few minutes around a release, and showing a hash for a build nobody can download yet would look like a mismatch — the one impression this feature must never create. If the log hasn't caught up it says so plainly.

**The copy understates what a hash proves.** It says these are the bytes Pollis published for this version — not that the build reproduces from source, and not a signature check. Those are `/artifacts`, which it links to. A verification affordance that overclaims is worse than none.

## Failure behaviour

A failed fetch degrades to a muted line pointing at `/artifacts`, never to an alarming state — a dead endpoint says nothing about the integrity of anyone's download and must not imply that it does. All remote values are escaped; there is no in-browser verification, matching `artifacts.js`.

Visually subordinate to the download cards by design — same 1px border, 8px radius and single accent as the rest of the page, no new visual language for a secondary block. Full 64-char hashes rather than truncated, since a truncated hash is where a near-miss hides.

**Note:** the site is a manual Pages deploy, so this needs `website-deploy.yml` running after merge.