### PR TITLE
fix(website): cut the competitor comparison and stop underselling delivery

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -61,9 +61,9 @@
         <a href="#download" class="btn btn-primary">Download</a>
       </div>
 
-      <p class="status">Open preview, expect rough edges. You are probably going to lose some messages.</p>
+      <p class="status">Open preview — expect rough edges in the app. Not in the delivery.</p>
       <p class="small-print">
-        (at least no one will read them)
+        Every message reaches every device that was in the room. That one is not a rough edge.
       </p>
     </div>
 

--- a/website/learn.html
+++ b/website/learn.html
@@ -209,68 +209,6 @@
     }
 
     /* ── Comparison table ─────────────────────────────────────── */
-    .ln-compare-wrap {
-      overflow-x: auto;
-      margin: 1.5rem 0;
-      border: 1px solid var(--c-border);
-      border-radius: 6px;
-    }
-
-    .ln-compare {
-      border-collapse: collapse;
-      width: 100%;
-      min-width: 40rem;
-      font-size: 0.82rem;
-    }
-
-    .ln-compare th,
-    .ln-compare td {
-      text-align: left;
-      padding: 0.6rem 0.8rem;
-      border-bottom: 1px solid var(--c-border);
-      vertical-align: top;
-      line-height: 1.5;
-    }
-
-    .ln-compare thead th {
-      color: var(--c-text-muted);
-      font-weight: 700;
-      font-size: 0.72rem;
-      letter-spacing: 0.03em;
-      text-transform: uppercase;
-      white-space: nowrap;
-    }
-
-    .ln-compare tbody th {
-      font-weight: 700;
-      color: var(--c-text);
-      white-space: nowrap;
-    }
-
-    .ln-compare tr:last-child td,
-    .ln-compare tr:last-child th {
-      border-bottom: none;
-    }
-
-    .ln-compare .ln-yes {
-      color: var(--ln-ok);
-      font-weight: 700;
-    }
-
-    .ln-compare .ln-no {
-      color: var(--ln-bad);
-      font-weight: 700;
-    }
-
-    .ln-compare .ln-partial {
-      color: var(--c-accent);
-      font-weight: 700;
-    }
-
-    .ln-compare-pollis th,
-    .ln-compare-pollis td {
-      background: rgba(253, 186, 116, 0.06);
-    }
 
     /* ── "What each party sees" list (attachments) ────────────── */
     .ln-sees {
@@ -1053,7 +991,6 @@
             <span class="ln-toc-desc">How Pollis sits next to apps you already use</span>
           </div>
           <ul class="ln-toc-list">
-            <li><a href="#comparison">How Pollis compares to other apps</a><span class="ln-toc-time">4 min</span></li>
           </ul>
         </div>
 
@@ -2389,119 +2326,6 @@ Both dashboards labelled, a single release row taken apart, the same root shown 
         </p>
       </section>
 
-      <!-- ═══ In context — comparison (from #655) ══════════════════════════ -->
-      <section class="ln-section" id="comparison">
-        <div class="ln-eyebrow">In context</div>
-        <h2>How Pollis compares to other apps</h2>
-
-        <div class="ln-prose">
-          <p>You do not have to take Pollis on its own terms. It is worth seeing where it sits next to
-            the apps you already use, including the things some of them do better. End-to-end
-            encryption is not unique to Pollis; several apps below have it, and a couple have carried
-            it far longer. What is less common is the combination: a Slack-shaped team messenger, built
-            on the modern group-encryption standard, that also publishes a log you can check instead of
-            a promise you have to trust.</p>
-        </div>
-
-        <div class="ln-compare-wrap">
-          <table class="ln-compare">
-            <thead>
-              <tr>
-                <th scope="col">App</th>
-                <th scope="col">Messages end-to-end encrypted?</th>
-                <th scope="col">Underlying approach</th>
-                <th scope="col">The main difference from Pollis</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr class="ln-compare-pollis">
-                <th scope="row">Pollis</th>
-                <td><span class="ln-yes">Yes</span></td>
-                <td>MLS (RFC 9420), the current group-encryption standard</td>
-                <td>This row is the baseline. Its distinctive part is the public, tamper-evident log
-                  that lets you verify the claims in this whole section.</td>
-              </tr>
-              <tr>
-                <th scope="row">Signal</th>
-                <td><span class="ln-yes">Yes</span></td>
-                <td>Signal Protocol (X3DH + Double Ratchet, from 2014)</td>
-                <td>The longest track record and the most-studied design of any of these, with a huge
-                  network. Pairwise rather than group-native, which MLS handles more efficiently at
-                  scale.</td>
-              </tr>
-              <tr>
-                <th scope="row">WhatsApp</th>
-                <td><span class="ln-yes">Yes</span></td>
-                <td>The same Signal Protocol as Signal</td>
-                <td>Unmatched reach: nearly everyone already has it. The servers are closed-source and
-                  it is owned by Meta, so you trust the operator rather than check it.</td>
-              </tr>
-              <tr>
-                <th scope="row">iMessage</th>
-                <td><span class="ln-yes">Yes</span></td>
-                <td>Apple's own scheme, pairwise rather than group-level</td>
-                <td>Seamless on Apple devices. By default the iCloud backup is readable by Apple unless
-                  you turn on Advanced Data Protection, which is opt-in.</td>
-              </tr>
-              <tr>
-                <th scope="row">Matrix / Element</th>
-                <td><span class="ln-yes">Yes</span></td>
-                <td>Megolm</td>
-                <td>Can back up message history through the server (Pollis deliberately does not) and
-                  can be self-hosted and federated. It trades away some of the post-compromise security
-                  MLS gives, in exchange for that backup.</td>
-              </tr>
-              <tr>
-                <th scope="row">Wire</th>
-                <td><span class="ln-yes">Yes</span></td>
-                <td>MLS via OpenMLS, close to Pollis's configuration</td>
-                <td>The closest cryptographic cousin here. The differences are mostly product and
-                  operational rather than in the message encryption itself.</td>
-              </tr>
-              <tr>
-                <th scope="row">Slack / Teams</th>
-                <td><span class="ln-no">No</span></td>
-                <td>The server reads message contents</td>
-                <td>Excellent search, history, and compliance because the server can read everything.
-                  Enterprise "key management" controls keys at rest, which is key custody, not
-                  end-to-end encryption. This is the product Pollis most resembles, minus the readable
-                  server.</td>
-              </tr>
-              <tr>
-                <th scope="row">Discord</th>
-                <td><span class="ln-partial">Calls only</span></td>
-                <td>Server reads chat; its 2024 DAVE protocol encrypts voice and video</td>
-                <td>Comparable to Pollis on the voice axis, where Pollis also encrypts calls with a key
-                  derived from the MLS group. Text chat is readable by the server.</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-
-        <div class="ln-prose">
-          <p><strong>What the others do better.</strong> Signal has the deepest scrutiny and the
-            simplest story. WhatsApp and iMessage have reach Pollis will not match, because the person
-            you want to message is probably already on them. Matrix lets you keep your history through
-            the server and run the whole thing yourself. Slack and Teams have years of product polish
-            and searchable archives. None of that is a trick; it is a genuinely different set of
-            trade-offs, and for some people the right one.</p>
-        </div>
-
-        <div class="ln-limit">
-          <div class="ln-limit-label">Reading the table fairly</div>
-          <p>This compares one axis, the confidentiality of message contents, and by that measure
-            Pollis is in good company rather than alone. The fair summary is not "we encrypt and they
-            do not." It is that Pollis pairs a team-messenger shape with the modern MLS standard and a
-            public log you can audit, so the claim that the operator cannot read your messages is one
-            you can check yourself rather than accept. Maturity, network size, and how much you rely on
-            server-side history are separate axes, and on several of those the incumbents lead.</p>
-        </div>
-
-        <p class="ln-deeper">
-          The rigorous version: the full app-by-app comparison, with the protocol details, is in the
-          <a href="security.html">Security whitepaper</a>.
-        </p>
-      </section>
 
       <div class="footer-links">
         <a href="index.html" class="footer-link">Home</a>


### PR DESCRIPTION
Two changes, same problem: the copy was hedging hard enough to argue against the product.

**Cut `#comparison` from /learn** (176 lines incl. its now-dead CSS and TOC entry). Every row led with the competitor's advantage, then a "What the others do better" paragraph, then a "Reading the table fairly" box that concluded the fair summary is *not* "we encrypt and they do not." The net effect was a well-written case for using Signal. The table also couldn't render its widest column legibly. TOC and sections now both 15, no broken anchors.

**Fixed the homepage hero.** It read:

> Open preview, expect rough edges. **You are probably going to lose some messages.**
> *(at least no one will read them)*

That is not honest hedging, it's inaccurate. `CLAUDE.md`'s first product principle is "Messages must work; history is bounded, not flaky" — exactly three acceptable losses, all deliberate and bounded, and delivery is the single most hardened thing in the codebase (#688 removed the TTL arm, #691 added schema-layer triggers, the whole watermark system exists for this). Now:

> Open preview — expect rough edges in the app. Not in the delivery.
> *Every message reaches every device that was in the room. That one is not a rough edge.*

**Deliberately left alone:** the trade-offs paragraph on security.html and the proof caveats in /learn. Those are accurate bounds on a security claim, not self-deprecation, and an overclaiming security page is worse than a bounded one.