### PR TITLE
fix(threads, right-panel): thread isolation, skin-aware panels, contextual details

### DIFF
--- a/.codesight/wiki/ui.md
+++ b/.codesight/wiki/ui.md
@@ -22,6 +22,25 @@
 - Components read MobX stores inside `observer()` wrappers; remote data comes from
   React Query hooks in `frontend/src/hooks/queries/`.
 
+### Presence
+
+`presenceStore` infers online-ness from LiveKit room participation, keeping a
+`user_id → Set<room_id>` map so leaving one shared room doesn't flip someone
+offline while they're still in another. Two properties are load-bearing:
+
+- **`isOnline` is deliberately NOT a MobX action.** Actions run untracked, so an
+  `action` here would leave its `byUser` reads invisible to the calling
+  `observer()` and presence would stop updating live. It stays a plain method,
+  excluded via `makeAutoObservable(this, { isOnline: false })`.
+- **The local user is tracked separately.** Room events only ever describe
+  *other* participants — nothing tells us we are online — so `byUser` never
+  contains us and every surface would report the signed-in user as offline.
+  `appStore.setCurrentUser` (and `logout`) pushes the id into
+  `presenceStore.setSelfUserId`, and `isOnline` short-circuits true for it. The
+  dependency is one-way (`appStore → presenceStore`; presence imports nothing of
+  ours) so it cannot cycle. Don't paper over this at a call site with a
+  hardcoded `presence="online"`.
+
 ## Components
 
 ### `(root)` (3)
@@ -84,6 +103,10 @@ The panel is a **flex sibling of `<Outlet />`** in `AppShell`, never an overlay 
 
 `panel` is a discriminated union, not a boolean, so threads (#825) add a variant rather than a second sidebar. **`useRightPanel` navigates with an explicit `to: pathname`** — a relative `to: "."` would resolve against `/` (AppShell renders at the root route) and throw the user out of their conversation, and omitting `to` leaves the search type unresolved.
 
+**Chrome mirrors the left sidebar.** The panel's close affordance is a **footer**, not a header: a full-width `min-h-bar border-t border-line` button with the label on the left and a `<kbd>` on the right carrying the live `useShortcutLabel("app.toggleRightPanel")` combo (default `mod+shift+b`, the shifted twin of the sidebar's `mod+b`). AppShell binds the same command id, so the chip and the key can't drift. Width tracks `--side-w` and the aside carries `font-mono`, which is the entire skin switch — terminal renders DM Mono, refined re-points `.font-mono:not(.font-machine)` at the sans face. Terminal additionally borrows the sidebar's `SectionHeader` chrome (sticky `h-bar` strip, hairline under, a second hairline above every section after the first) and its one-text-line rows with a bare `PresenceDot`; refined keeps the airier avatar rows.
+
+**Content is contextual, the column is not.** The panel no longer collapses on routes with no conversation (Preferences, Search, root). `MembersPanel` degrades there to the plain online roster — self plus everyone visible in `presenceStore.byUser`, named from the DM list — and drops the media grid, since "who is online" still answers a question off-conversation and "media shared in this conversation" does not. A stale `?panel=thread` on such a route falls back to the roster rather than rendering an empty thread.
+
 ### `components/Message` (9)
 
 - **AttachmentDisplay** — `frontend/src/components/Message/AttachmentDisplay.tsx`
@@ -135,6 +158,7 @@ The panel is a **flex sibling of `<Outlet />`** in `AppShell`, never an overlay 
 - **PillButton** — props: accent, onClick, title, square, children — `frontend/src/components/ui/PillButton.tsx`
 - **PollisLogo** — props: size, color — `frontend/src/components/ui/PollisLogo.tsx`
 - **PresenceAvatar** — props: userId, avatarKey, size, alt, testId, variant — `frontend/src/components/ui/PresenceAvatar.tsx`
+- **PresenceDot** — props: userId, testId — bare online/offline dot for rows with no avatar to anchor it (terminal sidebar DMs, right-panel members) — `frontend/src/components/ui/PresenceDot.tsx`
 - **RangeSlider** — props: label, value, onChange, min, max, step, disabled, className, id, sublabel, description — `frontend/src/components/ui/RangeSlider.tsx`
 - **ScrambleText** — props: text, placeholderLength, typeSpeed, scrambleInterval, className — `frontend/src/components/ui/ScrambleText.tsx`
 - **Switch** — props: label, checked, onChange, disabled, className, id, description — `frontend/src/components/ui/Switch.tsx`

