### PR TITLE
ci(cli): install dbus headers so the Linux CLI can link the OS keystore

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -54,6 +54,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # `keyring` (pollis-core's `os-keystore` feature) links libdbus via
+      # libdbus-sys, whose build script needs the dev package and pkg-config.
+      # The TUI carries that feature deliberately: without it the RELEASE binary
+      # falls back to a plaintext key file (see pollis-tui/Cargo.toml), which is
+      # what #876/#879 fixed. The runner does not ship dbus headers, so the
+      # build fails without this step.
+      - name: Install dbus development headers
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
The v1.9.4 CLI release failed its Linux build: `The system library \`dbus-1\` required by crate \`libdbus-sys\` was not found.`

Direct consequence of #879, which re-enabled `os-keystore` for `pollis-tui` so the released binary stops writing the identity keypair and session token to disk as plaintext JSON. That feature pulls `keyring` → `libdbus-sys`, whose build script needs `libdbus-1-dev` + `pkg-config`; the runner does not ship them. macOS and Windows built fine, so only this job needed the dependency.

Desktop v1.9.4 was unaffected and shipped correctly, provenance included.

**This fixes the build, not the runtime story — worth being explicit.** On a machine with no secret-service (a bare server over SSH, which is a plausible home for a terminal client) the keyring backend will now fail at *runtime* instead of silently writing plaintext. That is the right way round for a security tool, but it is a real cost for the CLI's likely audience, and installing headers does not address it.

The fix that serves both is encrypting the desktop file backend at rest, exactly as mobile already does via `android_kek`/`ios_kek` — filed separately. Until then the CLI trades headless usability for key confidentiality, deliberately.