### PR TITLE
fix(security): close all four high findings from the #876 audit

### DIFF
--- a/frontend/src/components/Message/MediaLinkUnfurl.tsx
+++ b/frontend/src/components/Message/MediaLinkUnfurl.tsx
@@ -69,9 +69,37 @@ interface MediaLinkUnfurlProps {
   text: string;
 }
 
+/// Hosts whose media loads without asking.
+///
+/// Only our own CDN: those bytes are already fetched from us, so previewing
+/// them tells a third party nothing it does not already know.
+const AUTO_LOAD_HOSTS = ["cdn.pollis.com"];
+
+function isFirstParty(url: string): boolean {
+  try {
+    return AUTO_LOAD_HOSTS.includes(new URL(ensureProtocol(url)).hostname.toLowerCase());
+  } catch {
+    return false;
+  }
+}
+
 export const MediaLinkUnfurl: React.FC<MediaLinkUnfurlProps> = ({ text }) => {
   const links = useMemo(() => extractMediaLinks(text), [text]);
   const [hidden, setHidden] = useState<Set<string>>(() => new Set());
+  // Third-party media loads only when the reader asks for it.
+  //
+  // Rendering `<img src>` straight from message text meant that merely OPENING
+  // a message made the app fetch from a host the sender chose — handing them
+  // the reader's IP address, user-agent and the moment they read it, from any
+  // message including an unaccepted DM request from a stranger. That is a
+  // read-receipt and a deanonymiser in one, and it defeats the relay overlay
+  // entirely: the overlay hides the client's address from OUR servers while
+  // this handed it to an arbitrary one.
+  //
+  // A click is the consent. It is deliberately per-URL and not remembered —
+  // the sender picks the URL, so a blanket "always load" would be a setting the
+  // attacker, not the user, gets to exploit.
+  const [revealed, setRevealed] = useState<Set<string>>(() => new Set());
 
   const handleClick = useCallback((url: string) => {
     shellOpen(ensureProtocol(url));
@@ -96,6 +124,24 @@ export const MediaLinkUnfurl: React.FC<MediaLinkUnfurlProps> = ({ text }) => {
     <div data-testid="media-link-unfurl" className="mt-2 flex flex-wrap gap-1">
       {visible.map((link) => {
         const href = ensureProtocol(link.url);
+        const show = revealed.has(link.url) || isFirstParty(link.url);
+        if (!show) {
+          return (
+            <button
+              key={link.url}
+              type="button"
+              data-testid="media-link-reveal"
+              onClick={() =>
+                setRevealed((prev) => new Set(prev).add(link.url))
+              }
+              title={`Load media from ${href} — this contacts that site directly`}
+              aria-label={`Load media from ${href}. This contacts that site directly and reveals your IP address to it.`}
+              className="flex h-24 w-24 shrink-0 items-center justify-center rounded-[var(--radius-control)] border border-line bg-surface-raised px-2 text-center text-2xs text-muted hover:bg-hover hover:text-fg"
+            >
+              Load {link.kind}
+            </button>
+          );
+        }
         const onError = () =>
           setHidden((prev) => {
             const next = new Set(prev);

--- a/pollis-core/src/commands/r2.rs
+++ b/pollis-core/src/commands/r2.rs
@@ -428,7 +428,29 @@ pub async fn download_media(
     let get_url = presign_r2(state, "get", &r2_key).await?;
     let overlay = state.overlay_handle();
     let ciphertext = r2_get_url(overlay.as_deref(), &get_url).await?;
-    decrypt_chunked(&ciphertext, &enc_key, &enc_nonce)
+    let plaintext = decrypt_chunked(&ciphertext, &enc_key, &enc_nonce)?;
+
+    // The object is CONTENT-ADDRESSED, so verify it actually is its address.
+    //
+    // AEAD alone proves nothing here: the key is DERIVED from `content_hash`
+    // (`derive_attachment_key` above), and that hash is known to everyone the
+    // attachment was shared with. Anyone holding it can therefore produce
+    // ciphertext that decrypts cleanly — the tag only proves the writer knew the
+    // hash, not that the bytes are the ones the sender meant. Re-hashing is what
+    // closes that: a substituted payload has a different digest and is refused,
+    // whoever managed to write it into R2.
+    //
+    // Cheap, and it also catches ordinary corruption in the shared convergent
+    // object rather than rendering it as genuine.
+    let actual = sha256_bytes(&plaintext);
+    if actual != hash_array {
+        return Err(Error::Other(anyhow::anyhow!(
+            "attachment {r2_key} failed its content-hash check — expected {content_hash}, \
+             got {}; refusing to return substituted or corrupted bytes",
+            hex::encode(actual)
+        )));
+    }
+    Ok(plaintext)
 }
 
 /// Resolve a media attachment to a loopback HTTP URL the webview can use

--- a/pollis-delivery/src/broker.rs
+++ b/pollis-delivery/src/broker.rs
@@ -869,6 +869,30 @@ pub async fn r2_presign(
         }
     }
 
+    // Per-object INTEGRITY gate on put: refuse to mint a `put` for a media
+    // object that is already referenced by a message.
+    //
+    // These objects are a global convergent dedup keyed on the content hash, so
+    // one `media/<hash>/…` key is shared by every conversation holding that
+    // attachment. An ungated `put` therefore let any authenticated user
+    // OVERWRITE anyone else's attachment — and because the AEAD key is derived
+    // from the hash (which every recipient knows), the replacement decrypts
+    // cleanly, so recipients rendered chosen plaintext as genuine.
+    //
+    // Refusing is safe precisely because the store is convergent: if the hash is
+    // already referenced the bytes are already there, so a legitimate uploader
+    // has nothing to write. Clients already skip re-upload on dedup hit.
+    // Belt-and-braces with the client-side check in `download_media`, which
+    // re-hashes after decrypting so a substitution is caught however it got in.
+    if http_method == "PUT" {
+        if let Some(content_hash) = content_hash_from_key(&parsed.key) {
+            let conn = state.db.conn()?;
+            if crate::messages::object_is_referenced(&conn, content_hash).await? {
+                return Ok(AuthRejection::Forbidden.into_response());
+            }
+        }
+    }
+
     let url = presign_r2_url(
         endpoint,
         bucket,

--- a/pollis-delivery/src/groups.rs
+++ b/pollis-delivery/src/groups.rs
@@ -46,7 +46,9 @@ use libsql::Connection;
 use serde::Deserialize;
 
 use crate::error::AppError;
-use crate::writes::{bad_request, gate, outcome_response, resolve_actor, WriteOutcome};
+use crate::writes::{
+    bad_request, conversation_id_taken, gate, outcome_response, resolve_actor, WriteOutcome,
+};
 use crate::AppState;
 
 // ── Shared authz helpers ─────────────────────────────────────────────────────
@@ -172,6 +174,12 @@ pub async fn apply_create_group(
         Ok(o) => o,
         Err(o) => return Ok(o),
     };
+    // Refuse an id already in use as any other kind of conversation. See
+    // `conversation_id_taken` — `is_member` ORs across dm/group/channel on one
+    // id, so reusing another conversation's id grants membership of it.
+    if conversation_id_taken(conn, &body.id).await? {
+        return Ok(WriteOutcome::Forbidden);
+    }
     let tx = conn.transaction().await?;
     tx.execute(
         "INSERT INTO groups (id, name, description, owner_id, created_at) VALUES (?1, ?2, ?3, ?4, ?5)",
@@ -446,6 +454,12 @@ pub async fn apply_create_channel(
         Err(o) => return Ok(o),
     };
     if authed.is_some() && group_role(conn, &body.group_id, &creator).await?.is_none() {
+        return Ok(WriteOutcome::Forbidden);
+    }
+    // Refuse an id already in use as any other kind of conversation. See
+    // `conversation_id_taken` — `is_member` ORs across dm/group/channel on one
+    // id, so reusing another conversation's id grants membership of it.
+    if conversation_id_taken(conn, &body.id).await? {
         return Ok(WriteOutcome::Forbidden);
     }
     conn.execute(

--- a/pollis-delivery/src/profile.rs
+++ b/pollis-delivery/src/profile.rs
@@ -46,7 +46,9 @@ use libsql::Connection;
 use serde::Deserialize;
 
 use crate::error::AppError;
-use crate::writes::{bad_request, gate, outcome_response, resolve_actor, WriteOutcome};
+use crate::writes::{
+    bad_request, conversation_id_taken, gate, outcome_response, resolve_actor, WriteOutcome,
+};
 use crate::AppState;
 
 // ── Shared block helper ──────────────────────────────────────────────────────
@@ -359,6 +361,12 @@ pub async fn apply_create_dm(
         }
     }
 
+    // Refuse an id already in use as any other kind of conversation. See
+    // `conversation_id_taken` — `is_member` ORs across dm/group/channel on one
+    // id, so reusing another conversation's id grants membership of it.
+    if conversation_id_taken(conn, &body.id).await? {
+        return Ok(WriteOutcome::Forbidden);
+    }
     let tx = conn.transaction().await?;
     tx.execute(
         "INSERT INTO dm_channel (id, created_by, created_at) VALUES (?1, ?2, ?3)",

--- a/pollis-delivery/src/writes.rs
+++ b/pollis-delivery/src/writes.rs
@@ -214,6 +214,36 @@ pub(crate) fn resolve_actor(
 ///
 /// Takes a bare [`Connection`] (the main DB) so the same gate is reusable from
 /// the integration harness, which drives a single shared connection rather than
+/// True when `id` is already in use as ANY kind of conversation — a DM channel,
+/// a group, or a channel.
+///
+/// The three live in separate tables with separate primary keys, so SQLite
+/// happily accepts the same id in all three. That is not a ULID collision
+/// (they do not collide by chance); every creation endpoint takes the id
+/// straight from the request body, so an attacker simply *names* an existing
+/// conversation. [`is_member`] then ORs across all three tables on one id, so
+/// creating a DM whose id is a victim group's id and adding yourself to it
+/// makes `is_member(victim_group, you)` true — membership of a group you were
+/// never in, and with it commit injection, GroupInfo/Welcome overwrite, and a
+/// LiveKit token for their room.
+///
+/// Every `create_*` path must call this before inserting. The durable fix is a
+/// single `conversation` table owning the id namespace so the database refuses
+/// this outright; this is the chokepoint that closes it today.
+pub async fn conversation_id_taken(conn: &Connection, id: &str) -> anyhow::Result<bool> {
+    let mut rows = conn
+        .query(
+            "SELECT 1 WHERE \
+                EXISTS (SELECT 1 FROM dm_channel WHERE id = ?1) \
+             OR EXISTS (SELECT 1 FROM groups     WHERE id = ?1) \
+             OR EXISTS (SELECT 1 FROM channels   WHERE id = ?1) \
+             LIMIT 1",
+            libsql::params![id.to_string()],
+        )
+        .await?;
+    Ok(rows.next().await?.is_some())
+}
+
 /// the DS's `AppState`.
 pub async fn is_member(
     conn: &Connection,
@@ -653,4 +683,109 @@ pub async fn upsert_welcome(
 fn b64_decode(s: &str) -> anyhow::Result<Vec<u8>> {
     use base64::Engine as _;
     Ok(base64::engine::general_purpose::STANDARD.decode(s)?)
+}
+
+#[cfg(test)]
+mod conversation_namespace_tests {
+    //! One id must never name two kinds of conversation.
+    //!
+    //! Not a ULID-collision concern — ULIDs do not collide by chance. Every
+    //! `create_*` endpoint takes the id straight from the request body, so an
+    //! attacker *names* an existing conversation rather than colliding with it.
+    //! Because `dm_channel`, `groups` and `channels` are separate tables with
+    //! separate primary keys, SQLite accepts the same id in all three, and
+    //! `is_member` ORs across all three on one id — so a DM whose id is a
+    //! victim group's id grants membership of that group.
+
+    use super::*;
+    use libsql::Connection;
+
+    const SCHEMA: &str = "\
+        CREATE TABLE dm_channel (id TEXT PRIMARY KEY);\
+        CREATE TABLE dm_channel_member (dm_channel_id TEXT NOT NULL, user_id TEXT NOT NULL);\
+        CREATE TABLE groups (id TEXT PRIMARY KEY);\
+        CREATE TABLE group_member (group_id TEXT NOT NULL, user_id TEXT NOT NULL, role TEXT);\
+        CREATE TABLE channels (id TEXT PRIMARY KEY, group_id TEXT NOT NULL);";
+
+    async fn conn() -> Connection {
+        let db = libsql::Builder::new_local(":memory:").build().await.unwrap();
+        let c = db.connect().unwrap();
+        c.execute_batch(SCHEMA).await.unwrap();
+        c
+    }
+
+    /// The exact attack: a group exists; its id must be refused everywhere else.
+    #[tokio::test]
+    async fn an_existing_group_id_is_taken_for_every_conversation_kind() {
+        let c = conn().await;
+        c.execute("INSERT INTO groups (id) VALUES ('victim-group')", ())
+            .await
+            .unwrap();
+
+        assert!(
+            conversation_id_taken(&c, "victim-group").await.unwrap(),
+            "a group's id must be refused to dm/create and channel/create — \
+             otherwise is_member() grants membership of the group"
+        );
+    }
+
+    #[tokio::test]
+    async fn dm_and_channel_ids_are_taken_too() {
+        let c = conn().await;
+        c.execute("INSERT INTO dm_channel (id) VALUES ('a-dm')", ())
+            .await
+            .unwrap();
+        c.execute(
+            "INSERT INTO channels (id, group_id) VALUES ('a-channel', 'g')",
+            (),
+        )
+        .await
+        .unwrap();
+
+        assert!(conversation_id_taken(&c, "a-dm").await.unwrap());
+        assert!(conversation_id_taken(&c, "a-channel").await.unwrap());
+    }
+
+    /// A fresh id is still free — without this the guard could be "refuse
+    /// everything" and the tests above would still pass.
+    #[tokio::test]
+    async fn an_unused_id_is_free() {
+        let c = conn().await;
+        c.execute("INSERT INTO groups (id) VALUES ('some-group')", ())
+            .await
+            .unwrap();
+
+        assert!(
+            !conversation_id_taken(&c, "a-brand-new-ulid").await.unwrap(),
+            "an unused id must remain creatable"
+        );
+    }
+
+    /// The property the guard protects: sharing an id across two tables is what
+    /// makes `is_member` answer for the wrong conversation.
+    #[tokio::test]
+    async fn a_shared_id_would_grant_membership_of_the_other_conversation() {
+        let c = conn().await;
+        // The victim's group — mallory is NOT a member.
+        c.execute("INSERT INTO groups (id) VALUES ('victim-group')", ())
+            .await
+            .unwrap();
+        // What the attack inserts if the guard is absent.
+        c.execute("INSERT INTO dm_channel (id) VALUES ('victim-group')", ())
+            .await
+            .unwrap();
+        c.execute(
+            "INSERT INTO dm_channel_member (dm_channel_id, user_id) \
+             VALUES ('victim-group', 'mallory')",
+            (),
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            is_member(&c, "victim-group", "mallory").await.unwrap(),
+            "documents WHY the guard exists: with the id shared, is_member \
+             answers true for a group mallory was never in"
+        );
+    }
 }

--- a/pollis-delivery/tests/attachment_refs.rs
+++ b/pollis-delivery/tests/attachment_refs.rs
@@ -418,33 +418,62 @@ async fn r2_presign_delete_passes_non_media_keys() {
     );
 }
 
-/// `get`/`put` are never reference-gated — only the shared-object integrity of
-/// `delete` is. A referenced object must still be freely fetchable/uploadable.
+/// `get` is never reference-gated: a referenced object must stay freely
+/// fetchable by everyone holding it.
+///
+/// `put` USED to be ungated too, and that was the bug. These objects are a
+/// global convergent dedup, so one `media/<hash>/…` key is shared by every
+/// conversation holding that attachment — an ungated `put` let any
+/// authenticated user overwrite anyone else's. The AEAD key is derived from the
+/// content hash, which every recipient knows, so the replacement decrypted
+/// cleanly and recipients rendered chosen plaintext as genuine.
 #[tokio::test]
-async fn r2_presign_get_and_put_are_not_gated() {
+async fn r2_presign_get_is_not_gated_but_put_of_a_referenced_object_is() {
     let db = fresh().await;
     let key = "media/hhhh/pic.enc";
     register_ref(&db, "hhhh", key, "m_p").await;
     let state = AppState::new(Arc::clone(&db), false).with_broker_config(r2_broker());
     let router = build_router_with_state(state);
 
-    for op in ["get", "put"] {
-        let body = serde_json::json!({ "operation": op, "key": key, "user_id": "u1" });
-        let req = Request::builder()
-            .method("POST")
-            .uri("/v1/r2/presign")
-            .header("content-type", "application/json")
-            .body(Body::from(serde_json::to_vec(&body).unwrap()))
-            .unwrap();
-        let resp = router.clone().oneshot(req).await.unwrap();
-        assert_eq!(
-            resp.status(),
-            StatusCode::OK,
-            "{op} must not be reference-gated even while the object is referenced"
-        );
-        // Sanity: the body carries a presigned URL.
-        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
-        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
-        assert!(json.get("url").and_then(|u| u.as_str()).is_some(), "presign returns a url");
-    }
+    let presign = |op: &'static str, key: String| {
+        let router = router.clone();
+        async move {
+            let body = serde_json::json!({ "operation": op, "key": key, "user_id": "u1" });
+            let req = Request::builder()
+                .method("POST")
+                .uri("/v1/r2/presign")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap();
+            router.oneshot(req).await.unwrap()
+        }
+    };
+
+    let get = presign("get", key.to_string()).await;
+    assert_eq!(
+        get.status(),
+        StatusCode::OK,
+        "get must stay ungated — everyone holding the attachment fetches this object"
+    );
+    let bytes = get.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert!(json.get("url").and_then(|u| u.as_str()).is_some(), "presign returns a url");
+
+    let put_existing = presign("put", key.to_string()).await;
+    assert_eq!(
+        put_existing.status(),
+        StatusCode::FORBIDDEN,
+        "put over an ALREADY-REFERENCED object must be refused — that overwrite is \
+         the attachment-substitution attack"
+    );
+
+    // The legitimate upload still works: a hash nobody references yet. Without
+    // this the gate could be "refuse every put" and the assertion above would
+    // still pass, while breaking all uploads.
+    let put_new = presign("put", "media/brandnewhash/pic.enc".to_string()).await;
+    assert_eq!(
+        put_new.status(),
+        StatusCode::OK,
+        "a first upload of an unreferenced hash must still be allowed"
+    );
 }

--- a/pollis-delivery/tests/envelope_retention.rs
+++ b/pollis-delivery/tests/envelope_retention.rs
@@ -64,6 +64,7 @@ CREATE TABLE message_envelope (\
   reply_to_id TEXT, type TEXT NOT NULL DEFAULT 'message', target_message_id TEXT);\
 CREATE TABLE user_device (user_id TEXT NOT NULL, device_id TEXT NOT NULL, revoked_at TEXT);\
 CREATE TABLE group_member (group_id TEXT NOT NULL, user_id TEXT NOT NULL, role TEXT NOT NULL DEFAULT 'member');\
+CREATE TABLE groups (id TEXT PRIMARY KEY);\
 CREATE TABLE channels (id TEXT PRIMARY KEY, group_id TEXT NOT NULL);\
 CREATE TABLE dm_channel (id TEXT PRIMARY KEY, created_by TEXT NOT NULL, created_at TEXT NOT NULL);\
 CREATE TABLE dm_channel_member (\

--- a/pollis-tui/Cargo.toml
+++ b/pollis-tui/Cargo.toml
@@ -17,9 +17,25 @@ name = "pollis_tui"
 path = "src/lib.rs"
 
 [dependencies]
-# Media + os-keystore OFF: the TUI is headless (no LiveKit/libwebrtc/cpal, no
-# keyring/dbus). Auth/pin/mls/messages all compile media-off. See docs/pollis-tui-spec.md §9.
-pollis-core = { path = "../pollis-core", default-features = false }
+# Media OFF (the TUI is headless — no LiveKit/libwebrtc/cpal); auth/pin/mls/
+# messages all compile media-off. See docs/pollis-tui-spec.md §9.
+#
+# os-keystore ON, deliberately re-enabled. Backend selection is compile-time
+# (`keystore.rs:366` vs `:561`): without this feature the RELEASE `pollis`
+# binary shipped by cli-release.yml falls to the file backend, whose own comment
+# says "debug builds only — release desktop uses the OS keychain backend".
+# That put the identity keypair and session token on disk as plaintext JSON,
+# removing one of the four components the threat model calls trusted and
+# reducing protection to a 4-digit PIN that is offline-exhaustible once the file
+# is copied. It was switched off alongside media because `keyring` wants
+# dbus/secret-service, but that is a runtime dependency, not a media one.
+#
+# Consequence to know: on a box with no secret-service (a bare server over SSH)
+# the keyring backend fails at runtime with a clear error rather than silently
+# writing plaintext. For a security tool that is the right way round. Encrypting
+# the file backend at rest — as mobile already does via android_kek/ios_kek —
+# is the durable fix that would serve both.
+pollis-core = { path = "../pollis-core", default-features = false, features = ["os-keystore"] }
 # Multi-thread runtime is REQUIRED: pollis-core's DB/keystore paths use
 # spawn_blocking, so a current-thread runtime deadlocks (spec §2).
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }


### PR DESCRIPTION
All four highs from #876, one commit each. The critical was fixed separately in #878.

Each was **verified against the code before fixing** — two turned out to be broader than reported, and one was reported under a misleading name.

### 1. Conversation-id namespace confusion — `6a05b4eb`
Reported as "colliding conversation ids", which is misleading: ULIDs do not collide by chance. **Every creation endpoint takes the id from the request body**, so an attacker simply *names* an existing conversation. `dm_channel`, `groups` and `channels` are separate tables with separate primary keys, so SQLite accepts the same id in all three — and `is_member` ORs across all three on one id. Creating a DM whose id is a victim group's id and adding yourself made `is_member(victim_group, you)` true: membership of a group you were never in, unlocking commit injection (a permanent MLS wedge), GroupInfo/Welcome overwrite, and a LiveKit token for their room.

**Broader than reported:** the audit named `dm/create`, but `create_group` and `create_channel` take client ids too, so the attack is symmetric. All three now call a shared `conversation_id_taken` guard. Four tests, including one that documents *why* the guard exists by showing a shared id granting membership, and one asserting a fresh id is still creatable so the guard cannot degenerate into "refuse everything".

> The durable fix is a single `conversation` table owning the id namespace, so the database refuses this outright rather than a chokepoint doing it — CLAUDE.md's own "DB constraint > protocol chokepoint" ordering. That needs a migration with a backfill; filing separately rather than pretending this check is the end of it.

### 2. Attachment forgery and destruction — `89eafe47`
Two defects, both fixed:
- **`download_media` never verified what it decrypted.** The AEAD key is *derived from* the content hash, and every recipient knows that hash — so anyone holding it can produce ciphertext that decrypts cleanly. The tag proved the writer knew the hash, not that the bytes were the sender's. It now re-hashes the plaintext and refuses a mismatch, so substitution is caught **however it got in**. This is the load-bearing half.
- **`put` presigns were ungated**, so any authenticated user could overwrite any shared convergent object. Now refused for an already-referenced hash — safe precisely because the store is convergent: if the hash is referenced the bytes already exist, so a legitimate uploader has nothing to write.

The existing `r2_presign_get_and_put_are_not_gated` test encoded the old behaviour, so it is rewritten rather than deleted: `get` stays ungated, `put` over a referenced object is refused, and a first upload of an unreferenced hash still succeeds.

### 3. CLI shipped plaintext keys — `069db0fd`
`pollis-tui` built `pollis-core` with `default-features = false`, dropping `os-keystore` alongside media. Backend selection is compile-time, so the **released** `pollis` binary used the file backend — whose own comment reads "debug builds only — release desktop uses the OS keychain backend". The identity keypair and session token were plaintext JSON on disk, removing one of the four components the threat model calls trusted and reducing protection to a 4-digit PIN that is offline-exhaustible once the file is copied.

`os-keystore` is re-enabled (media stays off). **Known consequence:** on a box with no secret-service — a bare server over SSH — the keyring backend now fails at runtime with a clear error instead of silently writing plaintext. For a security tool that is the right way round, but it is a behaviour change worth knowing. Encrypting the file backend at rest, as mobile already does via `android_kek`/`ios_kek`, is the durable fix that would serve both; noted in the manifest.

### 4. Unfurls leaked the reader's IP — `a5d5b3b9`
`<img src>` / `<video src>` rendered straight from message text, so **merely opening a message** fetched from a host the sender chose — handing them the reader's IP, user-agent and read timing, from any message including an unaccepted DM request from a stranger. A read receipt and a deanonymiser in one, and it defeated the relay overlay entirely: the overlay hides the client's address from *our* servers while this handed it to an arbitrary one.

Third-party media is now click-to-load; only `cdn.pollis.com` auto-loads, since those bytes come from us anyway. Deliberately per-URL and not remembered — the sender picks the URL, so a blanket "always load" would be a setting the attacker gets to exploit.

### Verification
Full `pollis-delivery` suite green (79 lib + all integration), `cargo check -p pollis-core`, a release `cargo build -p pollis-tui` to confirm it links the keychain backend, plus frontend `tsc` and `build`.

One incidental fix: `tests/envelope_retention.rs` was missing a `groups` table, which the new guard needs. That is the third time this pass that a hand-rolled test schema has diverged from the baseline — more evidence for the `pollis-schema` crate proposed in #875.