### PR TITLE
fix(livekit): raise the nginx connection ceiling and retire downpage.xyz

### DIFF
--- a/livekit/DEPLOY.md
+++ b/livekit/DEPLOY.md
@@ -28,7 +28,7 @@ the delivery/watchtower containers by network alias.
 livekit/
   docker-compose.yml   # livekit + nginx only (delivery/watchtower owned by #407)
   livekit.yml          # non-secret; deploy appends the keys: block from secrets
-  nginx.conf           # full ingress: rtc, downpage (LiveKit) + api, api-dev, deploy (delivery)
+  nginx.conf           # LiveKit ingress only: rtc.pollis.com -> livekit:7880
   DEPLOY.md
 ```
 
@@ -37,7 +37,6 @@ livekit/
 | Hostname | Upstream | Cert |
 |----------|----------|------|
 | `rtc.pollis.com` | `livekit:7880` | Let's Encrypt |
-| `downpage.xyz` | `livekit:7880` (legacy) | Let's Encrypt |
 | `api.pollis.com` | `delivery:8788` | Cloudflare Origin (`/etc/ssl/cloudflare/verify.pollis.com.*`) |
 | `api-dev.pollis.com` | `delivery-dev:8788` | Cloudflare Origin |
 | `deploy.pollis.com` | `watchtower:8080` | Cloudflare Origin |
@@ -76,10 +75,10 @@ Note: if the host (e.g. Hostinger) has a control-panel firewall, open the same
 ports there too — it overrides UFW.
 
 ### 2. Certs
-- **Let's Encrypt** (`rtc.pollis.com`, `downpage.xyz`) via host certbot:
+- **Let's Encrypt** (`rtc.pollis.com`) via host certbot:
   ```bash
   apt install certbot -y
-  certbot certonly --standalone -d rtc.pollis.com -d downpage.xyz
+  certbot certonly --standalone -d rtc.pollis.com
   ```
   Auto-renews via a systemd timer; nginx must reload to pick up renewals:
   ```bash

--- a/livekit/docker-compose.yml
+++ b/livekit/docker-compose.yml
@@ -1,8 +1,8 @@
 # LiveKit + nginx ingress stack for the Pollis VPS.
 #
 # Scope: this compose manages `livekit` and the `nginx` ingress in front of it.
-# nginx now serves ONLY the LiveKit endpoints (rtc.pollis.com / downpage.xyz →
-# livekit:7880). The Delivery Service moved to Cloudflare Containers (#515), so the
+# nginx serves ONLY LiveKit, on the single domain rtc.pollis.com -> livekit:7880.
+# (downpage.xyz was a legacy alias for the same upstream and is retired.) The Delivery Service moved to Cloudflare Containers (#515), so the
 # old `delivery` / `delivery-dev` / `watchtower` containers no longer run on this
 # VPS and were removed from nginx.conf — a dangling upstream fails `nginx -t` and
 # blocks the whole deploy. api(-dev).pollis.com now resolve to Cloudflare directly.
@@ -36,7 +36,7 @@ services:
       - "443:443"
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
-      # Let's Encrypt — rtc.pollis.com + downpage.xyz (LiveKit endpoints).
+      # Let's Encrypt — rtc.pollis.com (the only LiveKit endpoint).
       - /etc/letsencrypt:/etc/letsencrypt:ro
       # Cloudflare Origin cert — api / api-dev / deploy .pollis.com (delivery + watchtower).
       - /etc/ssl/cloudflare:/etc/ssl/cloudflare:ro

