### PR TITLE
fix(voice): stage tile video clipped at small window sizes

### DIFF
--- a/frontend/src/components/Voice/stage/voice-stage.css
+++ b/frontend/src/components/Voice/stage/voice-stage.css
@@ -126,12 +126,18 @@
    color: var(--vs-ink-faint);
 }
 
+/* Flex (not grid) centering: RemoteVideoTile's canvas fits via
+   max-width/max-height 100%, which only resolves against a definite
+   box. A grid's auto track would size to the canvas's intrinsic
+   (source-resolution) height and clip it at small window sizes. */
 .vs-tile-stage {
    flex: 1 1 auto;
    position: relative;
-   display: grid;
-   place-items: center;
+   display: flex;
+   align-items: center;
+   justify-content: center;
    min-height: 0;
+   min-width: 0;
 }
 
 .vs-tile-center {


### PR DESCRIPTION
`.vs-tile-stage` was a grid; the auto track sizes to the canvas's intrinsic (source-resolution) height — percentage max-height is ignored during intrinsic track sizing — so the video overflowed and was clipped by the tile's `overflow: hidden`. Now a flex centering container (the pattern every other `RemoteVideoTile` call site uses), so the canvas fits both axes at any window size.