### PR TITLE
fix(livekit): dial the server the DS minted the token for

### DIFF
--- a/.codesight/wiki/secrets-broker.md
+++ b/.codesight/wiki/secrets-broker.md
@@ -29,6 +29,15 @@ answers, like OTP with no Resend key).
 | `POST /v1/turso/token` | Mints a short-TTL **read-only** Turso token via the Platform API | `TURSO_PLATFORM_TOKEN`, `TURSO_ORG`, `TURSO_DB` |
 | `POST /v1/r2/presign` | SigV4 query-string presigned URL (GET/PUT/DELETE), path-style, `UNSIGNED-PAYLOAD`, `host`-only signed header | `R2_ENDPOINT`, `R2_BUCKET`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY` (`R2_REGION` defaults `auto`) |
 
+**The `/v1/livekit/token` response is `{token, url}`, and the URL is authoritative.**
+A LiveKit JWT is only accepted by the server that issued it, so the two travel
+together. Clients used to destructure the response as `(token, _url)` at six call
+sites and dial the compiled-in `config.livekit_url` instead — which baked the SFU
+address into every shipped binary and made relocating or regionalising the SFU a
+client-release problem. `ds_livekit_token` now resolves the precedence centrally
+(`resolve_livekit_url`: DS wins, config is the self-host fallback for a DS with no
+`LIVEKIT_URL`), so no call site can reintroduce it by ignoring a field.
+
 **Client cutover: DONE for every embeddable secret (#393).** `pollis-core` holds
 no LiveKit or R2 secret:
 - **R2** — `commands/r2.rs`'s `presign_r2` presigns every get/put/delete via the DS.

--- a/mobile/lib/realtime/client.ts
+++ b/mobile/lib/realtime/client.ts
@@ -58,9 +58,12 @@ function ensureGlobals(registerGlobals: () => void): void {
  * DS to mint it. Returns `null` on any failure so the caller can treat
  * realtime as unavailable rather than throwing.
  */
-export async function fetchRealtimeToken(room: string): Promise<string | null> {
+export async function fetchRealtimeToken(
+  room: string,
+): Promise<{ token: string; url: string } | null> {
   try {
-    return await invoke<string>("get_livekit_token", { room });
+    const r = await invoke<{ token: string; url: string }>("get_livekit_token", { room });
+    return r && r.token ? r : null;
   } catch {
     return null;
   }
@@ -77,12 +80,18 @@ export async function connectRealtime(
   roomName: string,
   onEvent: (e: RealtimeEvent) => void,
 ): Promise<Room | null> {
-  const url = process.env.EXPO_PUBLIC_LIVEKIT_URL;
-  if (!url) {
+  // The server address comes back WITH the token, because a LiveKit JWT is only
+  // valid at the server that issued it. `EXPO_PUBLIC_LIVEKIT_URL` remains as a
+  // build-time fallback for local dev against a DS that has no LIVEKIT_URL set,
+  // but it is no longer how production finds the SFU — otherwise moving the SFU
+  // would require shipping a new app binary.
+  const minted = await fetchRealtimeToken(roomName);
+  if (!minted) {
     return null;
   }
-  const token = await fetchRealtimeToken(roomName);
-  if (!token) {
+  const { token } = minted;
+  const url = minted.url || process.env.EXPO_PUBLIC_LIVEKIT_URL;
+  if (!url) {
     return null;
   }
 

--- a/pollis-core/src/bridge.rs
+++ b/pollis-core/src/bridge.rs
@@ -796,12 +796,16 @@ async fn invoke_inner(cmd: String, args_json: String) -> Result<String, BridgeEr
         // device's verified signature — matching desktop's `connect_rooms`
         // scheme (`{user_id}:{device_id}`), so multiple devices coexist. The
         // LiveKit API secret is no longer on the client (#393).
+        // Returns `{token, url}`, not a bare token. Mobile used to pair the
+        // token with a build-time `EXPO_PUBLIC_LIVEKIT_URL`, which pinned the SFU
+        // address into the app bundle exactly as the desktop config did. The URL
+        // the DS minted the token for is authoritative, so it ships with it.
         "get_livekit_token" => {
             let room: String = arg(&args, "room")?;
             let st = state()?;
-            let (token, _url) =
+            let (token, url) =
                 crate::commands::mls::ds_livekit_token(&st, &room, "realtime").await?;
-            ok(token)
+            ok(serde_json::json!({ "token": token, "url": url }))
         }
 
         // ----- media -----

--- a/pollis-core/src/commands/livekit/legacy.rs
+++ b/pollis-core/src/commands/livekit/legacy.rs
@@ -10,14 +10,26 @@ use crate::state::AppState;
 // derived from the verified signer there, so the client-supplied `identity` /
 // `display_name` args are ignored (kept for Tauri command-signature stability).
 
+/// A minted LiveKit credential: the JWT and the server it is valid at.
+///
+/// These are returned together on purpose. A LiveKit JWT is only accepted by the
+/// server that issued it, so handing back a bare token forces the caller to guess
+/// the address — which is how the SFU address ended up compiled into every shipped
+/// binary in the first place.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct LivekitCredential {
+    pub token: String,
+    pub url: String,
+}
+
 pub async fn get_livekit_token(
     room_name: String,
     _identity: String,
     _display_name: String,
     state: &Arc<AppState>,
-) -> Result<String> {
-    let (token, _url) = ds_livekit_token(state, &room_name, "realtime").await?;
-    Ok(token)
+) -> Result<LivekitCredential> {
+    let (token, url) = ds_livekit_token(state, &room_name, "realtime").await?;
+    Ok(LivekitCredential { token, url })
 }
 
 /// Mint a subscribe-only, hidden JWT for the renderer-side livekit-client
@@ -27,11 +39,17 @@ pub async fn get_livekit_view_token(
     _identity: String,
     _display_name: String,
     state: &Arc<AppState>,
-) -> Result<String> {
-    let (token, _url) = ds_livekit_token(state, &room_name, "view").await?;
-    Ok(token)
+) -> Result<LivekitCredential> {
+    let (token, url) = ds_livekit_token(state, &room_name, "view").await?;
+    Ok(LivekitCredential { token, url })
 }
 
+/// The compiled-in DEFAULT LiveKit address.
+///
+/// Deliberately not authoritative: it is only the fallback used when a
+/// self-hosted DS leaves `LIVEKIT_URL` unset. Anything that dials a room should
+/// use the `url` returned beside that room's token (`LivekitCredential`), because
+/// only the issuing server will accept the JWT.
 pub async fn get_livekit_url(state: &Arc<AppState>) -> Result<String> {
     Ok(state.config.livekit_url.clone())
 }

--- a/pollis-core/src/commands/livekit/mod.rs
+++ b/pollis-core/src/commands/livekit/mod.rs
@@ -40,7 +40,7 @@ mod realtime;
 
 pub(crate) use identity::{lookup_avatar_url, lookup_avatar_url_for_identity};
 
-pub use legacy::{get_livekit_token, get_livekit_url, get_livekit_view_token};
+pub use legacy::{get_livekit_token, get_livekit_url, get_livekit_view_token, LivekitCredential};
 pub use participants::{
     list_voice_participants, list_voice_room_counts, VoiceParticipantInfo, VoiceRoomCount,
 };

--- a/pollis-core/src/commands/livekit/realtime.rs
+++ b/pollis-core/src/commands/livekit/realtime.rs
@@ -31,7 +31,10 @@ pub async fn connect_rooms(
     _username: String,
     state: &Arc<AppState>,
 ) -> Result<()> {
-    let url = state.config.livekit_url.clone();
+    // NOTE: no compiled-in URL is read here any more. Each connect and each
+    // reconnect dials the address the DS returned alongside that room's token
+    // (`ds_livekit_token`), which falls back to `config.livekit_url` itself when
+    // a self-hosted DS leaves `LIVEKIT_URL` unset.
     let livekit_arc = Arc::clone(&state.livekit);
 
     // Per-device identity (`{user}:{device}`, so a user's devices coexist in a
@@ -80,17 +83,21 @@ pub async fn connect_rooms(
         // Participant token now minted by the DS (identity derived server-side
         // from the verified signer); the LiveKit API secret is no longer on the
         // client. See `commands::mls::ds_livekit_token` / `pollis-delivery::broker`.
-        let token = match crate::commands::mls::ds_livekit_token(state, &room_id, "realtime").await {
-            Ok((t, _url)) => t,
-            Err(e) => {
-                eprintln!("[realtime] token error for room {room_id}: {e}");
-                let mut lk = livekit_arc.lock().await;
-                lk.connecting.remove(&room_id);
-                continue;
-            }
-        };
+        // Take the URL the DS minted this token FOR, not the compiled-in one:
+        // the token is only valid at that server, and honouring it is what lets
+        // the SFU move or regionalise without shipping a client.
+        let (token, ds_url) =
+            match crate::commands::mls::ds_livekit_token(state, &room_id, "realtime").await {
+                Ok(pair) => pair,
+                Err(e) => {
+                    eprintln!("[realtime] token error for room {room_id}: {e}");
+                    let mut lk = livekit_arc.lock().await;
+                    lk.connecting.remove(&room_id);
+                    continue;
+                }
+            };
 
-        let url_owned = url.clone();
+        let url_owned = ds_url;
         let lk_arc_connect = Arc::clone(&livekit_arc);
         let user_id_owned = user_id.clone();
         let app_state_connect = Arc::clone(state);
@@ -222,8 +229,13 @@ pub async fn connect_rooms(
                                 }
                             }
 
-                            let token = match crate::commands::mls::ds_livekit_token(&app_state_task, &room_id_owned, "realtime").await {
-                                Ok((t, _url)) => t,
+                            // Re-read the URL on every reconnect, not just the
+                            // first connect: a reconnect is exactly when the DS
+                            // may hand us a different server (failover, or a
+                            // regional move), and reusing the original address
+                            // would pin us to a server that may be draining.
+                            let (token, reconnect_url) = match crate::commands::mls::ds_livekit_token(&app_state_task, &room_id_owned, "realtime").await {
+                                Ok(pair) => pair,
                                 Err(e) => {
                                     eprintln!("[realtime] reconnect token error for room {room_id_owned}: {e}");
                                     backoff = (backoff * 2).min(300);
@@ -231,7 +243,7 @@ pub async fn connect_rooms(
                                 }
                             };
 
-                            match Room::connect(&url_owned, &token, RoomOptions::default()).await {
+                            match Room::connect(&reconnect_url, &token, RoomOptions::default()).await {
                                 Ok((new_room, mut new_events)) => {
                                     let new_room = Arc::new(new_room);
                                     eprintln!("[realtime] reconnected room {room_id_owned}");

--- a/pollis-core/src/commands/mls/ds_client.rs
+++ b/pollis-core/src/commands/mls/ds_client.rs
@@ -238,7 +238,70 @@ pub async fn ds_livekit_token(
         .json()
         .await
         .map_err(|e| Error::Other(anyhow::anyhow!("ds_livekit_token decode: {e}")))?;
-    Ok((parsed.token, parsed.url))
+
+    // Resolve the fallback HERE, not at the call sites. The DS's URL is
+    // authoritative — it is the server that will accept this JWT — but every one
+    // of the six callers used to destructure it as `_url` and dial the compiled-in
+    // `config.livekit_url` instead, which baked the SFU address into every shipped
+    // binary and made "move the SFU" a client-release problem. Returning an
+    // already-resolved URL means a caller cannot reintroduce that bug by ignoring
+    // a field, and there is exactly one place the precedence is written down.
+    //
+    // Empty is the documented self-host case: a DS with no `LIVEKIT_URL` set. That
+    // degrades to the previous behaviour rather than dialing "".
+    let url = resolve_livekit_url(&parsed.url, &state.config.livekit_url);
+    Ok((parsed.token, url))
+}
+
+/// Precedence for which LiveKit address to dial: the DS's answer wins, the
+/// compiled-in config is only a fallback.
+///
+/// Pulled out as a pure function so the rule is testable without a live DS — the
+/// bug this replaces was invisible precisely because it lived inline at six call
+/// sites with nothing asserting it.
+pub fn resolve_livekit_url(ds_url: &str, config_url: &str) -> String {
+    if ds_url.trim().is_empty() {
+        config_url.to_string()
+    } else {
+        ds_url.to_string()
+    }
+}
+
+#[cfg(test)]
+mod livekit_url_tests {
+    use super::resolve_livekit_url;
+
+    /// The whole point: a DS-supplied address must never be discarded in favour
+    /// of the compiled-in one. This is the invalid state that shipped — the SFU
+    /// address baked into every binary, unmovable without a client release.
+    #[test]
+    fn ds_url_always_wins_over_config() {
+        assert_eq!(
+            resolve_livekit_url("wss://eu.pollis.com", "wss://rtc.pollis.com"),
+            "wss://eu.pollis.com"
+        );
+    }
+
+    /// Self-host case: a DS with no LIVEKIT_URL set must degrade to the
+    /// compiled-in default, never to an empty dial.
+    #[test]
+    fn empty_ds_url_falls_back_to_config() {
+        assert_eq!(
+            resolve_livekit_url("", "wss://rtc.pollis.com"),
+            "wss://rtc.pollis.com"
+        );
+        assert_eq!(
+            resolve_livekit_url("   ", "wss://rtc.pollis.com"),
+            "wss://rtc.pollis.com"
+        );
+    }
+
+    /// Both unset stays empty so the caller's "LiveKit is not configured" check
+    /// still fires, rather than dialing a whitespace URL.
+    #[test]
+    fn both_empty_stays_empty() {
+        assert_eq!(resolve_livekit_url("", ""), "");
+    }
 }
 
 /// Fan out a **content-free** control `payload` to a LiveKit `room` via the DS's

--- a/pollis-core/src/commands/voice/lifecycle.rs
+++ b/pollis-core/src/commands/voice/lifecycle.rs
@@ -120,8 +120,8 @@ pub async fn prepare_voice_connection(
     // already paid by the time the user clicks Join. Identity (`voice-{user}:
     // {device}`) is derived server-side from the verified signer — the LiveKit
     // API secret is no longer on the client. Non-fatal: warmup is best-effort.
