### PR TITLE
feat(messages): Slack-style threads in channels

### DIFF
--- a/.codesight/wiki/commands.md
+++ b/.codesight/wiki/commands.md
@@ -72,7 +72,9 @@ PIN is cryptographically load-bearing — see `pin-design.md`.
 - Also registered but undocumented here: `update_group`, `delete_group`, `update_channel`, `delete_channel`, `get_group_join_requests`, `get_my_join_request`. See Appendix A.
 
 ## messages (`commands/messages.rs`)
-- `send_message(conversation_id, sender_id, content, reply_to_id?, sender_username?)` → `Message`
+- `send_message(conversation_id, sender_id, content, reply_to_id?, thread_id?, sender_username?)` → `Message`
+- `read_thread_messages(thread_id)` → `Vec<ChannelMessage>` — one thread's replies, oldest-first, local-only (#825)
+- `list_thread_summaries(conversation_id)` → `Vec<ThreadSummary>` — reply count + last-reply time per thread root
 - `get_channel_messages(user_id, channel_id, limit, cursor?)` → `MessagePage`
 - `get_dm_messages(user_id, dm_channel_id, limit, cursor?)` → `MessagePage`
 - `edit_message(message_id, conversation_id, sender_id, new_content)`
@@ -184,7 +186,7 @@ sed -n '/generate_handler!\[/,/^\s*\]) *$/p' src-tauri/src/lib.rs
 - **`install_kind`** — `detect_managed_install`
 - **`livekit`** — `cancel_call`, `connect_rooms`, `get_livekit_token`, `get_livekit_url`, `get_livekit_view_token`, `list_voice_participants`, `list_voice_room_counts`, `publish_ping`, `publish_typing`, `publish_voice_presence`, `start_call`, `subscribe_realtime`
 - **`media_permissions`** — `get_media_permission_status`, `open_privacy_settings`, `revoke_media_permissions`, `set_revoke_media_on_exit`
-- **`messages`** — `add_reaction`, `delete_message`, `edit_message`, `get_channel_messages`, `get_dm_messages`, `get_message_retention`, `get_reactions`, `ingest_channel_envelopes`, `ingest_dm_envelopes`, `list_channel_previews`, `list_messages`, `list_messages_by_sender`, `read_channel_messages`, `read_dm_messages`, `remove_reaction`, `run_message_eviction`, `search_messages`, `send_message`, `set_message_retention`
+- **`messages`** — `add_reaction`, `delete_message`, `edit_message`, `get_channel_messages`, `get_dm_messages`, `get_message_retention`, `get_reactions`, `ingest_channel_envelopes`, `ingest_dm_envelopes`, `list_channel_previews`, `list_messages`, `list_messages_by_sender`, `list_thread_summaries`, `read_channel_messages`, `read_dm_messages`, `read_thread_messages`, `remove_reaction`, `run_message_eviction`, `search_messages`, `send_message`, `set_message_retention`
 - **`mls`** — `catch_up_all_mls_groups`, `poll_mls_welcomes`, `process_pending_commits`
 - **`overlay`** — `get_overlay_mode`, `set_overlay_mode`
 - **`pin`** — `get_unlock_state`, `lock`, `set_pin`, `unlock`
@@ -243,7 +245,7 @@ than hand-edit.
 
 **`blocks`** (3) — `block_user`, `list_blocked_users`, `unblock_user`
 
-**`messages`** (19) — `add_reaction`, `delete_message`, `edit_message`, `get_channel_messages`, `get_dm_messages`, `get_message_retention`, `get_reactions`, `ingest_channel_envelopes`, `ingest_dm_envelopes`, `list_channel_previews`, `list_messages`, `list_messages_by_sender`, `read_channel_messages`, `read_dm_messages`, `remove_reaction`, `run_message_eviction`, `search_messages`, `send_message`, `set_message_retention`
+**`messages`** (21) — `add_reaction`, `delete_message`, `edit_message`, `get_channel_messages`, `get_dm_messages`, `get_message_retention`, `get_reactions`, `ingest_channel_envelopes`, `ingest_dm_envelopes`, `list_channel_previews`, `list_messages`, `list_messages_by_sender`, `list_thread_summaries`, `read_channel_messages`, `read_dm_messages`, `read_thread_messages`, `remove_reaction`, `run_message_eviction`, `search_messages`, `send_message`, `set_message_retention`
 
 **`mls`** (3) — `catch_up_all_mls_groups`, `poll_mls_welcomes`, `process_pending_commits`
 

