### PR TITLE
feat(ui): right-hand context panel with members and shared media

### DIFF
--- a/.codesight/wiki/ui.md
+++ b/.codesight/wiki/ui.md
@@ -49,7 +49,7 @@
 - **PinEntryScreen** — props: userId, username, onUnlocked, onForgotPin, onSwitchAccount — `frontend/src/components/Auth/PinEntryScreen.tsx`
 - **SaveSecretKeyScreen** — props: secretKey, email, onConfirmed — `frontend/src/components/Auth/SaveSecretKeyScreen.tsx`
 
-### `components/Layout` (9)
+### `components/Layout` (14)
 
 - **AppShell** — `frontend/src/components/Layout/AppShell.tsx`
 - **BreadcrumbNav** — `frontend/src/components/Layout/BreadcrumbNav.tsx`
@@ -60,6 +60,26 @@
 - **StatusBarSummary** — props: icon, count, to, label, color, testId — `frontend/src/components/Layout/StatusBarSummary.tsx`
 - **TitleBar** — `frontend/src/components/Layout/TitleBar.tsx`
 - **WindowResizeEdges** — `frontend/src/components/Layout/WindowResizeEdges.tsx`
+
+#### `components/Layout/RightPanel` — right-hand context panel (#824)
+
+- **RightPanel** — the generic slot — `frontend/src/components/Layout/RightPanel/RightPanel.tsx`
+- **MembersPanel** — props: groupId, channelId, conversationId — `frontend/src/components/Layout/RightPanel/MembersPanel.tsx`
+- **MemberRow** — props: userId, label, avatarKey, isAdmin — `frontend/src/components/Layout/RightPanel/MemberRow.tsx`
+- **MediaGrid** — props: attachments — `frontend/src/components/Layout/RightPanel/MediaGrid.tsx`
+- **MediaTile** — props: attachment — `frontend/src/components/Layout/RightPanel/MediaTile.tsx`
+
+The panel is a **flex sibling of `<Outlet />`** in `AppShell`, never an overlay — opening it reflows the message list. Which panel is open lives in the URL, not in a store:
+
+| `?panel=` | Meaning |
+| --- | --- |
+| absent | Follow the default: the `right_panel_open_by_default` preference, else the skin (open in `refined`, closed in `terminal`). |
+| `members` | Explicitly open. |
+| `none` | Explicitly closed — distinct from absent, so a `refined` user can share a link with the panel shut. |
+
+`validatePanelSearch` (`frontend/src/types/panel.ts`) is declared on the **root** route, because the panel is AppShell's chrome rather than any one page's. It drops unrecognised values instead of throwing, so a stale or hand-edited link falls back to the default rather than blanking the app. `useRightPanel` resolves the precedence and owns the only write path.
+
+`panel` is a discriminated union, not a boolean, so threads (#825) add a variant rather than a second sidebar. **`useRightPanel` navigates with an explicit `to: pathname`** — a relative `to: "."` would resolve against `/` (AppShell renders at the root route) and throw the user out of their conversation, and omitting `to` leaves the search type unresolved.
 
 ### `components/Message` (9)
 

--- a/frontend/src/components/Layout/AppShell.tsx
+++ b/frontend/src/components/Layout/AppShell.tsx
@@ -6,6 +6,8 @@ import { TitleBar } from "./TitleBar";
 import { WindowResizeEdges } from "./WindowResizeEdges";
 import { BreadcrumbNav } from "./BreadcrumbNav";
 import { Sidebar } from "./Sidebar";
+import { RightPanel } from "./RightPanel/RightPanel";
+import { useRightPanel } from "./RightPanel/useRightPanel";
 import { StatusBarSummary } from "./StatusBarSummary";
 import { VoiceBar } from "../Voice/VoiceBar";
 import { useSkin } from "../../hooks/queries/usePreferences";
@@ -117,6 +119,9 @@ export const AppShell: React.FC = observer(() => {
 
   const currentUser = appStore.currentUser;
   const skin = useSkin();
+  // Panel open/closed lives in the URL, not in AppShell state — see
+  // `useRightPanel`. AppShell only needs the toggle for the shortcut.
+  const { toggle: toggleRightPanel } = useRightPanel();
 
   // Drive the looping ringtone off the incomingCall slot. Rust owns the
   // playback thread (`start_ring` / `stop_ring`) so the loop survives any
@@ -325,6 +330,10 @@ export const AppShell: React.FC = observer(() => {
 
   useGlobalShortcut("app.toggleSidebar", () => {
     setIsSidebarOpen((v) => !v);
+  });
+
+  useGlobalShortcut("app.toggleRightPanel", () => {
+    toggleRightPanel();
   });
 
   // Leaving uses history.back() so the prior chat view (and its selected
@@ -562,6 +571,10 @@ export const AppShell: React.FC = observer(() => {
           <Outlet />
           <ScreenShareViewer />
         </div>
+        {/* Right-hand context panel (#824) — a flex sibling of the outlet, so
+            opening it reflows the message list instead of covering it. Hidden
+            while the terminal view owns the region. */}
+        {!isTerminal && <RightPanel />}
         {terminalActivated && (
           <div
             style={{

--- a/frontend/src/components/Layout/RightPanel/MediaGrid.tsx
+++ b/frontend/src/components/Layout/RightPanel/MediaGrid.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { MediaTile } from "./MediaTile";
+import type { MessageAttachment } from "../../../types";
+
+interface MediaGridProps {
+  attachments: MessageAttachment[];
+}
+
+/**
+ * Shared-media grid for the active conversation, in the spirit of Messenger's
+ * "shared media" block. Newest first — the caller orders the list.
+ */
+export const MediaGrid: React.FC<MediaGridProps> = ({ attachments }) => {
+  if (attachments.length === 0) {
+    return (
+      <p className="px-2 text-xs text-muted">No media shared yet.</p>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-3 gap-1 px-2">
+      {attachments.map((attachment) => (
+        <MediaTile key={attachment.id} attachment={attachment} />
+      ))}
+    </div>
+  );
+};

--- a/frontend/src/components/Layout/RightPanel/MediaTile.tsx
+++ b/frontend/src/components/Layout/RightPanel/MediaTile.tsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from "react";
+import { FileIcon } from "lucide-react";
+import { getMediaUrl } from "../../../services/r2-upload";
+import type { MessageAttachment } from "../../../types";
+
+interface MediaTileProps {
+  attachment: MessageAttachment;
+}
+
+/**
+ * One square thumbnail in the right panel's media grid.
+ *
+ * Images resolve through the loopback media server exactly as
+ * `AttachmentDisplay` does — `getMediaUrl` returns
+ * `http://127.0.0.1:<port>/<token>/<hash>`, so bytes never cross the JSON IPC
+ * and the on-disk cache stays encrypted. Non-images (and anything that fails
+ * to resolve) fall back to an icon rather than an empty box, so the grid never
+ * shows holes.
+ */
+export const MediaTile: React.FC<MediaTileProps> = ({ attachment }) => {
+  const [url, setUrl] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+  const isImage = attachment.content_type.startsWith("image/");
+  // An attachment still uploading has no object_key yet; there is nothing to
+  // fetch until the send confirms.
+  const isPending = !attachment.object_key;
+
+  useEffect(() => {
+    if (!isImage || isPending || url || failed) {
+      return;
+    }
+    let mounted = true;
+    getMediaUrl(
+      attachment.object_key,
+      attachment.content_hash,
+      attachment.content_type,
+    )
+      .then((resolved) => {
+        if (mounted) {
+          setUrl(resolved);
+        }
+      })
+      .catch(() => {
+        if (mounted) {
+          setFailed(true);
+        }
+      });
+    return () => {
+      mounted = false;
+    };
+  }, [
+    isImage,
+    isPending,
+    url,
+    failed,
+    attachment.object_key,
+    attachment.content_hash,
+    attachment.content_type,
+  ]);
+
+  return (
+    <div
+      className="relative aspect-square overflow-hidden rounded border border-line bg-surface-raised"
+      title={attachment.filename}
+      data-testid="right-panel-media-tile"
+    >
+      {url ? (
+        <img
+          src={url}
+          alt={attachment.filename}
+          loading="lazy"
+          className="h-full w-full object-cover"
+          onError={() => setFailed(true)}
+        />
+      ) : (
+        <div className="flex h-full w-full items-center justify-center text-muted">
+          <FileIcon size={16} aria-hidden />
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/Layout/RightPanel/MemberRow.tsx
+++ b/frontend/src/components/Layout/RightPanel/MemberRow.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { observer } from "mobx-react-lite";
+import { useNavigate } from "@tanstack/react-router";
+import { PresenceAvatar } from "../../ui/PresenceAvatar";
+
+interface MemberRowProps {
+  userId: string;
+  label: string;
+  avatarKey?: string | null;
+  isAdmin: boolean;
+}
+
+/**
+ * One person in the right panel's member list. Clicking opens their profile,
+ * matching how member rows behave on the group Members page.
+ */
+export const MemberRow: React.FC<MemberRowProps> = observer(
+  ({ userId, label, avatarKey, isAdmin }) => {
+    const navigate = useNavigate();
+
+    return (
+      <button
+        type="button"
+        onClick={() => navigate({ to: "/user/$userId", params: { userId } })}
+        className="flex w-full items-center gap-2 rounded px-2 py-1 text-left hover:bg-hover"
+        data-testid={`right-panel-member-${userId}`}
+      >
+        <PresenceAvatar
+          userId={userId}
+          avatarKey={avatarKey}
+          size={24}
+          alt={label}
+          variant="list"
+        />
+        <span className="min-w-0 flex-1 truncate text-sm text-fg">{label}</span>
+        {isAdmin && (
+          <span className="shrink-0 text-xs uppercase tracking-wide text-muted">
+            admin
+          </span>
+        )}
+      </button>
+    );
+  },
+);

--- a/frontend/src/components/Layout/RightPanel/MembersPanel.tsx
+++ b/frontend/src/components/Layout/RightPanel/MembersPanel.tsx
@@ -1,0 +1,147 @@
+import React, { useMemo } from "react";
+import { observer } from "mobx-react-lite";
+import { appStore } from "../../../stores/appStore";
+import { presenceStore } from "../../../stores/presenceStore";
+import { useGroupMembers } from "../../../hooks/queries/useGroups";
+import { useMessages } from "../../../hooks/queries/useMessages";
+import { MemberRow } from "./MemberRow";
+import { MediaGrid } from "./MediaGrid";
+import type { MessageAttachment } from "../../../types";
+
+/**
+ * How many attachments the grid renders. Each tile resolves its own bytes
+ * through the media server, so an unbounded grid on a media-heavy channel
+ * would fan out into hundreds of fetches the moment the panel opens. The cap
+ * keeps that bounded; the conversation itself remains the full archive.
+ */
+const MEDIA_LIMIT = 30;
+
+interface MembersPanelProps {
+  groupId: string | null;
+  channelId: string | null;
+  conversationId: string | null;
+}
+
+/**
+ * Members + shared media for the active conversation — Discord's member list
+ * over Messenger's shared-media grid, which is what #824 asks for.
+ *
+ * Members come from the group for a channel/group route. A DM has no member
+ * table, so its two participants are derived from the conversation record.
+ */
+export const MembersPanel: React.FC<MembersPanelProps> = observer(
+  ({ groupId, channelId, conversationId }) => {
+    const { data: groupMembers = [] } = useGroupMembers(groupId);
+    const { messages } = useMessages(channelId, conversationId);
+    const currentUser = appStore.currentUser;
+    const dmConversations = appStore.dmConversations;
+
+    // Online first, then alphabetical. Reading `presenceStore.isOnline` here
+    // (inside an observer) is what keeps the ordering live as people join and
+    // leave — `isOnline` is deliberately not an action for exactly this.
+    const people = useMemo(() => {
+      if (conversationId) {
+        const dm = dmConversations.find((c) => c.id === conversationId);
+        if (!dm) {
+          return [];
+        }
+        const peer = dm.user2_id
+          ? [
+              {
+                userId: dm.user2_id,
+                label: dm.user2_identifier,
+                avatarKey: dm.user2_avatar_url ?? null,
+                isAdmin: false,
+              },
+            ]
+          : [];
+        const self = currentUser
+          ? [
+              {
+                userId: currentUser.id,
+                label: "You",
+                avatarKey: null,
+                isAdmin: false,
+              },
+            ]
+          : [];
+        return [...peer, ...self];
+      }
+
+      return [...groupMembers]
+        .map((m) => ({
+          userId: m.user_id,
+          label: m.display_name || m.username || m.user_id,
+          avatarKey: m.avatar_url ?? null,
+          isAdmin: m.role === "admin",
+        }))
+        .sort((a, b) => {
+          const aOnline = presenceStore.isOnline(a.userId);
+          const bOnline = presenceStore.isOnline(b.userId);
+          if (aOnline !== bOnline) {
+            return aOnline ? -1 : 1;
+          }
+          return a.label.localeCompare(b.label);
+        });
+    }, [
+      conversationId,
+      dmConversations,
+      currentUser,
+      groupMembers,
+      // Re-sort when anyone's presence flips. `byUser` is replaced (not
+      // mutated) by the store, so identity is a sound dependency.
+      presenceStore.byUser,
+    ]);
+
+    const attachments = useMemo(() => {
+      const seen = new Set<string>();
+      const out: MessageAttachment[] = [];
+      // `messages` is oldest-first; walk backwards so the grid leads with the
+      // most recent media.
+      for (let i = messages.length - 1; i >= 0 && out.length < MEDIA_LIMIT; i--) {
+        const message = messages[i];
+        if (message.deleted_at) {
+          continue;
+        }
+        for (const attachment of message.attachments ?? []) {
+          if (out.length >= MEDIA_LIMIT || seen.has(attachment.id)) {
+            continue;
+          }
+          seen.add(attachment.id);
+          out.push(attachment);
+        }
+      }
+      return out;
+    }, [messages]);
+
+    return (
+      <div className="flex h-full flex-col gap-4 overflow-y-auto py-3">
+        <section className="flex flex-col gap-1">
+          <h2 className="px-2 text-xs font-medium uppercase tracking-widest text-muted">
+            Members — {people.length}
+          </h2>
+          {people.length === 0 ? (
+            <p className="px-2 text-xs text-muted">No members to show.</p>
+          ) : (
+            people.map((person) => (
+              <MemberRow
+                key={person.userId}
+                userId={person.userId}
+                label={person.label}
+                avatarKey={person.avatarKey}
+                isAdmin={person.isAdmin}
+              />
+            ))
+          )}
+        </section>
+
+        <section className="flex flex-col gap-2">
+          <h2 className="px-2 text-xs font-medium uppercase tracking-widest text-muted">
+            Media
+          </h2>
+          <MediaGrid attachments={attachments} />
+        </section>
+      </div>
+    );
+  },
+);

--- a/frontend/src/components/Layout/RightPanel/RightPanel.tsx
+++ b/frontend/src/components/Layout/RightPanel/RightPanel.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { observer } from "mobx-react-lite";
+import { X } from "lucide-react";
+import { appStore } from "../../../stores/appStore";
+import { useRightPanel } from "./useRightPanel";
+import { MembersPanel } from "./MembersPanel";
+
+/**
+ * The right-hand context panel slot (#824).
+ *
+ * Deliberately a generic slot rather than a members-only sidebar: it switches
+ * on the `panel` search param, so the thread panel (#825) lands as another
+ * branch here instead of a second competing sidebar.
+ *
+ * Rendered as a flex sibling of `<Outlet />`, never a fixed overlay — the
+ * project bans modals and backdrops, and a real column also means the message
+ * list reflows instead of being covered.
+ */
+export const RightPanel: React.FC = observer(() => {
+  const { kind, isOpen, setPanel } = useRightPanel();
+
+  const groupId = appStore.selectedGroupId;
+  const channelId = appStore.selectedChannelId;
+  const conversationId = appStore.selectedConversationId;
+  // The panel is context for a conversation. On routes that have none
+  // (preferences, search, the root page) there is nothing to show, so the
+  // slot collapses rather than rendering an empty column.
+  const hasContext = Boolean(channelId || conversationId || groupId);
+
+  if (!isOpen || !hasContext) {
+    return null;
+  }
+
+  return (
+    <aside
+      className="flex w-72 shrink-0 flex-col border-l border-line bg-surface"
+      data-testid="right-panel"
+      aria-label="Conversation details"
+    >
+      <div className="flex h-bar shrink-0 items-center justify-between border-b border-line px-3">
+        <span className="text-xs font-medium uppercase tracking-widest text-dim">
+          Details
+        </span>
+        <button
+          type="button"
+          onClick={() => setPanel("none")}
+          className="rounded p-1 text-muted hover:bg-hover hover:text-fg"
+          aria-label="Close details panel"
+          data-testid="right-panel-close"
+        >
+          <X size={14} aria-hidden />
+        </button>
+      </div>
+
+      <div className="min-h-0 flex-1">
+        {kind === "members" && (
+          <MembersPanel
+            groupId={groupId}
+            channelId={channelId}
+            conversationId={conversationId}
+          />
+        )}
+      </div>
+    </aside>
+  );
+});

--- a/frontend/src/components/Layout/RightPanel/useRightPanel.ts
+++ b/frontend/src/components/Layout/RightPanel/useRightPanel.ts
@@ -1,0 +1,58 @@
+import { useCallback } from "react";
+import { useNavigate, useRouterState, useSearch } from "@tanstack/react-router";
+import { useSkin, usePreferences } from "../../../hooks/queries/usePreferences";
+import type { PanelKind, PanelSearch } from "../../../types/panel";
+
+/**
+ * Resolve which right-hand panel is open, and how to change it (#824).
+ *
+ * Precedence, most specific first:
+ *
+ *   1. an explicit `?panel=` in the URL — a shared link or an ad-hoc toggle,
+ *   2. the user's `right_panel_open_by_default` preference,
+ *   3. the skin default — open in `refined`, closed in `terminal`.
+ *
+ * Steps 2 and 3 are why an absent `panel` param is not the same as
+ * `panel=none`: absent defers to the default, `none` is an explicit close.
+ * Without that distinction a `refined` user could never share a link with the
+ * panel shut, and a `terminal` user could never share one with it open.
+ */
+export function useRightPanel() {
+  const navigate = useNavigate();
+  // `strict: false` because the panel is a root-level concern rendered by
+  // AppShell — it must read the same param from whichever route matched.
+  const search = useSearch({ strict: false }) as PanelSearch;
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+  const skin = useSkin();
+  const { query } = usePreferences();
+
+  const preferred = query.data?.right_panel_open_by_default;
+  const defaultOpen = preferred ?? skin === "refined";
+  const kind: PanelKind = search.panel ?? (defaultOpen ? "members" : "none");
+  const isOpen = kind !== "none";
+
+  const setPanel = useCallback(
+    (next: PanelKind) => {
+      // Target the concrete current pathname rather than a relative `"."`.
+      // This hook is used from AppShell, which renders at the ROOT route, so
+      // `"."` resolves against `/` and would navigate the user out of their
+      // conversation; omitting `to` entirely leaves the search type unresolved.
+      //
+      // `replace` so toggling the panel doesn't bury the previous route in
+      // history — back should leave the conversation, not rewind a series of
+      // panel toggles.
+      navigate({
+        to: pathname,
+        search: (prev: Record<string, unknown>) => ({ ...prev, panel: next }),
+        replace: true,
+      });
+    },
+    [navigate],
+  );
+
+  const toggle = useCallback(() => {
+    setPanel(isOpen ? "none" : "members");
+  }, [isOpen, setPanel]);
+
+  return { kind, isOpen, setPanel, toggle };
+}

--- a/frontend/src/hooks/queries/usePreferences.ts
+++ b/frontend/src/hooks/queries/usePreferences.ts
@@ -77,6 +77,16 @@ export interface PreferencesData {
   /** Whether the left sidebar is open by default at app start. */
   sidebar_open_by_default?: boolean;
   /**
+   * Whether the right-hand context panel (#824) is open by default.
+   *
+   * Deliberately tri-state: `undefined` means "follow the skin" — open in
+   * `refined`, closed in `terminal` — while `true`/`false` is an explicit
+   * choice that holds across both skins. Defaulting it to a boolean here
+   * would silently freeze whichever skin the user happened to be on when
+   * the preference row was first written.
+   */
+  right_panel_open_by_default?: boolean;
+  /**
    * Linux/Windows only: when true, closing the window hides the app to the
    * system tray instead of fully exiting. macOS already hides via the Dock
    * regardless. Default true.
@@ -342,6 +352,13 @@ export function usePreferences() {
         ),
         auto_join_voice: getPreference<boolean>(json, "auto_join_voice", false),
         sidebar_open_by_default: getPreference<boolean>(json, "sidebar_open_by_default", true),
+        // Default stays `undefined` on purpose — see the field docs. Absent
+        // means "follow the skin", which is not expressible as a boolean.
+        right_panel_open_by_default: getPreference<boolean | undefined>(
+          json,
+          "right_panel_open_by_default",
+          undefined,
+        ),
         close_to_tray: getPreference<boolean>(json, "close_to_tray", true),
         menubar_icon: getPreference<boolean>(json, "menubar_icon", false),
         revoke_media_on_exit: getPreference<boolean>(json, "revoke_media_on_exit", false),

--- a/frontend/src/keyboard/commands.ts
+++ b/frontend/src/keyboard/commands.ts
@@ -10,6 +10,7 @@
 
 export type ShortcutCommandId =
   | "app.toggleSidebar"
+  | "app.toggleRightPanel"
   | "app.toggleTerminal"
   | "app.toggleSearch"
   | "app.lock"
@@ -47,6 +48,14 @@ export const SHORTCUT_COMMANDS: Record<
     title: "Toggle sidebar",
     category: "Application",
     defaultCombo: "mod+b",
+  },
+  "app.toggleRightPanel": {
+    id: "app.toggleRightPanel",
+    title: "Toggle details panel",
+    category: "Application",
+    // Mirrors mod+b for the left sidebar, shifted — the two panels are the
+    // same gesture on opposite edges.
+    defaultCombo: "mod+shift+b",
   },
   "app.toggleTerminal": {
     id: "app.toggleTerminal",

--- a/frontend/src/pages/PreferencesPage.tsx
+++ b/frontend/src/pages/PreferencesPage.tsx
@@ -73,6 +73,7 @@ export const PreferencesPage: React.FC = observer(() => {
   const navigate = useNavigate();
   const currentUser = appStore.currentUser;
   const toggleSidebarLabel = useShortcutLabel("app.toggleSidebar");
+  const toggleRightPanelLabel = useShortcutLabel("app.toggleRightPanel");
   const [skin, setSkin] = useState<Skin>("terminal");
   const [hue, setHue] = useState<number>(38);
   const [saturation, setSaturation] = useState<number>(90);
@@ -84,6 +85,11 @@ export const PreferencesPage: React.FC = observer(() => {
   const [allowSoundEffects, setAllowSoundEffects] = useState<boolean>(true);
   const [allowCallRingtone, setAllowCallRingtone] = useState<boolean>(true);
   const [sidebarOpenByDefault, setSidebarOpenByDefault] = useState<boolean>(true);
+  // `undefined` until the user touches it — that state means "follow the
+  // skin" (open in refined, closed in terminal), which no boolean can encode.
+  const [rightPanelOpenByDefault, setRightPanelOpenByDefault] = useState<
+    boolean | undefined
+  >(undefined);
   const [closeToTray, setCloseToTray] = useState<boolean>(true);
   const [menubarIcon, setMenubarIcon] = useState<boolean>(false);
   const [overlayMode, setOverlayMode] = useState<OverlayMode>("off");
@@ -127,6 +133,9 @@ export const PreferencesPage: React.FC = observer(() => {
       if (query.data.sidebar_open_by_default !== undefined) {
         setSidebarOpenByDefault(query.data.sidebar_open_by_default);
       }
+      // No `!== undefined` guard: absent is a meaningful value here, and
+      // skipping it would strand the local state after a reset elsewhere.
+      setRightPanelOpenByDefault(query.data.right_panel_open_by_default);
       if (query.data.close_to_tray !== undefined) {
         setCloseToTray(query.data.close_to_tray);
       }
@@ -171,6 +180,7 @@ export const PreferencesPage: React.FC = observer(() => {
     skin?: Skin;
     notifications?: boolean; soundEffects?: boolean;
     sidebarOpenByDefault?: boolean;
+    rightPanelOpenByDefault?: boolean;
     closeToTray?: boolean;
     menubarIcon?: boolean;
     overlayMode?: OverlayMode;
@@ -184,6 +194,7 @@ export const PreferencesPage: React.FC = observer(() => {
     const notif = opts.notifications ?? allowDesktopNotifications;
     const sfx = opts.soundEffects ?? allowSoundEffects;
     const sidebar = opts.sidebarOpenByDefault ?? sidebarOpenByDefault;
+    const rightPanel = opts.rightPanelOpenByDefault ?? rightPanelOpenByDefault;
     const tray = opts.closeToTray ?? closeToTray;
     const menubar = opts.menubarIcon ?? menubarIcon;
     const overlay = opts.overlayMode ?? overlayMode;
@@ -205,6 +216,7 @@ export const PreferencesPage: React.FC = observer(() => {
       allow_desktop_notifications: notif,
       allow_sound_effects: sfx,
       sidebar_open_by_default: sidebar,
+      right_panel_open_by_default: rightPanel,
       close_to_tray: tray,
       menubar_icon: menubar,
       overlay_mode: overlay,
@@ -370,6 +382,11 @@ export const PreferencesPage: React.FC = observer(() => {
   const handleSidebarOpenByDefault = (val: boolean) => {
     setSidebarOpenByDefault(val);
     save({ sidebarOpenByDefault: val });
+  };
+
+  const handleRightPanelOpenByDefault = (val: boolean) => {
+    setRightPanelOpenByDefault(val);
+    save({ rightPanelOpenByDefault: val });
   };
 
   const handleCloseToTray = (val: boolean) => {
@@ -700,6 +717,20 @@ export const PreferencesPage: React.FC = observer(() => {
                 />
                 <p className="text-xs font-mono" style={{ color: "var(--c-text-muted)" }}>
                   Controls whether the left sidebar is open when the app starts. Toggle ad-hoc with {toggleSidebarLabel}.
+                </p>
+              </div>
+              <div className="flex flex-col gap-1.5">
+                <Switch
+                  id="pref-right-panel-default"
+                  label="Show details panel by default"
+                  checked={rightPanelOpenByDefault ?? skin === "refined"}
+                  onChange={handleRightPanelOpenByDefault}
+                />
+                <p className="text-xs font-mono" style={{ color: "var(--c-text-muted)" }}>
+                  Members and shared media for the channel or conversation
+                  you're viewing. Until you set this, it follows your theme —
+                  shown in Refined, hidden in Terminal. Toggle ad-hoc with{" "}
+                  {toggleRightPanelLabel}.
                 </p>
               </div>
               {!isMac && (

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -6,6 +6,7 @@ import {
 } from "@tanstack/react-router";
 import { AppShell } from "./components/Layout/AppShell";
 import type { RouterContext } from "./types/router";
+import { validatePanelSearch } from "./types/panel";
 import { RootPage } from "./pages/Root";
 import { GroupsPage } from "./pages/Groups";
 import { GroupPage } from "./pages/Group";
@@ -49,8 +50,13 @@ export type { RouterContext };
 // AppShell renders the chrome (TitleBar, VoiceBar, breadcrumb) + <Outlet />
 // for the matched child route's content area.
 
+// Search params are declared on the ROOT route because the right-hand panel
+// (#824) is chrome owned by AppShell, not by any one page — every route needs
+// to carry `panel` for the slot to survive navigation. Validating here once
+// also means a new panel kind is a change to `validatePanelSearch` alone.
 const rootRoute = createRootRouteWithContext<RouterContext>()({
   component: AppShell,
+  validateSearch: validatePanelSearch,
 });
 
 // ─── Route definitions ─────────────────────────────────────────────────────────

--- a/frontend/src/types/panel.ts
+++ b/frontend/src/types/panel.ts
@@ -1,0 +1,45 @@
+// Right-hand context panel (#824).
+//
+// The URL is the source of truth for WHICH panel is open; MobX holds only
+// ephemeral per-panel UI (scroll offset, drafts). That keeps the panel
+// linkable, restorable across a reload, and closable with the back button,
+// and it keeps the state flow deterministic as more panel kinds land.
+//
+// `panel` is a discriminated union rather than a boolean from the start, so
+// the thread panel (#825) arrives as an additive variant instead of a rewrite.
+
+/** Panel kinds that may appear in the URL. */
+export const PANEL_KINDS = ["members", "none"] as const;
+
+export type PanelKind = (typeof PANEL_KINDS)[number];
+
+export interface PanelSearch {
+  /**
+   * Which panel is open.
+   *
+   * Absent is meaningful and distinct from `"none"`. Absent means "use this
+   * user's default for the current skin"; `"none"` is an explicit close that
+   * survives a reload and travels in a shared link.
+   */
+  panel?: PanelKind;
+}
+
+function isPanelKind(value: unknown): value is PanelKind {
+  return (
+    typeof value === "string" &&
+    (PANEL_KINDS as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * Parse the panel search params off an arbitrary URL.
+ *
+ * Anything unrecognised is dropped rather than thrown: a hand-edited, stale,
+ * or future-version link should fall back to the user's default panel, never
+ * blank the app with a router error.
+ */
+export function validatePanelSearch(
+  search: Record<string, unknown>,
+): PanelSearch {
+  return isPanelKind(search.panel) ? { panel: search.panel } : {};
+}


### PR DESCRIPTION
Closes #824.

A right-hand panel showing context for the active route — Discord's member list over Messenger's shared-media grid. Members are presence-ordered (online first, then alphabetical); media is the most recent attachments in the conversation, capped at 30 so opening the panel on a media-heavy channel doesn't fan out into hundreds of media-server fetches.

## Open state lives in the URL

```
?panel=members   explicitly open
?panel=none      explicitly closed
(absent)         follow the default
```

Absent is deliberately distinct from `none`: absent defers to the `right_panel_open_by_default` preference, and failing that to the skin — **open in Refined, closed in Terminal**, as asked. Without that third state a Refined user could never share a link with the panel shut, nor a Terminal user one with it open.

`validatePanelSearch` is declared on the **root** route, since the panel is AppShell's chrome rather than any one page's, and it drops unrecognised values instead of throwing so a stale link degrades to the default rather than blanking the app. MobX is deliberately *not* the source of truth for what's open — that keeps the panel linkable, reload-safe, and closable with back. Ephemeral per-panel UI can still live in a store.

## Built as a generic slot

`panel` is a discriminated union rather than a boolean from the start, so #825's thread panel is an added variant in one `switch`, not a second competing sidebar.

## Notes

- The preference is tri-state (`boolean | undefined`). Defaulting it to a boolean would silently freeze whichever skin the user happened to be on when the row was first written.
- The panel is a flex sibling of `<Outlet />`, never a fixed overlay — the project bans modals/backdrops, and a real column also means the message list reflows instead of being covered.
- New `app.toggleRightPanel` shortcut, `mod+shift+b` — the left sidebar's `mod+b` gesture mirrored to the opposite edge.
- Hidden while the terminal view owns the region, and on routes with no conversation context.

## Verification

`tsc` and a production `vite build` both clean. **Not yet exercised in a running app** — a Tauri build from this worktree needs a fresh target dir and would contend with the other work in progress in the main checkout, so I left that for you or for a follow-up run.

One bug worth flagging, caught by typecheck rather than at runtime: the first cut used `navigate({ to: "." })`, which resolves against `/` because AppShell renders at the root route — every panel toggle would have thrown the user back to the index page. It now targets the concrete current pathname. Omitting `to` entirely does not work either; the search type resolves to `never`.