### PR TITLE
ci: stop running the 31-minute MLS gate for PRs that cannot touch Rust

### DIFF
--- a/.github/workflows/mls-tests.yml
+++ b/.github/workflows/mls-tests.yml
@@ -84,14 +84,37 @@ jobs:
               - '!website/**'
               - '!docs/**'
               - '!**/*.md'
+              # Surfaces that cannot change Rust behaviour. Before these were listed,
+              # a workflow-or-docs-only PR paid the full ~31-minute integration gate:
+              # five such PRs in one day cost ~2.5 hours of CI for changes that could
+              # not affect a single test.
+              - '!.github/**'
+              - '!scripts/**'
+              - '!.codesight/**'
+              - '!infra/**'
+              - '!learn/**'
+              - '!specs/**'
+              - '!e2e/**'
+            # ...but this workflow DEFINES the gate, so editing it must still run it.
+            # Exempting `.github/**` wholesale would let a change to the harness skip
+            # the very suite it configures — the one edit that most needs proving.
+            harness:
+              - '.github/workflows/mls-tests.yml'
       - name: Decide whether the heavy Rust gate must run
         id: decide
         env:
           EVENT: ${{ github.event_name }}
           FILTERED: ${{ steps.filter.outputs.rust }}
+          HARNESS: ${{ steps.filter.outputs.harness }}
         run: |
           if [ "$EVENT" = "pull_request" ]; then
-            echo "run_tests=$FILTERED" >> "$GITHUB_OUTPUT"
+            # Either a real Rust change, or an edit to this workflow itself.
+            if [ "$FILTERED" = "true" ] || [ "$HARNESS" = "true" ]; then
+              echo "run_tests=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "run_tests=false" >> "$GITHUB_OUTPUT"
+            fi
+            echo "rust=$FILTERED harness=$HARNESS"
           else
             # workflow_dispatch / schedule / any non-PR trigger: always run the
             # full gate (the marathon step keys off event_name inside the job).


### PR DESCRIPTION
The MLS integration gate takes **~31 minutes** and is the entire CI cost of a PR — every other workflow rounds to zero. It was being skipped only for `frontend/`, `website/`, `docs/` and `*.md` changes.

So a PR touching only workflows, `scripts/`, or the wiki paid the full 31 minutes for a change that cannot affect a single Rust test. **Five such PRs merged today — roughly 2.5 hours of CI for nothing.**

Measured, not assumed. For PR #800 (workflows + scripts + docs):

```
Frontend check          wall=0m
Scripts check           wall=0m
Supply Chain            wall=0m
MLS & delivery tests    wall=31m      <- the whole cost
```

And inside that job, `MLS integration flows harness` is 1473s of the 1860s; the ~90 flows tests are `#[serial]` because they share one Turso database.

## Change

Exempts the surfaces that cannot change Rust behaviour: `.github/**`, `scripts/**`, `.codesight/**`, `infra/**`, `learn/**`, `specs/**`, `e2e/**`.

**With one deliberate exception.** `.github/workflows/mls-tests.yml` *defines* this gate, so a blanket `.github/**` exemption would let a change to the harness skip the very suite it configures — the one edit that most needs proving. A second `harness` filter brings it back, and `run_tests` is `rust || harness`.

## Verified against real PRs before shipping

```
PR #800  run_tests=False  (workflows + scripts + docs)
PR #799  run_tests=False  (docs only)
PR #796  run_tests=False  (workflows + scripts + docs)
PR #794  run_tests=True   <- pollis-core/src/commands/device_enrollment.rs
PR #791  run_tests=True   <- src-tauri/gen/schemas/...
PR #785  run_tests=True   <- Cargo.lock, pollis-delivery/Cargo.toml
```

No false negatives on anything that touches Rust, `Cargo.lock`, or the test suite itself. `gate` still reports green on pass-or-exempt, so the merge-blocking check is unchanged.

## Not done here, and why

The obvious next win is **sharding the flows suite** — 24.5 serial minutes across parallel jobs. It needs a database per shard, because the tests share one Turso and `wipe()` between them, so it is a real change rather than a config tweak. Worth doing separately.

Splitting the ~4 minutes of unit tests into a parallel job was considered and rejected: a second job pays ~2.5 minutes of its own setup, so the net saving is about a minute and it doubles cache pressure.