--- a/.codesight/wiki/mls.md
+++ b/.codesight/wiki/mls.md
@@ -445,6 +445,8 @@ Both peers compute the same 32-byte key because both hold the same exporter secr
 **Send** (`send_message`):
 1. Poll welcomes → interleaved ingesting catch-up (`catch_up_mls_group_interleaved`) to reach the current epoch while decrypting any current-epoch inbound message first, so this device's own send can't strand it (#440)
 2. For a TEXT message, pad the plaintext to a size bucket (`messages::framing::pad`) so the ciphertext length no longer leaks the message length (metadata minimization, issue #331 v2, `docs/metadata-minimization-design.md` §4.1). Attachment envelopes are left unpadded. Then `try_mls_encrypt(local_db, group_id, plaintext)` → MLS ciphertext
+   - **Threads (#825):** a reply into a thread uses `messages::framing::pad_threaded`, which appends a `0xF7` trailer carrying the thread root's ULID **after** the plaintext, inside the same `0xF5` frame. `thread_id` therefore never reaches the DS or Turso — the server has no notion of a thread and cannot paginate one. A threaded send always takes the padded frame, attachment envelope or not, because the trailer has nowhere else to live; an unthreaded send is byte-for-byte what it was before threads.
+   - The trailer sits after the plaintext, and the header + length prefix are untouched, **so a client that predates threads reads the same length prefix and recovers exactly the same plaintext**. A thread reply degrades to an ordinary channel message on an old client rather than to mojibake — which a new marker byte would have caused, since `strip` returns unrecognised frames verbatim.
 3. Store ciphertext in `message_envelope` (remote) and `message` (local)
 
 **Receive** (`get_channel_messages` / `get_dm_messages`):

--- a/.codesight/wiki/ui.md
+++ b/.codesight/wiki/ui.md
@@ -65,6 +65,8 @@
 
 - **RightPanel** — the generic slot — `frontend/src/components/Layout/RightPanel/RightPanel.tsx`
 - **MembersPanel** — props: groupId, channelId, conversationId — `frontend/src/components/Layout/RightPanel/MembersPanel.tsx`
+- **ThreadPanel** — props: threadId, channelId, conversationId — `frontend/src/components/Layout/RightPanel/ThreadPanel.tsx`
+- **ThreadMessageRow** — props: message, isRoot — `frontend/src/components/Layout/RightPanel/ThreadMessageRow.tsx`
 - **MemberRow** — props: userId, label, avatarKey, isAdmin — `frontend/src/components/Layout/RightPanel/MemberRow.tsx`
 - **MediaGrid** — props: attachments — `frontend/src/components/Layout/RightPanel/MediaGrid.tsx`
 - **MediaTile** — props: attachment — `frontend/src/components/Layout/RightPanel/MediaTile.tsx`
@@ -75,6 +77,7 @@ The panel is a **flex sibling of `<Outlet />`** in `AppShell`, never an overlay 
 | --- | --- |
 | absent | Follow the default: the `right_panel_open_by_default` preference, else the skin (open in `refined`, closed in `terminal`). |
 | `members` | Explicitly open. |
+| `thread` | A thread is open; `?thread=<ULID>` names its root. Required iff `panel=thread` — `validatePanelSearch` drops the whole panel param rather than admit one without the other, so "thread open with no thread" is unrepresentable. |
 | `none` | Explicitly closed — distinct from absent, so a `refined` user can share a link with the panel shut. |
 
 `validatePanelSearch` (`frontend/src/types/panel.ts`) is declared on the **root** route, because the panel is AppShell's chrome rather than any one page's. It drops unrecognised values instead of throwing, so a stale or hand-edited link falls back to the default rather than blanking the app. `useRightPanel` resolves the precedence and owns the only write path.

--- a/frontend/src/components/Layout/MainContent.tsx
+++ b/frontend/src/components/Layout/MainContent.tsx
@@ -12,7 +12,8 @@ import { ChatInput, type Attachment, type ChatInputHandle } from "../ui/ChatInpu
 import { LoadingSpinner } from "../ui/LoaderSpinner";
 import { Button } from "../ui/Button";
 import { useMessages, useSendMessage, messageQueryKeys, useDeleteMessage, useEditMessage, useAcceptDMRequest, useBlockUser } from "../../hooks/queries";
-import { transformChannelMessage, type RawChannelMessage } from "../../hooks/queries/useMessages";
+import { transformChannelMessage, type RawChannelMessage, useThreadSummaries } from "../../hooks/queries/useMessages";
+import { useRightPanel } from "./RightPanel/useRightPanel";
 import { useGroupMembers, useDeleteChannel } from "../../hooks/queries/useGroups";
 import type { Message, MessageAttachment } from "../../types";
 import { blurhashFromUrl } from "../../utils/imageProcessing";
@@ -105,6 +106,19 @@ export const MainContent: React.FC<MainContentProps> = observer(({ pendingDmRequ
     selectedConversationId
   );
   const sendMessageMutation = useSendMessage();
+  // Threads (#825). `openThread` writes the panel search params; the summaries
+  // give each root message its "N replies" count without loading the thread.
+  const { openThread } = useRightPanel();
+  const { data: threadSummaries } = useThreadSummaries(
+    selectedChannelId ?? selectedConversationId ?? null,
+  );
+  const threadReplyCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const [threadId, summary] of threadSummaries ?? []) {
+      counts.set(threadId, summary.reply_count);
+    }
+    return counts;
+  }, [threadSummaries]);
   const deleteMessageMutation = useDeleteMessage();
   const editMessageMutation = useEditMessage();
 
@@ -501,6 +515,8 @@ export const MainContent: React.FC<MainContentProps> = observer(({ pendingDmRequ
             groupIdForNames={selectedGroupId ?? null}
             adminUserIds={selectedGroupId ? adminUserIds : undefined}
             viewerIsAdmin={viewerIsAdmin}
+            onOpenThread={openThread}
+            threadReplyCounts={threadReplyCounts}
             onReply={(id) => {
               setEditingMessage(null);
               setPendingDeleteId(null);

--- a/frontend/src/components/Layout/RightPanel/RightPanel.tsx
+++ b/frontend/src/components/Layout/RightPanel/RightPanel.tsx
@@ -4,6 +4,7 @@ import { X } from "lucide-react";
 import { appStore } from "../../../stores/appStore";
 import { useRightPanel } from "./useRightPanel";
 import { MembersPanel } from "./MembersPanel";
+import { ThreadPanel } from "./ThreadPanel";
 
 /**
  * The right-hand context panel slot (#824).
@@ -17,7 +18,7 @@ import { MembersPanel } from "./MembersPanel";
  * list reflows instead of being covered.
  */
 export const RightPanel: React.FC = observer(() => {
-  const { kind, isOpen, setPanel } = useRightPanel();
+  const { kind, isOpen, threadId, setPanel } = useRightPanel();
 
   const groupId = appStore.selectedGroupId;
   const channelId = appStore.selectedChannelId;
@@ -39,7 +40,7 @@ export const RightPanel: React.FC = observer(() => {
     >
       <div className="flex h-bar shrink-0 items-center justify-between border-b border-line px-3">
         <span className="text-xs font-medium uppercase tracking-widest text-dim">
-          Details
+          {kind === "thread" ? "Thread" : "Details"}
         </span>
         <button
           type="button"
@@ -56,6 +57,16 @@ export const RightPanel: React.FC = observer(() => {
         {kind === "members" && (
           <MembersPanel
             groupId={groupId}
+            channelId={channelId}
+            conversationId={conversationId}
+          />
+        )}
+        {/* `threadId` is non-null whenever kind is "thread" — the router drops
+            the panel param rather than admit one without the other — but the
+            guard keeps that guarantee local and typed. */}
+        {kind === "thread" && threadId && (
+          <ThreadPanel
+            threadId={threadId}
             channelId={channelId}
             conversationId={conversationId}
           />

--- a/frontend/src/components/Layout/RightPanel/ThreadMessageRow.tsx
+++ b/frontend/src/components/Layout/RightPanel/ThreadMessageRow.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { observer } from "mobx-react-lite";
+import { PresenceAvatar } from "../../ui/PresenceAvatar";
+import { AttachmentDisplay } from "../../Message/AttachmentDisplay";
+import type { Message } from "../../../types";
+
+interface ThreadMessageRowProps {
+  message: Message;
+  /** The thread's root message, rendered above the divider. */
+  isRoot?: boolean;
+}
+
+/**
+ * A single message inside the thread panel.
+ *
+ * Deliberately a narrow, panel-shaped row rather than a reuse of
+ * `MessageItem`: that component carries the full channel affordances (reply,
+ * edit, delete, pin, moderation, skin-aware grouping) and is sized for the
+ * main column. A thread row needs the author, the text, and any attachments.
+ */
+export const ThreadMessageRow: React.FC<ThreadMessageRowProps> = observer(
+  ({ message, isRoot = false }) => {
+    const author = message.sender_username ?? message.sender_id;
+
+    return (
+      <div
+        className="flex gap-2"
+        data-testid={isRoot ? "thread-root" : "thread-reply"}
+      >
+        <PresenceAvatar
+          userId={message.sender_id}
+          size={24}
+          alt={author}
+          variant="list"
+        />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-baseline gap-2">
+            <span className="truncate text-xs font-medium text-fg">
+              {author}
+            </span>
+            <span className="shrink-0 text-xs text-muted">
+              {new Date(message.created_at).toLocaleTimeString([], {
+                hour: "2-digit",
+                minute: "2-digit",
+              })}
+            </span>
+          </div>
+
+          {message.deleted_at ? (
+            <p className="text-sm italic text-muted">Message deleted</p>
+          ) : (
+            <>
+              {message.content_decrypted ? (
+                <p className="whitespace-pre-wrap break-words text-sm text-fg">
+                  {message.content_decrypted}
+                </p>
+              ) : (
+                <p className="text-sm italic text-muted">[encrypted]</p>
+              )}
+              {(message.attachments ?? []).map((attachment) => (
+                <div key={attachment.id} className="mt-1">
+                  <AttachmentDisplay attachment={attachment} />
+                </div>
+              ))}
+            </>
+          )}
+        </div>
+      </div>
+    );
+  },
+);

--- a/frontend/src/components/Layout/RightPanel/ThreadPanel.tsx
+++ b/frontend/src/components/Layout/RightPanel/ThreadPanel.tsx
@@ -1,0 +1,116 @@
+import React, { useMemo, useState } from "react";
+import { observer } from "mobx-react-lite";
+import { appStore } from "../../../stores/appStore";
+import {
+  useMessages,
+  useSendMessage,
+  useThreadMessages,
+} from "../../../hooks/queries/useMessages";
+import { Button } from "../../ui/Button";
+import { TextArea } from "../../ui/TextArea";
+import { ThreadMessageRow } from "./ThreadMessageRow";
+
+interface ThreadPanelProps {
+  /** ULID of the thread's root message. Guaranteed present by the router. */
+  threadId: string;
+  channelId: string | null;
+  conversationId: string | null;
+}
+
+/**
+ * One thread's conversation (#825) — Slack's thread pane, in the generic right
+ * panel slot from #824.
+ *
+ * The root message is read out of the channel's already-loaded page rather
+ * than refetched; a thread is always opened from a message that is on screen.
+ * When the root has scrolled out of the loaded window it simply renders
+ * without the quoted header, which is better than blocking the replies on a
+ * second round trip.
+ */
+export const ThreadPanel: React.FC<ThreadPanelProps> = observer(
+  ({ threadId, channelId, conversationId }) => {
+    const { messages } = useMessages(channelId, conversationId);
+    const { data: replies = [], isLoading } = useThreadMessages(threadId);
+    const sendMessage = useSendMessage();
+    const currentUser = appStore.currentUser;
+    const [draft, setDraft] = useState("");
+
+    const root = useMemo(
+      () => messages.find((m) => m.id === threadId) ?? null,
+      [messages, threadId],
+    );
+
+    const canSend = draft.trim().length > 0 && !!currentUser;
+
+    const submit = () => {
+      if (!canSend) {
+        return;
+      }
+      sendMessage.mutate({
+        channelId: channelId ?? "",
+        conversationId: conversationId ?? "",
+        content: draft.trim(),
+        threadId,
+      });
+      setDraft("");
+    };
+
+    return (
+      <div className="flex h-full flex-col">
+        <div className="min-h-0 flex-1 overflow-y-auto px-2 py-3">
+          {root && (
+            <div className="mb-3 border-b border-line pb-3">
+              <ThreadMessageRow message={root} isRoot />
+            </div>
+          )}
+
+          {isLoading ? (
+            <p className="px-1 text-xs text-muted">Loading replies…</p>
+          ) : replies.length === 0 ? (
+            <p className="px-1 text-xs text-muted">
+              No replies yet. Start the thread below.
+            </p>
+          ) : (
+            <div className="flex flex-col gap-2">
+              {replies.map((reply) => (
+                <ThreadMessageRow key={reply.id} message={reply} />
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* The thread composer is part of the panel, not a modal or an overlay
+            — it replaces nothing and covers nothing. */}
+        <div className="shrink-0 border-t border-line p-2">
+          <TextArea
+            id="thread-composer"
+            label="Reply in thread"
+            value={draft}
+            onChange={setDraft}
+            placeholder="Reply in thread…"
+            rows={2}
+            onKeyDown={(e) => {
+              // Enter sends, Shift+Enter newlines — the same contract as the
+              // main chat input.
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault();
+                submit();
+              }
+            }}
+          />
+          <div className="mt-2 flex justify-end">
+            <Button
+              size="sm"
+              variant="primary"
+              disabled={!canSend}
+              onClick={submit}
+              data-testid="thread-send"
+            >
+              Reply
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  },
+);

--- a/frontend/src/components/Layout/RightPanel/useRightPanel.ts
+++ b/frontend/src/components/Layout/RightPanel/useRightPanel.ts
@@ -4,7 +4,7 @@ import { useSkin, usePreferences } from "../../../hooks/queries/usePreferences";
 import type { PanelKind, PanelSearch } from "../../../types/panel";
 
 /**
- * Resolve which right-hand panel is open, and how to change it (#824).
+ * Resolve which right-hand panel is open, and how to change it (#824, #825).
  *
  * Precedence, most specific first:
  *
@@ -16,6 +16,10 @@ import type { PanelKind, PanelSearch } from "../../../types/panel";
  * `panel=none`: absent defers to the default, `none` is an explicit close.
  * Without that distinction a `refined` user could never share a link with the
  * panel shut, and a `terminal` user could never share one with it open.
+ *
+ * This hook is the ONLY writer of the panel params. Everything downstream
+ * reads `kind`/`threadId` and never constructs the search object itself, so
+ * the "thread open with no thread id" state has no way in.
  */
 export function useRightPanel() {
   const navigate = useNavigate();
@@ -30,9 +34,12 @@ export function useRightPanel() {
   const defaultOpen = preferred ?? skin === "refined";
   const kind: PanelKind = search.panel ?? (defaultOpen ? "members" : "none");
   const isOpen = kind !== "none";
+  // Guaranteed present when `kind === "thread"` — `validatePanelSearch` drops
+  // the whole panel param rather than admit one without the other.
+  const threadId = kind === "thread" ? (search.thread ?? null) : null;
 
-  const setPanel = useCallback(
-    (next: PanelKind) => {
+  const navigateSearch = useCallback(
+    (next: PanelSearch) => {
       // Target the concrete current pathname rather than a relative `"."`.
       // This hook is used from AppShell, which renders at the ROOT route, so
       // `"."` resolves against `/` and would navigate the user out of their
@@ -43,16 +50,39 @@ export function useRightPanel() {
       // panel toggles.
       navigate({
         to: pathname,
-        search: (prev: Record<string, unknown>) => ({ ...prev, panel: next }),
+        search: (prev: Record<string, unknown>) => ({
+          ...prev,
+          panel: next.panel,
+          // Always written, so leaving a thread cannot strand a stale
+          // `?thread=` on the URL for the next panel to trip over.
+          thread: next.thread,
+        }),
         replace: true,
       });
     },
-    [navigate],
+    // `pathname` belongs here: without it the callback closes over whichever
+    // route was matched when the hook first ran, and every later toggle would
+    // navigate back to that stale path.
+    [navigate, pathname],
+  );
+
+  const setPanel = useCallback(
+    (next: Exclude<PanelKind, "thread">) => {
+      navigateSearch({ panel: next, thread: undefined });
+    },
+    [navigateSearch],
+  );
+
+  const openThread = useCallback(
+    (rootMessageId: string) => {
+      navigateSearch({ panel: "thread", thread: rootMessageId });
+    },
+    [navigateSearch],
   );
 
   const toggle = useCallback(() => {
     setPanel(isOpen ? "none" : "members");
   }, [isOpen, setPanel]);
 
-  return { kind, isOpen, setPanel, toggle };
+  return { kind, isOpen, threadId, setPanel, openThread, toggle };
 }

--- a/frontend/src/components/Message/MessageItem.tsx
+++ b/frontend/src/components/Message/MessageItem.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { Reply, CornerUpLeft, Edit2, Trash2 } from "lucide-react";
+import { Reply, CornerUpLeft, Edit2, Trash2, MessagesSquare } from "lucide-react";
+import { ThreadReplyCount } from "./ThreadReplyCount";
 import { formatTimeOfDay, formatFullTimestamp } from "../../utils/format";
 import { observer } from "mobx-react-lite";
 import { appStore } from "../../stores/appStore";
@@ -26,6 +27,10 @@ interface MessageItemProps {
    * callers keep the full header. */
   isGroupStart?: boolean;
   onReply?: (messageId: string) => void;
+  /** Open this message's thread in the right panel (#825). */
+  onOpenThread?: (messageId: string) => void;
+  /** Replies this device holds for this message's thread, 0 if none. */
+  threadReplyCount?: number;
   onEdit?: (messageId: string) => void;
   onDelete?: (messageId: string) => void;
   onPin?: (messageId: string) => void;
@@ -45,6 +50,8 @@ export const MessageItem: React.FC<MessageItemProps> = observer(({
   canModerate = false,
   isGroupStart = true,
   onReply,
+  onOpenThread,
+  threadReplyCount = 0,
   onEdit,
   onDelete,
   onScrollToReply,
@@ -233,6 +240,14 @@ export const MessageItem: React.FC<MessageItemProps> = observer(({
 
           {/* Reactions row — disabled, needs more thought */}
           {/* <MessageReactions messageId={message.id} /> */}
+      <ThreadReplyCount
+        count={threadReplyCount}
+        onOpen={onOpenThread ? () => onOpenThread(message.id) : undefined}
+      />
+          <ThreadReplyCount
+            count={threadReplyCount}
+            onOpen={onOpenThread ? () => onOpenThread(message.id) : undefined}
+          />
         </div>
 
         {/* Floating hover action toolbar */}
@@ -246,6 +261,16 @@ export const MessageItem: React.FC<MessageItemProps> = observer(({
             >
               <Reply size={16} />
             </button>
+            {onOpenThread && (
+              <button
+                data-testid="thread-button"
+                onClick={() => onOpenThread(message.id)}
+                aria-label="Reply in thread"
+                className="p-1 text-[var(--c-text-muted)] hover:text-[var(--c-text-accent)]"
+              >
+                <MessagesSquare size={16} />
+              </button>
+            )}
             {isOwn && onEdit && (
               <button
                 data-testid="edit-button"
@@ -389,6 +414,16 @@ export const MessageItem: React.FC<MessageItemProps> = observer(({
             >
               <Reply size={18} />
             </button>
+            {onOpenThread && (
+              <button
+                data-testid="thread-button"
+                onClick={() => onOpenThread(message.id)}
+                aria-label="Reply in thread"
+                className="opacity-0 group-hover:opacity-100 text-[var(--c-text-muted)] hover:text-[var(--c-text-accent)]"
+              >
+                <MessagesSquare size={18} />
+              </button>
+            )}
             {isOwn && onEdit && (
               <button
                 data-testid="edit-button"

--- a/frontend/src/components/Message/MessageList.tsx
+++ b/frontend/src/components/Message/MessageList.tsx
@@ -107,6 +107,10 @@ interface MessageListProps {
    * deleting other members' messages for moderation. */
   viewerIsAdmin?: boolean;
   onReply?: (messageId: string) => void;
+  /** Open a message's thread in the right panel (#825). */
+  onOpenThread?: (messageId: string) => void;
+  /** messageId -> replies this device holds, for the "N replies" affordance. */
+  threadReplyCounts?: Map<string, number>;
   onEdit?: (messageId: string) => void;
   onDelete?: (messageId: string) => void;
   onPin?: (messageId: string) => void;
@@ -124,6 +128,8 @@ export const MessageList: React.FC<MessageListProps> = observer(({
   adminUserIds,
   viewerIsAdmin = false,
   onReply,
+  onOpenThread,
+  threadReplyCounts,
   onEdit,
   onDelete,
   onScrollToMessage,
@@ -362,6 +368,8 @@ export const MessageList: React.FC<MessageListProps> = observer(({
             canModerate={viewerIsAdmin}
             isGroupStart={isGroupStart}
             onReply={onReply}
+            onOpenThread={onOpenThread}
+            threadReplyCount={threadReplyCounts?.get(message.id) ?? 0}
             onEdit={onEdit}
             onDelete={onDelete}
             onScrollToReply={scrollToMessage}

--- a/frontend/src/components/Message/ThreadReplyCount.tsx
+++ b/frontend/src/components/Message/ThreadReplyCount.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { MessagesSquare } from "lucide-react";
+
+interface ThreadReplyCountProps {
+  /** Replies this device holds for this message's thread. */
+  count: number;
+  /** Omitted where threads aren't available, which also hides the affordance. */
+  onOpen?: () => void;
+}
+
+/**
+ * The "N replies" affordance under a message that has a thread (#825) — the
+ * only discoverable entry point into a thread from the channel, mirroring how
+ * Slack surfaces one.
+ *
+ * Renders nothing when there are no replies, so an ordinary message is
+ * completely unchanged.
+ */
+export const ThreadReplyCount: React.FC<ThreadReplyCountProps> = ({
+  count,
+  onOpen,
+}) => {
+  if (count <= 0 || !onOpen) {
+    return null;
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      data-testid="thread-reply-count"
+      className="mt-1 flex items-center gap-1 rounded px-1 py-0.5 text-xs text-accent hover:bg-hover"
+    >
+      <MessagesSquare size={12} aria-hidden />
+      {count === 1 ? "1 reply" : `${count} replies`}
+    </button>
+  );
+};

--- a/frontend/src/components/ui/TextArea.tsx
+++ b/frontend/src/components/ui/TextArea.tsx
@@ -12,6 +12,12 @@ interface TextAreaProps {
   rows?: number;
   className?: string;
   id?: string;
+  /**
+   * Key handler on the underlying `<textarea>`. Added for the thread composer
+   * (#825), which needs Enter-to-send with Shift+Enter for a newline — the
+   * same contract as the main chat input.
+   */
+  onKeyDown?: React.KeyboardEventHandler<HTMLTextAreaElement>;
 }
 
 export const TextArea: React.FC<TextAreaProps> = ({
@@ -25,6 +31,7 @@ export const TextArea: React.FC<TextAreaProps> = ({
   rows = 3,
   className = "",
   id,
+  onKeyDown,
 }) => {
   const [isFocused, setIsFocused] = useState(false);
   const inputId = id || `textarea-${Math.random().toString(36).substr(2, 9)}`;
@@ -50,6 +57,7 @@ export const TextArea: React.FC<TextAreaProps> = ({
           value={value}
           rows={rows}
           onChange={(e) => onChange(e.target.value)}
+          onKeyDown={onKeyDown}
           onFocus={() => setIsFocused(true)}
           onBlur={() => setIsFocused(false)}
           placeholder={placeholder}

--- a/frontend/src/hooks/queries/useMessages.ts
+++ b/frontend/src/hooks/queries/useMessages.ts
@@ -26,6 +26,9 @@ export const messageQueryKeys = {
   channel: (channelId: string | null) => ["messages", "channel", channelId] as const,
   conversation: (conversationId: string | null) => ["messages", "conversation", conversationId] as const,
   dmConversations: (userId: string | null) => ["dm-conversations", userId] as const,
+  thread: (threadId: string | null) => ["messages", "thread", threadId] as const,
+  threadSummaries: (conversationId: string | null) =>
+    ["messages", "thread-summaries", conversationId] as const,
 };
 
 export const lastMessageQueryKeys = {
@@ -53,6 +56,8 @@ type RawMessage = {
   sender_id: string;
   content?: string;
   reply_to_id?: string;
+  /** ULID of the thread root this was sent into (#825). */
+  thread_id?: string;
   sent_at: string;
 };
 
@@ -65,6 +70,8 @@ export type RawChannelMessage = {
   ciphertext: string;
   content?: string;
   reply_to_id?: string;
+  /** ULID of the thread root, recovered from inside the ciphertext (#825). */
+  thread_id?: string;
   sent_at: string;
   edited_at?: string;
   deleted_at?: string;
@@ -128,6 +135,7 @@ function transformMessage(m: RawMessage): Message {
     nonce: new Uint8Array(),
     content_decrypted: parsed?.text,
     reply_to_message_id: m.reply_to_id,
+    thread_id: m.thread_id,
     is_pinned: false,
     created_at: new Date(m.sent_at).getTime(),
     delivered: true,
@@ -151,6 +159,7 @@ export function transformChannelMessage(m: RawChannelMessage): Message {
     nonce: new Uint8Array(),
     content_decrypted: parsed?.text,
     reply_to_message_id: m.reply_to_id,
+    thread_id: m.thread_id,
     is_pinned: false,
     created_at: new Date(m.sent_at).getTime(),
     delivered: true,
@@ -271,11 +280,15 @@ export function useSendMessage() {
       conversationId,
       content,
       replyToMessageId,
+      threadId,
     }: {
       channelId: string;
       conversationId: string;
       content: string;
       replyToMessageId?: string;
+      // ULID of the thread root when sending into a thread (#825). Carried
+      // inside the MLS ciphertext, never in the DS request body.
+      threadId?: string;
       optimisticId?: string; // used by onSuccess to replace the optimistic stub
     }) => {
       if (!currentUser) {
@@ -288,6 +301,7 @@ export function useSendMessage() {
         senderId: currentUser.id,
         content,
         replyToId: replyToMessageId ?? null,
+        threadId: threadId ?? null,
         senderUsername: currentUser.username ?? null,
       });
     },
@@ -318,6 +332,20 @@ export function useSendMessage() {
 
       // Then invalidate in the background so we stay in sync with the server.
       queryClient.invalidateQueries({ queryKey });
+
+      // A threaded send (#825) also changes the open thread and that
+      // conversation's reply counts; without this the thread panel would show
+      // the reply only after a refetch on focus.
+      if (variables.threadId) {
+        queryClient.invalidateQueries({
+          queryKey: messageQueryKeys.thread(variables.threadId),
+        });
+        queryClient.invalidateQueries({
+          queryKey: messageQueryKeys.threadSummaries(
+            variables.channelId || variables.conversationId,
+          ),
+        });
+      }
     },
   });
 }
@@ -521,5 +549,63 @@ export function useEditMessage() {
         queryClient.invalidateQueries({ queryKey: context.queryKey });
       }
     },
+  });
+}
+
+/** Mirrors the Rust `ThreadSummary` in `pollis-core/src/commands/messages/types.rs`. */
+export type ThreadSummary = {
+  thread_id: string;
+  reply_count: number;
+  last_reply_at?: string;
+};
+
+/**
+ * Replies in one thread, oldest-first (#825).
+ *
+ * Local-only by construction: `thread_id` lives inside the MLS ciphertext, so
+ * the DS cannot be asked for a thread. This returns what this device has
+ * decrypted — the same bounded-history behaviour channels already have.
+ */
+export function useThreadMessages(threadId: string | null) {
+  const currentUser = useObserver(() => appStore.currentUser);
+
+  return useQuery({
+    queryKey: messageQueryKeys.thread(threadId),
+    queryFn: async (): Promise<Message[]> => {
+      if (!threadId) {
+        return [];
+      }
+      const rows = await invoke<RawChannelMessage[]>("read_thread_messages", {
+        threadId,
+      });
+      return (rows || []).map(transformChannelMessage);
+    },
+    enabled: !!threadId && !!currentUser,
+    staleTime: 1000 * 30,
+    refetchOnWindowFocus: true,
+  });
+}
+
+/**
+ * Reply counts per thread root for a conversation, so a channel row can show
+ * "N replies" without loading every thread.
+ */
+export function useThreadSummaries(conversationId: string | null) {
+  const currentUser = useObserver(() => appStore.currentUser);
+
+  return useQuery({
+    queryKey: messageQueryKeys.threadSummaries(conversationId),
+    queryFn: async (): Promise<Map<string, ThreadSummary>> => {
+      if (!conversationId) {
+        return new Map();
+      }
+      const rows = await invoke<ThreadSummary[]>("list_thread_summaries", {
+        conversationId,
+      });
+      return new Map((rows || []).map((r) => [r.thread_id, r]));
+    },
+    enabled: !!conversationId && !!currentUser,
+    staleTime: 1000 * 30,
+    refetchOnWindowFocus: true,
   });
 }

--- a/frontend/src/types/panel.ts
+++ b/frontend/src/types/panel.ts
@@ -1,15 +1,12 @@
-// Right-hand context panel (#824).
+// Right-hand context panel (#824), extended with threads (#825).
 //
 // The URL is the source of truth for WHICH panel is open; MobX holds only
 // ephemeral per-panel UI (scroll offset, drafts). That keeps the panel
 // linkable, restorable across a reload, and closable with the back button,
 // and it keeps the state flow deterministic as more panel kinds land.
-//
-// `panel` is a discriminated union rather than a boolean from the start, so
-// the thread panel (#825) arrives as an additive variant instead of a rewrite.
 
 /** Panel kinds that may appear in the URL. */
-export const PANEL_KINDS = ["members", "none"] as const;
+export const PANEL_KINDS = ["members", "thread", "none"] as const;
 
 export type PanelKind = (typeof PANEL_KINDS)[number];
 
@@ -22,6 +19,12 @@ export interface PanelSearch {
    * survives a reload and travels in a shared link.
    */
   panel?: PanelKind;
+  /**
+   * ULID of the open thread's root message. Required iff `panel === "thread"`
+   * — [`validatePanelSearch`] refuses to produce one without the other, so
+   * "thread panel open with no thread" is unrepresentable downstream.
+   */
+  thread?: string;
 }
 
 function isPanelKind(value: unknown): value is PanelKind {
@@ -37,9 +40,25 @@ function isPanelKind(value: unknown): value is PanelKind {
  * Anything unrecognised is dropped rather than thrown: a hand-edited, stale,
  * or future-version link should fall back to the user's default panel, never
  * blank the app with a router error.
+ *
+ * The two halves of the thread variant are validated together, so neither can
+ * appear without the other:
+ *
+ * - `?panel=thread` with no `thread` → dropped entirely (falls back to default)
+ * - `?thread=…` with no `panel=thread` → the stray id is dropped
  */
 export function validatePanelSearch(
   search: Record<string, unknown>,
 ): PanelSearch {
-  return isPanelKind(search.panel) ? { panel: search.panel } : {};
+  if (!isPanelKind(search.panel)) {
+    return {};
+  }
+  if (search.panel !== "thread") {
+    return { panel: search.panel };
+  }
+  const thread = search.thread;
+  if (typeof thread !== "string" || thread.length === 0) {
+    return {};
+  }
+  return { panel: "thread", thread };
 }

--- a/pollis-core/src/bridge.rs
+++ b/pollis-core/src/bridge.rs
@@ -604,12 +604,14 @@ async fn invoke_inner(cmd: String, args_json: String) -> Result<String, BridgeEr
             let sender_id: String = arg(&args, "senderId")?;
             let content: String = arg(&args, "content")?;
             let reply_to_id: Option<String> = arg_opt(&args, "replyToId")?;
+            let thread_id: Option<String> = arg_opt(&args, "threadId")?;
             let sender_username: Option<String> = arg_opt(&args, "senderUsername")?;
             ok(messages::send_message(
                 conversation_id,
                 sender_id,
                 content,
                 reply_to_id,
+                thread_id,
                 sender_username,
                 &state()?,
             )

--- a/pollis-core/src/commands/messages/framing.rs
+++ b/pollis-core/src/commands/messages/framing.rs
@@ -51,6 +51,41 @@ const PAD_FRAMING_V1: u8 = 0xF5;
 /// [`PAD_FRAMING_V1`], so it can never collide with legacy unpadded text.
 const REDACT_FRAMING_V1: u8 = 0xF6;
 
+/// Marker for the optional **thread trailer** (#825), written immediately
+/// after the real plaintext inside an otherwise ordinary [`PAD_FRAMING_V1`]
+/// text frame:
+///
+/// ```text
+///  byte 0        : PAD_FRAMING_V1 (0xF5)
+///  bytes 1..5    : u32 LE real-plaintext length      <- unchanged
+///  bytes 5..N    : real plaintext                    <- unchanged
+///  byte N        : THREAD_TRAILER_V1 (0xF7)
+///  bytes N+1..N+5: u32 LE thread-id length
+///  bytes N+5..M  : thread id (ULID, UTF-8)
+///  bytes M..     : zero padding up to the bucket size
+/// ```
+///
+/// ## Why a trailer instead of a new frame version
+///
+/// A brand-new marker byte (`0xF8…`) would have been the obvious move, but an
+/// OLD client hits the `strip` fallback on an unrecognised marker and returns
+/// the whole buffer verbatim — so every thread reply would render as binary
+/// mojibake on any client that predates this change. "Messages must work"
+/// (CLAUDE.md) rules that out.
+///
+/// Hanging the thread id off the END of the existing v1 frame keeps the header
+/// and the length prefix byte-for-byte what they always were, so an old
+/// client's `strip` reads the same length prefix, returns exactly the same
+/// plaintext, and never looks past it. A thread reply degrades to a perfectly
+/// ordinary channel message on an old client — it loses the threading, not the
+/// message.
+///
+/// The marker cannot be confused with padding (which is `0x00`) and cannot be
+/// confused with the plaintext (which ended at `N`), so its presence at `N` is
+/// unambiguous. It is drawn from the same reserved `0xF5..=0xFF` range as the
+/// frame markers so the two namespaces never collide.
+const THREAD_TRAILER_V1: u8 = 0xF7;
+
 /// Framing header: 1 version byte + 4-byte little-endian length prefix. Shared
 /// by the padded-text ([`PAD_FRAMING_V1`]) and redaction ([`REDACT_FRAMING_V1`])
 /// frames.
@@ -132,7 +167,13 @@ pub(crate) fn strip(buf: &[u8]) -> Vec<u8> {
 /// plaintext; a "delete for everyone" control message is
 /// [`Frame::Redaction`] carrying the target message id.
 pub(crate) enum Frame {
-    Text(Vec<u8>),
+    Text {
+        text: Vec<u8>,
+        /// Set when the sender wrote a thread trailer (#825) — the ULID of the
+        /// thread's root message. `None` for an ordinary channel message, and
+        /// for every message sent by a client that predates threads.
+        thread_id: Option<String>,
+    },
     Redaction(String),
 }
 
@@ -169,7 +210,68 @@ pub(crate) fn classify(buf: &[u8]) -> Frame {
             }
         }
     }
-    Frame::Text(strip(buf))
+    Frame::Text {
+        text: strip(buf),
+        thread_id: thread_of(buf),
+    }
+}
+
+/// Wrap `plaintext` in the v1 framing with a thread trailer naming
+/// `thread_id`, then zero-pad to the size bucket (#825).
+///
+/// Identical to [`pad`] up to the end of the plaintext — which is exactly what
+/// makes a thread reply readable on a client that has never heard of threads.
+pub(crate) fn pad_threaded(plaintext: &[u8], thread_id: &str) -> Vec<u8> {
+    let id = thread_id.as_bytes();
+    let mut buf = Vec::with_capacity(HEADER + plaintext.len() + HEADER + id.len());
+    buf.push(PAD_FRAMING_V1);
+    buf.extend_from_slice(&(plaintext.len() as u32).to_le_bytes());
+    buf.extend_from_slice(plaintext);
+    buf.push(THREAD_TRAILER_V1);
+    buf.extend_from_slice(&(id.len() as u32).to_le_bytes());
+    buf.extend_from_slice(id);
+    let target = padded_len(buf.len());
+    buf.resize(target, 0u8);
+    buf
+}
+
+/// Recover the thread id from a decrypted buffer, if the sender wrote one.
+///
+/// Returns `None` for every buffer [`pad`] produces, for legacy unpadded
+/// messages, for attachment envelopes, and for any malformed trailer — a
+/// message that merely loses its threading is far better than one that fails
+/// to decode, so every ambiguous case degrades to "not in a thread".
+pub(crate) fn thread_of(buf: &[u8]) -> Option<String> {
+    if buf.first() != Some(&PAD_FRAMING_V1) || buf.len() < HEADER {
+        return None;
+    }
+    let len = u32::from_le_bytes([buf[1], buf[2], buf[3], buf[4]]) as usize;
+    // `checked_add` because `len` is attacker-controlled in the sense that it
+    // arrives from a decrypted buffer we did not build; an overflow here would
+    // wrap and index somewhere arbitrary.
+    let end = HEADER.checked_add(len)?;
+    // `>=`, not `>`: the trailer marker itself must be within the buffer.
+    if end >= buf.len() || buf[end] != THREAD_TRAILER_V1 {
+        return None;
+    }
+    let id_len_at = end.checked_add(1)?;
+    let id_at = id_len_at.checked_add(4)?;
+    if id_at > buf.len() {
+        return None;
+    }
+    let id_len = u32::from_le_bytes([
+        buf[id_len_at],
+        buf[id_len_at + 1],
+        buf[id_len_at + 2],
+        buf[id_len_at + 3],
+    ]) as usize;
+    let id_end = id_at.checked_add(id_len)?;
+    if id_end > buf.len() {
+        return None;
+    }
+    std::str::from_utf8(&buf[id_at..id_end])
+        .ok()
+        .map(str::to_string)
 }
 
 #[cfg(test)]
@@ -279,7 +381,7 @@ mod tests {
             let framed = pad_redaction(id);
             match classify(&framed) {
                 Frame::Redaction(got) => assert_eq!(got, id, "redaction id must round-trip"),
-                Frame::Text(_) => panic!("a redaction frame must classify as Redaction (id={id:?})"),
+                Frame::Text { .. } => panic!("a redaction frame must classify as Redaction (id={id:?})"),
             }
         }
     }
@@ -307,7 +409,7 @@ mod tests {
         ];
         for &buf in cases {
             match classify(buf) {
-                Frame::Text(plaintext) => assert_eq!(plaintext, strip(buf)),
+                Frame::Text { text, .. } => assert_eq!(text, strip(buf)),
                 Frame::Redaction(_) => panic!("non-redaction payload misclassified: {buf:?}"),
             }
         }
@@ -321,6 +423,111 @@ mod tests {
         let mut bad = vec![REDACT_FRAMING_V1];
         bad.extend_from_slice(&999u32.to_le_bytes());
         bad.extend_from_slice(b"short");
-        assert!(matches!(classify(&bad), Frame::Text(_)));
+        assert!(matches!(classify(&bad), Frame::Text { .. }));
+    }
+
+    // ── Thread trailer (#825) ───────────────────────────────────────────────
+
+    const THREAD: &str = "01J8XQ2M5H7NR3T0V9WZ4KDCEB";
+
+    /// THE load-bearing back-compat test. A client that predates threads only
+    /// ever calls `strip`; if the trailer disturbed the header or the length
+    /// prefix, every thread reply would render as mojibake on an old client.
+    /// `strip` must return the plaintext byte-for-byte, exactly as it does for
+    /// an unthreaded `pad`.
+    #[test]
+    fn old_client_strip_recovers_thread_reply_verbatim() {
+        for text in [
+            "".as_bytes(),
+            "ok".as_bytes(),
+            "a longer reply that crosses a bucket boundary ".repeat(20).as_bytes(),
+            // Multi-byte UTF-8 must survive untouched.
+            "héllo → 🧵".as_bytes(),
+        ] {
+            let framed = pad_threaded(text, THREAD);
+            assert_eq!(
+                strip(&framed),
+                text,
+                "a threads-unaware client must recover the plaintext exactly",
+            );
+        }
+    }
+
+    #[test]
+    fn pad_threaded_roundtrips_thread_id() {
+        let framed = pad_threaded(b"in a thread", THREAD);
+        assert_eq!(thread_of(&framed).as_deref(), Some(THREAD));
+        match classify(&framed) {
+            Frame::Text { text, thread_id } => {
+                assert_eq!(text, b"in a thread");
+                assert_eq!(thread_id.as_deref(), Some(THREAD));
+            }
+            Frame::Redaction(_) => panic!("threaded text misclassified as redaction"),
+        }
+    }
+
+    /// An ordinary send carries no trailer, so it must never be mistaken for a
+    /// thread reply — including when the plaintext itself ends in the trailer
+    /// marker byte or in zeros.
+    #[test]
+    fn unthreaded_payloads_have_no_thread_id() {
+        assert_eq!(thread_of(&pad(b"plain message")), None);
+        assert_eq!(thread_of(&pad(b"")), None);
+        assert_eq!(thread_of(&pad(&[0x00, 0x00, 0x00])), None);
+        assert_eq!(thread_of(&pad(&[THREAD_TRAILER_V1])), None);
+        // Legacy unpadded text and attachment envelopes.
+        assert_eq!(thread_of(b"legacy unpadded"), None);
+        assert_eq!(thread_of(br#"{"_att":[]}"#), None);
+        assert_eq!(thread_of(&[]), None);
+        // A redaction frame is not a text frame and has no thread.
+        assert_eq!(thread_of(&pad_redaction("01JABC")), None);
+    }
+
+    /// A truncated or hostile trailer degrades to "no thread" instead of
+    /// panicking. These cannot arise from `pad_threaded`; the ingest path must
+    /// survive them anyway, since the buffer is only as trustworthy as the
+    /// sender.
+    #[test]
+    fn malformed_thread_trailer_degrades_to_none() {
+        let good = pad_threaded(b"hi", THREAD);
+        let text_end = HEADER + 2;
+
+        // Trailer marker present but the id length prefix is truncated away.
+        let truncated = good[..text_end + 1].to_vec();
+        assert_eq!(thread_of(&truncated), None);
+
+        // Id length prefix overruns the buffer.
+        let mut overrun = good[..text_end + 1].to_vec();
+        overrun.extend_from_slice(&9_999u32.to_le_bytes());
+        overrun.extend_from_slice(b"short");
+        assert_eq!(thread_of(&overrun), None);
+
+        // Length prefix large enough that `HEADER + len` would overflow.
+        let mut overflow = vec![PAD_FRAMING_V1];
+        overflow.extend_from_slice(&u32::MAX.to_le_bytes());
+        overflow.extend_from_slice(b"body");
+        assert_eq!(thread_of(&overflow), None);
+
+        // Non-UTF-8 thread id.
+        let mut bad_utf8 = good[..text_end + 1].to_vec();
+        bad_utf8.extend_from_slice(&2u32.to_le_bytes());
+        bad_utf8.extend_from_slice(&[0xFF, 0xFE]);
+        assert_eq!(thread_of(&bad_utf8), None);
+    }
+
+    /// The trailer must not defeat the padding it sits inside — a thread reply
+    /// is still bucketed, so its ciphertext length leaks no more than an
+    /// ordinary short message's does.
+    #[test]
+    fn threaded_payloads_are_still_bucketed() {
+        for text in ["a", "a much longer thread reply", ""] {
+            let framed = pad_threaded(text.as_bytes(), THREAD);
+            assert_eq!(
+                framed.len(),
+                padded_len(framed.len()),
+                "threaded payload escaped its size bucket",
+            );
+            assert_eq!(framed.len(), MIN_BUCKET, "short replies must collapse");
+        }
     }
 }

--- a/pollis-core/src/commands/messages/ingest.rs
+++ b/pollis-core/src/commands/messages/ingest.rs
@@ -562,13 +562,17 @@ fn decrypt_and_persist_one(
                 // Ordinary text / attachment message. Strip size padding (issue
                 // #331 v2, §4.1) — a no-op for legacy unpadded sends and for
                 // attachment envelopes, so old and new clients interoperate.
-                super::framing::Frame::Text(plaintext) => {
-                    if let Ok(text) = String::from_utf8(plaintext) {
+                // `thread_id` (#825) rides inside the ciphertext as a trailer on
+                // this same frame, so it is recovered here and nowhere else —
+                // the DS and Turso never see it. `None` for every unthreaded
+                // send and for every message from a threads-unaware client.
+                super::framing::Frame::Text { text, thread_id } => {
+                    if let Ok(text) = String::from_utf8(text) {
                         let _ = conn.execute(
                             "INSERT OR IGNORE INTO message
-                             (id, conversation_id, sender_id, ciphertext, content, reply_to_id, sent_at)
-                             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
-                            rusqlite::params![id, conversation_id, cred_sender, bytes, text, reply_to_id, sent_at],
+                             (id, conversation_id, sender_id, ciphertext, content, reply_to_id, thread_id, sent_at)
+                             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                            rusqlite::params![id, conversation_id, cred_sender, bytes, text, reply_to_id, thread_id, sent_at],
                         );
                     }
                 }

--- a/pollis-core/src/commands/messages/mod.rs
+++ b/pollis-core/src/commands/messages/mod.rs
@@ -22,7 +22,7 @@ pub mod watermark;
 // ── Types ────────────────────────────────────────────────────────────────────
 pub use types::{
     ChannelMessage, ChannelPreview, Message, MessageCursor, MessagePage, MessageWithContext,
-    SearchResult,
+    SearchResult, ThreadSummary,
 };
 
 // ── Send ─────────────────────────────────────────────────────────────────────
@@ -31,7 +31,8 @@ pub use send::send_message;
 // ── Read / list / search ─────────────────────────────────────────────────────
 pub use read::{
     get_channel_messages, get_dm_messages, list_channel_previews, list_messages,
-    list_messages_by_sender, read_channel_messages, read_dm_messages, search_messages,
+    list_messages_by_sender, list_thread_summaries, read_channel_messages, read_dm_messages,
+    read_thread_messages, search_messages,
 };
 
 // ── Ingest (envelope pull + watermark + cleanup) ─────────────────────────────

--- a/pollis-core/src/commands/messages/read.rs
+++ b/pollis-core/src/commands/messages/read.rs
@@ -9,7 +9,7 @@ use crate::db::queries::CHANNEL_PREVIEWS as QUERY_CHANNEL_PREVIEWS;
 use super::ingest::{ingest_channel_envelopes_inner, ingest_dm_envelopes_inner};
 use super::types::{
     ChannelMessage, ChannelPreview, Message, MessageCursor, MessagePage, MessageWithContext,
-    SearchResult,
+    SearchResult, ThreadSummary,
 };
 
 pub async fn list_messages(
@@ -30,7 +30,7 @@ pub async fn list_messages(
         ).unwrap_or_else(|_| chrono::Utc::now().to_rfc3339());
 
         let mut stmt = db.conn().prepare(
-            "SELECT id, conversation_id, sender_id, content, reply_to_id, sent_at
+            "SELECT id, conversation_id, sender_id, content, reply_to_id, thread_id, sent_at
              FROM message
              WHERE conversation_id = ?1 AND sent_at < ?2
              ORDER BY sent_at DESC LIMIT ?3"
@@ -44,14 +44,15 @@ pub async fn list_messages(
                 sender_id: row.get(2)?,
                 content: row.get(3)?,
                 reply_to_id: row.get(4)?,
-                sent_at: row.get(5)?,
+                thread_id: row.get(5)?,
+                sent_at: row.get(6)?,
             }),
         )?;
 
         rows.filter_map(|r| r.ok()).collect()
     } else {
         let mut stmt = db.conn().prepare(
-            "SELECT id, conversation_id, sender_id, content, reply_to_id, sent_at
+            "SELECT id, conversation_id, sender_id, content, reply_to_id, thread_id, sent_at
              FROM message
              WHERE conversation_id = ?1
              ORDER BY sent_at DESC LIMIT ?2"
@@ -65,7 +66,8 @@ pub async fn list_messages(
                 sender_id: row.get(2)?,
                 content: row.get(3)?,
                 reply_to_id: row.get(4)?,
-                sent_at: row.get(5)?,
+                thread_id: row.get(5)?,
+                sent_at: row.get(6)?,
             }),
         )?;
 
@@ -106,6 +108,32 @@ pub async fn get_channel_messages(
     Ok(MessagePage { messages, next_cursor })
 }
 
+/// Map a `message` row to a [`ChannelMessage`].
+///
+/// Shared by the channel/DM page reads and the thread read (#825), so every
+/// caller must SELECT the same column order:
+/// `id, conversation_id, sender_id, ciphertext, content, reply_to_id, sent_at,
+///  edited_at, deleted_at, thread_id`.
+fn row_to_channel_message(row: &rusqlite::Row<'_>) -> rusqlite::Result<ChannelMessage> {
+    let ct: Vec<u8> = row.get(3)?;
+    let content: Option<String> = row.get(4)?;
+    let deleted_at: Option<String> = row.get(8)?;
+    Ok(ChannelMessage {
+        id: row.get(0)?,
+        conversation_id: row.get(1)?,
+        sender_id: row.get(2)?,
+        sender_username: None,
+        ciphertext: format!("mls:{}", hex::encode(&ct)),
+        // Soft-deleted messages mask content to None regardless of cache.
+        content: if deleted_at.is_some() { None } else { content },
+        reply_to_id: row.get(5)?,
+        thread_id: row.get(9)?,
+        sent_at: row.get(6)?,
+        edited_at: row.get(7)?,
+        deleted_at,
+    })
+}
+
 /// Read a page of messages for a conversation from the local `message` table,
 /// newest-first. Used by both channel and DM read paths after ingest has
 /// persisted any new envelopes.
@@ -118,36 +146,17 @@ async fn read_local_channel_page(
     let guard = state.local_db.lock().await;
     let db = guard.as_ref().ok_or_else(|| crate::error::Error::Other(anyhow::anyhow!("Not signed in")))?;
 
-    fn row_to_message(row: &rusqlite::Row<'_>) -> rusqlite::Result<ChannelMessage> {
-        let ct: Vec<u8> = row.get(3)?;
-        let content: Option<String> = row.get(4)?;
-        let deleted_at: Option<String> = row.get(8)?;
-        Ok(ChannelMessage {
-            id: row.get(0)?,
-            conversation_id: row.get(1)?,
-            sender_id: row.get(2)?,
-            sender_username: None,
-            ciphertext: format!("mls:{}", hex::encode(&ct)),
-            // Soft-deleted messages mask content to None regardless of cache.
-            content: if deleted_at.is_some() { None } else { content },
-            reply_to_id: row.get(5)?,
-            sent_at: row.get(6)?,
-            edited_at: row.get(7)?,
-            deleted_at,
-        })
-    }
-
     let mut rows: Vec<ChannelMessage> = Vec::new();
     match cursor {
         None => {
             let mut stmt = db.conn().prepare(
-                "SELECT id, conversation_id, sender_id, ciphertext, content, reply_to_id, sent_at, edited_at, deleted_at
+                "SELECT id, conversation_id, sender_id, ciphertext, content, reply_to_id, sent_at, edited_at, deleted_at, thread_id
                  FROM message
                  WHERE conversation_id = ?1
                  ORDER BY sent_at DESC, id DESC
                  LIMIT ?2"
             )?;
-            let mapped = stmt.query_map(rusqlite::params![conversation_id, limit], row_to_message)?;
+            let mapped = stmt.query_map(rusqlite::params![conversation_id, limit], row_to_channel_message)?;
             for r in mapped {
                 if let Ok(m) = r {
                     rows.push(m);
@@ -156,14 +165,14 @@ async fn read_local_channel_page(
         }
         Some(c) => {
             let mut stmt = db.conn().prepare(
-                "SELECT id, conversation_id, sender_id, ciphertext, content, reply_to_id, sent_at, edited_at, deleted_at
+                "SELECT id, conversation_id, sender_id, ciphertext, content, reply_to_id, sent_at, edited_at, deleted_at, thread_id
                  FROM message
                  WHERE conversation_id = ?1
                    AND (sent_at < ?2 OR (sent_at = ?2 AND id < ?3))
                  ORDER BY sent_at DESC, id DESC
                  LIMIT ?4"
             )?;
-            let mapped = stmt.query_map(rusqlite::params![conversation_id, c.sent_at, c.id, limit], row_to_message)?;
+            let mapped = stmt.query_map(rusqlite::params![conversation_id, c.sent_at, c.id, limit], row_to_channel_message)?;
             for r in mapped {
                 if let Ok(m) = r {
                     rows.push(m);
@@ -429,5 +438,75 @@ pub async fn search_messages(
         },
     )?;
 
+    Ok(rows.filter_map(|r| r.ok()).collect())
+}
+
+/// One thread's replies, oldest-first (#825).
+///
+/// Purely local: `thread_id` lives inside the MLS ciphertext and is recovered
+/// at ingest, so the DS cannot be asked for a thread and there is nothing to
+/// paginate server-side. What this device has decrypted is the thread. A device
+/// that joined later, or a fresh install, sees only what it holds — the same
+/// bounded-history behaviour that already applies to channels.
+///
+/// The root message itself is NOT included; it is already rendered in the
+/// channel, and the caller has it.
+pub async fn read_thread_messages(
+    thread_id: String,
+    state: &Arc<AppState>,
+) -> Result<Vec<ChannelMessage>> {
+    // The rusqlite connection and its statements are not `Send`, so every one
+    // of them has to be dropped before the `.await` below — an explicit
+    // `drop()` is not enough, since the generated future still captures them.
+    // Scoping the whole DB read in a block is what keeps this command `Send`.
+    let mut messages: Vec<ChannelMessage> = {
+        let guard = state.local_db.lock().await;
+        let db = guard
+            .as_ref()
+            .ok_or_else(|| crate::error::Error::Other(anyhow::anyhow!("Not signed in")))?;
+
+        let mut stmt = db.conn().prepare(
+            "SELECT id, conversation_id, sender_id, ciphertext, content, reply_to_id, sent_at, edited_at, deleted_at, thread_id
+             FROM message
+             WHERE thread_id = ?1
+             ORDER BY sent_at ASC, id ASC",
+        )?;
+        let mapped = stmt.query_map(rusqlite::params![thread_id], row_to_channel_message)?;
+        mapped.filter_map(|r| r.ok()).collect()
+    };
+
+    attach_sender_usernames_local(state, &mut messages).await?;
+    Ok(messages)
+}
+
+/// Reply count and last-reply time for every thread in a conversation (#825).
+///
+/// Drives the "N replies" affordance under a root message without loading each
+/// thread. Soft-deleted replies are excluded from the count so a thread whose
+/// replies were all deleted stops advertising itself.
+pub async fn list_thread_summaries(
+    conversation_id: String,
+    state: &Arc<AppState>,
+) -> Result<Vec<ThreadSummary>> {
+    let guard = state.local_db.lock().await;
+    let db = guard
+        .as_ref()
+        .ok_or_else(|| crate::error::Error::Other(anyhow::anyhow!("Not signed in")))?;
+
+    let mut stmt = db.conn().prepare(
+        "SELECT thread_id, COUNT(*) AS reply_count, MAX(sent_at) AS last_reply_at
+         FROM message
+         WHERE conversation_id = ?1
+           AND thread_id IS NOT NULL
+           AND deleted_at IS NULL
+         GROUP BY thread_id",
+    )?;
+    let rows = stmt.query_map(rusqlite::params![conversation_id], |row| {
+        Ok(ThreadSummary {
+            thread_id: row.get(0)?,
+            reply_count: row.get(1)?,
+            last_reply_at: row.get(2)?,
+        })
+    })?;
     Ok(rows.filter_map(|r| r.ok()).collect())
 }

--- a/pollis-core/src/commands/messages/send.rs
+++ b/pollis-core/src/commands/messages/send.rs
@@ -19,6 +19,10 @@ pub async fn send_message(
     sender_id: String,
     content: String,
     reply_to_id: Option<String>,
+    // ULID of the thread root this message replies into (#825). `None` for an
+    // ordinary channel message. Travels only inside the MLS ciphertext — it is
+    // never included in the DS request body.
+    thread_id: Option<String>,
     sender_username: Option<String>,
     state: &Arc<AppState>,
 ) -> Result<Message> {
@@ -84,9 +88,9 @@ pub async fn send_message(
             ))?;
             let empty: Vec<u8> = Vec::new();
             db.conn().execute(
-                "INSERT INTO message (id, conversation_id, sender_id, ciphertext, content, reply_to_id, sent_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
-                rusqlite::params![id, conversation_id, sender_id, empty, content, reply_to_id, now],
+                "INSERT INTO message (id, conversation_id, sender_id, ciphertext, content, reply_to_id, thread_id, sent_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                rusqlite::params![id, conversation_id, sender_id, empty, content, reply_to_id, thread_id, now],
             )?;
         }
         return Ok(Message {
@@ -95,6 +99,7 @@ pub async fn send_message(
             sender_id,
             content: Some(content),
             reply_to_id,
+            thread_id,
             sent_at: now,
         });
     }
@@ -137,10 +142,22 @@ pub async fn send_message(
         // MLS ciphertext, so only members see it and there's no schema/server
         // change. Attachment envelopes are left unpadded — their R2 blob size is
         // inherent and dedup depends on it.
-        let plaintext: Vec<u8> = if super::edit_delete::is_attachment_content(&content) {
-            content.as_bytes().to_vec()
-        } else {
-            super::framing::pad(content.as_bytes())
+        //
+        // A THREADED send (#825) always takes the padded frame, attachment
+        // envelope or not, because the thread id rides in that frame's trailer
+        // and there is nowhere else inside the ciphertext to put it. Padding an
+        // attachment envelope is harmless — the exemption above exists because
+        // the R2 blob size already leaks, not because padding would hurt — and
+        // an old client still strips a `0xF5` frame correctly, so a threaded
+        // attachment stays readable on clients that predate threads.
+        //
+        // An UNTHREADED send is byte-for-byte what it was before threads.
+        let plaintext: Vec<u8> = match thread_id.as_deref() {
+            Some(thread) => super::framing::pad_threaded(content.as_bytes(), thread),
+            None if super::edit_delete::is_attachment_content(&content) => {
+                content.as_bytes().to_vec()
+            }
+            None => super::framing::pad(content.as_bytes()),
         };
 
         let mls_bytes = crate::commands::mls::try_mls_encrypt(db.conn(), &mls_group_id, &plaintext)
@@ -151,9 +168,9 @@ pub async fn send_message(
         let mls_ct_str = format!("mls:{}", hex::encode(&mls_bytes));
 
         db.conn().execute(
-            "INSERT INTO message (id, conversation_id, sender_id, ciphertext, content, reply_to_id, sent_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
-            rusqlite::params![id, conversation_id, sender_id, mls_bytes, content, reply_to_id, now],
+            "INSERT INTO message (id, conversation_id, sender_id, ciphertext, content, reply_to_id, thread_id, sent_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            rusqlite::params![id, conversation_id, sender_id, mls_bytes, content, reply_to_id, thread_id, now],
         )?;
 
         mls_ct_str
@@ -305,6 +322,7 @@ pub async fn send_message(
         sender_id,
         content: Some(content),
         reply_to_id,
+        thread_id,
         sent_at: now,
     })
 }

--- a/pollis-core/src/commands/messages/types.rs
+++ b/pollis-core/src/commands/messages/types.rs
@@ -7,6 +7,10 @@ pub struct Message {
     pub sender_id: String,
     pub content: Option<String>,
     pub reply_to_id: Option<String>,
+    /// ULID of the thread root this message replies into (#825), or `None` for
+    /// an ordinary channel message. Recovered from inside the MLS ciphertext —
+    /// never a server-visible field.
+    pub thread_id: Option<String>,
     pub sent_at: String,
 }
 
@@ -48,6 +52,8 @@ pub struct ChannelMessage {
     pub ciphertext: String,
     pub content: Option<String>,
     pub reply_to_id: Option<String>,
+    /// See [`Message::thread_id`].
+    pub thread_id: Option<String>,
     pub sent_at: String,
     pub edited_at: Option<String>,
     pub deleted_at: Option<String>,
@@ -81,4 +87,19 @@ pub struct SearchResult {
     pub sent_at: String,
     /// Surrounding context — same as content for now.
     pub snippet: String,
+}
+
+/// Reply count and last-reply time for one thread (#825), used to render the
+/// "N replies" affordance under a root message without loading the thread.
+///
+/// Derived entirely from decrypted local rows — the server has no notion of a
+/// thread, so these numbers describe what THIS device holds.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ThreadSummary {
+    /// ULID of the thread root message.
+    pub thread_id: String,
+    /// Replies this device holds, excluding soft-deleted ones.
+    pub reply_count: i64,
+    /// `sent_at` of the newest reply this device holds.
+    pub last_reply_at: Option<String>,
 }

--- a/pollis-core/src/db/local.rs
+++ b/pollis-core/src/db/local.rs
@@ -94,6 +94,10 @@ impl LocalDb {
         if !is_fresh {
             ensure_incremental_auto_vacuum(&conn)?;
         }
+        // Additive columns run BEFORE the schema batch, because that batch now
+        // contains an index over one of them and `CREATE INDEX` on a column an
+        // existing DB has not gained yet would fail the whole batch.
+        add_missing_columns(&conn)?;
         conn.execute_batch(SCHEMA)?;
         conn.execute(
             "INSERT OR REPLACE INTO kv (key, value) VALUES ('schema_version', ?1)",
@@ -137,6 +141,51 @@ pub const ALLOWED_RETENTION_DAYS: [i64; 4] = [0, 30, 90, 365];
 /// A no-op if already FULL/INCREMENTAL, so it is safe to call on every open.
 /// `VACUUM` is required because `auto_vacuum` cannot otherwise change on a DB
 /// that already holds tables; it rewrites the file and preserves all data.
+/// Columns added to EXISTING tables since a database was first created.
+///
+/// `local_schema.sql` is re-applied on every open, but `CREATE TABLE IF NOT
+/// EXISTS` cannot widen a table that already exists — and the alternative,
+/// bumping [`LOCAL_SCHEMA_VERSION`], DELETES the database file along with the
+/// device's MLS state and the user's entire message history. Adding a nullable
+/// column is not remotely worth that, so additive columns land here instead.
+///
+/// Each entry must be nullable or carry a DEFAULT, so existing rows stay valid
+/// without a backfill.
+const ADDITIVE_COLUMNS: &[(&str, &str, &str)] = &[
+    // (table, column, full ALTER fragment)
+    ("message", "thread_id", "ALTER TABLE message ADD COLUMN thread_id TEXT"),
+];
+
+/// Apply [`ADDITIVE_COLUMNS`] to a database that predates them.
+///
+/// Runs on every open and is idempotent. Two failures are expected and
+/// tolerated rather than propagated:
+///
+/// * **"duplicate column name"** — the column is already there, i.e. every
+///   open after the first.
+/// * **"no such table"** — a fresh database, where the schema batch that
+///   follows creates the table already carrying the column.
+///
+/// Anything else is a real error and is surfaced, on the same principle as the
+/// wipe guard in `open_at`: we do not quietly paper over failures we do not
+/// understand on a database holding the user's history.
+fn add_missing_columns(conn: &Connection) -> Result<()> {
+    for (table, column, stmt) in ADDITIVE_COLUMNS {
+        match conn.execute(stmt, []) {
+            Ok(_) => {}
+            Err(rusqlite::Error::SqliteFailure(_, Some(ref msg)))
+                if msg.contains("duplicate column name")
+                    || msg.starts_with("no such table") => {}
+            Err(e) => {
+                return Err(Error::Other(anyhow::anyhow!(
+                    "add column {table}.{column}: {e}"
+                )))
+            }
+        }
+    }
+    Ok(())
+}
+
 fn ensure_incremental_auto_vacuum(conn: &Connection) -> Result<()> {
     // 0 = NONE, 1 = FULL, 2 = INCREMENTAL.
     let mode: i64 = conn.query_row("PRAGMA auto_vacuum;", [], |row| row.get(0))?;
@@ -212,6 +261,97 @@ mod tests {
 
     fn db() -> LocalDb {
         LocalDb::open_in_memory().expect("in-memory db")
+    }
+
+    /// #825: gaining `message.thread_id` must NOT cost the user their history.
+    ///
+    /// Builds a database with the pre-thread `message` shape, puts a message in
+    /// it, then runs the same open-path steps `open_at` runs — additive columns
+    /// first, then the schema batch. The row, and the MLS state alongside it,
+    /// must still be there afterwards. Bumping `LOCAL_SCHEMA_VERSION` instead
+    /// would delete the file and fail this test, which is the point.
+    #[test]
+    fn additive_column_preserves_existing_history() {
+        let conn = Connection::open_in_memory().expect("open");
+
+        // The `message` table exactly as it was before threads: no thread_id.
+        conn.execute_batch(
+            "CREATE TABLE message (
+                 id TEXT PRIMARY KEY,
+                 conversation_id TEXT NOT NULL,
+                 sender_id TEXT NOT NULL,
+                 ciphertext BLOB NOT NULL,
+                 content TEXT,
+                 reply_to_id TEXT,
+                 sent_at TEXT NOT NULL,
+                 received_at TEXT NOT NULL DEFAULT (datetime('now')),
+                 delivered INTEGER NOT NULL DEFAULT 0,
+                 edited_at TEXT,
+                 deleted_at TEXT
+             );
+             CREATE TABLE mls_kv (k TEXT PRIMARY KEY, v BLOB NOT NULL);",
+        )
+        .expect("legacy schema");
+
+        conn.execute(
+            "INSERT INTO message (id, conversation_id, sender_id, ciphertext, content, sent_at)
+             VALUES ('old1', 'conv1', 'user1', X'deadbeef', 'from before threads', '2024-01-01T00:00:00Z')",
+            [],
+        )
+        .expect("seed history");
+        conn.execute(
+            "INSERT INTO mls_kv (k, v) VALUES ('group_state', X'c0ffee')",
+            [],
+        )
+        .expect("seed mls state");
+
+        // The upgrade, in the order `open_at` performs it.
+        add_missing_columns(&conn).expect("additive columns");
+        conn.execute_batch(SCHEMA).expect("schema batch");
+
+        // History survived.
+        let (content, thread_id): (String, Option<String>) = conn
+            .query_row(
+                "SELECT content, thread_id FROM message WHERE id = 'old1'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("pre-existing message still present");
+        assert_eq!(content, "from before threads");
+        assert_eq!(thread_id, None, "pre-thread messages are not in a thread");
+
+        // MLS state survived — the expensive half of a wipe.
+        let mls: Vec<u8> = conn
+            .query_row("SELECT v FROM mls_kv WHERE k = 'group_state'", [], |row| {
+                row.get(0)
+            })
+            .expect("mls state still present");
+        assert_eq!(mls, vec![0xc0, 0xff, 0xee]);
+
+        // The new column is usable, and re-running the upgrade is a no-op.
+        add_missing_columns(&conn).expect("second run must be idempotent");
+        conn.execute(
+            "INSERT INTO message (id, conversation_id, sender_id, ciphertext, content, thread_id, sent_at)
+             VALUES ('new1', 'conv1', 'user1', X'01', 'reply', 'old1', '2024-01-02T00:00:00Z')",
+            [],
+        )
+        .expect("thread_id is writable");
+    }
+
+    /// A fresh database has no `message` table when additive columns run, and
+    /// that must not be an error — the schema batch right after creates the
+    /// table already carrying the column.
+    #[test]
+    fn additive_columns_tolerate_a_fresh_database() {
+        let conn = Connection::open_in_memory().expect("open");
+        add_missing_columns(&conn).expect("no such table must be tolerated");
+        conn.execute_batch(SCHEMA).expect("schema batch");
+        conn.execute(
+            "INSERT INTO message (id, conversation_id, sender_id, ciphertext, thread_id, sent_at)
+             VALUES ('m1', 'c1', 'u1', X'00', 't1', '2024-01-01T00:00:00Z')",
+            [],
+        )
+        .expect("fresh db has thread_id");
     }
 
     #[test]

--- a/pollis-core/src/db/local_schema.sql
+++ b/pollis-core/src/db/local_schema.sql
@@ -25,10 +25,23 @@ CREATE TABLE IF NOT EXISTS message (
     received_at TEXT NOT NULL DEFAULT (datetime('now')),
     delivered INTEGER NOT NULL DEFAULT 0,
     edited_at TEXT,
-    deleted_at TEXT
+    deleted_at TEXT,
+    -- ULID of the thread root this message replies into, NULL for an ordinary
+    -- channel message (#825). Only ever populated from the decrypted MLS
+    -- payload — it is never sent to, or read from, the DS.
+    --
+    -- This column is ALSO added to pre-existing databases by
+    -- `add_missing_columns` in `local.rs`; CREATE TABLE IF NOT EXISTS is a
+    -- no-op once the table exists, so this line only serves fresh DBs.
+    thread_id TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_message_conversation ON message(conversation_id, sent_at);
+
+-- Thread lookup: fetching one thread's replies, and counting replies per root.
+-- Created on every open like the eviction index above, so existing DBs gain it
+-- without a schema-version bump (which would wipe history).
+CREATE INDEX IF NOT EXISTS idx_message_thread ON message(thread_id, sent_at);
 
 -- Eviction scan index: lookback/retention sweeps delete by received_at. Run on
 -- every open (this schema is re-applied each open) so existing DBs gain it

--- a/pollis-tui/src/home.rs
+++ b/pollis-tui/src/home.rs
@@ -493,6 +493,7 @@ mod tests {
             ciphertext: String::new(),
             content: Some(content.to_string()),
             reply_to_id: None,
+            thread_id: None,
             sent_at: sent_at.to_string(),
             edited_at: None,
             deleted_at: None,

--- a/pollis-tui/src/send.rs
+++ b/pollis-tui/src/send.rs
@@ -37,6 +37,12 @@ pub async fn send_message(
     sender_id: &str,
     content: &str,
     reply_to_id: Option<String>,
+    // ULID of the thread root this message replies into (#825). Threaded through
+    // rather than hardcoded `None` at the core call: the TUI has no thread UI yet,
+    // but the wrapper stays a faithful passthrough so adding one is a caller
+    // change, not a signature change — and so a thread reply can never be
+    // silently flattened into the channel by this path.
+    thread_id: Option<String>,
     sender_username: Option<String>,
     state: &Arc<AppState>,
 ) -> Result<Message> {
@@ -45,6 +51,7 @@ pub async fn send_message(
         sender_id.to_string(),
         content.to_string(),
         reply_to_id,
+        thread_id,
         sender_username,
         state,
     )
@@ -153,7 +160,8 @@ pub async fn send_text(
     conv_id: &str,
     text: &str,
 ) -> Result<Message> {
-    send_message(conv_id, user_id, text, None, username, state).await
+    // No thread UI in the TUI yet — an ordinary channel message.
+    send_message(conv_id, user_id, text, None, None, username, state).await
 }
 
 /// Create a group named `name` owned by `user_id`, with the default text

--- a/pollis-tui/tests/common/mod.rs
+++ b/pollis-tui/tests/common/mod.rs
@@ -1377,6 +1377,8 @@ impl TestClient {
             self.user_id().to_string(),
             content.to_string(),
             None,
+            // reply_to_id / thread_id: an ordinary channel message.
+            None,
             username,
             &self.state,
         )

--- a/src-tauri/src/commands/messages.rs
+++ b/src-tauri/src/commands/messages.rs
@@ -14,8 +14,8 @@ pub async fn list_messages(conversation_id: String, limit: Option<i64>, before_i
 }
 
 #[tauri::command]
-pub async fn send_message(conversation_id: String, sender_id: String, content: String, reply_to_id: Option<String>, sender_username: Option<String>, state: State<'_, Arc<AppState>>) -> Result<Message> {
-    pollis_core::commands::messages::send_message(conversation_id, sender_id, content, reply_to_id, sender_username, &state).await
+pub async fn send_message(conversation_id: String, sender_id: String, content: String, reply_to_id: Option<String>, thread_id: Option<String>, sender_username: Option<String>, state: State<'_, Arc<AppState>>) -> Result<Message> {
+    pollis_core::commands::messages::send_message(conversation_id, sender_id, content, reply_to_id, thread_id, sender_username, &state).await
 }
 
 #[tauri::command]
@@ -36,6 +36,16 @@ pub async fn read_channel_messages(channel_id: String, limit: Option<i64>, curso
 #[tauri::command]
 pub async fn read_dm_messages(dm_channel_id: String, limit: Option<i64>, cursor: Option<MessageCursor>, state: State<'_, Arc<AppState>>) -> Result<MessagePage> {
     pollis_core::commands::messages::read_dm_messages(dm_channel_id, limit, cursor, &state).await
+}
+
+#[tauri::command]
+pub async fn read_thread_messages(thread_id: String, state: State<'_, Arc<AppState>>) -> Result<Vec<ChannelMessage>> {
+    pollis_core::commands::messages::read_thread_messages(thread_id, &state).await
+}
+
+#[tauri::command]
+pub async fn list_thread_summaries(conversation_id: String, state: State<'_, Arc<AppState>>) -> Result<Vec<ThreadSummary>> {
+    pollis_core::commands::messages::list_thread_summaries(conversation_id, &state).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -525,6 +525,8 @@ pub fn run() {
             commands::messages::get_dm_messages,
             commands::messages::read_channel_messages,
             commands::messages::read_dm_messages,
+            commands::messages::read_thread_messages,
+            commands::messages::list_thread_summaries,
             commands::messages::ingest_channel_envelopes,
             commands::messages::ingest_dm_envelopes,
             commands::messages::list_messages_by_sender,

--- a/src-tauri/src/test_harness.rs
+++ b/src-tauri/src/test_harness.rs
@@ -105,6 +105,8 @@ pub fn build_client_app(state: Arc<AppState>) -> Result<(App<MockRuntime>, Webvi
             crate::commands::messages::get_dm_messages,
             crate::commands::messages::read_channel_messages,
             crate::commands::messages::read_dm_messages,
+            crate::commands::messages::read_thread_messages,
+            crate::commands::messages::list_thread_summaries,
             crate::commands::messages::list_messages_by_sender,
             crate::commands::messages::list_channel_previews,
             crate::commands::messages::search_messages,


### PR DESCRIPTION
Re-targets #829 at `main`.

#829 was a **stacked PR** — its base was `feat/right-context-panel`, not `main`. Merging it therefore landed the threads work on that feature branch, which had already been squashed into main via #826. Net effect: #829 reported MERGED while none of its content reached `main`. Verified rather than assumed — `thread_id` was absent from `pollis-core/src/commands/messages/send.rs` on main afterwards.

This is the same commit, cherry-picked onto `main`. Clean, no conflicts, 29 files.

Contents, unchanged from #829 plus the build fix:

- Slack-style threads in channels, with `thread_id` sealed **inside** the MLS ciphertext — never in the DS request body, so the server cannot see which messages belong to which thread.
- `fix(tui)`: threads `thread_id` through the CLI send path. `pollis-core` fans out to desktop, CLI and mobile; `pollis-tui` was missed, which broke the build at three sites (`send.rs`, a `home.rs` fixture, and `tests/common/mod.rs`). Invisible to `cargo check -p pollis` — only `--workspace --all-targets` catches it.

The TUI wrapper takes `thread_id` as a passthrough rather than hardcoding `None` at the core call: the TUI has no thread UI yet, but this way adding one is a caller change instead of a signature change, and a thread reply can never be silently flattened into the channel by that path.

`cargo check --workspace --all-targets` is clean and `pollis-tui`'s 23 unit tests pass locally.