### PR TITLE
perf(terminal): cut Linux input lag — canvas renderer rung, coalesced acks

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-shell": "^2.3.5",
     "@tauri-apps/plugin-updater": "^2.10.0",
+    "@xterm/addon-canvas": "^0.7.0",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-webgl": "^0.18.0",
     "@xterm/xterm": "^5.5.0",

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -3,6 +3,7 @@ import { invoke, Channel } from "../bridge";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebglAddon } from "@xterm/addon-webgl";
+import { CanvasAddon } from "@xterm/addon-canvas";
 import "@xterm/xterm/css/xterm.css";
 
 interface TerminalViewProps {
@@ -51,12 +52,35 @@ const TerminalView: React.FC<TerminalViewProps> = ({ visible }) => {
     const fit = new FitAddon();
     term.loadAddon(fit);
     term.open(containerRef.current);
+    // Renderer, best first. xterm has three and the gap between them is the
+    // difference between typing feeling instant and feeling staggered:
+    // WebGL > canvas > DOM, and DOM repaints spans on the CPU.
+    //
+    // This matters far more on Linux than macOS. WKWebView is accelerated, so
+    // macOS gets WebGL. On Linux the app launches with
+    // WEBKIT_DISABLE_COMPOSITING_MODE=1 (src-tauri/src/main.rs — it is there to
+    // stop WebKitGTK aborting at startup on drivers without working GBM/EGL),
+    // and with accelerated compositing off WebKitGTK has no WebGL at all. The
+    // previous code caught that failure and said nothing, so every Linux user
+    // silently fell all the way to DOM. Canvas is the rung in between and needs
+    // no GPU compositing, which is why it is worth carrying.
+    let renderer: "webgl" | "canvas" | "dom" = "dom";
     try {
       term.loadAddon(new WebglAddon());
+      renderer = "webgl";
     } catch {
-      // WebGL unavailable (some Linux WebKitGTK builds) — xterm falls
-      // back to its DOM renderer automatically.
+      try {
+        term.loadAddon(new CanvasAddon());
+        renderer = "canvas";
+      } catch {
+        // Both unavailable — xterm uses its DOM renderer.
+      }
     }
+    // Logged because it is otherwise invisible: the addons fail by throwing at
+    // load time, so "is this accelerated?" was previously unanswerable without
+    // a debugger. If this ever reads `dom` on a machine that should manage
+    // better, that is the bug, not the terminal code.
+    console.info(`[terminal] renderer: ${renderer}`);
 
     termRef.current = term;
     fitRef.current = fit;
@@ -82,18 +106,51 @@ const TerminalView: React.FC<TerminalViewProps> = ({ visible }) => {
     // NOT TextDecode per-chunk. The write callback fires once the chunk is
     // actually parsed/rendered: that's the true end-to-end backpressure
     // signal we credit back to the aggregator via terminal_ack.
+    // Acks are COALESCED, not one per rendered chunk.
+    //
+    // The write path is binary, but this ack is JSON — and it used to fire from
+    // every single xterm write callback. While you type, the shell echoes each
+    // keystroke as its own chunk, so every character cost a JSON
+    // serialize/parse round trip on top of the keystroke's own invoke: two IPC
+    // hops per key, on WebKitGTK, which is the webview least able to afford
+    // them. That is a large part of why typing felt staggered on Linux and fine
+    // on macOS.
+    //
+    // Safe to batch because the aggregator needs EVENTUAL credit, not
+    // per-chunk precision: it only parks above HIGH_WATERMARK (1 MiB) and
+    // resumes below LOW_WATERMARK (256 KiB) — see commands/terminal_unix.rs.
+    // So we flush on a frame, and immediately once enough is outstanding that
+    // sitting on it could park a bulk producer mid-stream.
+    let pendingAck = 0;
+    let ackScheduled = false;
+    let ackFrame = 0;
+    const ACK_FLUSH_BYTES = 64 * 1024;
+    const flushAck = () => {
+      ackScheduled = false;
+      const bytes = pendingAck;
+      pendingAck = 0;
+      const id = terminalIdRef.current;
+      if (id === null || bytes === 0) {
+        return;
+      }
+      invoke("terminal_ack", { terminalId: id, bytes }).catch((e) =>
+        console.warn("terminal_ack failed", e),
+      );
+    };
+
     const channel = new Channel<ArrayBuffer>();
     channel.onmessage = (buf) => {
       const bytes = new Uint8Array(buf);
       term.write(bytes, () => {
-        const id = terminalIdRef.current;
-        if (id === null) {
+        pendingAck += bytes.byteLength;
+        if (pendingAck >= ACK_FLUSH_BYTES) {
+          flushAck();
           return;
         }
-        invoke("terminal_ack", {
-          terminalId: id,
-          bytes: bytes.byteLength,
-        }).catch((e) => console.warn("terminal_ack failed", e));
+        if (!ackScheduled) {
+          ackScheduled = true;
+          ackFrame = requestAnimationFrame(flushAck);
+        }
       });
     };
 
@@ -175,6 +232,12 @@ const TerminalView: React.FC<TerminalViewProps> = ({ visible }) => {
       cancelAnimationFrame(readyRaf);
       window.removeEventListener("beforeunload", onBeforeUnload);
       resizeObserver.disconnect();
+      // Drop any scheduled ack: the session is being closed, so the credit has
+      // nowhere to go and the callback would fire against a dead id.
+      if (ackScheduled) {
+        cancelAnimationFrame(ackFrame);
+        ackScheduled = false;
+      }
       onDataDisposable.dispose();
       const id = terminalIdRef.current;
       if (id !== null) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       '@tauri-apps/plugin-updater':
         specifier: ^2.10.0
         version: 2.10.1
+      '@xterm/addon-canvas':
+        specifier: ^0.7.0
+        version: 0.7.0(@xterm/xterm@5.5.0)
       '@xterm/addon-fit':
         specifier: ^0.10.0
         version: 0.10.0(@xterm/xterm@5.5.0)
@@ -858,105 +861,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1074,79 +1061,66 @@ packages:
     resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
     resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
     resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
     resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.2':
     resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.2':
     resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
@@ -1252,35 +1226,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-arm64-musl@2.11.4':
     resolution: {integrity: sha512-v277UnT/fB64xAfSroL5N3Km3tLmvATWqJJw/wRI+g6o+HkeD0slyE7gOhNs1MbjE41R7bQOTxMVoL3aomUJmw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.11.4':
     resolution: {integrity: sha512-qqgNkQ2u1yZHxjhxsZaxUtRDW8dIqIYm33rx/mzwQv0SfY9x1B+iraj8vWeFiXjjSVVhEMepXSOts1TqPzvXNQ==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-gnu@2.11.4':
     resolution: {integrity: sha512-2VRNWl84FOH0m2giiDkO2h0QXlcMJeX+zJDpI5kDIQAx6s+geF3v48F4DXfJez4GS/FdoDGnPnw1C2iYGbQ7bQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-musl@2.11.4':
     resolution: {integrity: sha512-o9GyhYor/nc7xarmwDE3ka2szuW3uuZzXjHWh64Q8YX5AtSgxdQkFWzrY4O8KiGtVNvFBI14H3Q49Qj5TOIP/A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-win32-arm64-msvc@2.11.4':
     resolution: {integrity: sha512-ld5Ehb598m0VkYyylRPNeCFsBe/km0jxis6KgMpl3IGY6I/i1RwQXO05I1AsXUXO2WC6AvB/Lw4qTf/asiuEiQ==}
@@ -1386,6 +1355,11 @@ packages:
   '@wdio/utils@8.46.0':
     resolution: {integrity: sha512-C94kJjZhEfPUNbOA69BQr1SgziQYgjNXK8S1GJXQKuwxN/24PQkYCzeBqXstfxyTXyOwoQCcEZAQ/qJccboufQ==}
     engines: {node: ^16.13 || >=18}
+
+  '@xterm/addon-canvas@0.7.0':
+    resolution: {integrity: sha512-LF5LYcfvefJuJ7QotNRdRSPc9YASAVDeoT5uyXS/nZshZXjYplGXRECBGiznwvhNL2I8bq1Lf5MzRwstsYQ2Iw==}
+    peerDependencies:
+      '@xterm/xterm': ^5.0.0
 
   '@xterm/addon-fit@0.10.0':
     resolution: {integrity: sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==}
@@ -3867,6 +3841,10 @@ snapshots:
       - bare-buffer
       - react-native-b4a
       - supports-color
+
+  '@xterm/addon-canvas@0.7.0(@xterm/xterm@5.5.0)':
+    dependencies:
+      '@xterm/xterm': 5.5.0
 
   '@xterm/addon-fit@0.10.0(@xterm/xterm@5.5.0)':
     dependencies:

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -294,9 +294,23 @@ pub fn run() {
 
     // WebKitGTK 2.42+ attempts DMA-BUF rendering and aborts if GBM/EGL is
     // unavailable (e.g. certain GPU drivers, VMs, Wayland compositors without
-    // DRM). Disable it unconditionally so the app doesn't crash on launch.
+    // DRM). Disable it so the app doesn't crash on launch.
+    //
+    // NOT unconditional, despite what this comment used to say. `main.rs`
+    // deliberately skips both WebKit disables when POLLIS_ENABLE_COMPOSITING is
+    // set, and this line then set one of them straight back — so the documented
+    // escape hatch could not actually be exercised, and nobody could measure
+    // the accelerated path even by asking for it. Honouring the same opt-in
+    // here is what makes that flag mean something.
+    //
+    // The perf stake is real: with WebKitGTK's accelerated compositing off
+    // there is no WebGL, so the in-app terminal falls back to a slower renderer
+    // (see TerminalView.tsx). Launching at all still wins over launching fast,
+    // which is why the conservative path remains the default.
     #[cfg(target_os = "linux")]
-    std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+    if std::env::var("POLLIS_ENABLE_COMPOSITING").is_err() {
+        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+    }
 
     // WebKit uses GStreamer for media playback. The `autoaudiosink` element
     // (gst-plugins-good) is not always installed. When it is missing, GStreamer


### PR DESCRIPTION
Typing in the in-app terminal is staggered on Linux and fine on macOS. The terminal backend is not the problem — it already does binary IPC, read coalescing and watermarked backpressure. The asymmetry is in the webview.

**Why Linux is slower.** `src-tauri/src/main.rs` launches with `WEBKIT_DISABLE_COMPOSITING_MODE=1` (and DMABuf off) so WebKitGTK doesn't abort at startup on drivers without working GBM/EGL. With accelerated compositing off there is no WebGL, so `new WebglAddon()` throws — and the previous code caught that and said nothing, dropping every Linux user to xterm's **DOM renderer**, which repaints spans on the CPU. macOS is WKWebView, accelerated, so it gets WebGL. A fast GPU doesn't help when nothing is on it.

**These changes do not touch the launch flags.** They stay: launching at all beats launching fast.

1. **Canvas renderer rung.** The fallback chain was WebGL → DOM; canvas sits between them, needs no GPU compositing, and is a large improvement over DOM on a CPU-bound path. Ships `@xterm/addon-canvas` (frontend package only).
2. **The active renderer is now logged.** The addons fail by throwing at load time, so "is this accelerated?" was previously unanswerable without a debugger. If it ever reads `dom` on a machine that should do better, that is the bug.
3. **Acks are coalesced.** The keystroke write is binary, but `terminal_ack` is JSON and fired from *every* xterm write callback — and while you type the shell echoes each keystroke as its own chunk, so every character cost a JSON round trip on top of its own invoke: two IPC hops per key on the webview least able to afford them. Now accumulated and flushed on a frame, or immediately past 64 KiB. Safe because the aggregator needs eventual credit, not per-chunk precision — it only parks above 1 MiB and resumes below 256 KiB. A pending frame is cancelled on teardown so it can't fire against a closed session.
4. **`POLLIS_ENABLE_COMPOSITING` actually works now.** `main.rs` deliberately skips both WebKit disables when it is set, then `lib.rs` set `WEBKIT_DISABLE_DMABUF_RENDERER=1` straight back unconditionally — so the documented escape hatch could not be exercised and the accelerated path could not be measured even on request. Same opt-in is honoured in both places; the conservative path is still the default.

**Worth testing next, separately:** the two flags do different jobs. DMABuf-off is what addresses the launch abort; compositing-mode-off is the heavier hammer that costs WebGL, and the code comment treats it as belt-and-braces ("DMABUF alone isn't enough on **some** drivers"). Keeping DMABuf disabled while letting compositing stay on may launch fine *and* restore WebGL. With fix 4 in, that is now a one-run experiment instead of a code change.

**Verification:** `tsc` clean, `pnpm --filter frontend build` clean, `cargo check -p pollis` clean. Not measured end-to-end — I have not run the app, so the renderer log line is deliberately there to make the result checkable rather than assumed.