-    let token = match crate::commands::mls::ds_livekit_token(state, &channel_id, "voice").await {
-        Ok((t, _url)) => t,
+    let (token, ds_url) = match crate::commands::mls::ds_livekit_token(state, &channel_id, "voice").await {
+        Ok(pair) => pair,
         Err(e) => {
             eprintln!("[voice] warmup token error (non-fatal): {e}");
             return Ok(());
@@ -132,7 +132,7 @@ pub async fn prepare_voice_connection(
     // clicks Join, they'll race this — that's fine, the worst case is a
     // single redundant TLS handshake. Errors are non-fatal: this whole
     // command is best-effort.
-    let warm_url = url.clone();
+    let warm_url = ds_url.clone();
     let task = tokio::spawn(async move {
         // Reuse the same twirp transform `livekit::room_service_list_participants`
         // uses; we don't import it to keep the dependency direction clean.
@@ -174,6 +174,7 @@ pub async fn prepare_voice_connection(
     voice.warmup = Some(VoiceWarmup {
         channel_id,
         token,
+        url: ds_url,
         created_at: Instant::now(),
         user_id,
         display_name,
@@ -239,10 +240,12 @@ pub async fn join_voice_channel(
         JoinGuard(Arc::clone(&voice.joining))
     };
 
-    let url = state.config.livekit_url.clone();
-    if url.is_empty() {
-        return Err(anyhow::anyhow!("LiveKit is not configured on this server").into());
-    }
+    // The URL is no longer read from config here — it now arrives with the token
+    // (cached warmup pair, or the DS response below), so the emptiness check moved
+    // to after the token is resolved. `ds_livekit_token` already falls back to
+    // `config.livekit_url` when a self-hosted DS leaves `LIVEKIT_URL` unset, so an
+    // empty value here still means "LiveKit is not configured" — just checked one
+    // step later.
 
     // Per-device LiveKit identity (#140): `voice-{user_id}:{device_id}`. Lets a
     // second device of the same user join the room as a distinct participant
@@ -257,7 +260,7 @@ pub async fn join_voice_channel(
     // the warmup is stale or for a different room/user we mint a new token.
     // VoiceWarmup implements Drop (to abort its background task) so we can't
     // simply destructure it; clone the token out before dropping the entry.
-    let cached_token: Option<String> = {
+    let cached_token: Option<(String, String)> = {
         let mut voice = state.voice.lock().await;
         let usable = voice
             .warmup
@@ -270,7 +273,8 @@ pub async fn join_voice_channel(
             })
             .unwrap_or(false);
         if usable {
-            let cloned = voice.warmup.as_ref().map(|w| w.token.clone());
+            // Token and URL travel together — see `VoiceWarmup::url`.
+            let cloned = voice.warmup.as_ref().map(|w| (w.token.clone(), w.url.clone()));
             // Drop the entry now — its background task is no longer needed.
             voice.warmup = None;
             cloned
@@ -283,10 +287,10 @@ pub async fn join_voice_channel(
     // ── Phase: jwt_mint ────────────────────────────────────────────────────
     // 0 if a warmup-cached token was usable.
     let jwt_mint_ms;
-    let token: String = match cached_token {
-        Some(t) => {
+    let (token, url): (String, String) = match cached_token {
+        Some(pair) => {
             jwt_mint_ms = 0;
-            t
+            pair
         }
         None => {
             // DS-minted (identity derived server-side; matches `local_identity`
@@ -294,11 +298,14 @@ pub async fn join_voice_channel(
             // verified signature). Now a network round-trip, not a local sign —
             // still on the join hot path, so it stays phase-timed.
             let jwt_start = Instant::now();
-            let (t, _url) = crate::commands::mls::ds_livekit_token(state, &channel_id, "voice").await?;
+            let pair = crate::commands::mls::ds_livekit_token(state, &channel_id, "voice").await?;
             jwt_mint_ms = jwt_start.elapsed().as_millis() as u64;
-            t
+            pair
         }
     };
+    if url.is_empty() {
+        return Err(anyhow::anyhow!("LiveKit is not configured on this server").into());
+    }
 
     // ── Run room connect and mic init concurrently ─────────────────────────
     // Both are independent and individually expensive on cold starts. Running

--- a/pollis-core/src/commands/voice/types.rs
+++ b/pollis-core/src/commands/voice/types.rs
@@ -32,6 +32,12 @@ use crate::commands::{
 pub struct VoiceWarmup {
     pub channel_id: String,
     pub token: String,
+    /// The LiveKit ws URL the DS minted `token` FOR. Cached alongside the token
+    /// because the two are a pair — a JWT is only valid at the server that
+    /// issued it, so reusing a warm token against a different address would fail
+    /// authentication. Carrying it here is what lets the SFU move between the
+    /// warmup and the join without stranding the cached credential.
+    pub url: String,
     /// When the prepared token was created. Used to discard stale entries.
     pub created_at: Instant,
     /// When the underlying user identity was captured. Mismatches against

--- a/src-tauri/src/commands/livekit.rs
+++ b/src-tauri/src/commands/livekit.rs
@@ -9,12 +9,12 @@ use crate::state::AppState;
 pub use pollis_core::commands::livekit::*;
 
 #[tauri::command]
-pub async fn get_livekit_token(room_name: String, identity: String, display_name: String, state: State<'_, Arc<AppState>>) -> Result<String> {
+pub async fn get_livekit_token(room_name: String, identity: String, display_name: String, state: State<'_, Arc<AppState>>) -> Result<pollis_core::commands::livekit::LivekitCredential> {
     pollis_core::commands::livekit::get_livekit_token(room_name, identity, display_name, &state).await
 }
 
 #[tauri::command]
-pub async fn get_livekit_view_token(room_name: String, identity: String, display_name: String, state: State<'_, Arc<AppState>>) -> Result<String> {
+pub async fn get_livekit_view_token(room_name: String, identity: String, display_name: String, state: State<'_, Arc<AppState>>) -> Result<pollis_core::commands::livekit::LivekitCredential> {
     pollis_core::commands::livekit::get_livekit_view_token(room_name, identity, display_name, &state).await
 }
 


### PR DESCRIPTION
The Delivery Service returns `{token, url}` from `/v1/livekit/token`. Every client call site destructured it as `(token, _url)` and dialed the compiled-in `config.livekit_url` instead.

A LiveKit JWT is only accepted by the server that issued it, so throwing the URL away meant **the SFU address was baked into every shipped binary** — relocating or regionalising the SFU was a client-release problem, and the release had to reach the fleet before the server could rely on it.

**Fixed centrally, not per-site.** `ds_livekit_token` now resolves precedence once and returns a URL callers can trust, so nobody can reintroduce this by ignoring a field:

```rust
pub fn resolve_livekit_url(ds_url: &str, config_url: &str) -> String
```

DS wins; the compiled-in value is only the fallback for a self-hosted DS with no `LIVEKIT_URL` set. Three tests encode it, including the invalid state that shipped (`ds_url_always_wins_over_config`) and the degrade-not-dial-empty case.

Call sites updated:

- `livekit/realtime.rs` — initial connect, **and the reconnect loop**, which now re-reads the URL each attempt. A reconnect is exactly when the DS may hand back a different server (failover or a regional move); reusing the original address would pin the client to a draining server.
- `voice/lifecycle.rs` — warmup and join. `VoiceWarmup` gained a `url` field: it caches a token, and a cached token dialed at a different address fails authentication, so the pair has to travel together. The "LiveKit is not configured" check moved to after resolution.
- `livekit/legacy.rs` — `get_livekit_token` / `get_livekit_view_token` now return a `LivekitCredential { token, url }` instead of a bare token. Nothing in the desktop renderer calls these, but leaving the `_url` pattern in place re-plants the bug for whoever wires them up next. `get_livekit_url` is documented as the compiled-in *default*, explicitly not authoritative.
- `bridge.rs` — mobile's `get_livekit_token` returns `{token, url}`.

**Mobile had the same defect** from the other direction: `connectRealtime` paired the DS token with a build-time `EXPO_PUBLIC_LIVEKIT_URL`, pinning the SFU into the app bundle. It now uses the URL that arrives with the token, keeping the env var as a local-dev fallback.

Verified: `cargo check -p pollis-core --all-features`, `cargo check -p pollis --no-default-features --features test-harness`, mobile `tsc --noEmit`, and the three new unit tests.

Docs: `.codesight/wiki/secrets-broker.md` records the response shape and the precedence rule.