### PR TITLE
fix(livekit): serve TURNS on 443 via nginx SNI demux and widen the relay range

### DIFF
--- a/.github/workflows/livekit-deploy.yml
+++ b/.github/workflows/livekit-deploy.yml
@@ -76,6 +76,26 @@ jobs:
             printf '  %s: %s\n' "${LIVEKIT_API_KEY}" "${LIVEKIT_API_SECRET}"
           } >> livekit/livekit.yml
 
+      - name: Preflight — TURN hostname resolves straight to this box
+        run: |
+          set -euo pipefail
+          # LiveKit hands clients `turns:turn.pollis.com:443` (the port is
+          # hardcoded — see livekit.yml). If that name does not resolve, or
+          # resolves to anything other than this VPS, TURN is dead on arrival and
+          # the failure is invisible: ICE just never finds a working candidate.
+          # In particular a Cloudflare-PROXIED record (orange cloud) resolves to
+          # Cloudflare, which does not speak TURN — it must be DNS-only.
+          got="$(getent ahostsv4 turn.pollis.com | awk '{print $1}' | sort -u | tr '\n' ' ' | sed 's/ $//')" || true
+          if [ -z "${got}" ]; then
+            echo "::error::turn.pollis.com does not resolve. Create a DNS-only (grey-cloud) A record -> ${VPS_HOST} before deploying."
+            exit 1
+          fi
+          if [ "${got}" != "${VPS_HOST}" ]; then
+            echo "::error::turn.pollis.com resolves to '${got}', expected '${VPS_HOST}'. A proxied/CDN record cannot carry TURN."
+            exit 1
+          fi
+          echo "turn.pollis.com -> ${got}"
+
       - name: Set up SSH
         run: |
           set -euo pipefail
@@ -83,6 +103,51 @@ jobs:
           printf '%s\n' "${{ secrets.VPS_SSH_KEY }}" > ~/.ssh/id_deploy
           chmod 600 ~/.ssh/id_deploy
           ssh-keyscan -H "${VPS_HOST}" >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Preflight — host is ready for the widened relay range
+        run: |
+          set -euo pipefail
+          ssh -i ~/.ssh/id_deploy "${VPS_USER}@${VPS_HOST}" 'bash -seuo pipefail' <<'REMOTE'
+            fail=0
+
+            # 1. Userland proxy MUST be off. Docker forks two docker-proxy
+            #    processes per published port; at 1000 relay ports that is 2000
+            #    processes and ~22s of container start (measured), which this
+            #    7 GB box will not survive. Disabled, the contiguous range is a
+            #    single iptables DNAT rule and costs nothing. Checked BEFORE
+            #    `compose up` so a missing setting aborts instead of OOMing.
+            if ! grep -Eq '"userland-proxy"[[:space:]]*:[[:space:]]*false' /etc/docker/daemon.json 2>/dev/null; then
+              echo "::error::/etc/docker/daemon.json is missing '\"userland-proxy\": false'. See livekit/DEPLOY.md — set it and 'systemctl restart docker' before deploying."
+              fail=1
+            fi
+
+            # 2. The TURNS certificate must cover turn.pollis.com. nginx serves
+            #    the rtc.pollis.com lineage on both hostnames, so turn must be a
+            #    SAN on it or every client's TLS verification fails silently.
+            CERT=/etc/letsencrypt/live/rtc.pollis.com/fullchain.pem
+            if [ ! -f "${CERT}" ]; then
+              echo "::error::${CERT} is missing."
+              fail=1
+            elif ! openssl x509 -in "${CERT}" -noout -text | grep -q 'DNS:turn.pollis.com'; then
+              echo "::error::${CERT} has no turn.pollis.com SAN. Expand it (see livekit/DEPLOY.md) before deploying."
+              fail=1
+            fi
+
+            # 3. Firewall must pass the whole relay range. Ports LiveKit
+            #    allocates but the firewall drops are the silent-relay-failure
+            #    bug this deploy is fixing. Only enforced when ufw is the active
+            #    firewall — a control-panel firewall can't be checked from here.
+            if command -v ufw >/dev/null && ufw status 2>/dev/null | grep -q '^Status: active'; then
+              if ! ufw status | grep -q '30000:30999/udp'; then
+                echo "::error::ufw does not allow 30000:30999/udp. Run 'ufw allow 30000:30999/udp' (see livekit/DEPLOY.md)."
+                fail=1
+              fi
+            else
+              echo "::warning::ufw inactive or absent — verify the relay range 30000-30999/udp is open in the host control-panel firewall."
+            fi
+
+            exit "${fail}"
+          REMOTE
 
       - name: Sync config to the box (staging dir)
         run: |