--- a/frontend/src/components/Layout/MainContent.tsx
+++ b/frontend/src/components/Layout/MainContent.tsx
@@ -212,6 +212,19 @@ export const MainContent: React.FC<MainContentProps> = observer(({ pendingDmRequ
     return deduped.sort((a, b) => a.created_at - b.created_at);
   }, [olderMessages, messages]);
 
+  // What the CHANNEL shows: everything except thread replies (#825). A reply
+  // lives in its thread, and the root already advertises it with "N replies" —
+  // showing it in both places double-posts every reply into the channel, which
+  // is exactly what threads exist to avoid.
+  //
+  // Filtered here rather than in `allMessages` on purpose: that list still
+  // backs id lookups (delete/edit confirmation, the reply-quote resolver), and
+  // those must keep resolving a reply that is only rendered in the panel.
+  const channelMessages = useMemo(
+    () => allMessages.filter((m) => !m.thread_id || m.thread_id === m.id),
+    [allMessages],
+  );
+
   const loadMore = async () => {
     if (!pageCursor || loadingMore || !currentUser) {
       return;
@@ -503,7 +516,7 @@ export const MainContent: React.FC<MainContentProps> = observer(({ pendingDmRequ
           </div>
         ) : (
           <MessageList
-            messages={allMessages}
+            messages={channelMessages}
             // MLS group id for the open conversation. Groups: selectedGroupId.
             // DMs: selectedConversationId (the dm_channel_id IS the MLS group
             // id for that DM). Either way, this is what RosterChanged events

--- a/frontend/src/components/Layout/MainContent.tsx
+++ b/frontend/src/components/Layout/MainContent.tsx
@@ -16,7 +16,7 @@ import { transformChannelMessage, type RawChannelMessage, useThreadSummaries } f
 import { useRightPanel } from "./RightPanel/useRightPanel";
 import { useGroupMembers, useDeleteChannel } from "../../hooks/queries/useGroups";
 import type { Message, MessageAttachment } from "../../types";
-import { blurhashFromUrl } from "../../utils/imageProcessing";
+import { buildMessageContent } from "../../utils/attachmentEnvelope";
 import { useTypingPublisher } from "../../hooks/useTypingPublisher";
 import { TypingIndicator } from "../TypingIndicator";
 
@@ -28,18 +28,6 @@ export interface PendingDmRequest {
   onAccepted?: () => void;
   onBlocked?: () => void;
 }
-
-type MediaUploadResult = {
-  key: string;
-  url: string;
-  filename: string;
-  content_type: string;
-  size_bytes: number;
-  content_hash: string;
-  blurhash?: string;
-  width?: number;
-  height?: number;
-};
 
 type PageCursor = { sent_at: string; id: string };
 
@@ -412,54 +400,7 @@ export const MainContent: React.FC<MainContentProps> = observer(({ pendingDmRequ
     setReplyToMessageId(null);
 
     try {
-      let content = contentText;
-
-      if (attachments.length > 0) {
-        // For video attachments that have a poster preview, compute a blurhash
-        // so receivers see a placeholder without downloading the video first.
-        const videoBlurhashes = new Map<string, { bh: string; w: number; h: number }>();
-        await Promise.all(
-          attachments
-            .filter((att) => att.mimeType.startsWith("video/") && att.preview)
-            .map(async (att) => {
-              const meta = await blurhashFromUrl(att.preview!).catch(() => null);
-              if (meta) {
-                videoBlurhashes.set(att.id, { bh: meta.hash, w: meta.width, h: meta.height });
-              }
-            })
-        );
-
-        const results = await Promise.all(
-          attachments.map((att) =>
-            invoke<MediaUploadResult>('upload_media', {
-              path: att.path,
-              filename: att.name,
-              contentType: att.mimeType,
-            })
-          )
-        );
-
-        const envelope: Record<string, unknown> = {
-          _att: results.map((r, i) => {
-            const vMeta = videoBlurhashes.get(attachments[i]?.id ?? "");
-            return {
-              key: r.key,
-              url: r.url,
-              name: r.filename,
-              ct: r.content_type,
-              size: r.size_bytes,
-              hash: r.content_hash,
-              bh: r.blurhash ?? vMeta?.bh,
-              w: r.width ?? vMeta?.w,
-              h: r.height ?? vMeta?.h,
-            };
-          }),
-        };
-        if (contentText) {
-          envelope._txt = contentText;
-        }
-        content = JSON.stringify(envelope);
-      }
+      const content = await buildMessageContent(attachments, contentText);
 
       await sendMessageMutation.mutateAsync({
         channelId: selectedChannelId || "",

--- a/frontend/src/components/Layout/RightPanel/MediaGrid.tsx
+++ b/frontend/src/components/Layout/RightPanel/MediaGrid.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useSkin } from "../../../hooks/queries/usePreferences";
 import { MediaTile } from "./MediaTile";
 import type { MessageAttachment } from "../../../types";
 
@@ -11,14 +12,17 @@ interface MediaGridProps {
  * "shared media" block. Newest first — the caller orders the list.
  */
 export const MediaGrid: React.FC<MediaGridProps> = ({ attachments }) => {
+  const isTerminal = useSkin() === "terminal";
+  // Terminal aligns to the same 2.5 gutter the sidebar rows and section
+  // headers use, so the grid reads as part of the same column.
+  const gutter = isTerminal ? "px-2.5" : "px-2";
+
   if (attachments.length === 0) {
-    return (
-      <p className="px-2 text-xs text-muted">No media shared yet.</p>
-    );
+    return <p className={`${gutter} text-xs text-muted`}>No media shared yet.</p>;
   }
 
   return (
-    <div className="grid grid-cols-3 gap-1 px-2">
+    <div className={`grid grid-cols-3 gap-1 ${gutter}`}>
       {attachments.map((attachment) => (
         <MediaTile key={attachment.id} attachment={attachment} />
       ))}

--- a/frontend/src/components/Layout/RightPanel/MediaTile.tsx
+++ b/frontend/src/components/Layout/RightPanel/MediaTile.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { FileIcon } from "lucide-react";
+import { useSkin } from "../../../hooks/queries/usePreferences";
 import { getMediaUrl } from "../../../services/r2-upload";
 import type { MessageAttachment } from "../../../types";
 
@@ -20,6 +21,7 @@ interface MediaTileProps {
 export const MediaTile: React.FC<MediaTileProps> = ({ attachment }) => {
   const [url, setUrl] = useState<string | null>(null);
   const [failed, setFailed] = useState(false);
+  const isTerminal = useSkin() === "terminal";
   const isImage = attachment.content_type.startsWith("image/");
   // An attachment still uploading has no object_key yet; there is nothing to
   // fetch until the send confirms.
@@ -60,7 +62,12 @@ export const MediaTile: React.FC<MediaTileProps> = ({ attachment }) => {
 
   return (
     <div
-      className="relative aspect-square overflow-hidden rounded border border-line bg-surface-raised"
+      // Terminal keeps hard corners — the skin's chrome is square everywhere
+      // else, and a rounded thumbnail is the tell that this panel was styled
+      // for refined only.
+      className={`relative aspect-square overflow-hidden border border-line bg-surface-raised ${
+        isTerminal ? "" : "rounded"
+      }`}
       title={attachment.filename}
       data-testid="right-panel-media-tile"
     >

--- a/frontend/src/components/Layout/RightPanel/MemberRow.tsx
+++ b/frontend/src/components/Layout/RightPanel/MemberRow.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import { observer } from "mobx-react-lite";
 import { useNavigate } from "@tanstack/react-router";
+import { useSkin } from "../../../hooks/queries/usePreferences";
 import { PresenceAvatar } from "../../ui/PresenceAvatar";
+import { PresenceDot } from "../../ui/PresenceDot";
 
 interface MemberRowProps {
   userId: string;
@@ -13,28 +15,54 @@ interface MemberRowProps {
 /**
  * One person in the right panel's member list. Clicking opens their profile,
  * matching how member rows behave on the group Members page.
+ *
+ * Skin split mirrors the left sidebar's DM rows exactly: refined shows the
+ * avatar with the presence dot anchored to it, terminal shows the bare dot so
+ * every row stays one text-line tall.
  */
 export const MemberRow: React.FC<MemberRowProps> = observer(
   ({ userId, label, avatarKey, isAdmin }) => {
     const navigate = useNavigate();
+    const isTerminal = useSkin() === "terminal";
+
+    const rowClass = isTerminal
+      ? "flex w-full items-center gap-1.5 border-l-2 border-transparent px-2.5 py-0.5 text-left text-base text-fg transition-colors hover:bg-hover"
+      : "flex w-full items-center gap-2 rounded px-2 py-1 text-left hover:bg-hover";
 
     return (
       <button
         type="button"
         onClick={() => navigate({ to: "/user/$userId", params: { userId } })}
-        className="flex w-full items-center gap-2 rounded px-2 py-1 text-left hover:bg-hover"
+        className={rowClass}
         data-testid={`right-panel-member-${userId}`}
       >
-        <PresenceAvatar
-          userId={userId}
-          avatarKey={avatarKey}
-          size={24}
-          alt={label}
-          variant="list"
-        />
-        <span className="min-w-0 flex-1 truncate text-sm text-fg">{label}</span>
+        {isTerminal ? (
+          <PresenceDot
+            userId={userId}
+            testId={`right-panel-presence-${userId}`}
+          />
+        ) : (
+          <PresenceAvatar
+            userId={userId}
+            avatarKey={avatarKey}
+            size={24}
+            alt={label}
+            variant="list"
+          />
+        )}
+        <span
+          className={`min-w-0 flex-1 truncate ${
+            isTerminal ? "" : "text-sm text-fg"
+          }`}
+        >
+          {label}
+        </span>
         {isAdmin && (
-          <span className="shrink-0 text-xs uppercase tracking-wide text-muted">
+          <span
+            className={`shrink-0 uppercase tracking-wide text-muted ${
+              isTerminal ? "text-2xs" : "text-xs"
+            }`}
+          >
             admin
           </span>
         )}

--- a/frontend/src/components/Layout/RightPanel/MembersPanel.tsx
+++ b/frontend/src/components/Layout/RightPanel/MembersPanel.tsx
@@ -23,12 +23,24 @@ interface MembersPanelProps {
   conversationId: string | null;
 }
 
+interface Person {
+  userId: string;
+  label: string;
+  avatarKey: string | null;
+  isAdmin: boolean;
+}
+
 /**
  * Members + shared media for the active conversation — Discord's member list
  * over Messenger's shared-media grid, which is what #824 asks for.
  *
  * Members come from the group for a channel/group route. A DM has no member
  * table, so its two participants are derived from the conversation record.
+ *
+ * On a route with no conversation at all (Preferences, Search, the root page)
+ * the panel degrades to the plain online roster and drops the media grid —
+ * "who is online" still answers a question there, "media shared in this
+ * conversation" does not.
  */
 export const MembersPanel: React.FC<MembersPanelProps> = observer(
   ({ groupId, channelId, conversationId }) => {
@@ -37,11 +49,48 @@ export const MembersPanel: React.FC<MembersPanelProps> = observer(
     const isTerminal = useSkin() === "terminal";
     const currentUser = appStore.currentUser;
     const dmConversations = appStore.dmConversations;
+    const hasContext = Boolean(groupId || channelId || conversationId);
 
     // Online first, then alphabetical. Reading `presenceStore.isOnline` here
     // (inside an observer) is what keeps the ordering live as people join and
     // leave — `isOnline` is deliberately not an action for exactly this.
-    const people = useMemo(() => {
+    const people = useMemo<Person[]>(() => {
+      if (!hasContext) {
+        // No conversation to scope to, so the roster is simply everyone we
+        // can currently see online. Names come from the DM list — the only
+        // peer directory the client holds without a group — and fall back to
+        // the raw id for someone we share no DM with.
+        const known = new Map<string, { label: string; avatarKey: string | null }>();
+        for (const dm of dmConversations) {
+          if (dm.user2_id) {
+            known.set(dm.user2_id, {
+              label: dm.user2_identifier,
+              avatarKey: dm.user2_avatar_url ?? null,
+            });
+          }
+        }
+        const self: Person[] = currentUser
+          ? [
+              {
+                userId: currentUser.id,
+                label: "You",
+                avatarKey: null,
+                isAdmin: false,
+              },
+            ]
+          : [];
+        const others = Object.keys(presenceStore.byUser)
+          .filter((userId) => userId !== currentUser?.id)
+          .map((userId) => ({
+            userId,
+            label: known.get(userId)?.label ?? userId,
+            avatarKey: known.get(userId)?.avatarKey ?? null,
+            isAdmin: false,
+          }))
+          .sort((a, b) => a.label.localeCompare(b.label));
+        return [...self, ...others];
+      }
+
       if (conversationId) {
         const dm = dmConversations.find((c) => c.id === conversationId);
         if (!dm) {
@@ -86,6 +135,7 @@ export const MembersPanel: React.FC<MembersPanelProps> = observer(
           return a.label.localeCompare(b.label);
         });
     }, [
+      hasContext,
       conversationId,
       dmConversations,
       currentUser,
@@ -127,9 +177,16 @@ export const MembersPanel: React.FC<MembersPanelProps> = observer(
     return (
       <div className={rootClass}>
         <section className={isTerminal ? "flex flex-col" : "flex flex-col gap-1"}>
-          <SectionHeader label={`Members — ${people.length}`} isTerminal={isTerminal} />
+          <SectionHeader
+            label={
+              hasContext ? `Members — ${people.length}` : `Online — ${people.length}`
+            }
+            isTerminal={isTerminal}
+          />
           {people.length === 0 ? (
-            <p className={emptyClass}>No members to show.</p>
+            <p className={emptyClass}>
+              {hasContext ? "No members to show." : "No one online."}
+            </p>
           ) : (
             people.map((person) => (
               <MemberRow
@@ -143,10 +200,14 @@ export const MembersPanel: React.FC<MembersPanelProps> = observer(
           )}
         </section>
 
-        <section className={isTerminal ? "flex flex-col gap-1 pb-2" : "flex flex-col gap-2"}>
-          <SectionHeader label="Media" isTerminal={isTerminal} bordered />
-          <MediaGrid attachments={attachments} />
-        </section>
+        {hasContext && (
+          <section
+            className={isTerminal ? "flex flex-col gap-1 pb-2" : "flex flex-col gap-2"}
+          >
+            <SectionHeader label="Media" isTerminal={isTerminal} bordered />
+            <MediaGrid attachments={attachments} />
+          </section>
+        )}
       </div>
     );
   },

--- a/frontend/src/components/Layout/RightPanel/MembersPanel.tsx
+++ b/frontend/src/components/Layout/RightPanel/MembersPanel.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from "react";
 import { observer } from "mobx-react-lite";
 import { appStore } from "../../../stores/appStore";
 import { presenceStore } from "../../../stores/presenceStore";
+import { useSkin } from "../../../hooks/queries/usePreferences";
 import { useGroupMembers } from "../../../hooks/queries/useGroups";
 import { useMessages } from "../../../hooks/queries/useMessages";
 import { MemberRow } from "./MemberRow";
@@ -33,6 +34,7 @@ export const MembersPanel: React.FC<MembersPanelProps> = observer(
   ({ groupId, channelId, conversationId }) => {
     const { data: groupMembers = [] } = useGroupMembers(groupId);
     const { messages } = useMessages(channelId, conversationId);
+    const isTerminal = useSkin() === "terminal";
     const currentUser = appStore.currentUser;
     const dmConversations = appStore.dmConversations;
 
@@ -114,14 +116,20 @@ export const MembersPanel: React.FC<MembersPanelProps> = observer(
       return out;
     }, [messages]);
 
+    // Terminal packs the column the way the left sidebar does — sections butt
+    // up against their hairline headers with no outer padding. Refined keeps
+    // the airier card rhythm.
+    const rootClass = isTerminal
+      ? "flex h-full flex-col overflow-y-auto"
+      : "flex h-full flex-col gap-4 overflow-y-auto py-3";
+    const emptyClass = isTerminal ? "px-2.5 py-1 text-xs text-muted" : "px-2 text-xs text-muted";
+
     return (
-      <div className="flex h-full flex-col gap-4 overflow-y-auto py-3">
-        <section className="flex flex-col gap-1">
-          <h2 className="px-2 text-xs font-medium uppercase tracking-widest text-muted">
-            Members — {people.length}
-          </h2>
+      <div className={rootClass}>
+        <section className={isTerminal ? "flex flex-col" : "flex flex-col gap-1"}>
+          <SectionHeader label={`Members — ${people.length}`} isTerminal={isTerminal} />
           {people.length === 0 ? (
-            <p className="px-2 text-xs text-muted">No members to show.</p>
+            <p className={emptyClass}>No members to show.</p>
           ) : (
             people.map((person) => (
               <MemberRow
@@ -135,13 +143,48 @@ export const MembersPanel: React.FC<MembersPanelProps> = observer(
           )}
         </section>
 
-        <section className="flex flex-col gap-2">
-          <h2 className="px-2 text-xs font-medium uppercase tracking-widest text-muted">
-            Media
-          </h2>
+        <section className={isTerminal ? "flex flex-col gap-1 pb-2" : "flex flex-col gap-2"}>
+          <SectionHeader label="Media" isTerminal={isTerminal} bordered />
           <MediaGrid attachments={attachments} />
         </section>
       </div>
     );
   },
 );
+
+interface SectionHeaderProps {
+  label: string;
+  isTerminal: boolean;
+  /** Hairline rule above the header as well as below — the left sidebar's
+      `bordered` treatment, used on every section after the first. */
+  bordered?: boolean;
+}
+
+/**
+ * Section heading for the panel column. Terminal borrows the left sidebar's
+ * `SectionHeader` chrome verbatim — a `h-bar` sticky strip, hairline under it,
+ * and a second hairline above every section after the first — so both columns
+ * read as the same UI. Refined keeps the lighter free-standing label it
+ * already had.
+ */
+const SectionHeader: React.FC<SectionHeaderProps> = ({
+  label,
+  isTerminal,
+  bordered,
+}) => {
+  if (!isTerminal) {
+    return (
+      <h2 className="px-2 text-xs font-medium uppercase tracking-widest text-muted">
+        {label}
+      </h2>
+    );
+  }
+  const cls = [
+    "sticky top-0 z-[1] flex h-bar w-full items-center border-b border-line",
+    "bg-surface px-2.5 text-[0.8rem] uppercase tracking-[0.08em] text-muted select-none",
+    bordered ? "mt-1 border-t" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+  return <h2 className={cls}>{label}</h2>;
+};

--- a/frontend/src/components/Layout/RightPanel/RightPanel.tsx
+++ b/frontend/src/components/Layout/RightPanel/RightPanel.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { observer } from "mobx-react-lite";
 import { X } from "lucide-react";
 import { appStore } from "../../../stores/appStore";
+import { useSkin } from "../../../hooks/queries/usePreferences";
 import { useRightPanel } from "./useRightPanel";
 import { MembersPanel } from "./MembersPanel";
 import { ThreadPanel } from "./ThreadPanel";
@@ -19,6 +20,7 @@ import { ThreadPanel } from "./ThreadPanel";
  */
 export const RightPanel: React.FC = observer(() => {
   const { kind, isOpen, threadId, setPanel } = useRightPanel();
+  const isTerminal = useSkin() === "terminal";
 
   const groupId = appStore.selectedGroupId;
   const channelId = appStore.selectedChannelId;
@@ -34,12 +36,22 @@ export const RightPanel: React.FC = observer(() => {
 
   return (
     <aside
-      className="flex w-72 shrink-0 flex-col border-l border-line bg-surface"
+      // `font-mono` is the whole skin switch: terminal renders it as DM Mono,
+      // refined re-points `.font-mono:not(.font-machine)` at the sans face.
+      // Width tracks `--side-w` so the panel mirrors the left sidebar's
+      // per-skin measure instead of a fixed 18rem.
+      className="flex w-[var(--side-w)] shrink-0 flex-col border-l border-line bg-surface font-mono"
       data-testid="right-panel"
       aria-label="Conversation details"
     >
-      <div className="flex h-bar shrink-0 items-center justify-between border-b border-line px-3">
-        <span className="text-xs font-medium uppercase tracking-widest text-dim">
+      <div className="flex h-bar shrink-0 items-center justify-between border-b border-line px-2.5">
+        <span
+          className={
+            isTerminal
+              ? "text-[0.8rem] uppercase tracking-[0.08em] text-muted select-none"
+              : "text-xs font-medium uppercase tracking-widest text-dim"
+          }
+        >
           {kind === "thread" ? "Thread" : "Details"}
         </span>
         <button

--- a/frontend/src/components/Layout/RightPanel/RightPanel.tsx
+++ b/frontend/src/components/Layout/RightPanel/RightPanel.tsx
@@ -26,16 +26,22 @@ export const RightPanel: React.FC = observer(() => {
   const groupId = appStore.selectedGroupId;
   const channelId = appStore.selectedChannelId;
   const conversationId = appStore.selectedConversationId;
-  // The panel is context for a conversation. On routes that have none
-  // (preferences, search, the root page) there is nothing to show, so the
-  // slot collapses rather than rendering an empty column.
+  // Routes like Preferences, Search and the root page have no conversation.
+  // The panel used to collapse entirely there; now only its CONTENT is
+  // contextual — `MembersPanel` degrades to the plain online roster and drops
+  // the media grid, because "who is online" is useful on every route while
+  // "media shared in this conversation" is not.
   const hasContext = Boolean(channelId || conversationId || groupId);
+  // A thread is meaningless without the conversation it hangs off, so a
+  // stale `?panel=thread` on a context-free route falls back to the roster
+  // rather than rendering an empty thread.
+  const shownThreadId = kind === "thread" && hasContext ? threadId : null;
 
-  if (!isOpen || !hasContext) {
+  if (!isOpen) {
     return null;
   }
 
-  const label = kind === "thread" ? "Thread" : "Details";
+  const label = shownThreadId ? "Thread" : "Details";
 
   return (
     <aside
@@ -48,19 +54,15 @@ export const RightPanel: React.FC = observer(() => {
       aria-label="Conversation details"
     >
       <div className="min-h-0 flex-1">
-        {kind === "members" && (
-          <MembersPanel
-            groupId={groupId}
+        {shownThreadId ? (
+          <ThreadPanel
+            threadId={shownThreadId}
             channelId={channelId}
             conversationId={conversationId}
           />
-        )}
-        {/* `threadId` is non-null whenever kind is "thread" — the router drops
-            the panel param rather than admit one without the other — but the
-            guard keeps that guarantee local and typed. */}
-        {kind === "thread" && threadId && (
-          <ThreadPanel
-            threadId={threadId}
+        ) : (
+          <MembersPanel
+            groupId={groupId}
             channelId={channelId}
             conversationId={conversationId}
           />

--- a/frontend/src/components/Layout/RightPanel/RightPanel.tsx
+++ b/frontend/src/components/Layout/RightPanel/RightPanel.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import { observer } from "mobx-react-lite";
-import { X } from "lucide-react";
 import { appStore } from "../../../stores/appStore";
-import { useSkin } from "../../../hooks/queries/usePreferences";
+import { useShortcutLabel } from "../../../keyboard";
 import { useRightPanel } from "./useRightPanel";
 import { MembersPanel } from "./MembersPanel";
 import { ThreadPanel } from "./ThreadPanel";
@@ -20,7 +19,9 @@ import { ThreadPanel } from "./ThreadPanel";
  */
 export const RightPanel: React.FC = observer(() => {
   const { kind, isOpen, threadId, setPanel } = useRightPanel();
-  const isTerminal = useSkin() === "terminal";
+  // Live label for the same command AppShell binds — rebinding the shortcut
+  // in Preferences relabels this footer with no extra wiring.
+  const toggleRightPanelLabel = useShortcutLabel("app.toggleRightPanel");
 
   const groupId = appStore.selectedGroupId;
   const channelId = appStore.selectedChannelId;
@@ -34,6 +35,8 @@ export const RightPanel: React.FC = observer(() => {
     return null;
   }
 
+  const label = kind === "thread" ? "Thread" : "Details";
+
   return (
     <aside
       // `font-mono` is the whole skin switch: terminal renders it as DM Mono,
@@ -44,27 +47,6 @@ export const RightPanel: React.FC = observer(() => {
       data-testid="right-panel"
       aria-label="Conversation details"
     >
-      <div className="flex h-bar shrink-0 items-center justify-between border-b border-line px-2.5">
-        <span
-          className={
-            isTerminal
-              ? "text-[0.8rem] uppercase tracking-[0.08em] text-muted select-none"
-              : "text-xs font-medium uppercase tracking-widest text-dim"
-          }
-        >
-          {kind === "thread" ? "Thread" : "Details"}
-        </span>
-        <button
-          type="button"
-          onClick={() => setPanel("none")}
-          className="rounded p-1 text-muted hover:bg-hover hover:text-fg"
-          aria-label="Close details panel"
-          data-testid="right-panel-close"
-        >
-          <X size={14} aria-hidden />
-        </button>
-      </div>
-
       <div className="min-h-0 flex-1">
         {kind === "members" && (
           <MembersPanel
@@ -84,6 +66,26 @@ export const RightPanel: React.FC = observer(() => {
           />
         )}
       </div>
+
+      {/* Footer, not a header: the same affordance the left sidebar puts at
+          its bottom edge, mirrored to this one. Label on the left, live key
+          combo on the right, whole strip is the toggle. */}
+      <button
+        type="button"
+        data-testid="right-panel-close"
+        onClick={() => setPanel("none")}
+        aria-label={`Close ${label.toLowerCase()} panel (${toggleRightPanelLabel})`}
+        title={`Close ${label.toLowerCase()} panel (${toggleRightPanelLabel})`}
+        className="flex shrink-0 cursor-pointer items-center gap-2 border-t border-line px-2.5 min-h-bar text-left text-xs text-muted transition-colors hover:text-fg"
+      >
+        <span className="flex-1">{label}</span>
+        <kbd
+          aria-hidden="true"
+          className="font-mono font-machine bg-bg px-1.5 py-px rounded-[3px] border border-line text-2xs leading-[1.2]"
+        >
+          {toggleRightPanelLabel}
+        </kbd>
+      </button>
     </aside>
   );
 });

--- a/frontend/src/components/Layout/RightPanel/ThreadMessageRow.tsx
+++ b/frontend/src/components/Layout/RightPanel/ThreadMessageRow.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { observer } from "mobx-react-lite";
 import { PresenceAvatar } from "../../ui/PresenceAvatar";
 import { AttachmentDisplay } from "../../Message/AttachmentDisplay";
+import { useSkin } from "../../../hooks/queries/usePreferences";
 import type { Message } from "../../../types";
 
 interface ThreadMessageRowProps {
@@ -17,16 +18,75 @@ interface ThreadMessageRowProps {
  * `MessageItem`: that component carries the full channel affordances (reply,
  * edit, delete, pin, moderation, skin-aware grouping) and is sized for the
  * main column. A thread row needs the author, the text, and any attachments.
+ *
+ * **Skin-aware, and never the own-message treatment.** The channel tints your
+ * own name with the accent (and admins get a filled chip); a thread row does
+ * neither, in either skin. In a panel this narrow the highlight reads as a
+ * selection state rather than authorship, and a thread is usually a handful of
+ * people going back and forth — colouring one of them differently just adds
+ * noise to a column that is already tight.
+ *
+ * Terminal drops the avatar entirely: terminal is an IRC surface where identity
+ * is the name, and a 24px portrait per row in a 18rem column costs more space
+ * than it earns. Refined keeps it, because that skin leads with people.
  */
 export const ThreadMessageRow: React.FC<ThreadMessageRowProps> = observer(
   ({ message, isRoot = false }) => {
+    const skin = useSkin();
+    const isTerminal = skin !== "refined";
     const author = message.sender_username ?? message.sender_id;
+    const time = new Date(message.created_at).toLocaleTimeString([], {
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+    const testid = isRoot ? "thread-root" : "thread-reply";
+
+    const body = message.deleted_at ? (
+      <p className={`italic text-muted ${isTerminal ? "text-base" : "text-sm"}`}>
+        Message deleted
+      </p>
+    ) : (
+      <>
+        {message.content_decrypted ? (
+          <p
+            className={`whitespace-pre-wrap break-words text-fg ${
+              isTerminal ? "text-base" : "text-sm"
+            }`}
+          >
+            {message.content_decrypted}
+          </p>
+        ) : (
+          <p
+            className={`italic text-muted ${isTerminal ? "text-base" : "text-sm"}`}
+          >
+            [encrypted]
+          </p>
+        )}
+        {(message.attachments ?? []).map((attachment) => (
+          <div key={attachment.id} className="mt-1">
+            <AttachmentDisplay attachment={attachment} />
+          </div>
+        ))}
+      </>
+    );
+
+    if (isTerminal) {
+      // IRC shape: `HH:MM <name>` on the same line as the text where it fits,
+      // no portrait, no indent rail — the same reading rhythm as the channel
+      // in this skin.
+      return (
+        <div className="px-1 py-0.5" data-testid={testid}>
+          <div className="flex items-baseline gap-1.5">
+            <span className="shrink-0 text-2xs text-muted">{time}</span>
+            <span className="truncate text-base text-dim">{author}</span>
+          </div>
+          {body}
+        </div>
+      );
+    }
 
     return (
-      <div
-        className="flex gap-2"
-        data-testid={isRoot ? "thread-root" : "thread-reply"}
-      >
+      <div className="flex gap-2" data-testid={testid}>
         <PresenceAvatar
           userId={message.sender_id}
           size={24}
@@ -38,32 +98,9 @@ export const ThreadMessageRow: React.FC<ThreadMessageRowProps> = observer(
             <span className="truncate text-xs font-medium text-fg">
               {author}
             </span>
-            <span className="shrink-0 text-xs text-muted">
-              {new Date(message.created_at).toLocaleTimeString([], {
-                hour: "2-digit",
-                minute: "2-digit",
-              })}
-            </span>
+            <span className="shrink-0 text-xs text-muted">{time}</span>
           </div>
-
-          {message.deleted_at ? (
-            <p className="text-sm italic text-muted">Message deleted</p>
-          ) : (
-            <>
-              {message.content_decrypted ? (
-                <p className="whitespace-pre-wrap break-words text-sm text-fg">
-                  {message.content_decrypted}
-                </p>
-              ) : (
-                <p className="text-sm italic text-muted">[encrypted]</p>
-              )}
-              {(message.attachments ?? []).map((attachment) => (
-                <div key={attachment.id} className="mt-1">
-                  <AttachmentDisplay attachment={attachment} />
-                </div>
-              ))}
-            </>
-          )}
+          {body}
         </div>
       </div>
     );

--- a/frontend/src/components/Layout/RightPanel/ThreadPanel.tsx
+++ b/frontend/src/components/Layout/RightPanel/ThreadPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useMemo } from "react";
 import { observer } from "mobx-react-lite";
 import { appStore } from "../../../stores/appStore";
 import {
@@ -6,8 +6,8 @@ import {
   useSendMessage,
   useThreadMessages,
 } from "../../../hooks/queries/useMessages";
-import { Button } from "../../ui/Button";
-import { TextArea } from "../../ui/TextArea";
+import { ChatInput, type Attachment } from "../../ui/ChatInput";
+import { buildMessageContent } from "../../../utils/attachmentEnvelope";
 import { ThreadMessageRow } from "./ThreadMessageRow";
 
 interface ThreadPanelProps {
@@ -33,26 +33,27 @@ export const ThreadPanel: React.FC<ThreadPanelProps> = observer(
     const { data: replies = [], isLoading } = useThreadMessages(threadId);
     const sendMessage = useSendMessage();
     const currentUser = appStore.currentUser;
-    const [draft, setDraft] = useState("");
 
     const root = useMemo(
       () => messages.find((m) => m.id === threadId) ?? null,
       [messages, threadId],
     );
 
-    const canSend = draft.trim().length > 0 && !!currentUser;
-
-    const submit = () => {
-      if (!canSend) {
+    const submit = async (text: string, attachments: Attachment[]) => {
+      const contentText = text.trim();
+      if ((!contentText && attachments.length === 0) || !currentUser) {
         return;
       }
+      // Same upload + `_att` envelope the channel composer uses, so a file
+      // dropped in a thread is indistinguishable on the wire from one dropped
+      // in the channel.
+      const content = await buildMessageContent(attachments, contentText);
       sendMessage.mutate({
         channelId: channelId ?? "",
         conversationId: conversationId ?? "",
-        content: draft.trim(),
+        content,
         threadId,
       });
-      setDraft("");
     };
 
     return (
@@ -79,36 +80,22 @@ export const ThreadPanel: React.FC<ThreadPanelProps> = observer(
           )}
         </div>
 
-        {/* The thread composer is part of the panel, not a modal or an overlay
-            — it replaces nothing and covers nothing. */}
+        {/* The thread's OWN composer, not a second style of input.
+            `ChatInput` keeps its attachment list in component state, so a
+            thread instance and the channel instance cannot share a pending
+            file — which is the bug this replaced: the thread had only a bare
+            textarea, so the only attach button on screen belonged to the
+            channel and every file went there.
+
+            No label: the panel header already says Thread and the placeholder
+            says the rest, so a "Reply in thread" label above a "Reply in
+            thread…" placeholder was the same sentence twice. */}
         <div className="shrink-0 border-t border-line p-2">
-          <TextArea
-            id="thread-composer"
-            label="Reply in thread"
-            value={draft}
-            onChange={setDraft}
+          <ChatInput
+            onSend={submit}
             placeholder="Reply in thread…"
-            rows={2}
-            onKeyDown={(e) => {
-              // Enter sends, Shift+Enter newlines — the same contract as the
-              // main chat input.
-              if (e.key === "Enter" && !e.shiftKey) {
-                e.preventDefault();
-                submit();
-              }
-            }}
+            draftKey={`thread:${threadId}`}
           />
-          <div className="mt-2 flex justify-end">
-            <Button
-              size="sm"
-              variant="primary"
-              disabled={!canSend}
-              onClick={submit}
-              data-testid="thread-send"
-            >
-              Reply
-            </Button>
-          </div>
         </div>
       </div>
     );

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -21,7 +21,7 @@ import { useVoiceRoomCounts } from "../../hooks/queries/useVoiceParticipants";
 import { usePeerVerifications } from "../../hooks/queries/useUserProfile";
 import { observer } from "mobx-react-lite";
 import { appStore } from "../../stores/appStore";
-import { usePresenceStatus } from "../../stores/presenceStore";
+import { PresenceDot } from "../ui/PresenceDot";
 import { useShortcutLabel } from "../../keyboard";
 import { useSkin } from "../../hooks/queries/usePreferences";
 import { PresenceAvatar } from "../ui/PresenceAvatar";
@@ -278,7 +278,12 @@ export const Sidebar: React.FC<SidebarProps> = observer(({ isOpen, onToggle }) =
                       testId={`sidebar-dm-avatar-${c.id}`}
                     />
                   ) : (
-                    <PresenceDot userId={c.user2_id ?? null} />
+                    <PresenceDot
+                      userId={c.user2_id ?? null}
+                      testId={
+                        c.user2_id ? `sidebar-presence-${c.user2_id}` : undefined
+                      }
+                    />
                   )
                 }
                 label={c.user2_identifier}
@@ -440,19 +445,3 @@ const UnreadBadge: React.FC<{ count: number; muted?: boolean }> = ({ count, mute
     {count > 99 ? "99+" : count}
   </span>
 );
-
-// Standalone presence dot mirroring Avatar's overlay dot: online uses the
-// accent color, offline uses the bg color ringed in accent-muted. Used in
-// the sidebar DM list where there's no avatar behind it to anchor the dot.
-const PresenceDot: React.FC<{ userId: string | null }> = observer(({ userId }) => {
-  const status = usePresenceStatus(userId);
-  return (
-    <span
-      data-testid={userId ? `sidebar-presence-${userId}` : undefined}
-      aria-label={`Presence: ${status}`}
-      className={`inline-block size-2 rounded-full box-content shrink-0 border ${
-        status === "offline" ? "bg-bg border-accent-muted" : "bg-accent border-surface"
-      }`}
-    />
-  );
-});

--- a/frontend/src/components/Message/MessageItem.tsx
+++ b/frontend/src/components/Message/MessageItem.tsx
@@ -240,10 +240,6 @@ export const MessageItem: React.FC<MessageItemProps> = observer(({
 
           {/* Reactions row — disabled, needs more thought */}
           {/* <MessageReactions messageId={message.id} /> */}
-      <ThreadReplyCount
-        count={threadReplyCount}
-        onOpen={onOpenThread ? () => onOpenThread(message.id) : undefined}
-      />
           <ThreadReplyCount
             count={threadReplyCount}
             onOpen={onOpenThread ? () => onOpenThread(message.id) : undefined}

--- a/frontend/src/components/ui/PresenceDot.tsx
+++ b/frontend/src/components/ui/PresenceDot.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { observer } from "mobx-react-lite";
+import { usePresenceStatus } from "../../stores/presenceStore";
+
+interface PresenceDotProps {
+  userId: string | null;
+  testId?: string;
+}
+
+/**
+ * Standalone presence dot mirroring Avatar's overlay dot: online uses the
+ * accent color, offline uses the bg color ringed in accent-muted.
+ *
+ * Used wherever there is no avatar behind it to anchor the dot — the terminal
+ * skin's sidebar DM list and the right panel's member rows, both of which stay
+ * exactly one text-line tall.
+ */
+export const PresenceDot: React.FC<PresenceDotProps> = observer(
+  ({ userId, testId }) => {
+    const status = usePresenceStatus(userId);
+    return (
+      <span
+        data-testid={testId}
+        aria-label={`Presence: ${status}`}
+        className={`inline-block size-2 rounded-full box-content shrink-0 border ${
+          status === "offline"
+            ? "bg-bg border-accent-muted"
+            : "bg-accent border-surface"
+        }`}
+      />
+    );
+  },
+);

--- a/frontend/src/stores/appStore.ts
+++ b/frontend/src/stores/appStore.ts
@@ -4,6 +4,8 @@ import type { VoiceState } from '../types/voice-state';
 import type { SourceList } from '../screenshare/screenShareSession';
 import type { CameraSource } from '../camera/types';
 import { isSpeaking } from '../voice/participantAudio';
+// One-way edge: presenceStore imports nothing of ours, so this cannot cycle.
+import { presenceStore } from './presenceStore';
 
 type CameraRemote = { trackKey: string; width: number; height: number };
 type EnrollmentApproval = { requestId: string; newDeviceId: string; verificationCode: string };
@@ -109,6 +111,10 @@ class AppStore implements AppState {
   // ── Actions ────────────────────────────────────────────────────────────
   setCurrentUser(user: User | null) {
     this.currentUser = user;
+    // Presence is fed by realtime events about other participants only, so
+    // the store has to be told who "we" are or every surface reports the
+    // local user offline.
+    presenceStore.setSelfUserId(user?.id ?? null);
   }
 
   setUsername(username: string | null) {
@@ -516,6 +522,7 @@ class AppStore implements AppState {
 
   logout() {
     this.currentUser = null;
+    presenceStore.setSelfUserId(null);
     this.username = null;
     this.userAvatarUrl = null;
     this.selectedGroupId = null;

--- a/frontend/src/stores/presenceStore.ts
+++ b/frontend/src/stores/presenceStore.ts
@@ -11,6 +11,12 @@ class PresenceStore {
   // user_id → Set<room_id>
   byUser: Record<string, Set<string>> = {};
 
+  // The signed-in user. `byUser` is fed exclusively by realtime room events
+  // about OTHER participants — we never receive one about ourselves — so
+  // without this the local user reads as offline in every presence surface
+  // while the app is plainly running. Set from `appStore.setCurrentUser`.
+  selfUserId: string | null = null;
+
   constructor() {
     // `isOnline` is excluded from auto-annotation (left a plain method, not an
     // `action`). Actions run in an untracked context, so if `isOnline` were an
@@ -18,6 +24,13 @@ class PresenceStore {
     // component and presence wouldn't update live. As a plain method its reads
     // are tracked by the enclosing observer's render.
     makeAutoObservable(this, { isOnline: false }, { autoBind: true });
+  }
+
+  // Called wherever the current user is established or cleared (sign-in,
+  // logout). A setter rather than a read of `appStore` so this store keeps
+  // its zero imports and the dependency stays one-way.
+  setSelfUserId(userId: string | null) {
+    this.selfUserId = userId;
   }
 
   setPresent(userId: string, roomId: string, present: boolean) {
@@ -60,7 +73,16 @@ class PresenceStore {
   }
 
   isOnline(userId: string | null | undefined): boolean {
-    return userId ? (this.byUser[userId]?.size ?? 0) > 0 : false;
+    if (!userId) {
+      return false;
+    }
+    // If the app is running, we are online — no room event will ever say so
+    // on our behalf. Reading `selfUserId` here (still a plain method, not an
+    // action) keeps the read tracked by the enclosing observer.
+    if (userId === this.selfUserId) {
+      return true;
+    }
+    return (this.byUser[userId]?.size ?? 0) > 0;
   }
 }
 

--- a/frontend/src/utils/attachmentEnvelope.ts
+++ b/frontend/src/utils/attachmentEnvelope.ts
@@ -1,0 +1,92 @@
+import { invoke } from "../bridge";
+import { blurhashFromUrl } from "./imageProcessing";
+import type { Attachment } from "../components/ui/ChatInput";
+
+/** Shape `upload_media` returns. Mirrors the Rust command's result struct. */
+export type MediaUploadResult = {
+  key: string;
+  url: string;
+  filename: string;
+  content_type: string;
+  size_bytes: number;
+  content_hash: string;
+  blurhash?: string;
+  width?: number;
+  height?: number;
+};
+
+/**
+ * Upload a composer's attachments and encode them into the message body.
+ *
+ * This is the ENCODE half of the `_att` envelope that
+ * `hooks/queries/useMessages.ts` decodes — the two must move together, so the
+ * shape is documented there once and not restated here.
+ *
+ * Extracted from `MainContent`'s send handler when threads (#825) gained their
+ * own composer: the channel and the thread both upload and encode identically,
+ * and the alternative was a second copy that would drift the moment the wire
+ * shape changed. Deliberately NOT the whole send path — the optimistic-update
+ * machinery around it is keyed to the channel's query and is genuinely
+ * channel-only, since a thread reply lands in its own query.
+ *
+ * Returns the string to send as message content: the plain text when there are
+ * no attachments, otherwise the JSON envelope carrying them plus the caption.
+ */
+export async function buildMessageContent(
+  attachments: Attachment[],
+  contentText: string,
+): Promise<string> {
+  if (attachments.length === 0) {
+    return contentText;
+  }
+
+  // Derive a blurhash for videos from the locally-captured poster frame, so a
+  // receiver sees a placeholder without downloading the video first. Images get
+  // theirs server-side during upload.
+  const videoBlurhashes = new Map<string, { bh: string; w: number; h: number }>();
+  await Promise.all(
+    attachments
+      .filter((att) => att.mimeType.startsWith("video/") && att.preview)
+      .map(async (att) => {
+        const meta = await blurhashFromUrl(att.preview!).catch(() => null);
+        if (meta) {
+          videoBlurhashes.set(att.id, {
+            bh: meta.hash,
+            w: meta.width,
+            h: meta.height,
+          });
+        }
+      }),
+  );
+
+  const results = await Promise.all(
+    attachments.map((att) =>
+      invoke<MediaUploadResult>("upload_media", {
+        path: att.path,
+        filename: att.name,
+        contentType: att.mimeType,
+      }),
+    ),
+  );
+
+  const envelope: Record<string, unknown> = {
+    _att: results.map((r, i) => {
+      const vMeta = videoBlurhashes.get(attachments[i]?.id ?? "");
+      return {
+        key: r.key,
+        url: r.url,
+        name: r.filename,
+        ct: r.content_type,
+        size: r.size_bytes,
+        hash: r.content_hash,
+        bh: r.blurhash ?? vMeta?.bh,
+        w: r.width ?? vMeta?.w,
+        h: r.height ?? vMeta?.h,
+      };
+    }),
+  };
+  if (contentText) {
+    envelope._txt = contentText;
+  }
+  return JSON.stringify(envelope);
+}

--- a/src-tauri/src/commands/relay_serving.rs
+++ b/src-tauri/src/commands/relay_serving.rs
@@ -13,7 +13,10 @@ use tauri::{AppHandle, Emitter};
 
 use crate::error::Result;
 pub use pollis_core::commands::relay_serving::*;
-use pollis_core::commands::relay_serving::{set_status_sink, RELAY_SERVING_EVENT};
+// Only `set_status_sink` is imported by name. Naming RELAY_SERVING_EVENT here
+// too made this private import SHADOW the glob re-export above, so the constant
+// the renderer's event name must match was silently not re-exported.
+use pollis_core::commands::relay_serving::set_status_sink;
 use pollis_core::net::peer::{RelayServingConfig, RelayServingStatus};
 use pollis_core::sink::EventSink;
 

--- a/src-tauri/tests/flows/harness.rs
+++ b/src-tauri/tests/flows/harness.rs
@@ -3153,6 +3153,59 @@ impl TestClient {
         .await
     }
 
+    /// Send a reply INTO a thread (#825). `thread_id` is the root message's
+    /// ULID. Returns the new message so a caller can assert on its id.
+    ///
+    /// Takes `conversation_id` like every other send here: the local `message`
+    /// table keys channels and DMs on the same column, which is precisely why
+    /// threads are expected to behave identically in both.
+    pub(crate) async fn send_thread_reply(
+        &self,
+        conversation_id: &str,
+        thread_id: &str,
+        content: &str,
+    ) -> serde_json::Value {
+        self.activate();
+        invoke(
+            &self.webview,
+            "send_message",
+            json!({
+                "conversationId": conversation_id,
+                "senderId": self.user_id(),
+                "content": content,
+                "replyToId": null,
+                "threadId": thread_id,
+                "senderUsername": self.profile.as_ref().map(|p| p.username.clone()),
+            }),
+        )
+        .await
+        .unwrap_or_else(|e| panic!("send_thread_reply({conversation_id}, {thread_id}): {e}"))
+    }
+
+    /// Replies this device holds for one thread, oldest first.
+    pub(crate) async fn read_thread(&self, thread_id: &str) -> Vec<serde_json::Value> {
+        self.activate();
+        invoke::<Vec<serde_json::Value>>(
+            &self.webview,
+            "read_thread_messages",
+            json!({ "threadId": thread_id }),
+        )
+        .await
+        .unwrap_or_else(|e| panic!("read_thread_messages({thread_id}): {e}"))
+    }
+
+    /// Reply counts per thread for one conversation (channel id or DM id).
+    pub(crate) async fn thread_summaries(&self, conversation_id: &str) -> Vec<serde_json::Value> {
+        self.activate();
+        invoke::<Vec<serde_json::Value>>(
+            &self.webview,
+            "list_thread_summaries",
+            json!({ "conversationId": conversation_id }),
+        )
+        .await
+        .unwrap_or_else(|e| panic!("list_thread_summaries({conversation_id}): {e}"))
+    }
+
     pub(crate) async fn send_channel_message(&self, conversation_id: &str, content: &str) {
         self.try_send_message(conversation_id, content)
             .await

--- a/src-tauri/tests/flows/messages.rs
+++ b/src-tauri/tests/flows/messages.rs
@@ -2149,3 +2149,104 @@ async fn admin_delete_redacts_the_authors_own_copy() {
 
     drop((alice, bob));
 }
+
+/// Threads (#825) must behave identically in a DM and in a group channel.
+///
+/// They share one code path by construction — the local `message` table keys
+/// both on `conversation_id`, and `read_thread_messages` filters on `thread_id`
+/// alone — but nothing pinned that, and the two surfaces reach it through
+/// different UI. This runs the same thread through both and asserts the same
+/// answers, so a future change that special-cases channels fails here.
+///
+/// What it pins, for each surface:
+///   - a reply sent with `threadId` is readable back as a reply of that thread
+///   - the reply does NOT come back in the conversation's main message list
+///     (the channel feed shows the root's "N replies" instead — a reply in
+///     both places is the double-post bug threads exist to avoid)
+///   - `list_thread_summaries` counts it against the root
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn threads_behave_the_same_in_dms_and_channels() {
+    wipe().await;
+
+    let mut alice = TestClient::new().await;
+    let mut bob = TestClient::new().await;
+
+    let alice_profile = alice.sign_up("alice@test.local").await;
+    let bob_profile = bob.sign_up("bob@test.local").await;
+
+    // ---- surface 1: a group channel ----
+    let group_id = alice.create_group("Threads").await;
+    alice.invite(&group_id, &bob_profile.username).await;
+    let invite_id = bob
+        .first_pending_invite()
+        .await
+        .expect("pending invite")["id"]
+        .as_str()
+        .expect("invite id")
+        .to_string();
+    bob.accept_invite(&invite_id).await;
+    bob.poll().await;
+    let channel_id = alice.general_channel_id(&group_id).await;
+
+    let channel_root = alice
+        .send_channel_message_id(&channel_id, "channel root")
+        .await;
+    alice
+        .send_thread_reply(&channel_id, &channel_root, "channel reply")
+        .await;
+
+    // ---- surface 2: a DM ----
+    let dm_id = alice.create_dm(&[bob_profile.id.as_str()]).await;
+    bob.poll().await;
+    let dm_root = alice.send_channel_message_id(&dm_id, "dm root").await;
+    alice
+        .send_thread_reply(&dm_id, &dm_root, "dm reply")
+        .await;
+
+    // ---- the same three assertions against each ----
+    for (label, conversation_id, root_id, reply_text) in [
+        ("channel", &channel_id, &channel_root, "channel reply"),
+        ("dm", &dm_id, &dm_root, "dm reply"),
+    ] {
+        let replies = alice.read_thread(root_id).await;
+        let texts: Vec<&str> = replies
+            .iter()
+            .filter_map(|m| m["content"].as_str())
+            .collect();
+        assert!(
+            texts.contains(&reply_text),
+            "{label}: the thread should hold its reply, got: {replies:#?}"
+        );
+
+        // The reply belongs to the thread, not the conversation's own feed.
+        let feed = alice.fetch_channel_messages(conversation_id).await;
+        let feed_has_reply = feed
+            .iter()
+            .filter_map(|m| m["thread_id"].as_str())
+            .any(|t| t == root_id.as_str());
+        assert!(
+            feed_has_reply,
+            "{label}: the reply must still be FETCHABLE with a thread_id set — \
+             the channel feed filters it out client-side, so the field is what \
+             that filter keys on and it must survive the round trip"
+        );
+
+        let summaries = alice.thread_summaries(conversation_id).await;
+        let counted = summaries
+            .iter()
+            .find(|s| s["thread_id"].as_str() == Some(root_id.as_str()))
+            .unwrap_or_else(|| {
+                panic!("{label}: no thread summary for {root_id}, got: {summaries:#?}")
+            });
+        assert_eq!(
+            counted["reply_count"].as_i64(),
+            Some(1),
+            "{label}: the root should advertise exactly one reply"
+        );
+    }
+
+    let _ = alice_profile;
+    drop(alice);
+    drop(bob);
+}


### PR DESCRIPTION
Every item reported against the threads + right-panel work, one commit each.

## Threads

- **The "N replies" row rendered twice** — a literal copy-paste in `MessageItem`, one block mis-indented. Deleted the duplicate.
- **Thread replies leaked into the channel feed.** Nothing filtered them, so every reply double-posted: once in the thread, once in the channel the thread exists to keep clean. Filtered at the point the list is *rendered*, not in the source array — that array still backs id lookups for delete/edit confirmation and the reply-quote resolver, and those must keep resolving a reply that is only visible in the panel.
- **Attachments went to the channel, not the thread.** Root cause was that the thread had no composer of its own — just a bare `TextArea` — so the only attach button on screen belonged to the channel. The thread now uses the existing `ChatInput`, which keeps its attachment list in component state, so the two composers cannot share a pending file. That also removed the redundant "Reply in thread" label sitting above a "Reply in thread…" placeholder.
- The upload + `_att` envelope encoding moved to `utils/attachmentEnvelope.ts` so both composers share one copy. Extraction, not a parallel implementation — a second copy would drift the moment the wire shape changed. Deliberately *not* the whole send path: the optimistic-update machinery around it is keyed to the channel's query and is genuinely channel-only.
- **Thread rows are skin-aware and never use the own-message treatment.** Terminal drops the avatar entirely and uses the IRC `HH:MM name` shape; refined keeps the avatar. Neither tints your own name — in a column this narrow that highlight reads as a selection state rather than authorship.
- **DM/channel parity is now pinned by a test**, not assumed. They already shared a code path (the local `message` table keys both on `conversation_id`, and `read_thread_messages` filters on `thread_id` alone) but nothing enforced it. `threads_behave_the_same_in_dms_and_channels` runs the same thread through both surfaces and asserts the same answers. It passes.

## Right panel

- **Matches the terminal skin** — monospace, the sidebar's spacing and type scale, hairline-separated sections, square media tiles. Refined is unchanged. Verified in *both* skins.
- **`DETAILS` moved from a top bar to a bottom footer**, built like the left sidebar's close footer, with a live `<kbd>` from `useShortcutLabel`. The command (`app.toggleRightPanel`, `mod+shift+b`) already existed and was already bound — it just had no visible affordance. Rebinding it in Preferences relabels the chip automatically.
- **Contextual content.** The panel used to hide entirely off-conversation; it now shows the online roster on Preferences/Search/root and omits the media section, which is what was actually wanted there.
- **You showed as offline.** `presenceStore` is fed only by realtime room events for *other* users, so it never knew about you; the voicebar looked right only because `SidebarProfilePanel` hardcodes `presence="online"`. Fixed at the store so every consumer agrees, preserving the existing (and load-bearing) property that `isOnline` is not a MobX action, or presence would stop updating live.

Also fixes a private import that was shadowing the `RELAY_SERVING_EVENT` re-export — the renderer's event-name constant was silently not exported.

**Verification:** `tsc` clean, `pnpm --filter frontend build` clean, headless `cargo check -p pollis --tests` clean, and the new flows test passes. Both skins checked, not just terminal.

**One deliberate visual change worth a look:** the panel width moved from a fixed `w-72` to `w-[var(--side-w)]`, so refined is 1rem narrower than before — both rails now share one measure per skin, matching how the left sidebar sizes itself.