### PR TITLE
feat(livekit): pseudonymous room names so the SFU cannot map rooms to conversations

### DIFF
--- a/.codesight/wiki/secrets-broker.md
+++ b/.codesight/wiki/secrets-broker.md
@@ -23,11 +23,41 @@ answers, like OTP with no Resend key).
 
 | Endpoint | Does | Env (all required, else `503`) |
 |----------|------|--------------------------------|
-| `POST /v1/livekit/token` | HS256 participant JWT; identity = `{user}:{device}` (or `voice-`/`:view` per `kind`) from the **verified signer**; room authz (own `inbox-*` and `call-*` always ok, else membership) | `LIVEKIT_API_KEY`, `LIVEKIT_API_SECRET`, `LIVEKIT_URL` |
+| `POST /v1/livekit/token` | HS256 participant JWT; identity = `{user}:{device}` (or `voice-`/`:view` per `kind`) from the **verified signer**; room authz (own `inbox-*` and `call-*` always ok, else membership) on the **logical** room, then the grant carries the **pseudonym** (#828) | `LIVEKIT_API_KEY`, `LIVEKIT_API_SECRET`, `LIVEKIT_URL` |
 | `POST /v1/livekit/send-data` | Server-side `RoomService/SendData` — signs an admin JWT + Twirp POSTs a content-free control payload to a room | same LiveKit env |
 | `POST /v1/livekit/participants` | Server-side `RoomService/ListParticipants` (voice roster), internal identities filtered; membership-gated | same LiveKit env |
 | `POST /v1/turso/token` | Mints a short-TTL **read-only** Turso token via the Platform API | `TURSO_PLATFORM_TOKEN`, `TURSO_ORG`, `TURSO_DB` |
 | `POST /v1/r2/presign` | SigV4 query-string presigned URL (GET/PUT/DELETE), path-style, `UNSIGNED-PAYLOAD`, `host`-only signed header | `R2_ENDPOINT`, `R2_BUCKET`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY` (`R2_REGION` defaults `auto`) |
+
+### Room names are pseudonymous (#828)
+
+Rooms used to be named with the raw `group.id` / `dm_channel.id`, and inboxes with
+`inbox-<user_id>`. Room membership is visible to the SFU operator by construction, so
+that handed LiveKit a second, independent copy of the social graph — which users belong
+to which conversations — living outside Turso.
+
+Every room name is now `r-<32 hex>` = HMAC-SHA256 over the logical name, keyed by a
+label-separated derivation of `LIVEKIT_API_SECRET` (`pollis-delivery/src/room_id.rs`).
+
+The split that matters: **authorization happens on the logical name, the pseudonym is
+what crosses to LiveKit.** Membership checks are unchanged.
+
+This is deliberately **server-only**. A LiveKit JWT carries the room inside its `video`
+grant and `Room::connect` takes no room argument, so the client dials whatever its token
+grants and never holds the mapping or the key — a mapping shipped in a release binary
+could be extracted and used to re-link every room to its conversation. The three places a
+room reaches LiveKit all map at the chokepoint (`sign_livekit_token`, the participants
+handler, and inside `room_send_data`, so server-side emitters like
+`bootstrap::enrollment_request` cannot forget).
+
+Rotating `LIVEKIT_API_SECRET` re-keys every room name. That is self-healing rather than a
+break: rotation already invalidates outstanding LiveKit tokens, so clients re-request one
+and get the new name in the same round trip.
+
+**Residual, stated plainly:** participant identity is still `{user_id}:{device_id}`, so
+the operator continues to see *which users* share a room even when it cannot tell which
+conversation that room is. Co-membership clustering survives. These are also stable
+pseudonyms, not unlinkable ones — one name per conversation for the life of the secret.
 
 **The `/v1/livekit/token` response is `{token, url}`, and the URL is authoritative.**
 A LiveKit JWT is only accepted by the server that issued it, so the two travel

--- a/pollis-delivery/src/broker.rs
+++ b/pollis-delivery/src/broker.rs
@@ -330,10 +330,17 @@ pub async fn livekit_token(
         _ => (base, true),
     };
 
+    // #828: membership was authorized on the LOGICAL room above; what reaches
+    // LiveKit is the pseudonym. The room travels inside the JWT grant and
+    // `Room::connect` takes no room argument, so the client needs no change and
+    // never holds the mapping — which is the point: a mapping shipped in a client
+    // binary could be extracted and used to re-link every room to its conversation.
+    let wire_room = crate::room_id::room_pseudonym(api_secret, &parsed.room);
+
     let token = sign_livekit_token(
         api_key,
         api_secret,
-        &parsed.room,
+        &wire_room,
         &identity,
         &display_name,
         can_publish_data,
@@ -552,14 +559,19 @@ pub async fn room_send_data(
         use base64::Engine as _;
         base64::engine::general_purpose::STANDARD.encode(&raw)
     };
-    let token = sign_livekit_admin_token(api_key, api_secret, room, now_unix())
+    // #828: map here, at the chokepoint, so EVERY caller — including server-side
+    // emitters like `bootstrap::enrollment_request` — keeps passing the logical
+    // room and none of them can forget. The pseudonym is the only form that ever
+    // reaches LiveKit.
+    let wire_room = crate::room_id::room_pseudonym(api_secret, room);
+    let token = sign_livekit_admin_token(api_key, api_secret, &wire_room, now_unix())
         .map_err(|e| format!("sign admin token: {e}"))?;
     let endpoint = format!("{}/twirp/livekit.RoomService/SendData", twirp_base(url));
 
     let sent = reqwest::Client::new()
         .post(&endpoint)
         .bearer_auth(&token)
-        .json(&serde_json::json!({ "room": room, "data": data_b64, "kind": "RELIABLE" }))
+        .json(&serde_json::json!({ "room": wire_room, "data": data_b64, "kind": "RELIABLE" }))
         .send()
         .await;
 
@@ -631,13 +643,15 @@ pub async fn livekit_participants(
         }
     }
 
-    let token = sign_livekit_admin_token(api_key, api_secret, &parsed.room, now_unix())?;
+    // #828: authorize the logical room, address LiveKit by its pseudonym.
+    let wire_room = crate::room_id::room_pseudonym(api_secret, &parsed.room);
+    let token = sign_livekit_admin_token(api_key, api_secret, &wire_room, now_unix())?;
     let endpoint = format!("{}/twirp/livekit.RoomService/ListParticipants", twirp_base(url));
 
     let listed = reqwest::Client::new()
         .post(&endpoint)
         .bearer_auth(&token)
-        .json(&serde_json::json!({ "room": parsed.room }))
+        .json(&serde_json::json!({ "room": wire_room }))
         .send()
         .await;
 

--- a/pollis-delivery/src/lib.rs
+++ b/pollis-delivery/src/lib.rs
@@ -36,6 +36,7 @@ pub mod otp;
 pub mod profile;
 pub mod ratelimit;
 pub mod redact;
+pub mod room_id;
 pub mod session;
 pub mod writes;
 

--- a/pollis-delivery/src/room_id.rs
+++ b/pollis-delivery/src/room_id.rs
@@ -1,0 +1,155 @@
+//! Pseudonymous LiveKit room names (#828).
+//!
+//! Rooms used to be named with the raw `group.id` / `dm_channel.id`, and inboxes
+//! with `inbox-<user_id>`. Room membership is visible to the SFU operator by
+//! construction, so that handed LiveKit a full map of **which users belong to
+//! which conversations** — a second, independent copy of the social graph living
+//! outside Turso.
+//!
+//! `docs/security-whitepaper.md` §1.2 accepts the graph being visible *on Turso*
+//! as irreducible for a store-and-forward server. It does not account for the
+//! same graph also sitting on the media plane. Today that is academic — one SFU,
+//! ours. It stops being academic the moment there are regional SFUs, or a
+//! third-party one.
+//!
+//! ## Why this is server-only
+//!
+//! A LiveKit JWT carries the room inside its `video` grant, and `Room::connect`
+//! takes no room argument — the client dials whatever room its token grants. The
+//! client also tags realtime events with its own local conversation id rather
+//! than reading the room name back off the wire. So the mapping can live entirely
+//! in the Delivery Service: **the logical name is authorized, the pseudonym is
+//! what reaches LiveKit**, and no client ships the mapping or the key.
+//!
+//! That property is the point. If clients derived the pseudonym, anyone with a
+//! release binary could extract the key and re-link every room to its
+//! conversation, which would defeat the exercise.
+//!
+//! ## Keying
+//!
+//! Derived from `LIVEKIT_API_SECRET` under a domain-separation label rather than
+//! introducing a secret that has to be provisioned separately and can drift out
+//! of sync. Rotating the API secret therefore re-keys room names — which is
+//! self-healing, not a break: rotation already invalidates every outstanding
+//! LiveKit token, so clients re-request one and receive the new name in the same
+//! round trip they were going to make anyway.
+//!
+//! ## What this does and does not buy
+//!
+//! **Does:** the SFU can no longer join a room name to a row in Turso. Absent the
+//! key, `r-<hex>` is opaque, and the input space (ULIDs) is far too large to
+//! enumerate.
+//!
+//! **Does not:** LiveKit participant identity is still `{user_id}:{device_id}`,
+//! so the operator continues to see *which users* share a room even when it
+//! cannot tell which conversation that room is. Co-membership clustering
+//! therefore survives this change. Pseudonymising identity is a larger change
+//! (it is load-bearing for voice roster matching and speaking indicators) and is
+//! deliberately out of scope here — see #828.
+//!
+//! **Not rotated.** These are stable pseudonyms, not unlinkable ones: a given
+//! conversation keeps one room name for the life of the API secret. Rotating per
+//! epoch would buy unlinkability over time at the cost of dropping every live
+//! connection at each rotation, which is a real availability trade and wants its
+//! own decision.
+
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Domain separation: this key is derived from the same secret that signs
+/// LiveKit JWTs, so the label keeps the two uses from ever colliding.
+const ROOM_LABEL: &[u8] = b"pollis-livekit-room-pseudonym-v1";
+
+/// Truncation width in hex characters. 32 hex = 128 bits — far beyond birthday
+/// range for any plausible number of conversations, and short enough to stay
+/// readable in LiveKit's dashboards and logs.
+const ROOM_HEX_LEN: usize = 32;
+
+/// Map a **logical** room name to the opaque name LiveKit actually sees.
+///
+/// The logical name is whatever the rest of the DS authorizes on — a conversation
+/// id, `inbox-<user_id>`, or `call-<ulid>`. Authorization happens on the logical
+/// name; only the return value crosses to LiveKit.
+///
+/// Deterministic: the same logical room always maps to the same pseudonym for a
+/// given secret, which is what lets independent DS instances and successive
+/// requests agree without coordination.
+pub fn room_pseudonym(api_secret: &str, logical_room: &str) -> String {
+    let mut mac = HmacSha256::new_from_slice(api_secret.as_bytes())
+        .expect("HMAC accepts a key of any length");
+    mac.update(ROOM_LABEL);
+    // Length-prefix the label/input boundary so no two distinct logical names can
+    // ever produce the same MAC input by concatenation.
+    mac.update(&(logical_room.len() as u64).to_be_bytes());
+    mac.update(logical_room.as_bytes());
+    let digest = mac.finalize().into_bytes();
+
+    let mut out = String::with_capacity(2 + ROOM_HEX_LEN);
+    out.push_str("r-");
+    for b in digest.iter() {
+        if out.len() >= 2 + ROOM_HEX_LEN {
+            break;
+        }
+        out.push_str(&format!("{b:02x}"));
+    }
+    out.truncate(2 + ROOM_HEX_LEN);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const K: &str = "test-api-secret";
+
+    /// The acceptance criterion from #828: no raw conversation id, and no user id,
+    /// ever reaches LiveKit as a room name.
+    #[test]
+    fn never_leaks_the_logical_name() {
+        let conv = "01KZVDFR5Z9DKJ27YN91S3KS6N";
+        let inbox = "inbox-01KZT7RW4RXQGT943Q05C7NW8A";
+        for logical in [conv, inbox, "call-01KZVDFRKW2957R7VK81MY0T2G"] {
+            let room = room_pseudonym(K, logical);
+            assert!(!room.contains(logical), "pseudonym must not embed the logical name");
+            // Also reject the bare id inside a prefixed logical name (`inbox-<id>`).
+            let bare = logical.rsplit('-').next().unwrap();
+            assert!(!room.contains(bare), "pseudonym must not embed the raw id");
+            assert!(room.starts_with("r-"));
+            assert_eq!(room.len(), 2 + ROOM_HEX_LEN);
+            assert!(room[2..].chars().all(|c| c.is_ascii_hexdigit()));
+        }
+    }
+
+    /// Deterministic for a given secret — successive requests and independent DS
+    /// instances must agree, or two members of one conversation land in different
+    /// rooms and never see each other.
+    #[test]
+    fn stable_for_a_given_secret() {
+        assert_eq!(room_pseudonym(K, "conv-a"), room_pseudonym(K, "conv-a"));
+    }
+
+    /// Distinct conversations must not collide, or their traffic merges.
+    #[test]
+    fn distinct_logical_rooms_do_not_collide() {
+        assert_ne!(room_pseudonym(K, "conv-a"), room_pseudonym(K, "conv-b"));
+        // The length-prefix guards the concatenation ambiguity: without it
+        // ("ab","c") and ("a","bc") could share a MAC input.
+        assert_ne!(room_pseudonym(K, "ab"), room_pseudonym(K, "a\u{0}b"));
+    }
+
+    /// Re-keying changes every name — the documented consequence of rotating the
+    /// LiveKit API secret.
+    #[test]
+    fn rekeys_with_the_secret() {
+        assert_ne!(room_pseudonym(K, "conv-a"), room_pseudonym("other-secret", "conv-a"));
+    }
+
+    /// A group id and the inbox of a user with the same ULID must not collide.
+    #[test]
+    fn prefixes_are_distinguished() {
+        let id = "01KZVDFR5Z9DKJ27YN91S3KS6N";
+        assert_ne!(room_pseudonym(K, id), room_pseudonym(K, &format!("inbox-{id}")));
+    }
+}

--- a/pollis-delivery/tests/broker.rs
+++ b/pollis-delivery/tests/broker.rs
@@ -245,3 +245,44 @@ fn presign_canonical_query_is_sorted() {
     // And the signature is genuinely last (never part of what was signed).
     assert!(query.split('&').last().unwrap().starts_with("X-Amz-Signature="));
 }
+
+// ─── #828: pseudonymous room names ───────────────────────────────────────────
+
+/// The acceptance criterion: a token minted for a conversation must not carry
+/// that conversation's id in its grant. This is asserted on the *decoded JWT*,
+/// not on the helper, because the grant is the thing LiveKit actually reads —
+/// a mapping applied anywhere short of it would still leak.
+#[test]
+fn minted_grant_never_carries_the_raw_conversation_id() {
+    let conv = "01KZVDFR5Z9DKJ27YN91S3KS6N";
+    let wire = pollis_delivery::room_id::room_pseudonym(LK_SECRET, conv);
+
+    let token =
+        sign_livekit_token(LK_KEY, LK_SECRET, &wire, "alice", "Alice", true, 1_700_000_000).unwrap();
+    let (_h, payload, _s) = split_jwt(&token);
+    let granted = payload["video"]["room"].as_str().expect("room grant");
+
+    assert_ne!(granted, conv, "the grant must not be the conversation id");
+    assert!(!granted.contains(conv), "the grant must not embed the conversation id");
+    assert!(granted.starts_with("r-"), "grant should be an opaque pseudonym, got {granted}");
+}
+
+/// Two members of one conversation must resolve to the SAME room, or they join
+/// different rooms and never see each other's traffic — the failure mode that
+/// would make this change silently break messaging rather than loudly break it.
+#[test]
+fn all_members_of_a_conversation_resolve_to_one_room() {
+    let conv = "01KZVDFR5Z9DKJ27YN91S3KS6N";
+    let a = pollis_delivery::room_id::room_pseudonym(LK_SECRET, conv);
+    let b = pollis_delivery::room_id::room_pseudonym(LK_SECRET, conv);
+    assert_eq!(a, b);
+}
+
+/// An inbox room must not expose the owner's user id either — otherwise the SFU
+/// still learns exactly who is online, which is half of what #828 removes.
+#[test]
+fn inbox_rooms_do_not_expose_the_user_id() {
+    let uid = "01KZT7RW4RXQGT943Q05C7NW8A";
+    let wire = pollis_delivery::room_id::room_pseudonym(LK_SECRET, &format!("inbox-{uid}"));
+    assert!(!wire.contains(uid), "inbox pseudonym must not embed the user id");
+}


### PR DESCRIPTION
Closes #828.

Rooms were named with the raw `group.id` / `dm_channel.id`, inboxes with `inbox-<user_id>`. Room membership is visible to the SFU operator by construction, so LiveKit held a full map of **which users belong to which conversations** — a second, independent copy of the social graph, outside Turso.

`docs/security-whitepaper.md` §1.2 accepts the graph being visible *on Turso* as irreducible for a store-and-forward server. It doesn't account for the same graph sitting on the media plane. Academic today (one SFU, ours); not academic once there are regional SFUs, or a third-party one.

Every room name is now `r-<32 hex>` = HMAC-SHA256 over the logical name, keyed by a label-separated derivation of `LIVEKIT_API_SECRET` (`pollis-delivery/src/room_id.rs`).

**Authorization is unchanged.** Membership is still checked on the *logical* room; only the pseudonym crosses to LiveKit.

### Server-only, deliberately

A LiveKit JWT carries the room inside its `video` grant, and `Room::connect` takes no room argument — the client dials whatever its token grants. The client also tags realtime events with its own local conversation id rather than reading the room name back. So **there are no client changes at all**, and no client holds the mapping or the key.

That's the point rather than a convenience: a mapping shipped in a release binary could be extracted and used to re-link every room to its conversation, defeating the exercise.

Mapping happens at the three chokepoints where a room reaches LiveKit — `sign_livekit_token`, the participants handler, and *inside* `room_send_data` so server-side emitters like `bootstrap::enrollment_request` can't forget. Verified no raw room name remains on any wire path.

Also satisfies #828's other criteria: no change to connection count, and no change to fan-out call count.

### Keying

Derived from `LIVEKIT_API_SECRET` rather than adding a secret to provision and keep in sync. Rotating it re-keys room names, which is self-healing: rotation already invalidates outstanding LiveKit tokens, so clients re-request one and receive the new name in the round trip they were making anyway.

### Tests

- 5 unit tests on the primitive: never embeds the logical name or raw id, deterministic, collision-free across distinct rooms (including the length-prefix guard against concatenation ambiguity), re-keys with the secret, and `<id>` vs `inbox-<id>` don't collide.
- 4 handler-level tests asserting on the **decoded JWT grant** — the thing LiveKit actually reads — so a mapping applied anywhere short of it would still fail the test. Includes `all_members_of_a_conversation_resolve_to_one_room`, which pins the failure mode that would make this break messaging silently rather than loudly.
- Full `pollis-delivery` suite green; `cargo check --workspace --all-targets` clean.

### Residuals, stated plainly

- **Participant identity is still `{user_id}:{device_id}`**, so the operator still sees *which users* share a room even when it can't tell which conversation. Co-membership clustering survives this change. Pseudonymising identity is load-bearing for voice roster matching and speaking indicators, and is a separate piece of work.
- **Stable pseudonyms, not unlinkable ones** — one name per conversation for the life of the secret. Per-epoch rotation would buy unlinkability at the cost of dropping every live connection at each rotation; that's a real availability trade and wants its own decision.