@@ -153,3 +218,28 @@ jobs:
           curl -fsS --retry 10 --retry-delay 3 --retry-all-errors --retry-connrefused --max-time 20 https://rtc.pollis.com ; echo
           # (The Delivery Service moved to Cloudflare Containers in #515 and is no
           # longer proxied by this nginx, so there's nothing DS-related to assert here.)
+
+      - name: Validate — TURNS answers on 443 with a hostname-valid cert
+        run: |
+          set -euo pipefail
+          # The whole point of this stack: a client on a network that only allows
+          # 443 must be able to complete TLS to turn.pollis.com:443 and have the
+          # certificate verify against that name. `-verify_return_error` +
+          # `-verify_hostname` make a bad SAN a hard failure rather than a warning
+          # buried in output, because the client-side symptom is silence.
+          echo | openssl s_client -connect turn.pollis.com:443 \
+            -servername turn.pollis.com \
+            -verify_hostname turn.pollis.com \
+            -verify_return_error -brief 2>&1 | sed 's/^/  /'
+          # And prove the SNI actually routed to TURN, not back to the web vhost:
+          # the web vhost speaks HTTP, so an HTTP request over this TLS session
+          # would answer 200/301. TURN does not, so an empty/non-HTTP reply is the
+          # pass condition.
+          resp="$(printf 'GET / HTTP/1.1\r\nHost: turn.pollis.com\r\nConnection: close\r\n\r\n' \
+            | timeout 20 openssl s_client -connect turn.pollis.com:443 -servername turn.pollis.com -quiet 2>/dev/null \
+            | head -c 64 || true)"
+          if printf '%s' "${resp}" | grep -q '^HTTP/1'; then
+            printf '::error::turn.pollis.com:443 answered HTTP (%s) — SNI demux fell through to the web vhost, TURN is NOT reachable.\n' "${resp}"
+            exit 1
+          fi
+          echo "turn.pollis.com:443 did not answer HTTP — routed to the TURN listener."

--- a/docs/deployments.md
+++ b/docs/deployments.md
@@ -125,6 +125,15 @@ There are **4 shipped executables/sites**, **4 running backend services**, and
 - **From:** `livekit/` (compose + nginx ingress; runs **upstream** LiveKit images, not our build)
 - **Pipeline:** `.github/workflows/livekit-deploy.yml` — `workflow_dispatch` (env choice prod/dev). SSH + compose on the VPS.
 - **Runs at:** VPS. Frames are E2EE (the SFU forwards ciphertext).
+- **Ingress:** everything on **443**, split by TLS SNI in nginx's `stream` block —
+  `rtc.pollis.com` → HTTPS/WSS → `livekit:7880`; `turn.pollis.com` → TURNS,
+  terminated by nginx → `livekit:5349`. TURN *must* be on 443 (LiveKit hardcodes
+  `turns:<domain>:443` in the ICE servers it hands clients, and 443 is what
+  restrictive networks let through). Host prerequisites the pipeline cannot
+  create — a DNS-only A record for `turn.pollis.com`, a cert with that SAN, and
+  `"userland-proxy": false` in `/etc/docker/daemon.json` — are **preflight-gated**
+  in the workflow, which aborts rather than deploying a silently-broken relay.
+  Details + relay-port sizing: `livekit/DEPLOY.md`.
 
 ### Relay pool — closed-overlay first-party relay nodes
 - **From:** `pollis-relay/` (the `pollis-relay` binary; shares the offline device-cert primitive `pollis-device-cert`)

--- a/livekit/DEPLOY.md
+++ b/livekit/DEPLOY.md
@@ -28,24 +28,46 @@ the delivery/watchtower containers by network alias.
 livekit/
   docker-compose.yml   # livekit + nginx only (delivery/watchtower owned by #407)
   livekit.yml          # non-secret; deploy appends the keys: block from secrets
