### PR TITLE
fix(release): pin cosign-installer to v4.1.2 — there is no moving v4 tag

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1173,7 +1173,13 @@ jobs:
       # Pinned installer action — never an unpinned curl. Puts the `cosign` CLI
       # on the runner for the sign-blob pass below.
       #
-      # v4, not v3: the v3 line stopped at v3.10.1 (2025-10) and its hardcoded
+      # Pinned to an EXACT version, not `@v4`: sigstore/cosign-installer
+      # publishes no moving `v4` tag (v3 has one, v4 does not), so `@v4` is
+      # unresolvable and the job dies in "Set up job" before a single step runs
+      # — which is exactly how v1.9.1 lost its provenance. Bumping a major by
+      # convention is not safe here; check the tag exists.
+      #
+      # v4.x, not v3: the v3 line stopped at v3.10.1 (2025-10) and its hardcoded
       # digest for cosign's release signing key went stale, so every run now dies
       # with "Fetched public key does not match expected digest" (curl exit 22).
       # That is what silently cost v1.9.0 its provenance — the SLSA attestations
@@ -1186,7 +1192,7 @@ jobs:
       # installer and the CLI generation in one step would make a failure
       # ambiguous, so the CLI contract stays fixed here and moves on its own.
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.1.2
         with:
           cosign-release: 'v2.6.5'
 

--- a/docs/deployments.md
+++ b/docs/deployments.md
@@ -303,6 +303,21 @@ A green workflow is **not** proof the new bits are serving traffic. For anything
 - **Desktop / CLI** — the new version appears under `cdn.pollis.com/releases/<version>/…` and in the `latest.json` / `cli/latest.json` manifest.
 - **Website** — the change is live on **pollis.com** (Cloudflare Pages deploy is a manual button; `main` being green ≠ deployed).
 - **Transparency log** — `verify.pollis.com` STH advanced; `pollis-verify` still passes.
+- **Provenance (`provenance` job) — check it explicitly, every release.** It is the *second*,
+  independent sigstore anchor, it runs `continue-on-error`-adjacent to everything else, and it has
+  now failed twice for two unrelated reasons (v1.9.0: a stale key digest in `cosign-installer@v3`;
+  v1.9.1: `@v4` is not a real tag, so the job died in "Set up job"). **Both times every other part
+  of the release was perfectly healthy**, which is exactly why it needs its own line here. Verify
+  the artifact it is supposed to publish actually exists rather than reading the job status:
+  ```bash
+  curl -sIo /dev/null -w '%{http_code}\n' \
+    "https://cdn.pollis.com/releases/<tag>/pollis-<tag>-linux.deb.intoto.jsonl"   # want 200
+  ```
+  A 404 means every BinaryRecord leaf for that tag carries a `provenance_uri` that resolves to
+  nothing. **It is not repairable in place** — re-runs use the workflow from the tagged commit, and
+  `attest-release.yml` backfills the transparency log only, with no cosign/provenance path. So the
+  choice is a fresh tag or a release that ships with the primary anchor alone; decide deliberately
+  rather than discovering it later.
 - **Migration** — confirm it's recorded in prod `schema_migrations` after the deploy that was supposed to apply it.
 
 If a target is deferred, it is now **known-stale** — say so, and make sure the eventual deploy that ships it is on someone's radar.


### PR DESCRIPTION
My fix in #834 was wrong and v1.9.1 lost its provenance because of it.

`sigstore/cosign-installer` publishes **no moving `v4` tag** — `v3` has one, `v4` does not; only `v4.1.2` exists. So `@v4` was unresolvable and the `provenance` job died in **"Set up job"**, before a single step ran. Different failure from v1.9.0 (which got as far as the install and failed on a stale key digest), same outcome: the SLSA attestations and cosign signatures were never published, so v1.9.1's transparency-log leaves point at 404s.

Pinned to the exact version, which is also the right practice for a security-relevant action rather than trusting a floating major.

**Verified the tag actually resolves this time** — `v4` returns 404 from the git refs API, `v4.1.2` resolves to `6f9f177`. That check is what I should have run before #834.

Everything else in v1.9.1 shipped correctly: 7 release assets, installers live on the CDN, AUR at 1.9.1, migrations a no-op, `attest-and-log` green, and both DS environments deployed and confirmed on `7ba54fb4`.