### PR TITLE
fix(release): unbreak provenance — cosign-installer v3's key digest is stale

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1172,8 +1172,23 @@ jobs:
 
       # Pinned installer action — never an unpinned curl. Puts the `cosign` CLI
       # on the runner for the sign-blob pass below.
+      #
+      # v4, not v3: the v3 line stopped at v3.10.1 (2025-10) and its hardcoded
+      # digest for cosign's release signing key went stale, so every run now dies
+      # with "Fetched public key does not match expected digest" (curl exit 22).
+      # That is what silently cost v1.9.0 its provenance — the SLSA attestations
+      # were generated, then the publish step was skipped, leaving each
+      # transparency-log leaf's `provenance_uri` pointing at a 404.
+      #
+      # cosign itself is pinned to the 2.x line deliberately. The sign-blob loop
+      # below is written to the v2 CLI (`--output-signature`/`--output-certificate`);
+      # v4's default is cosign 3.x, which changes bundle defaults. Bumping the
+      # installer and the CLI generation in one step would make a failure
+      # ambiguous, so the CLI contract stays fixed here and moves on its own.
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@v4
+        with:
+          cosign-release: 'v2.6.5'
 
       # cosign sign-blob each staged artifact keylessly (Fulcio/Rekor, ambient
       # GitHub Actions OIDC — no Pollis key). Emits a detached .sig + the signing


### PR DESCRIPTION
The v1.9.0 desktop release failed its `provenance` job. Root cause is upstream: `sigstore/cosign-installer@v3` stopped at v3.10.1 (2025-10) and its hardcoded digest for cosign's release signing key is now stale, so the install dies with `Fetched public key does not match expected digest` (curl exit 22). Re-running reproduced it exactly — not transient.

**What that cost.** The SLSA attestations were *generated* (step 6 succeeded), then `Install cosign` failed, so `sign-blob` and the R2 publish were skipped. Each transparency-log leaf for v1.9.0 carries a `provenance_uri` that now **404s** — confirmed against `cdn.pollis.com/releases/v1.9.0/…intoto.jsonl`. The primary Pollis-signed transparency anchor is intact; it is the second, independent sigstore anchor that is missing.

**Fix:** move to the maintained `@v4` line. cosign itself is pinned to `v2.6.5` rather than taking v4's 3.x default, because the sign-blob loop is written to the v2 CLI (`--output-signature`/`--output-certificate`) and v3 changes bundle defaults — bumping the installer and the CLI generation together would make any failure ambiguous.

**Unverified until it runs.** There is no standalone workflow that exercises the installer, so this is proven by the next release, not by CI here. Worth watching the `provenance` job on the next tag.

**v1.9.0 is not repairable without a rebuild.** Re-runs use the workflow from the tagged commit, so they will keep failing, and `attest-release.yml` backfills the transparency log only — it has no cosign/provenance path. Options are to leave v1.9.0 with the primary anchor only, or cut v1.9.1 off this fix. Everything else in v1.9.0 shipped correctly: installers on R2 and GitHub, AUR at 1.9.0, migrations a no-op, `attest-and-log` green.