-  nginx.conf           # LiveKit ingress only: rtc.pollis.com -> livekit:7880
+  nginx.conf           # LiveKit ingress: SNI demux on 443 (web + TURNS)
   DEPLOY.md
 ```
 
 ### Ingress routing (nginx.conf)
 
-| Hostname | Upstream | Cert |
-|----------|----------|------|
-| `rtc.pollis.com` | `livekit:7880` | Let's Encrypt |
-| `api.pollis.com` | `delivery:8788` | Cloudflare Origin (`/etc/ssl/cloudflare/verify.pollis.com.*`) |
-| `api-dev.pollis.com` | `delivery-dev:8788` | Cloudflare Origin |
-| `deploy.pollis.com` | `watchtower:8080` | Cloudflare Origin |
+Everything arrives on **port 443** and is split by TLS SNI in nginx's `stream`
+block (`ssl_preread`), because only one process can bind 443:
+
+| SNI | Terminated by | Upstream | Cert |
+|-----|---------------|----------|------|
+| `rtc.pollis.com` | nginx `http` vhost | `livekit:7880` (HTTPS/WSS) | Let's Encrypt |
+| `turn.pollis.com` | nginx `stream` server | `livekit:5349` (plaintext TURN) | same LE cert, via SAN |
+| anything else / no SNI | nginx `http` vhost | `livekit:7880` | Let's Encrypt |
+
+> **Why TURN is on 443 at all.** LiveKit hardcodes the ICE server URL it hands
+> clients as `turns:<turn.domain>:443?transport=tcp` — it does **not**
+> interpolate `tls_port`. While `livekit.yml` said `tls_port: 5349`, clients were
+> being told to reach TURNS on 443, where nginx answered with HTTP; TURNS never
+> worked, and it fails silently (ICE just never finds a working candidate). 443
+> is also the port restrictive corporate/hotel/carrier networks actually let
+> through — the networks whose users need a relay in the first place.
+
+> **Why nginx terminates the TURN TLS** (`turn.external_tls: true` in
+> `livekit.yml`) instead of passing it through to LiveKit's own TLS listener:
+> the certbot cron reloads **nginx**, whereas LiveKit reads its certificate once
+> at process start. A LiveKit-terminated listener would serve an expired cert
+> ~60 days after every renewal. LiveKit no longer gets `/etc/letsencrypt`
+> mounted at all.
 
 > **Ordering dependency:** nginx resolves `proxy_pass` upstreams at config load,
-> so the `delivery`/`delivery-dev`/`watchtower` containers must be **up before
-> nginx starts or reloads** — otherwise nginx fails with "host not found in
-> upstream". On a fresh box, deploy the Delivery Service (#407) first. The deploy
-> workflow runs `nginx -t` before reloading to catch this.
+> so upstream containers must be **up before nginx starts or reloads** —
+> otherwise nginx fails with "host not found in upstream". The deploy workflow
+> runs `nginx -t` before reloading to catch this.
+
+> **Connection accounting:** a 443 connection now costs **four** `worker_connections`
+> slots (stream accept, stream→loopback, loopback accept, upstream) rather than
+> two, which is why `worker_connections` moved 8192 → 16384. PROXY protocol
+> carries the real client IP across the loopback hop, so access logs keep showing
+> real addresses instead of `127.0.0.1`.
 
 ## Workflow requirements (one-time)
 
@@ -67,27 +89,73 @@ curl -fsSL https://get.docker.com | sh
 ufw allow 80/tcp && ufw allow 443/tcp
 ufw allow 7881/tcp          # ICE TCP
 ufw allow 7882/udp          # ICE UDP
-ufw allow 5349/tcp          # TURNS (TURN over TLS, for VPNs)
-ufw allow 30000:30100/udp   # TURN relay media ports
+ufw allow 30000:30999/udp   # TURN relay media ports
 ufw reload
 ```
 Note: if the host (e.g. Hostinger) has a control-panel firewall, open the same
 ports there too — it overrides UFW.
 
