### PR TITLE
fix(website): wrap the pinned log key instead of letting it overflow its card

### DIFF
--- a/website/artifacts.html
+++ b/website/artifacts.html
@@ -260,10 +260,16 @@
     }
 
     /* ── Copy chip ────────────────────────────────────────────── */
+    /* The pinned ML-DSA-44 key is shown in full: ~2624 hex chars with no space
+       or hyphen to break on. `anywhere` (not `break-word`) is required — it is
+       the only value that also shrinks the chip's min-content width, so the
+       chip stops forcing its flex parent wider than the card. */
     .art-copy {
       display: inline-flex;
       align-items: center;
       gap: 0.35rem;
+      overflow-wrap: anywhere;
+      text-align: left;
       font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', monospace;
       font-size: inherit;
       color: var(--c-text);


### PR DESCRIPTION
On /artifacts, under "The one key you trust", the pinned ML-DSA-44 public key ran off the right edge of its card and off the page.

The key is ~2624 hex characters with no space or hyphen to break on, and the chip is a flex item whose default `min-width: auto` makes its minimum size its min-content width — the whole unbroken string. `overflow-wrap: anywhere` is the fix: it is the only value that also reduces min-content width, so `break-word` would not have worked here. `text-align: left` stops the UA's button centering from raggedly centering the wrapped block.

Measured with a headless Firefox harness against the real CSS and the real key:

| | chip width | card inner width | overflow |
|---|---|---|---|
| before | 21404px | 742px | **20662px** |
| after | 742px | 742px | **0** |

No ancestor was defeating the wrap — `body { overflow-x: hidden }` was only hiding the runaway. The sibling full-length values (`.art-meta`, `.art-tree-detail`, and everything on transparency.html) already set `word-break: break-all` and were left alone; the table SHA-256s are rendered through `shortHash()`.