--- a/livekit/nginx.conf
+++ b/livekit/nginx.conf
@@ -1,4 +1,29 @@
-events {}
+# LiveKit ingress. Sole domain: rtc.pollis.com.
+
+# One worker per core. Left unset, nginx runs a SINGLE worker regardless of how
+# many cores the box has — which is what it was doing in production.
+worker_processes auto;
+
+# Raise the per-worker fd ceiling above worker_connections, or the connection
+# limit below is silently capped by the default 1024 open files.
+worker_rlimit_nofile 65535;
+
+events {
+    # THE CEILING THAT BIT US. Unset, nginx falls back to its compiled default of
+    # 512 — and as a reverse proxy every client costs TWO slots (one downstream,
+    # one to the upstream), so the real limit was ~256 concurrent connections.
+    #
+    # Pollis opens a persistent WebRTC session per group, per DM, plus an inbox —
+    # roughly a dozen per signed-in user — so that ceiling was reached at about
+    # TWENTY concurrent users, on a box that was 87% idle at the time.
+    #
+    # Measured 2026-08-11 with `lk load-test` against prod: 50 subscribers → 1
+    # failure, 150 → 0, 300 → 46, 1000 → 746, 1500 → 1246. CPU never rose above
+    # 13% because rejected connections cost nothing, which makes this failure mode
+    # look like healthy headroom on every dashboard.
+    worker_connections 8192;
+    multi_accept on;
+}
 
 http {
     map $http_upgrade $connection_upgrade {
@@ -6,14 +31,14 @@ http {
         "" close;
     }
 
-    # HTTP -> HTTPS for the LiveKit names served here.
+    # HTTP -> HTTPS.
     server {
         listen 80;
-        server_name rtc.pollis.com downpage.xyz;
+        server_name rtc.pollis.com;
         return 301 https://$host$request_uri;
     }
 
-    # LiveKit (canonical endpoint)
+    # LiveKit — the only endpoint this ingress serves.
     server {
         listen 443 ssl;
         server_name rtc.pollis.com;
@@ -32,25 +57,10 @@ http {
         }
     }
 
-    # LiveKit legacy endpoint — kept for already-shipped clients during transition
-    server {
-        listen 443 ssl;
-        server_name downpage.xyz;
-
-        ssl_certificate /etc/letsencrypt/live/downpage.xyz/fullchain.pem;
-        ssl_certificate_key /etc/letsencrypt/live/downpage.xyz/privkey.pem;
-
-        location / {
-            proxy_pass http://livekit:7880;
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection $connection_upgrade;
-            proxy_set_header Host $host;
-            proxy_read_timeout 3600s;
-            proxy_send_timeout 3600s;
-        }
-    }
-
+    # NOTE: downpage.xyz was a legacy alias for this same LiveKit upstream and is
+    # retired — rtc.pollis.com is the sole LiveKit domain. Its certbot entry should
+    # be dropped from the renewal list too (see DEPLOY.md).
+    #
     # NOTE: api.pollis.com / api-dev.pollis.com / deploy.pollis.com used to be
     # proxied here to the standalone `delivery` / `delivery-dev` / `watchtower`
     # containers (#407). The Delivery Service moved to Cloudflare Containers


### PR DESCRIPTION
The LiveKit ingress was refusing roughly three quarters of connections while the box sat at 87% idle.

`nginx.conf` opened with a bare `events {}` and never set `worker_processes`. nginx therefore ran a **single worker** (confirmed on the live container) with its compiled default of **512 `worker_connections`**. As a reverse proxy every client costs two slots — one downstream, one upstream — so the real ceiling was **~256 concurrent connections**.

Pollis opens a persistent WebRTC session per group, per DM, plus an inbox — about a dozen per signed-in user — so that ceiling landed at roughly **twenty concurrent users**.

Measured against prod with `lk load-test` (idle subscribers, no media):

| subscribers | failures | CPU busy |
|---|---|---|
| 50 | 1 | 3% |
| 150 | 0 | 6% |
| 300 | 46 | 13% |
| 1000 | 746 | 12% |
| 1500 | 1246 | 11% |

Failures start exactly where 256 is crossed, and **CPU stops climbing** past it because rejected connections cost nothing — which is why this looked like healthy headroom rather than a wall. Errors were `context deadline exceeded` on `GET /rtc/validate`: nginx accepting TCP, then never servicing it.

**Fix:** `worker_processes auto`, `worker_connections 8192`, `multi_accept on`, and `worker_rlimit_nofile 65535` (container hard limit is 1048576, verified, so this is safe).

**Also retires `downpage.xyz`** — a legacy alias pointing at the same LiveKit upstream, already labelled "(legacy)" in DEPLOY.md. `rtc.pollis.com` is now the sole domain, across nginx.conf, DEPLOY.md and docker-compose.yml. Its certbot entry should be dropped from the renewal list on the box; DEPLOY.md's `certbot certonly` line is updated accordingly. While in DEPLOY.md, removed the `api` / `api-dev` ingress rows that #515 already deleted from nginx.conf.

Validated with `nginx -t` against the pinned `nginx:1.29-alpine` digest before pushing.