+**5349 is deliberately NOT open and no longer published by docker.** TURNS
+arrives on 443, nginx terminates it and forwards plaintext TURN over the compose
+network to `livekit:5349`; nothing outside nginx should reach that listener. If
+you are upgrading an existing box, drop the old rules:
+```bash
+ufw delete allow 5349/tcp
+ufw delete allow 30000:30100/udp
+```
+
+**Docker's iptables rules override UFW** for *published* container ports, so
+UFW alone cannot close a published port — that is why 5349 was removed from the
+`ports:` list in `docker-compose.yml` rather than just firewalled off.
+
+### 1b. Disable Docker's userland proxy (**required**)
+```bash
+# /etc/docker/daemon.json
+{ "userland-proxy": false }
+```
+```bash
+systemctl restart docker
+```
+Docker forks **two `docker-proxy` processes per published port**. Measured
+locally: a 1000-port UDP range → 2000 processes and ~22 s of container start;
+a 250-port range → 500 processes and ~5.6 s. At the relay range this stack now
+publishes, that would exhaust the 7 GB box. With the userland proxy disabled the
+whole contiguous range collapses into iptables DNAT and costs essentially
+nothing. **The deploy workflow hard-fails if this setting is absent**, before it
+touches the stack.
+
 ### 2. Certs
-- **Let's Encrypt** (`rtc.pollis.com`) via host certbot:
+- **Let's Encrypt** — one certificate covering **both** `rtc.pollis.com` and
+  `turn.pollis.com` (nginx serves the same lineage on both SNIs, so
+  `turn.pollis.com` must be a SAN or clients' TLS verification fails and TURN
+  silently never connects). `--standalone` needs port 80, which nginx holds:
   ```bash
   apt install certbot -y
-  certbot certonly --standalone -d rtc.pollis.com
+  cd /root/livekit && docker compose stop nginx
+  certbot certonly --standalone --expand -d rtc.pollis.com -d turn.pollis.com
+  docker compose start nginx
+  ```
+  `--expand` keeps the lineage named `rtc.pollis.com`, so the paths in
+  `nginx.conf` do not move. Verify:
+  ```bash
+  openssl x509 -in /etc/letsencrypt/live/rtc.pollis.com/fullchain.pem -noout -text \
+    | grep -A1 'Subject Alternative Name'
   ```
   Auto-renews via a systemd timer; nginx must reload to pick up renewals:
   ```bash
   # crontab -e
   0 3 * * * certbot renew --quiet && docker compose -f /root/livekit/docker-compose.yml exec -T nginx nginx -s reload
   ```
