### PR TITLE
fix(livekit-deploy): stop docker compose exec from swallowing the rest of the deploy script

### DIFF
--- a/.github/workflows/livekit-deploy.yml
+++ b/.github/workflows/livekit-deploy.yml
@@ -112,13 +112,34 @@ jobs:
 
             # nginx.conf may have changed without the service def changing (bind
             # mount, content-only) — validate then reload to pick it up gracefully.
-            docker compose exec -T nginx nginx -t
-            docker compose exec -T nginx nginx -s reload
+            #
+            # `< /dev/null` ON EVERY `exec -T` IS LOAD-BEARING, NOT TIDINESS.
+            # This script is fed to ssh on stdin via the heredoc below, and
+            # `docker compose exec -T` forwards ITS stdin to the container — so
+            # without the redirect it consumes the rest of this script. Every line
+            # after the first `exec -T` was silently skipped, and because the
+            # swallowed lines never ran, the step still exited 0 and the deploy
+            # reported success. Symptom: nginx.conf and livekit.yml changes appeared
+            # to deploy but never took effect (verified 2026-08-11 — the containers'
+            # StartedAt was 8h older than a "successful" deploy).
+            docker compose exec -T nginx nginx -t < /dev/null
+
+            # `nginx -s reload` is the graceful path, but in the official image nginx
+            # runs as PID 1 with `daemon off`; SIGHUP via the container is the
+            # reliable equivalent and needs no pidfile lookup. Workers respawn with
+            # the new worker_processes / worker_connections; existing connections drain.
+            docker kill -s HUP livekit-nginx-1
 
             # livekit reads its config only at start — restart to apply livekit.yml.
-            docker compose restart livekit
+            docker compose restart livekit < /dev/null
 
-            docker compose ps
+            # Prove the reload actually happened: fresh workers, and the effective
+            # connection ceiling. A deploy that cannot show this has not applied.
+            echo "--- nginx workers after reload ---"
+            docker compose exec -T nginx ps -o pid,etime,args < /dev/null 2>/dev/null | grep -E "master|worker" || true
+            docker compose exec -T nginx nginx -T < /dev/null 2>/dev/null | grep -E "worker_processes|worker_connections" || true
+
+            docker compose ps < /dev/null
           REMOTE
 
       - name: Validate — LiveKit up


### PR DESCRIPTION
`livekit-deploy.yml` has been reporting success while silently skipping most of its own work.

The remote script is piped to `ssh` on stdin via a heredoc. `docker compose exec -T` forwards **its** stdin to the container — so the first `exec -T` consumed the remainder of the script. Everything after it never ran, and because the swallowed lines never executed, nothing failed and the step exited 0.

Skipped on every deploy since:

- `docker compose exec -T nginx nginx -s reload` — **nginx.conf changes never took effect**
- `docker compose restart livekit` — **livekit.yml changes never took effect**
- `docker compose ps`

Verified on the box rather than inferred. After a "successful" deploy at `19:12:52Z`:

```
/livekit-livekit-1 started=2026-08-11T11:18:09Z
/livekit-nginx-1   started=2026-08-11T11:18:03Z
```

Eight hours older than the deploy. The step's log ends 20 ms after `nginx -t`, with no output from the reload or the restart — both produce output when they run.

This is why #817's connection-ceiling fix appeared to deploy but left the old 512-connection workers serving; the workers only respawned after a manual SIGHUP.

**Fix:** `< /dev/null` on every `exec -T` (and on `restart`/`ps` for the same reason), with a comment explaining why it is load-bearing so nobody tidies it away.

**Also:** swapped `nginx -s reload` for `docker kill -s HUP livekit-nginx-1`. In the official image nginx runs as PID 1 with `daemon off`; SIGHUP to the container is the reliable reload and needs no pidfile lookup.

**Also:** the deploy now prints worker ages and the effective `worker_processes` / `worker_connections` after reloading. A deploy that cannot show fresh workers has not applied its config, and that should be visible in the log instead of requiring someone to SSH in and compare timestamps.

`scripts/check-workflows.py` passes.

> Note: `livekit.yml` carries the TURN settings (`tls_port: 5349`, `relay_range 30000-30100`). Any past change to those was never applied to the running server — worth re-checking against intent once this lands.