-- **Cloudflare Origin cert** for `api`/`api-dev`/`deploy.pollis.com` at
-  `/etc/ssl/cloudflare/verify.pollis.com.{pem,key}` (Cloudflare runs Full
-  (strict) in front of these).
+  Renewal is `--standalone` too, so the timer needs nginx off port 80 for the
+  moment it runs; if renewals start failing, switch the lineage to `--webroot`.
+- **DNS:** `turn.pollis.com` needs an **A record straight to the VPS
+  (`31.97.140.76`), DNS-only — no Cloudflare proxy.** A proxied record resolves
+  to Cloudflare, which does not speak TURN. The deploy workflow refuses to run
+  unless `turn.pollis.com` resolves to `VPS_HOST`.
+- **Cloudflare Origin cert** at `/etc/ssl/cloudflare/verify.pollis.com.{pem,key}`
+  — a leftover from when `api`/`api-dev`/`deploy.pollis.com` were proxied here.
+  The Delivery Service moved to Cloudflare Containers (#515); the mount remains
+  but nothing in `nginx.conf` reads it.
 
 ### 3. Host tunables (UDP receive buffer)
 LiveKit warns and drops packets under load if the OS UDP receive buffer is below
@@ -109,6 +177,11 @@ resolve, then hit the **Deploy LiveKit + nginx** button.
 |----------|----------|
 | WebSocket (prod) | `wss://rtc.pollis.com` |
 | HTTP API | `https://rtc.pollis.com` |
+| TURNS (relay fallback) | `turns:turn.pollis.com:443?transport=tcp` |
+
+Clients do not configure TURN — LiveKit hands the URL above to every participant
+in the ICE server list. The `:443` is hardcoded in LiveKit, not derived from
+`turn.tls_port`.
 
 ## Useful commands (on the box)
 
@@ -121,10 +194,34 @@ docker compose exec nginx nginx -s reload     # graceful reload after a cert ren
 docker stats                      # live CPU/memory per container
 ```
 
+## Useful commands (TURN)
+
+```bash
+# Does 443 speak TURN under the turn SNI? (should NOT answer HTTP)
+openssl s_client -connect turn.pollis.com:443 -servername turn.pollis.com \
+  -verify_hostname turn.pollis.com -verify_return_error -brief
+
+# Does 443 still speak HTTPS under the web SNI?
+curl -sS https://rtc.pollis.com
+
+# How many relay ports are actually in use right now
+docker compose exec -T livekit sh -c 'ss -lun' | awk '$5 ~ /:3[0-9]{4}$/' | wc -l
+```
+
 ## Performance notes
 
-- Each participant media track consumes one UDP port from the 30000–30100 range
-  (TURN relay); ~100 ports handles a healthy number of concurrent users.
+- **Relay ports: 30000–30999 (1000 ports).** One UDP port per TURN *allocation*,
+  and a LiveKit client opens **two** peer connections (publisher + subscriber),
+  so budget ~2 ports per concurrent relayed participant. 1000 ports ≈ 250
+  concurrent participants with slack for allocations still draining —
+  comfortably past what 2 vCPU can serve, and past the 150-subscriber level that
+  load-tested clean. The old 101-port range capped this at ~50 participants
+  regardless of how idle the CPU was.
+- Changing the range means editing **three** places in lockstep —
+  `relay_range_*` in `livekit.yml`, the `ports:` publish in
+  `docker-compose.yml`, and the host firewall. Ports LiveKit allocates but the
+  firewall drops produce silent relay failures.
+- Do not widen much further without re-measuring: every published port is
+  iptables state, and with the userland proxy accidentally re-enabled it is also
+  two processes per port (see §1b).
 - LiveKit exposes Prometheus metrics at `/metrics` for future monitoring.
-- Expanding the UDP range means editing the port mapping in `docker-compose.yml`
-  *and* the firewall; large ranges slow Docker startup.

--- a/livekit/docker-compose.yml
+++ b/livekit/docker-compose.yml
@@ -1,7 +1,9 @@
 # LiveKit + nginx ingress stack for the Pollis VPS.
 #
 # Scope: this compose manages `livekit` and the `nginx` ingress in front of it.
-# nginx serves ONLY LiveKit, on the single domain rtc.pollis.com -> livekit:7880.
+# nginx serves ONLY LiveKit, and owns port 443 for BOTH of its hostnames: it
+# demultiplexes by TLS SNI, sending rtc.pollis.com -> livekit:7880 (HTTPS/WSS)
+# and turn.pollis.com -> livekit:5349 (TURN over TLS, terminated by nginx).
 # (downpage.xyz was a legacy alias for the same upstream and is retired.) The Delivery Service moved to Cloudflare Containers (#515), so the
 # old `delivery` / `delivery-dev` / `watchtower` containers no longer run on this
 # VPS and were removed from nginx.conf — a dangling upstream fails `nginx -t` and
@@ -19,13 +21,30 @@ services:
     ports:
       - "7881:7881"             # ICE TCP candidates
       - "7882:7882/udp"         # ICE UDP (single-port mux)
-      - "5349:5349"             # TURNS (TURN over TLS)
-      - "30000-30100:30000-30100/udp"  # TURN relay media ports
+      # 5349 is NOT published. TURNS now arrives on 443, is terminated by nginx
+      # and forwarded over the compose network to livekit:5349 as plaintext —
+      # so the TURN listener must not be reachable from the internet at all.
+      #
+      # TURN relay media ports. Widened 30000-30100 (101 ports) -> 30000-30999:
+      # one UDP port per TURN allocation and two allocations per participant
+      # (publisher + subscriber peer connection) capped relayed concurrency at
+      # roughly FIFTY participants, independent of CPU. This range must stay in
+      # lockstep with relay_range_* in livekit.yml and the host firewall.
+      #
+      # REQUIRES `"userland-proxy": false` in /etc/docker/daemon.json — see
+      # DEPLOY.md. With the userland proxy on, Docker forks TWO docker-proxy
+      # processes PER PUBLISHED PORT: measured 1000 ports -> 2000 processes and
+      # 22s of container start, which this 7 GB box will not survive. Disabled,
+      # the whole contiguous range collapses into iptables DNAT and costs
+      # nothing. The deploy workflow refuses to run if it is still enabled.
+      - "30000-30999:30000-30999/udp"
     volumes:
       # livekit.yml is rendered on the box with the `keys:` block appended from
       # secrets by the deploy workflow — see livekit.yml's trailing note.
       - ./livekit.yml:/etc/livekit.yml
-      - /etc/letsencrypt:/etc/letsencrypt:ro
+      # NOTE: /etc/letsencrypt is deliberately no longer mounted here. With
+      # `turn.external_tls: true` nginx terminates TURNS, so LiveKit never reads
+      # a TLS keypair — one fewer process holding the private key.
     command: --config /etc/livekit.yml
     restart: unless-stopped
 

--- a/livekit/livekit.yml
+++ b/livekit/livekit.yml
@@ -5,17 +5,43 @@ rtc:
   use_external_ip: true
   use_ice_lite: true
 
-# TURNS (TURN over TLS on port 5349) — handles VPNs that block UDP and
-# non-443 ports. relay_range_* are the UDP ports LiveKit allocates to
-# actually relay media; they must be open in the firewall.
+# TURNS — TURN over TLS, the fallback path for clients that cannot get a direct
+# UDP route (corporate/hotel/carrier NAT, UDP-blocking VPNs).
+#
+# THE PORT IS NOT CONFIGURABLE. LiveKit hardcodes the URL it hands to clients as
+# `turns:<domain>:443?transport=tcp` (pkg/service/roommanager.go, v1.10.0) — it
+# does NOT interpolate tls_port. `tls_port` below only decides which port the
+# server LISTENS on. So while this said `tls_port: 5349`, every client was told
+# to reach TURNS at rtc.pollis.com:443, where nginx answered with HTTP and the
+# TURN handshake died. TURNS has never worked in production, and it fails
+# silently: ICE just falls back to candidates that don't work either.
+#
+# The fix: nginx owns :443 and demultiplexes by TLS SNI (see nginx.conf) —
+# rtc.pollis.com stays the web/WSS vhost, turn.pollis.com is terminated and
+# forwarded here as plaintext TURN. Hence `external_tls: true` and the
+# `domain` being turn.pollis.com rather than rtc.pollis.com: the domain field
+# IS the hostname clients dial, so it must be the one nginx routes to TURN.
+#
+# external_tls also means LiveKit no longer reads the TLS keypair (cert_file /
+# key_file are ignored on this path). That is deliberate: nginx already reloads
+# on the certbot renewal cron, whereas LiveKit only loads certs at process
+# start, so a LiveKit-terminated TURNS listener would quietly serve an expired
+# certificate ~60 days after every renewal.
 turn:
   enabled: true
-  domain: rtc.pollis.com
+  domain: turn.pollis.com
   tls_port: 5349
-  cert_file: /etc/letsencrypt/live/rtc.pollis.com/fullchain.pem
-  key_file: /etc/letsencrypt/live/rtc.pollis.com/privkey.pem
+  external_tls: true
+  # UDP ports LiveKit allocates to relay media. One port per TURN allocation,
+  # and a LiveKit client opens two peer connections (publisher + subscriber),
+  # so budget ~2 ports per concurrent participant. 1000 ports covers ~250
+  # concurrent relayed participants with slack for allocations still draining —
+  # comfortably past what 2 vCPU can serve. Widening these REQUIRES widening
+  # the docker publish range and the host firewall to match (see DEPLOY.md);
+  # ports LiveKit allocates but the firewall drops produce silent relay
+  # failures, which is the exact failure mode this block already had.
   relay_range_start: 30000
-  relay_range_end: 30100
+  relay_range_end: 30999
 
 # NOTE: the `keys:` block is intentionally NOT committed. The deploy workflow
 # (.github/workflows/livekit-deploy.yml) appends it on the box from the

--- a/livekit/nginx.conf
+++ b/livekit/nginx.conf
@@ -1,4 +1,7 @@
-# LiveKit ingress. Sole domain: rtc.pollis.com.
+# LiveKit ingress. Two hostnames, one IP, one port 443:
+#   rtc.pollis.com   -> HTTPS / WSS signalling  -> livekit:7880
+#   turn.pollis.com  -> TURN over TLS (TURNS)   -> livekit:5349
+# They are separated at layer 4 by TLS SNI (see the `stream` block below).
 
 # One worker per core. Left unset, nginx runs a SINGLE worker regardless of how
 # many cores the box has — which is what it was doing in production.
@@ -21,8 +24,85 @@ events {
     # failure, 150 → 0, 300 → 46, 1000 → 746, 1500 → 1246. CPU never rose above
     # 13% because rejected connections cost nothing, which makes this failure mode
     # look like healthy headroom on every dashboard.
-    worker_connections 8192;
+    #
+    # RAISED 8192 -> 16384 because SNI demux DOUBLES the slot cost again: a 443
+    # connection is now stream-in + stream-to-loopback + loopback-accept +
+    # upstream = FOUR slots, not two. Keeping 8192 would have quietly halved the
+    # ceiling that #817 just raised.
+    worker_connections 16384;
     multi_accept on;
+}
+
+# ── Layer-4 SNI demultiplexer ────────────────────────────────────────────────
+# nginx and LiveKit's TURN listener both need port 443: nginx because that is
+# where HTTPS/WSS lives, TURN because LiveKit hardcodes `turns:<domain>:443` in
+# the ICE servers it hands to clients (see livekit.yml), and because 443 is the
+# one port restrictive networks reliably let through — the networks whose users
+# need a relay in the first place. Only one process can bind 443, so nginx binds
+# it and routes by the SNI in the TLS ClientHello, which `ssl_preread` reads
+# WITHOUT terminating the connection.
+#
+# `stream` is a top-level sibling of `http`, not a block inside it. It requires
+# ngx_stream_ssl_preread_module; the pinned nginx:1.29-alpine is built
+# --with-stream_ssl_preread_module (verified via `nginx -V` against the image
+# digest in docker-compose.yml).
+stream {
+    map $ssl_preread_server_name $tls443_backend {
+        turn.pollis.com  turns_terminator;
+        rtc.pollis.com   web_terminator;
+        # No SNI, an unknown name, or non-TLS junk lands on the web vhost, which
+        # is what reached those clients before this block existed.
+        default          web_terminator;
+    }
+
+    # Both backends are inside this container's own network namespace — the
+    # loopback here is private to nginx and is not reachable from the host or
+    # the network, so nothing new is exposed by listening on it.
+    upstream web_terminator {
+        server 127.0.0.1:8443;
+    }
+    upstream turns_terminator {
+        server 127.0.0.1:8349;
+    }
+
+    server {
+        listen 443;
+        ssl_preread on;
+        proxy_pass $tls443_backend;
+
+        # PROXY protocol carries the real client address across the loopback
+        # hop; without it every access log and every real_ip lookup downstream
+        # would read 127.0.0.1. Both backends below opt in to reading it.
+        proxy_protocol on;
+
+        proxy_connect_timeout 5s;
+        # TURN allocations and WSS signalling are both long-lived; the stream
+        # default of 10m would sever idle-but-live sessions.
+        proxy_timeout 3600s;
+    }
+
+    # TURNS terminator. nginx does the TLS, LiveKit gets plaintext TURN — which
+    # is what `turn.external_tls: true` in livekit.yml configures it to expect.
+    # Terminating here (rather than passing the TLS through to LiveKit) is what
+    # keeps the TURN certificate fresh: the certbot cron reloads nginx, while
+    # LiveKit would hold whatever cert it read at process start.
+    server {
+        listen 127.0.0.1:8349 ssl proxy_protocol;
+
+        # Same certificate as the web vhost — turn.pollis.com must be a SAN on
+        # the rtc.pollis.com lineage. See DEPLOY.md; a cert without that SAN
+        # fails the client's TLS verification and TURN silently never connects.
+        ssl_certificate /etc/letsencrypt/live/rtc.pollis.com/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/rtc.pollis.com/privkey.pem;
+        ssl_protocols TLSv1.2 TLSv1.3;
+
+        # livekit:5349 is reachable over the compose network and is deliberately
+        # NOT published to the host — nothing outside this nginx should speak to
+        # LiveKit's plaintext TURN listener.
+        proxy_pass livekit:5349;
+        proxy_connect_timeout 5s;
+        proxy_timeout 3600s;
+    }
 }
 
 http {
@@ -31,17 +111,22 @@ http {
         "" close;
     }
 
-    # HTTP -> HTTPS.
+    # HTTP -> HTTPS. Still a real host-facing listener: port 80 is not
+    # demultiplexed, and certbot's HTTP-01 challenge needs it.
     server {
         listen 80;
-        server_name rtc.pollis.com;
+        server_name rtc.pollis.com turn.pollis.com;
         return 301 https://$host$request_uri;
     }
 
-    # LiveKit — the only endpoint this ingress serves.
+    # LiveKit signalling. Fed by the stream block above rather than binding 443
+    # directly, so it takes its client address from the PROXY header.
     server {
-        listen 443 ssl;
+        listen 127.0.0.1:8443 ssl proxy_protocol;
         server_name rtc.pollis.com;
+
+        set_real_ip_from 127.0.0.1;
+        real_ip_header proxy_protocol;
 
         ssl_certificate /etc/letsencrypt/live/rtc.pollis.com/fullchain.pem;
         ssl_certificate_key /etc/letsencrypt/live/rtc.pollis.com/privkey.pem;
@@ -58,8 +143,8 @@ http {
     }
 
     # NOTE: downpage.xyz was a legacy alias for this same LiveKit upstream and is
-    # retired — rtc.pollis.com is the sole LiveKit domain. Its certbot entry should
-    # be dropped from the renewal list too (see DEPLOY.md).
+    # retired — rtc.pollis.com is the sole LiveKit *web* domain, and
+    # turn.pollis.com exists only as an SNI label for the TURN path.
     #
     # NOTE: api.pollis.com / api-dev.pollis.com / deploy.pollis.com used to be
     # proxied here to the standalone `delivery` / `delivery-dev` / `watchtower`


### PR DESCRIPTION
TURNS was never reachable. LiveKit hardcodes the ICE URL it hands clients as `turns:<turn.domain>:443` (`pkg/service/roommanager.go`, v1.10.0) — it does **not** interpolate `tls_port`. With `tls_port: 5349`, clients were told to dial `rtc.pollis.com:443`, where nginx answered HTTP. So the relay path was dead for everyone, not merely for users behind port-5349-blocking networks, and it failed silently.

**443 is now shared by TLS SNI** in an nginx `stream` block (`ssl_preread`):

| SNI | Terminated by | Upstream |
|---|---|---|
| `rtc.pollis.com` | nginx `http` vhost | `livekit:7880` (HTTPS/WSS) |
| `turn.pollis.com` | nginx `stream` server | `livekit:5349` (plaintext TURN) |

nginx terminates the TURN TLS (`turn.external_tls: true`) rather than passing it through, because the certbot cron reloads nginx while LiveKit only reads certs at process start — a LiveKit-terminated listener would serve an expired cert ~60 days after every renewal. LiveKit no longer gets `/etc/letsencrypt` mounted, and 5349 is no longer published.

**Relay range 30000–30100 → 30000–30999.** One UDP port per TURN allocation and two peer connections per LiveKit client, so 101 ports capped relayed concurrency near 50 participants regardless of CPU; 1000 covers ~250.

`worker_connections` 8192 → 16384: SNI demux makes a 443 connection cost four slots, not two, which would otherwise have halved the ceiling #817 just raised. PROXY protocol keeps real client IPs across the loopback hop.

**Host prerequisites the pipeline cannot create** — DNS-only `turn.pollis.com` A record, a cert carrying that SAN, `"userland-proxy": false` in `/etc/docker/daemon.json` (Docker forks two `docker-proxy` processes per published port: measured 1000 ports → 2000 processes, ~22 s start), and `ufw allow 30000:30999/udp`. All four are **preflight-gated in the workflow**, which aborts rather than deploying a silently-broken relay; a post-deploy step asserts 443 under the TURN SNI does not answer HTTP.

Verified locally against the pinned image digest: `nginx -t` passes, `--with-stream_ssl_preread_module` present in `nginx -V`, and a live stack with throwaway certs proved both SNI paths route correctly (TLS terminated for `turn.pollis.com` and plaintext delivered to `livekit:5349`, verified with `-verify_hostname`). Not verified: a real TURN allocation against real LiveKit, and the box's actual firewall/daemon state.

Docs updated: `livekit/DEPLOY.md`, `docs/deployments.md`.
