### PR TITLE
feat(messages): per-person @username mentions that actually notify

### DIFF
--- a/.codesight/wiki/notifications.md
+++ b/.codesight/wiki/notifications.md
@@ -53,6 +53,12 @@ const CATEGORIES: Record<Category, CategoryConfig> = {
   // channel_message). Badge is left to the accompanying new_message event so a
   // connected client doesn't double-count unread.
   all_mention:       { sound: 'ping',  osNotif: true,                            cooldownMs: 2500 },
+  // @username in a group (#843) — someone spoke to YOU by name, which is a
+  // personal event, so it is treated like a DM rather than like channel
+  // chatter: ping, OS notification, AND the status-bar alert that names the
+  // sender. Deliberately louder than `all_mention` (addressed to a room, not
+  // to you) — that alert is the difference.
+  user_mention:      { sound: 'ping',  osNotif: true,               alert: true, cooldownMs: 2500 },
 };
 ```
 
@@ -71,7 +77,7 @@ const CATEGORIES: Record<Category, CategoryConfig> = {
 ### Conventions
 
 1. **Anything with `osNotif: true` should also have `sound: 'ping'`.** Users always hear every system notification. Don't ship a silent OS banner. The one exception is `incoming_call`, which has no `sound` because it plays a *ringtone* on its own device-local gate (`honorsRingtonePref`) rather than a one-shot sfx — muting ringing on one device must not silence every other alert on it.
-2. **Pings are reserved for personal events.** Channel chatter only updates the badge — noisy rooms must not become a constant ping.
+2. **Pings are reserved for personal events.** Channel chatter only updates the badge — noisy rooms must not become a constant ping. Mentions are the sanctioned exception, and they earn it by being addressed: `@all` to the room, `@username` to you specifically.
 3. **`badge` and `alert` are never cooldown-gated.** The unread count must stay accurate; only sound and OS notifications dedupe.
 
 ## Categorization (the call site)
@@ -189,11 +195,51 @@ Cooldown is keyed by `${category}:${roomId ?? '_global'}`. It applies only to so
 - A burst across two DM rooms pings twice (different cooldown buckets).
 - If sound is disabled but OS notif is enabled, the OS notification still fires and starts the cooldown.
 
+## Mentions (#843)
+
+`@all` and `@username` are the only channel events that wake anyone. Both are
+decided **in Rust**, in `pollis-core/src/commands/messages/send.rs`:
+
+- `mention_audience(is_channel, content, members)` returns `Everyone` (a DM, or
+  a channel `@all`), `Only(user_ids)` (a channel naming specific members), or
+  `Nobody` (ordinary channel chatter). Its unit tests are the invariant: a
+  per-user mention wakes exactly the people named, and a plain channel message
+  wakes nobody.
+- That one value drives BOTH fanouts, so they cannot drift: the inbox ping
+  (`all_mention` to every member, or `user_mention` to just the named ones) and
+  the background push (`notify_new_message(..., only, ...)`, which intersects
+  the subset with real membership so it can only ever remove recipients).
+
+**Mentions cannot leak.** `members` is the roster of the conversation the
+sender already belongs to, so an `@name` matching nobody in the room resolves
+to nothing on both the server and the client. The composer's suggestion list
+is derived from the same roster (`useMentionCandidates`) — there is
+deliberately no username lookup behind it, because a directory search would let
+anyone enumerate users outside their own groups and DMs just by typing.
+
+Client side, `MessageBody` tokenizes only mentions that resolve, so a
+highlighted token always means a real person was actually notified. Your own
+mention (and `@all`, which addresses you too) renders as a filled accent block;
+someone else's renders as a quiet tinted chip.
+
+Composer UX branches per skin (`useSkin()`): terminal gets a ghosted inline
+autosuggest accepted with Tab — the fish / zsh-autosuggestions idiom, offered
+only when the caret is at the end of the line — and refined gets the
+Slack-style list above the composer (arrows / Enter / Tab / Esc). Neither is a
+modal, a portal, or a fixed overlay.
+
 ## Files
 
 | File | Role |
 |---|---|
 | `frontend/src/utils/notify.ts` | Dispatcher + category table |
+| `frontend/src/utils/mentions.ts` | Mention parsing + ranking; mirrors the Rust matcher |
+| `frontend/src/hooks/queries/useMentionCandidates.ts` | Roster-derived mention pool (the no-leak boundary) |
+| `frontend/src/components/ui/MentionGhost.tsx` | Terminal skin's inline ghost completion |
+| `frontend/src/components/ui/MentionSuggestList.tsx` | Refined skin's Slack-style suggestion list |
+| `frontend/src/components/Message/MessageBody.tsx` | Splits mention tokens out, delegates the rest to `LinkifiedText` |
+| `pollis-core/src/commands/messages/send.rs` | `mention_audience()` — who gets woken, + the inbox fanout |
+| `pollis-core/src/commands/push.rs` | `notify_new_message(..., only, ...)` recipient filter |
 | `frontend/src/utils/sfx.ts` | `playSfx()` wrapper around `play_sfx` Rust command |
 | `frontend/src/hooks/useLiveKitRealtime.ts` | Categorizes incoming Rust events, calls `notify(...)`, owns pref + permission sync |
 | `frontend/src/voice/voiceBridge.ts` | Calls `notify('voice_self_join'/'voice_self_leave')` for local actions (was `hooks/useVoiceChannel.ts`, deleted) |
@@ -205,4 +251,5 @@ Cooldown is keyed by `${category}:${roomId ?? '_global'}`. It applies only to so
 
 ## Related issues
 
+- #843 — per-user `@username` mentions that notify the mentioned user.
 - #186 — original audit + dispatcher refactor (PR #202).

--- a/.codesight/wiki/testing.md
+++ b/.codesight/wiki/testing.md
@@ -1,10 +1,11 @@
 # Testing
 
-Pollis has three tiers of automated tests:
+Pollis has four tiers of automated tests:
 
 1. **Unit tests** (in-crate `#[cfg(test)]` modules) — pure logic, in-memory rusqlite schemas, no I/O.
 2. **Integration harness** (`src-tauri/tests/flows.rs`) — drives the real `pollis-core` commands end-to-end against a disposable test Turso database. Most of this document covers the harness.
-3. **WebDriver E2E tests** (`e2e/`) — drives the real shipped Tauri app (native WebKitGTK WebView, real Rust core) via `tauri-driver`. See [WebDriver E2E tests](#webdriver-e2e-tests-e2e) below.
+3. **WebDriver E2E tests** (`e2e/*.js`) — drives the real shipped Tauri app (native WebKitGTK WebView, real Rust core) via `tauri-driver`. See [WebDriver E2E tests](#webdriver-e2e-tests-e2e) below.
+4. **Playwright UI specs** (`e2e/*.spec.js`) — front-end interaction only, against the browser build with `VITE_PLAYWRIGHT=true` (Tauri IPC mocked in `frontend/src/__mocks__/`). No backend, seconds to run. See [Playwright UI specs](#playwright-ui-specs-e2especjs) below.
 
 > The harness is built on top of Tauri's test machinery (`tauri::test::get_ipc_response` + `MockRuntime`). Tauri is the shipping shell, so the harness drives the real command logic through the same dispatch path the app uses, headlessly — `pollis-core` is the unit under test, reached through the `#[tauri::command]` shims exactly as at runtime.
 
@@ -567,3 +568,36 @@ Full details — how the stack is stood up, `.env.test` schema bootstrap,
 `data-testid` conventions, and the WebKitWebDriver quirks (native `.click()`
 doesn't fire React handlers, IPv6-only Vite loopback, orphan-process
 reaping) — live in `e2e/README.md`, not duplicated here.
+
+## Playwright UI specs (`e2e/*.spec.js`)
+
+For behaviour that lives entirely in the renderer — composer interaction,
+per-skin branching, how a message body renders — the native stack costs minutes
+and proves nothing extra. These specs drive the **browser** build with
+`VITE_PLAYWRIGHT=true`, which vite-aliases `@tauri-apps/api/*` to
+`frontend/src/__mocks__/`. Real React tree, real CSS tokens, real `useSkin()`
+branching; no MLS, no delivery service, no Turso.
+
+```bash
+pnpm --filter @pollis/e2e exec playwright install chromium   # once
+pnpm --filter @pollis/e2e e2e:ui                             # all specs
+```
+
+| spec | what it proves |
+|---|---|
+| `mentions.spec.js` | `@username` autocomplete + rendering in BOTH skins (#843) |
+
+Three things to know before writing one:
+
+- **Fixtures go in `window.__POLLIS_PRELOAD__`** via `page.addInitScript`, read
+  once by the mock on load. Extend `MockStore` in `frontend/src/__mocks__/tauri-core.ts`
+  to add a new fixture slice.
+- **Navigate through the UI, not the URL.** The router uses
+  `createMemoryHistory` (`frontend/src/router.tsx`), so `page.goto('/groups/…')`
+  changes the address bar and renders Root anyway. Click
+  `menu-item-groups` → `group-option-<id>` → `channel-option-<id>`.
+- **The mock is a real surface — keep it current.** An unhandled command returns
+  `null`, and `null` is not `undefined`, so `const { data = [] }` defaults do NOT
+  catch it and the page dies in an error boundary. When a Rust command is renamed
+  (`get_channel_messages` → `read_channel_messages`) the mock silently rots until
+  someone runs these specs.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,4 +1,36 @@
-# E2E tests (real Tauri app, driven via WebDriver)
+# E2E tests
+
+Two suites live here, for two different jobs.
+
+**1. WebDriver scenarios (`*.js`)** — the bulk of this directory. They drive the
+**actual native desktop app**: the real WebKitGTK WebView inside the Tauri
+shell, talking to the real Rust core over Tauri IPC. Use these for anything
+that has to prove real delivery, MLS, or cross-client convergence.
+
+**2. Playwright UI specs (`*.spec.js`)** — pure front-end interaction against
+the browser build with `VITE_PLAYWRIGHT=true`, which vite-aliases
+`@tauri-apps/api/*` to the mocks in `frontend/src/__mocks__/`. Real React tree,
+real CSS tokens, real skin branching — but no delivery service, no Turso, no
+MLS, so they need no backend and run in seconds. Use these for composer and
+rendering behaviour, where the native stack would add minutes and prove
+nothing extra.
+
+```bash
+pnpm --filter @pollis/e2e e2e:ui                 # all Playwright UI specs
+pnpm --filter @pollis/e2e e2e:ui mentions        # just the mentions spec
+```
+
+| spec | what it proves |
+|---|---|
+| `mentions.spec.js` | `@username` autocomplete + rendering in BOTH skins: terminal ghost-completes on Tab with no pop-over; refined drives the Slack-style list with arrows/Enter/Tab/Esc; your own mention renders stronger than a peer's; an unresolvable `@name` offers nothing |
+
+First run needs the browser once: `pnpm --filter @pollis/e2e exec playwright install chromium`.
+
+The rest of this document covers the WebDriver scenarios.
+
+---
+
+## WebDriver scenarios (real Tauri app)
 
 Drives the **actual native desktop app** — the real WebKitGTK WebView inside the
 Tauri shell, talking to the real Rust core over Tauri IPC — not the browser

--- a/e2e/mentions.spec.js
+++ b/e2e/mentions.spec.js
@@ -1,0 +1,233 @@
+// @ts-check
+/*
+ * @username mentions — composer autocomplete + message rendering, BOTH skins (#843).
+ *
+ * Runs against the browser build with `VITE_PLAYWRIGHT=true`, so
+ * `@tauri-apps/api/*` resolves to `frontend/src/__mocks__/`. That gives the
+ * real React tree, the real CSS tokens and the real skin branching with no
+ * MLS, no delivery service and no Turso — which is exactly the surface this
+ * feature lives on. The backend half of #843 (who actually gets pushed) is
+ * covered by the unit tests in `pollis-core/src/commands/messages/send.rs`.
+ *
+ * What each skin must prove:
+ *   terminal — a GHOSTED inline completion after the caret, accepted with Tab,
+ *              and NO pop-over list anywhere.
+ *   refined  — the Slack/Discord list above the composer: arrow keys move the
+ *              highlight, Enter accepts, Esc dismisses.
+ * Plus, in both: your own mention renders stronger than someone else's.
+ */
+
+const path = require("path");
+const { test, expect } = require("@playwright/test");
+
+// Proof screenshots land beside the WebDriver scenarios' own artifacts.
+const shot = (name) => path.join(__dirname, "artifacts", name);
+
+const ME = { id: "u_me", email: "me@pollis.test", username: "mia" };
+const GROUP_ID = "g_mentions";
+const CHANNEL_ID = "c_general";
+
+// Two candidates share the "da" prefix so ranking and arrow-key movement are
+// both observable; "sam" matches neither, proving the list actually filters.
+// "mia" is the signed-in user and must never be offered — you can't mention
+// yourself.
+const MEMBERS = [
+  { user_id: "u_me", username: "mia", role: "admin", joined_at: "2026-01-01T00:00:00Z" },
+  { user_id: "u_dana", username: "dana", role: "member", joined_at: "2026-01-01T00:00:00Z" },
+  { user_id: "u_dave", username: "dave", role: "member", joined_at: "2026-01-01T00:00:00Z" },
+  { user_id: "u_sam", username: "sam", role: "member", joined_at: "2026-01-01T00:00:00Z" },
+];
+
+const MESSAGES = [
+  {
+    id: "m1",
+    conversation_id: CHANNEL_ID,
+    sender_id: "u_dana",
+    sender_username: "dana",
+    ciphertext: "",
+    content: "morning @mia can you review this",
+    sent_at: "2026-08-01T09:00:00Z",
+  },
+  {
+    id: "m2",
+    conversation_id: CHANNEL_ID,
+    sender_id: "u_dana",
+    sender_username: "dana",
+    ciphertext: "",
+    content: "also @dave owns the deploy",
+    sent_at: "2026-08-01T09:01:00Z",
+  },
+];
+
+function preloadFor(skin) {
+  return {
+    session: ME,
+    profile: { id: ME.id, username: ME.username },
+    groups: [
+      {
+        id: GROUP_ID,
+        name: "mentions",
+        owner_id: ME.id,
+        created_at: "2026-01-01T00:00:00Z",
+        current_user_role: "admin",
+      },
+    ],
+    channels: { [GROUP_ID]: [{ id: CHANNEL_ID, group_id: GROUP_ID, name: "general" }] },
+    groupMembers: { [GROUP_ID]: MEMBERS },
+    messages: { [CHANNEL_ID]: MESSAGES },
+    dmChannels: [],
+    preferences: { skin },
+  };
+}
+
+/**
+ * Boot with the given skin and walk into the channel.
+ *
+ * The router runs on a MEMORY history (`createMemoryHistory` in
+ * `frontend/src/router.tsx`), so a deep-link `goto` sets the browser URL but
+ * the app still renders Root. Navigation has to go through the UI, exactly as
+ * the WebDriver scenarios do.
+ */
+async function openChannel(page, skin) {
+  await page.addInitScript((data) => {
+    // @ts-ignore — read by frontend/src/__mocks__/tauri-core.ts on load.
+    window.__POLLIS_PRELOAD__ = data;
+  }, preloadFor(skin));
+  await page.goto("/");
+  await expect(page.getByTestId("app-ready")).toBeAttached();
+
+  await page.getByTestId("menu-item-groups").click();
+  await page.getByTestId(`group-option-${GROUP_ID}`).click();
+  await page.getByTestId(`channel-option-${CHANNEL_ID}`).click();
+
+  await expect(page.getByTestId("message-input")).toBeVisible();
+  // The composer only offers candidates once the roster query resolves, and
+  // the rendered history is what the token assertions read.
+  await expect(page.getByTestId("message-content").first()).toBeVisible();
+}
+
+const composer = (page) => page.getByTestId("message-input");
+
+test.describe("terminal skin", () => {
+  test("ghost-completes an @mention on Tab, with no pop-over", async ({ page }) => {
+    await openChannel(page, "terminal");
+
+    await composer(page).click();
+    await composer(page).pressSequentially("hey @da");
+
+    // The completion is ghosted inline after the caret…
+    const ghost = page.getByTestId("mention-ghost");
+    await expect(ghost).toBeVisible();
+    await expect(ghost).toHaveText("na");
+
+    // …and there is emphatically no list. This is the hard requirement for
+    // this skin: the ghost IS the whole interaction.
+    await expect(page.getByTestId("mention-suggest-list")).toHaveCount(0);
+
+    await page.screenshot({ path: shot("mentions-terminal-ghost.png") });
+
+    // Tab accepts it, leaving a completed mention and a trailing space.
+    await composer(page).press("Tab");
+    await expect(composer(page)).toHaveValue("hey @dana ");
+    await expect(page.getByTestId("mention-ghost")).toHaveCount(0);
+  });
+
+  test("Escape hides the ghost and Enter still sends", async ({ page }) => {
+    await openChannel(page, "terminal");
+
+    await composer(page).click();
+    await composer(page).pressSequentially("hey @da");
+    await expect(page.getByTestId("mention-ghost")).toBeVisible();
+
+    await composer(page).press("Escape");
+    await expect(page.getByTestId("mention-ghost")).toHaveCount(0);
+
+    // With no suggestion on offer, Enter goes back to sending.
+    await composer(page).press("Enter");
+    await expect(composer(page)).toHaveValue("");
+  });
+
+  test("renders your own mention stronger than someone else's", async ({ page }) => {
+    await openChannel(page, "terminal");
+
+    // "@mia" is the signed-in user; "@dave" is a peer.
+    await expect(page.locator('[data-testid="mention-self"][data-mention="mia"]')).toBeVisible();
+    await expect(page.locator('[data-testid="mention-other"][data-mention="dave"]')).toBeVisible();
+
+    await page.screenshot({ path: shot("mentions-terminal-tokens.png") });
+  });
+});
+
+test.describe("refined skin", () => {
+  test("selects from the inline list with arrow keys and Enter", async ({ page }) => {
+    await openChannel(page, "refined");
+
+    await composer(page).click();
+    await composer(page).pressSequentially("hey @da");
+
+    // The Slack-style list, not a ghost.
+    const list = page.getByTestId("mention-suggest-list");
+    await expect(list).toBeVisible();
+    await expect(page.getByTestId("mention-ghost")).toHaveCount(0);
+
+    // Prefix matches rank first, so "dana" then "dave". "sam" is filtered out,
+    // and "mia" is never offered because it's the signed-in user.
+    await expect(page.getByTestId("mention-option-dana")).toBeVisible();
+    await expect(page.getByTestId("mention-option-dave")).toBeVisible();
+    await expect(page.getByTestId("mention-option-sam")).toHaveCount(0);
+    await expect(page.getByTestId("mention-option-mia")).toHaveCount(0);
+
+    // First row starts highlighted.
+    await expect(page.getByTestId("mention-option-dana")).toHaveAttribute("data-active", "true");
+
+    await page.screenshot({ path: shot("mentions-refined-list.png") });
+
+    // Arrow down moves the highlight, Enter accepts it.
+    await composer(page).press("ArrowDown");
+    await expect(page.getByTestId("mention-option-dave")).toHaveAttribute("data-active", "true");
+    await composer(page).press("Enter");
+
+    await expect(composer(page)).toHaveValue("hey @dave ");
+    await expect(page.getByTestId("mention-suggest-list")).toHaveCount(0);
+  });
+
+  test("Tab also accepts, and Escape dismisses without sending", async ({ page }) => {
+    await openChannel(page, "refined");
+
+    await composer(page).click();
+    await composer(page).pressSequentially("hey @da");
+    await expect(page.getByTestId("mention-suggest-list")).toBeVisible();
+
+    await composer(page).press("Tab");
+    await expect(composer(page)).toHaveValue("hey @dana ");
+
+    // Re-open, then dismiss with Escape — the text must survive untouched.
+    await composer(page).pressSequentially("@da");
+    await expect(page.getByTestId("mention-suggest-list")).toBeVisible();
+    await composer(page).press("Escape");
+    await expect(page.getByTestId("mention-suggest-list")).toHaveCount(0);
+    await expect(composer(page)).toHaveValue("hey @dana @da");
+  });
+
+  test("renders your own mention stronger than someone else's", async ({ page }) => {
+    await openChannel(page, "refined");
+
+    await expect(page.locator('[data-testid="mention-self"][data-mention="mia"]')).toBeVisible();
+    await expect(page.locator('[data-testid="mention-other"][data-mention="dave"]')).toBeVisible();
+
+    await page.screenshot({ path: shot("mentions-refined-tokens.png") });
+  });
+});
+
+// Nobody called "nobody" is in this channel, so nothing would be notified and
+// nothing should be offered — the suggestion never invents a user, which is
+// the composer-side half of "mentions must not leak".
+for (const skin of ["terminal", "refined"]) {
+  test(`an unresolvable @name offers nothing — ${skin}`, async ({ page }) => {
+    await openChannel(page, skin);
+    await composer(page).click();
+    await composer(page).pressSequentially("hello @nobody");
+    await expect(page.getByTestId("mention-suggest-list")).toHaveCount(0);
+    await expect(page.getByTestId("mention-ghost")).toHaveCount(0);
+  });
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -2,13 +2,15 @@
   "name": "@pollis/e2e",
   "version": "0.0.0",
   "private": true,
-  "description": "End-to-end tests that drive the real Tauri desktop app via WebDriver (tauri-driver + WebKitWebDriver).",
+  "description": "End-to-end tests: WebDriver scenarios against the real Tauri desktop app (*.js), plus Playwright UI specs against the mocked browser build (*.spec.js).",
   "type": "commonjs",
   "scripts": {
-    "e2e": "node ./run.js"
+    "e2e": "node ./run.js",
+    "e2e:ui": "playwright test -c playwright.config.js"
   },
   "devDependencies": {
     "dotenv": "^16",
-    "webdriverio": "^8"
+    "webdriverio": "^8",
+    "@playwright/test": "^1.50.0"
   }
 }

--- a/e2e/playwright.config.js
+++ b/e2e/playwright.config.js
@@ -1,0 +1,45 @@
+// Playwright config for the UI-level specs (`e2e/*.spec.js`).
+//
+// These drive the BROWSER build of the frontend with `VITE_PLAYWRIGHT=true`,
+// which vite-aliases `@tauri-apps/api/*` to the mocks in
+// `frontend/src/__mocks__/`. That is the whole point: a composer-interaction
+// test needs the real React tree and the real CSS tokens, but nothing from
+// MLS, the delivery service, or Turso — so it runs anywhere, with no backend.
+//
+// The WebDriver scenarios (`e2e/*.js`, run via `pnpm e2e <name>`) are a
+// different tool for a different job: they drive the real native Tauri shell
+// end-to-end. Neither replaces the other.
+const { defineConfig, devices } = require("@playwright/test");
+
+const PORT = 5174;
+
+module.exports = defineConfig({
+  testDir: __dirname,
+  testMatch: /.*\.spec\.js$/,
+  outputDir: `${__dirname}/artifacts/playwright`,
+  // Composer interaction is keystroke-by-keystroke; give it room on a cold
+  // dev-server transform without being generous enough to hide a hang.
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
+  fullyParallel: false,
+  workers: 1,
+  reporter: [["list"]],
+  use: {
+    baseURL: `http://127.0.0.1:${PORT}`,
+    screenshot: "only-on-failure",
+    trace: "retain-on-failure",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: {
+    // `exec vite` rather than `dev --`: pnpm swallows the `--` separator and
+    // vite ends up back on its default port. `--host 127.0.0.1` is load-
+    // bearing too — vite's default `localhost` binds IPv6-only on some Linux
+    // boxes, which leaves the v4 baseURL below permanently unreachable.
+    command: `pnpm --filter frontend exec vite --port ${PORT} --strictPort --host 127.0.0.1`,
+    url: `http://127.0.0.1:${PORT}`,
+    cwd: `${__dirname}/..`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    env: { VITE_PLAYWRIGHT: "true" },
+  },
+});

--- a/frontend/src/__mocks__/tauri-core.ts
+++ b/frontend/src/__mocks__/tauri-core.ts
@@ -43,6 +43,15 @@ interface MockProfile {
   avatar_url?: string;
 }
 
+interface MockGroupMember {
+  user_id: string;
+  username?: string;
+  display_name?: string;
+  avatar_url?: string;
+  role: 'admin' | 'member';
+  joined_at: string;
+}
+
 interface MockDmChannel {
   id: string;
   created_by: string;
@@ -57,6 +66,10 @@ interface MockStore {
   channels: Record<string, MockChannel[]>;
   messages: Record<string, MockMessage[]>;
   dmChannels: MockDmChannel[];
+  // Keyed by group id. Drives the @mention candidate list (#843), which is
+  // deliberately derived from roster membership only.
+  groupMembers: Record<string, MockGroupMember[]>;
+  preferences: Record<string, unknown>;
 }
 
 const preload = (window as any).__POLLIS_PRELOAD__ ?? {};
@@ -68,6 +81,8 @@ const store: MockStore = {
   channels: preload.channels ?? {},
   messages: preload.messages ?? {},
   dmChannels: preload.dmChannels ?? [],
+  groupMembers: preload.groupMembers ?? {},
+  preferences: preload.preferences ?? {},
 };
 
 // Expose for test inspection via page.evaluate(() => window.__tauriMock)
@@ -99,6 +114,56 @@ function handleCommand(command: string, args: Record<string, unknown>): unknown 
     case 'set_pin':
     case 'unlock':
     case 'lock':
+      return null;
+
+    // Startup asks whether this device is still registered and SIGNS OUT when
+    // the answer is falsy — an unhandled command returning null therefore
+    // dead-ends the app on the loading screen rather than reaching the UI.
+    case 'is_current_device_registered':
+      return true;
+
+    // Callers index or iterate these, so `null` throws where `[]` is inert.
+    // `= []` destructuring defaults only cover `undefined`, not `null`.
+    case 'list_peer_verifications':
+    case 'list_pending_invites':
+    case 'get_pending_invites':
+    case 'list_dm_requests':
+    case 'list_join_requests':
+    case 'get_join_requests':
+    case 'get_group_join_requests':
+    case 'list_pending_enrollment_requests':
+    case 'list_devices':
+    case 'list_blocked_users':
+    case 'get_pinned_messages':
+    case 'list_known_accounts':
+      return [];
+
+    // Realtime / MLS background work the browser build has no backend for.
+    case 'connect_rooms':
+    case 'subscribe_realtime':
+    case 'poll_mls_welcomes':
+    case 'catch_up_all_mls_groups':
+    case 'ingest_channel_envelopes':
+    case 'ingest_dm_envelopes':
+    case 'stop_ring':
+    case 'start_ring':
+    case 'tray_set_unread':
+      return null;
+
+    case 'plugin:notification|is_permission_granted':
+      return false;
+
+    // Loopback media server URL — nothing serves it in the browser.
+    case 'screenshare_ws_url':
+      return null;
+
+    // Desktop-shell side effects with no browser equivalent. Explicit no-ops
+    // so they don't show up as "unhandled" noise in test output.
+    case 'tray_set_enabled':
+    case 'tray_set_close_to_tray':
+    case 'tray_set_voice_state':
+    case 'set_revoke_media_on_exit':
+    case 'mark_update_required':
       return null;
 
     case 'initialize_identity':
@@ -167,6 +232,20 @@ function handleCommand(command: string, args: Record<string, unknown>): unknown 
       return store.channels[groupId] ?? [];
     }
 
+    // The group list + every breadcrumb reads this one, not `list_user_groups`.
+    case 'list_user_groups_with_channels':
+      return store.groups.map((g) => ({
+        ...g,
+        channels: store.channels[g.id] ?? [],
+        current_user_role: (g as MockGroup & { current_user_role?: string })
+          .current_user_role ?? 'member',
+      }));
+
+    case 'get_group_members': {
+      const { groupId } = args as { groupId: string };
+      return store.groupMembers[groupId] ?? [];
+    }
+
     case 'create_channel': {
       const { groupId, name, description } = args as {
         groupId: string;
@@ -192,15 +271,23 @@ function handleCommand(command: string, args: Record<string, unknown>): unknown 
       return store.messages[conversationId] ?? [];
     }
 
-    case 'get_channel_messages': {
+    // `read_*` are the live command names; the `get_*` spellings are kept as
+    // aliases so older callers (and this mock's own history) still resolve.
+    case 'get_channel_messages':
+    case 'read_channel_messages': {
       const { channelId } = args as { channelId: string };
       const messages = store.messages[channelId] ?? [];
       return { messages, next_cursor: null };
     }
 
-    case 'get_dm_messages': {
-      const { dmChannelId } = args as { dmChannelId: string };
-      const messages = store.messages[dmChannelId] ?? [];
+    case 'get_dm_messages':
+    case 'read_dm_messages': {
+      const { dmChannelId, conversationId } = args as {
+        dmChannelId?: string;
+        conversationId?: string;
+      };
+      const key = dmChannelId ?? conversationId ?? '';
+      const messages = store.messages[key] ?? [];
       return { messages, next_cursor: null };
     }
 
@@ -208,7 +295,17 @@ function handleCommand(command: string, args: Record<string, unknown>): unknown 
       return store.dmChannels;
 
     case 'get_preferences':
-      return '{}';
+      return JSON.stringify(store.preferences);
+
+    case 'save_preferences': {
+      const { preferencesJson } = args as { preferencesJson?: string };
+      try {
+        store.preferences = { ...store.preferences, ...JSON.parse(preferencesJson ?? '{}') };
+      } catch {
+        // malformed payload — leave the stored prefs alone
+      }
+      return null;
+    }
 
     case 'send_message': {
       const { conversationId, senderId, content, replyToId } = args as {
@@ -278,4 +375,50 @@ export function invoke<T>(command: string, args?: Record<string, unknown>): Prom
       }
     }, 0);
   });
+}
+
+/**
+ * `@tauri-apps/api/core` also exports `Channel` and `convertFileSrc`, and
+ * `frontend/src/bridge` imports both. A vite alias replaces the WHOLE module,
+ * so the mock has to carry every named export the bridge reaches for or the
+ * dep scan fails outright — which is what had quietly broken
+ * `VITE_PLAYWRIGHT=true` mode.
+ *
+ * Neither needs real behaviour here: `hasTauri()` is false in the browser, so
+ * `bridge/invoke.ts` picks its own inert StubChannel over this one, and no
+ * mocked command serves real files.
+ */
+export class Channel<T = unknown> {
+  onmessage: ((message: T) => void) | null = null;
+
+  toJSON(): string {
+    return "__CHANNEL__:mock";
+  }
+}
+
+export function convertFileSrc(path: string): string {
+  return path;
+}
+
+/**
+ * The alias replaces `@tauri-apps/api/core` for EVERY importer, not just our
+ * own bridge — the `@tauri-apps/plugin-*` packages pull `Resource` and
+ * `addPluginListener` from it as well, and a missing export fails the dep
+ * pre-bundle for the whole app. None of them are exercised in mock mode; they
+ * exist so the module's shape matches.
+ */
+export class Resource {
+  readonly rid: number = 0;
+
+  async close(): Promise<void> {
+    // no resource to release in the browser mock
+  }
+}
+
+export async function addPluginListener(
+  _plugin: string,
+  _event: string,
+  _cb: (payload: unknown) => void,
+): Promise<{ unregister: () => Promise<void> }> {
+  return { unregister: async () => {} };
 }

--- a/frontend/src/components/Message/MentionToken.tsx
+++ b/frontend/src/components/Message/MentionToken.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+
+interface MentionTokenProps {
+  /** Username as typed, without the leading '@'. */
+  name: string;
+  /** True when this mention addresses the reader — `@you` or `@all`. */
+  isSelf: boolean;
+  skin: "terminal" | "refined";
+}
+
+/**
+ * A resolved `@mention` inside a message body (#843).
+ *
+ * Two strengths, deliberately far apart: a mention of YOU is a filled accent
+ * block you cannot scroll past, while a mention of someone else is a quiet
+ * tinted chip that reads as a name rather than an alert. That difference is
+ * the whole point — a mention should feel like being spoken to.
+ *
+ * Each skin renders the same distinction in its own idiom: terminal keeps the
+ * square, inverted-block treatment it already uses for admin name badges;
+ * refined uses the rounded chip Slack made familiar.
+ */
+export const MentionToken: React.FC<MentionTokenProps> = ({ name, isSelf, skin }) => {
+  const shared = "rounded-[var(--radius-chip)] px-1";
+  const font = skin === "terminal" ? "font-mono" : "";
+
+  const tone = isSelf
+    ? "bg-accent text-bg font-semibold"
+    : "bg-active text-accent";
+
+  return (
+    <span
+      data-testid={isSelf ? "mention-self" : "mention-other"}
+      data-mention={name}
+      className={`${shared} ${font} ${tone}`}
+    >
+      @{name}
+    </span>
+  );
+};

--- a/frontend/src/components/Message/MessageBody.tsx
+++ b/frontend/src/components/Message/MessageBody.tsx
@@ -1,0 +1,76 @@
+import React, { useMemo } from "react";
+import { observer } from "mobx-react-lite";
+import { appStore } from "../../stores/appStore";
+import { LinkifiedText } from "../ui/LinkifiedText";
+import { MentionToken } from "./MentionToken";
+import { useSkin } from "../../hooks/queries/usePreferences";
+import { useMentionCandidates } from "../../hooks/queries/useMentionCandidates";
+import { findMentions } from "../../utils/mentions";
+
+interface MessageBodyProps {
+  text: string;
+}
+
+/**
+ * A message body: `@mentions` rendered as tokens, everything else handed to
+ * `LinkifiedText` unchanged (#843).
+ *
+ * Only mentions that RESOLVE are tokenized — `@all`, and any name belonging to
+ * someone in this conversation. An `@nobody` stays plain text, which keeps the
+ * rendering honest: a highlighted token means a real person was actually
+ * notified. The resolution set is the same conversation roster the composer
+ * suggests from, so rendering never reveals a user the reader couldn't
+ * already see.
+ *
+ * `LinkifiedText` is untouched by this — it still owns URL detection, and each
+ * non-mention slice is delegated to it, so a message can contain both.
+ */
+export const MessageBody: React.FC<MessageBodyProps> = observer(({ text }) => {
+  const skin = useSkin();
+  const candidates = useMentionCandidates();
+  const { currentUser } = appStore;
+  const selfName = currentUser?.username?.toLowerCase();
+
+  const known = useMemo(() => {
+    const set = new Set<string>(["all"]);
+    for (const c of candidates) {
+      set.add(c.username.toLowerCase());
+    }
+    if (selfName) {
+      set.add(selfName);
+    }
+    return set;
+  }, [candidates, selfName]);
+
+  const parts = useMemo(() => {
+    const mentions = findMentions(text).filter((m) => known.has(m.name));
+    if (mentions.length === 0) {
+      return null;
+    }
+    const nodes: React.ReactNode[] = [];
+    let cursor = 0;
+    for (const m of mentions) {
+      if (m.start > cursor) {
+        nodes.push(
+          <LinkifiedText key={`t${cursor}`} text={text.slice(cursor, m.start)} />,
+        );
+      }
+      // `@all` speaks to everyone, so it is a mention of the reader too.
+      const isSelf = m.name === "all" || m.name === selfName;
+      nodes.push(
+        <MentionToken key={`m${m.start}`} name={m.raw} isSelf={isSelf} skin={skin} />,
+      );
+      cursor = m.end;
+    }
+    if (cursor < text.length) {
+      nodes.push(<LinkifiedText key={`t${cursor}`} text={text.slice(cursor)} />);
+    }
+    return nodes;
+  }, [text, known, selfName, skin]);
+
+  if (parts === null) {
+    return <LinkifiedText text={text} />;
+  }
+
+  return <>{parts}</>;
+});

--- a/frontend/src/components/Message/MessageItem.tsx
+++ b/frontend/src/components/Message/MessageItem.tsx
@@ -4,7 +4,7 @@ import { ThreadReplyCount } from "./ThreadReplyCount";
 import { formatTimeOfDay, formatFullTimestamp } from "../../utils/format";
 import { observer } from "mobx-react-lite";
 import { appStore } from "../../stores/appStore";
-import { LinkifiedText } from "../ui/LinkifiedText";
+import { MessageBody } from "./MessageBody";
 import { MediaLinkUnfurl } from "./MediaLinkUnfurl";
 import { getUsernameColor, useBackgroundIsLight } from "../../utils/usernameColor";
 import { useSkin } from "../../hooks/queries/usePreferences";
@@ -220,7 +220,7 @@ export const MessageItem: React.FC<MessageItemProps> = observer(({
               lineHeight: "var(--lh)",
             }}
           >
-            <LinkifiedText text={content} />
+            <MessageBody text={content} />
             {message.edited_at && !isDeleted && (
               <span className="ml-1 text-xs" style={{ color: "var(--c-text-muted)" }}>
                 (edited)
@@ -386,7 +386,7 @@ export const MessageItem: React.FC<MessageItemProps> = observer(({
             whiteSpace: "pre-wrap",
           }}
         >
-          <LinkifiedText text={content} />
+          <MessageBody text={content} />
           {message.edited_at && !isDeleted && (
             <span className="ml-1 text-xs" style={{ color: "var(--c-text-muted)" }}>
               (edited)

--- a/frontend/src/components/Message/MessageItem.tsx
+++ b/frontend/src/components/Message/MessageItem.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Reply, CornerUpLeft, Edit2, Trash2, MessagesSquare } from "lucide-react";
+import { Reply, CornerUpLeft, Edit2, Trash2, MessagesSquare, Bookmark, Link } from "lucide-react";
 import { ThreadReplyCount } from "./ThreadReplyCount";
 import { formatTimeOfDay, formatFullTimestamp } from "../../utils/format";
 import { observer } from "mobx-react-lite";
@@ -33,6 +33,11 @@ interface MessageItemProps {
   threadReplyCount?: number;
   onEdit?: (messageId: string) => void;
   onDelete?: (messageId: string) => void;
+  /** Bookmarks + permalinks (#854). All optional — when the parent doesn't
+   * pass them the affordances simply don't render. Wired from `MessageList`. */
+  onToggleSave?: (messageId: string) => void;
+  onCopyLink?: (messageId: string) => void;
+  isSaved?: boolean;
   onPin?: (messageId: string) => void;
   onScrollToReply?: (messageId: string) => void;
 }
@@ -54,6 +59,9 @@ export const MessageItem: React.FC<MessageItemProps> = observer(({
   threadReplyCount = 0,
   onEdit,
   onDelete,
+  onToggleSave,
+  onCopyLink,
+  isSaved = false,
   onScrollToReply,
 }) => {
   const { currentUser } = appStore;
@@ -267,6 +275,26 @@ export const MessageItem: React.FC<MessageItemProps> = observer(({
                 <MessagesSquare size={16} />
               </button>
             )}
+            {onToggleSave && (
+              <button
+                data-testid="save-button"
+                onClick={() => onToggleSave(message.id)}
+                aria-label={isSaved ? "Remove bookmark" : "Save message"}
+                className="p-1 text-[var(--c-text-muted)] hover:text-[var(--c-text-accent)]"
+              >
+                <Bookmark size={16} fill={isSaved ? "currentColor" : "none"} />
+              </button>
+            )}
+            {onCopyLink && (
+              <button
+                data-testid="copy-link-button"
+                onClick={() => onCopyLink(message.id)}
+                aria-label="Copy link to message"
+                className="p-1 text-[var(--c-text-muted)] hover:text-[var(--c-text-accent)]"
+              >
+                <Link size={16} />
+              </button>
+            )}
             {isOwn && onEdit && (
               <button
                 data-testid="edit-button"
@@ -418,6 +446,26 @@ export const MessageItem: React.FC<MessageItemProps> = observer(({
                 className="opacity-0 group-hover:opacity-100 text-[var(--c-text-muted)] hover:text-[var(--c-text-accent)]"
               >
                 <MessagesSquare size={18} />
+              </button>
+            )}
+            {onToggleSave && (
+              <button
+                data-testid="save-button"
+                onClick={() => onToggleSave(message.id)}
+                aria-label={isSaved ? "Remove bookmark" : "Save message"}
+                className="opacity-0 group-hover:opacity-100 text-[var(--c-text-muted)] hover:text-[var(--c-text-accent)]"
+              >
+                <Bookmark size={18} fill={isSaved ? "currentColor" : "none"} />
+              </button>
+            )}
+            {onCopyLink && (
+              <button
+                data-testid="copy-link-button"
+                onClick={() => onCopyLink(message.id)}
+                aria-label="Copy link to message"
+                className="opacity-0 group-hover:opacity-100 text-[var(--c-text-muted)] hover:text-[var(--c-text-accent)]"
+              >
+                <Link size={18} />
               </button>
             )}
             {isOwn && onEdit && (

--- a/frontend/src/components/ui/ChatInput.tsx
+++ b/frontend/src/components/ui/ChatInput.tsx
@@ -15,7 +15,17 @@ import { formatFileSize } from "../../utils/format";
 import { observer } from "mobx-react-lite";
 import { dropTargetStore } from "../../stores/dropTargetStore";
 import { getDraft, setDraft } from "../../utils/drafts";
-import { mentionsAll } from "../../utils/mentions";
+import {
+  mentionsAll,
+  mentionQueryAt,
+  applyMention,
+  rankMentionCandidates,
+  type MentionCandidate,
+} from "../../utils/mentions";
+import { useMentionCandidates } from "../../hooks/queries/useMentionCandidates";
+import { useSkin } from "../../hooks/queries/usePreferences";
+import { MentionGhost } from "./MentionGhost";
+import { MentionSuggestList } from "./MentionSuggestList";
 
 // Attachment carries a filesystem path so Rust can read the file directly —
 // no bytes-over-IPC bottleneck, no size limit.
@@ -415,6 +425,71 @@ const ChatInputInner: React.ForwardRefRenderFunction<ChatInputHandle, ChatInputP
   // when the send will fan out an `all_mention`.
   const willNotifyEveryone = canNotifyAll && mentionsAll(message);
 
+  // ── @mention autocomplete (#843) ─────────────────────────────────────────
+  // Candidates come from the roster of the conversation the user is already
+  // in — never a directory lookup. See useMentionCandidates for why.
+  const skin = useSkin();
+  const mentionCandidates = useMentionCandidates();
+  const [caret, setCaret] = useState(0);
+  const [activeIndex, setActiveIndex] = useState(0);
+  // Esc hides the suggestions for the current token; typing brings them back.
+  const [mentionDismissed, setMentionDismissed] = useState(false);
+  // Mirrors the textarea's scroll so the terminal ghost stays aligned once
+  // the message wraps past the visible box.
+  const [scrollTop, setScrollTop] = useState(0);
+  // Where to put the caret after a completion is inserted. Applied in the
+  // effect below, once React has committed the new value to the textarea.
+  const pendingCaretRef = useRef<number | null>(null);
+
+  const mentionQuery = mentionDismissed ? null : mentionQueryAt(message, caret);
+  const suggestions = mentionQuery
+    ? rankMentionCandidates(mentionCandidates, mentionQuery.query)
+    : [];
+
+  // Terminal skin: the ghost can only ever APPEND to what's typed, so it needs
+  // a prefix match, and — like fish / zsh-autosuggestions — it is only offered
+  // when the caret sits at the end of the line.
+  const ghostTarget =
+    skin === "terminal" && mentionQuery && caret === message.length
+      ? suggestions.find((c) =>
+          c.username.toLowerCase().startsWith(mentionQuery.query),
+        )
+      : undefined;
+  const ghostText = ghostTarget
+    ? ghostTarget.username.slice(mentionQuery!.query.length)
+    : "";
+
+  // Refined skin: the Slack-style list. Terminal never opens one.
+  const showSuggestList = skin === "refined" && suggestions.length > 0;
+
+  // Keep the highlight in range as the candidate list narrows on each keystroke.
+  useEffect(() => {
+    setActiveIndex((prev) => (prev < suggestions.length ? prev : 0));
+  }, [suggestions.length]);
+
+  useEffect(() => {
+    const pending = pendingCaretRef.current;
+    if (pending === null || !textareaRef.current) {
+      return;
+    }
+    pendingCaretRef.current = null;
+    textareaRef.current.setSelectionRange(pending, pending);
+    textareaRef.current.focus();
+    setCaret(pending);
+  }, [message]);
+
+  const acceptMention = useCallback((candidate: MentionCandidate) => {
+    const next = applyMention(message, caret, candidate.username);
+    if (next.text === message) {
+      return;
+    }
+    pendingCaretRef.current = next.caret;
+    setMessage(next.text);
+    setDraft(draftKey, next.text);
+    onValueChange?.(next.text);
+    setActiveIndex(0);
+  }, [message, caret, draftKey, onValueChange]);
+
   const handleSend = () => {
     if (!message.trim() && attachments.length === 0) { return; }
     if (hasLoadingAttachments) { return; }
@@ -432,6 +507,49 @@ const ChatInputInner: React.ForwardRefRenderFunction<ChatInputHandle, ChatInputP
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
+    // Mention keys are handled BEFORE the Enter-sends branch: while a
+    // suggestion is on offer, Enter accepts it rather than sending a
+    // half-typed name, exactly as Slack and Discord behave.
+    if (showSuggestList) {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setActiveIndex((i) => (i + 1) % suggestions.length);
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setActiveIndex((i) => (i - 1 + suggestions.length) % suggestions.length);
+        return;
+      }
+      if (e.key === "Enter" || e.key === "Tab") {
+        e.preventDefault();
+        acceptMention(suggestions[activeIndex]);
+        return;
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        setMentionDismissed(true);
+        return;
+      }
+    }
+
+    // Terminal skin: Tab accepts the ghosted completion. There is nothing to
+    // arrow through and nothing to dismiss beyond hiding the ghost.
+    if (ghostTarget) {
+      if (e.key === "Tab") {
+        e.preventDefault();
+        acceptMention(ghostTarget);
+        return;
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        setMentionDismissed(true);
+        return;
+      }
+    }
+
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       handleSend();
@@ -485,9 +603,20 @@ const ChatInputInner: React.ForwardRefRenderFunction<ChatInputHandle, ChatInputP
 
   return (
     <div
-      className={`border-t ${className}`}
+      className={`relative border-t ${className}`}
       style={{ borderColor: "var(--c-border)", background: "var(--c-bg)" }}
     >
+      {/* Refined skin's mention list. Anchored to this container with
+          `absolute`, never a portal or a fixed overlay. */}
+      {showSuggestList && mentionQuery && (
+        <MentionSuggestList
+          candidates={suggestions}
+          activeIndex={activeIndex}
+          query={mentionQuery.query}
+          onSelect={acceptMention}
+          onHover={setActiveIndex}
+        />
+      )}
 
       {/* Attachment previews */}
       {attachments.length > 0 && (
@@ -534,41 +663,56 @@ const ChatInputInner: React.ForwardRefRenderFunction<ChatInputHandle, ChatInputP
           <Plus className="w-4 h-4" />
         </button>
 
-        <textarea
-          ref={textareaRef}
-          data-testid="message-input"
-          value={message}
-          onChange={(e) => {
-            const next = e.target.value;
-            setMessage(next);
-            setDraft(draftKey, next);
-            onValueChange?.(next);
-          }}
-          onFocus={() => setIsFocused(true)}
-          onBlur={() => setIsFocused(false)}
-          onKeyDown={handleKeyDown}
-          onPaste={handlePaste}
-          placeholder={placeholder}
-          disabled={disabled}
-          autoFocus={autoFocus}
-          autoComplete="off"
-          autoCorrect="off"
-          autoCapitalize="off"
-          spellCheck={false}
-          rows={1}
-          className={`chat-input-textarea flex-1 min-w-0 px-2 py-1 resize-none font-mono text-sm transition-colors${isFocused ? " is-focused" : ""}`}
-          style={{
-            lineHeight: "1.5rem",
-            minHeight: "1.5rem",
-            borderRadius: "4px",
-            background: isFocused ? "var(--c-accent)" : "var(--c-hover)",
-            color: isFocused ? "var(--c-bg)" : "var(--c-text)",
-            outline: "none",
-            border: "none",
-            opacity: disabled ? 0.5 : 1,
-          }}
-          aria-label="Message input"
-        />
+        {/* Positioning context for the terminal skin's inline ghost, which
+            mirrors this exact box. */}
+        <div className="relative flex-1 min-w-0">
+          <textarea
+            ref={textareaRef}
+            data-testid="message-input"
+            value={message}
+            onChange={(e) => {
+              const next = e.target.value;
+              setMessage(next);
+              setDraft(draftKey, next);
+              onValueChange?.(next);
+              setCaret(e.target.selectionStart ?? next.length);
+              // Any edit re-opens suggestions that Esc had hidden.
+              setMentionDismissed(false);
+            }}
+            onSelect={(e) => setCaret(e.currentTarget.selectionStart ?? 0)}
+            onScroll={(e) => setScrollTop(e.currentTarget.scrollTop)}
+            onFocus={() => setIsFocused(true)}
+            onBlur={() => setIsFocused(false)}
+            onKeyDown={handleKeyDown}
+            onPaste={handlePaste}
+            placeholder={placeholder}
+            disabled={disabled}
+            autoFocus={autoFocus}
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="off"
+            spellCheck={false}
+            rows={1}
+            className={`chat-input-textarea w-full px-2 py-1 resize-none font-mono text-sm transition-colors${isFocused ? " is-focused" : ""}`}
+            style={{
+              lineHeight: "1.5rem",
+              minHeight: "1.5rem",
+              borderRadius: "4px",
+              background: isFocused ? "var(--c-accent)" : "var(--c-hover)",
+              color: isFocused ? "var(--c-bg)" : "var(--c-text)",
+              outline: "none",
+              border: "none",
+              opacity: disabled ? 0.5 : 1,
+            }}
+            aria-label="Message input"
+          />
+          <MentionGhost
+            value={message}
+            ghost={ghostText}
+            focused={isFocused}
+            scrollTop={scrollTop}
+          />
+        </div>
 
         <button
           onClick={handleSend}

--- a/frontend/src/components/ui/MentionGhost.tsx
+++ b/frontend/src/components/ui/MentionGhost.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+
+interface MentionGhostProps {
+  /** The textarea's full current value. Rendered invisibly to position the ghost. */
+  value: string;
+  /** The completion suffix shown after the caret, e.g. "na" for "@da" → "@dana". */
+  ghost: string;
+  /** Whether the textarea is focused — the terminal composer inverts its colours. */
+  focused: boolean;
+  /** The textarea's scrollTop, so the mirror stays aligned on a wrapped message. */
+  scrollTop: number;
+}
+
+/**
+ * Terminal skin's inline autosuggest (#843) — the completion appears as
+ * dimmed text directly after the caret and Tab accepts it.
+ *
+ * This is a MIRROR, not a pop-over: an absolutely-positioned, pointer-events-
+ * none copy of the textarea's box that renders the current value with
+ * `visibility: hidden` (which preserves layout exactly) followed by the ghost.
+ * The ghost therefore lands precisely where the caret is, with no measurement
+ * and no floating element. Nothing here is fixed-position, portalled, or
+ * overlaid on the app — it is a child of the composer's own input box.
+ *
+ * The caller only supplies a `ghost` while the caret sits at the END of the
+ * value, which is exactly how fish and zsh-autosuggestions behave: the
+ * suggestion is offered for the tail of the line, and typing in the middle of
+ * a line simply doesn't offer one. That is the terminal idiom this skin is
+ * imitating, not a limitation worked around.
+ */
+export const MentionGhost: React.FC<MentionGhostProps> = ({
+  value,
+  ghost,
+  focused,
+  scrollTop,
+}) => {
+  if (!ghost) {
+    return null;
+  }
+
+  return (
+    <div
+      className="absolute inset-0 overflow-hidden pointer-events-none"
+      aria-hidden="true"
+    >
+      {/* Typography here MUST match the textarea in ChatInput exactly —
+          same padding, font, size and line-height — or the ghost drifts. */}
+      <div
+        className="px-2 py-1 font-mono text-sm whitespace-pre-wrap break-words"
+        style={{ lineHeight: "1.5rem", transform: `translateY(${-scrollTop}px)` }}
+      >
+        <span className="invisible">{value}</span>
+        {/* Focused, the terminal input is an accent block with bg-coloured
+            text, so the ghost dims the bg colour; unfocused it dims the
+            normal foreground. */}
+        <span
+          data-testid="mention-ghost"
+          className={focused ? "text-bg opacity-60" : "text-muted"}
+        >
+          {ghost}
+        </span>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/ui/MentionSuggestList.tsx
+++ b/frontend/src/components/ui/MentionSuggestList.tsx
@@ -1,0 +1,117 @@
+import React, { useEffect, useRef } from "react";
+import { Avatar } from "./Avatar";
+import type { MentionCandidate } from "../../utils/mentions";
+
+interface MentionSuggestListProps {
+  candidates: MentionCandidate[];
+  /** Index of the highlighted row — moved by the arrow keys in ChatInput. */
+  activeIndex: number;
+  /** What the user has typed after the '@', used to bold the matched prefix. */
+  query: string;
+  onSelect: (candidate: MentionCandidate) => void;
+  onHover: (index: number) => void;
+}
+
+/**
+ * Highlight the part of `username` that matches what the user has typed —
+ * the small touch that makes Slack's list feel responsive to each keystroke.
+ */
+const MatchedName: React.FC<{ username: string; query: string }> = ({
+  username,
+  query,
+}) => {
+  const at = query ? username.toLowerCase().indexOf(query.toLowerCase()) : -1;
+  if (at < 0) {
+    return <>{username}</>;
+  }
+  return (
+    <>
+      {username.slice(0, at)}
+      <span className="font-semibold text-accent">
+        {username.slice(at, at + query.length)}
+      </span>
+      {username.slice(at + query.length)}
+    </>
+  );
+};
+
+/**
+ * Refined skin's mention autocomplete (#843) — the Slack/Discord inline list
+ * that sits directly above the composer. Arrow keys move, Enter/Tab accept,
+ * Esc dismisses; all of that is driven by ChatInput's key handler, which owns
+ * the textarea.
+ *
+ * Positioning is `absolute` INSIDE the composer's own relative container
+ * (`bottom-full`), not a portal to `document.body` and not `position: fixed`.
+ * It is a normal part of the composer's layout that happens to overhang the
+ * message list, which is exactly what Slack does and what the no-modals rule
+ * allows.
+ */
+export const MentionSuggestList: React.FC<MentionSuggestListProps> = ({
+  candidates,
+  activeIndex,
+  query,
+  onSelect,
+  onHover,
+}) => {
+  const activeRef = useRef<HTMLButtonElement>(null);
+
+  // Keep the highlighted row in view when the arrow keys walk past the edge
+  // of the scroll box.
+  useEffect(() => {
+    activeRef.current?.scrollIntoView({ block: "nearest" });
+  }, [activeIndex]);
+
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      data-testid="mention-suggest-list"
+      role="listbox"
+      aria-label="Mention suggestions"
+      className="absolute bottom-full left-0 right-0 z-20 mb-1 mx-2 overflow-hidden rounded-panel border border-line bg-surface-raised"
+    >
+      <div className="px-3 py-1.5 border-b border-line text-2xs text-muted select-none">
+        Members matching <span className="text-fg">@{query}</span>
+      </div>
+      {/* Caps the list at roughly six rows (max-h-60 is 15rem, so it tracks
+          the user's font setting rather than a pixel height). */}
+      <div className="max-h-60 overflow-y-auto py-1">
+        {candidates.map((c, i) => {
+          const isActive = i === activeIndex;
+          return (
+            <button
+              key={c.userId}
+              ref={isActive ? activeRef : undefined}
+              type="button"
+              role="option"
+              aria-selected={isActive}
+              data-testid={`mention-option-${c.username}`}
+              data-active={isActive ? "true" : undefined}
+              // The composer must keep focus — a blur would tear down the
+              // list before the click ever lands.
+              onMouseDown={(e) => {
+                e.preventDefault();
+                onSelect(c);
+              }}
+              onMouseEnter={() => onHover(i)}
+              className={`w-full flex items-center gap-2 px-3 py-1.5 text-left text-sm hover:bg-hover ${
+                isActive ? "bg-active" : ""
+              }`}
+            >
+              <Avatar avatarKey={c.avatarUrl ?? null} size={22} alt={c.username} />
+              <span className="truncate text-fg">
+                <MatchedName username={c.username} query={query} />
+              </span>
+              {c.displayName && c.displayName !== c.username && (
+                <span className="truncate text-xs text-muted">{c.displayName}</span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/hooks/queries/useMentionCandidates.ts
+++ b/frontend/src/hooks/queries/useMentionCandidates.ts
@@ -1,0 +1,64 @@
+import { useMemo } from "react";
+import { useObserver } from "mobx-react-lite";
+import { appStore } from "../../stores/appStore";
+import { useGroupMembers } from "./useGroups";
+import { useDMConversations } from "./useMessages";
+import type { MentionCandidate } from "../../utils/mentions";
+
+/**
+ * The people the current user may `@mention` in the conversation they're
+ * looking at (#843).
+ *
+ * PRIVACY: the pool is derived exclusively from membership the user can
+ * already see — the selected group's roster, or the other party in the
+ * selected DM. There is deliberately NO username lookup behind this: a
+ * directory search would let anyone enumerate users outside their own
+ * groups and DMs just by typing into a composer. The backend resolves
+ * mentions against the same roster, so an `@name` nobody in the room
+ * answers to is inert on both sides.
+ *
+ * The current user is excluded — you can't mention yourself.
+ */
+export function useMentionCandidates(): MentionCandidate[] {
+  const currentUser = useObserver(() => appStore.currentUser);
+  const selectedGroupId = useObserver(() => appStore.selectedGroupId);
+  const selectedChannelId = useObserver(() => appStore.selectedChannelId);
+  const selectedConversationId = useObserver(() => appStore.selectedConversationId);
+
+  // Only fetch the roster when a channel is actually selected — a DM composer
+  // has no group to read.
+  const groupMembers = useGroupMembers(selectedChannelId ? selectedGroupId : null);
+  const dmConversations = useDMConversations();
+
+  const members = groupMembers.data;
+  const conversations = dmConversations.data;
+
+  return useMemo(() => {
+    if (selectedChannelId) {
+      return (members ?? [])
+        .filter((m) => m.user_id !== currentUser?.id && !!m.username)
+        .map((m) => ({
+          userId: m.user_id,
+          username: m.username!,
+          displayName: m.display_name,
+          avatarUrl: m.avatar_url,
+        }));
+    }
+
+    if (selectedConversationId) {
+      const dm = (conversations ?? []).find((c) => c.id === selectedConversationId);
+      if (!dm?.user2_id) {
+        return [];
+      }
+      return [
+        {
+          userId: dm.user2_id,
+          username: dm.user2_identifier,
+          avatarUrl: dm.user2_avatar_url,
+        },
+      ];
+    }
+
+    return [];
+  }, [selectedChannelId, selectedConversationId, members, conversations, currentUser?.id]);
+}

--- a/frontend/src/hooks/useLiveKitRealtime.ts
+++ b/frontend/src/hooks/useLiveKitRealtime.ts
@@ -43,6 +43,16 @@ type RealtimeEvent =
     sender_id: string;
     sender_username: string | null;
   }
+  // Per-user @username mention (#843). Same shape as all_mention — the
+  // difference is the audience: the backend publishes this ONLY to the
+  // members the message names.
+  | {
+    type: 'user_mention';
+    group_id: string;
+    channel_id: string;
+    sender_id: string;
+    sender_username: string | null;
+  }
   | {
     // Sent to every device on the user's inbox when one of their devices is
     // revoked. Each device re-checks its own registration and only the
@@ -701,6 +711,25 @@ export function useLiveKitRealtime() {
           roomId: event.channel_id,
           title,
           body: `${senderUsername} mentioned @all`,
+          senderUsername,
+        });
+        return;
+      }
+
+      // @username mention in a group (#843). Same inbox-room delivery as
+      // all_mention, but the backend only sends it to the members actually
+      // named — so receiving one means this message is addressed to us, and
+      // it routes to the louder `user_mention` category. Skip our own.
+      if (event.type === 'user_mention') {
+        if (event.sender_id === currentUserIdRef.current) {
+          return;
+        }
+        const senderUsername = event.sender_username ?? 'Someone';
+        const title = roomNameMapRef.current.get(event.channel_id) ?? 'New mention';
+        notify('user_mention', {
+          roomId: event.channel_id,
+          title,
+          body: `${senderUsername} mentioned you`,
           senderUsername,
         });
         return;

--- a/frontend/src/utils/mentions.ts
+++ b/frontend/src/utils/mentions.ts
@@ -12,3 +12,174 @@ export function mentionsAll(content: string): boolean {
     return trimmed.toLowerCase() === "@all";
   });
 }
+
+// Characters that may appear INSIDE a username after the leading '@'. Mirrors
+// `is_mention_body_char()` in send.rs — deliberately wide (the `users.username`
+// column has no charset constraint) but closed over sentence punctuation.
+const MENTION_BODY = /[\p{L}\p{N}_.-]/u;
+
+// A mention opens only at the start of the string or right after whitespace,
+// which is what stops "email@allcorp" and "a@b.com" from reading as mentions.
+// The body is captured greedily; trailing '.', '-' and '_' are trimmed by the
+// callers below so "@dana." mentions `dana`.
+const MENTION_RE = /(^|\s)@([\p{L}\p{N}_.-]+)/gu;
+
+// Trailing punctuation the Rust side trims off a mention body.
+const MENTION_TRAIL = /[.\-_]+$/;
+
+/** One `@mention` found in a string, with the slice it occupies. */
+export interface MentionMatch {
+  /** Username as typed, without the leading '@'. */
+  raw: string;
+  /** Lowercased username — what matching compares on. */
+  name: string;
+  /** Index of the '@' in the source string. */
+  start: number;
+  /** Index one past the last character of the mention. */
+  end: number;
+}
+
+/**
+ * Every `@mention` in `text`, in order, including `@all`.
+ *
+ * MIRROR: `mention_tokens()` in pollis-core/src/commands/messages/send.rs,
+ * except that this keeps `@all` (the renderer highlights it; the backend
+ * handles it through `mentions_all()` instead). The two must agree on what
+ * counts as a mention or the composer will promise a ping the backend does
+ * not send.
+ */
+export function findMentions(text: string): MentionMatch[] {
+  const out: MentionMatch[] = [];
+  MENTION_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = MENTION_RE.exec(text)) !== null) {
+    const lead = match[1].length;
+    const body = match[2].replace(MENTION_TRAIL, "");
+    if (body.length === 0) {
+      continue;
+    }
+    const start = match.index + lead;
+    out.push({
+      raw: body,
+      name: body.toLowerCase(),
+      start,
+      // +1 for the '@' itself.
+      end: start + 1 + body.length,
+    });
+  }
+  return out;
+}
+
+/**
+ * Lowercased usernames named in `text`, excluding `@all`. Mirrors
+ * `mention_tokens()` exactly — this is the set the backend resolves against
+ * the channel roster.
+ */
+export function mentionTokens(text: string): string[] {
+  return findMentions(text)
+    .map((m) => m.name)
+    .filter((n) => n !== "all");
+}
+
+/** An in-progress `@…` the caret is sitting inside. */
+export interface MentionQuery {
+  /** Index of the '@'. */
+  start: number;
+  /** Caret index — always the end of the query. */
+  end: number;
+  /** Text typed after the '@', lowercased. Empty right after typing '@'. */
+  query: string;
+}
+
+/**
+ * The mention the caret is currently typing, or null.
+ *
+ * Only an unterminated run of mention-body characters immediately before the
+ * caret counts, so the suggestion disappears the moment the user types a
+ * space — matching Slack/Discord, where a completed mention stops offering
+ * alternatives.
+ */
+export function mentionQueryAt(text: string, caret: number): MentionQuery | null {
+  let i = caret;
+  while (i > 0 && MENTION_BODY.test(text[i - 1])) {
+    i -= 1;
+  }
+  // The character before the run must be the '@' that opens the mention.
+  if (i === 0 || text[i - 1] !== "@") {
+    return null;
+  }
+  const at = i - 1;
+  // …and that '@' must itself start the string or follow whitespace.
+  if (at > 0 && !/\s/.test(text[at - 1])) {
+    return null;
+  }
+  return { start: at, end: caret, query: text.slice(i, caret).toLowerCase() };
+}
+
+/**
+ * Replace the mention query at `caret` with `@username `, returning the new
+ * text and where the caret should land. A trailing space is appended so the
+ * user can keep typing straight away (Slack/Discord do the same).
+ */
+export function applyMention(
+  text: string,
+  caret: number,
+  username: string,
+): { text: string; caret: number } {
+  const q = mentionQueryAt(text, caret);
+  if (!q) {
+    return { text, caret };
+  }
+  const inserted = `@${username} `;
+  const next = text.slice(0, q.start) + inserted + text.slice(q.end);
+  return { text: next, caret: q.start + inserted.length };
+}
+
+/** A person who can be mentioned — normalized across group members and DMs. */
+export interface MentionCandidate {
+  userId: string;
+  username: string;
+  displayName?: string;
+  avatarUrl?: string;
+}
+
+/** Max suggestions shown at once, matching Slack's composer list depth. */
+export const MENTION_SUGGESTION_LIMIT = 8;
+
+/**
+ * Candidates matching `query`, best first.
+ *
+ * Prefix matches rank above substring matches (so "da" offers `dana` before
+ * `adam`), ties break alphabetically, and an empty query lists everyone. The
+ * pool is only ever the members the user can already see — this function never
+ * widens it, which is what keeps mentions from becoming a user directory.
+ */
+export function rankMentionCandidates(
+  candidates: MentionCandidate[],
+  query: string,
+  limit: number = MENTION_SUGGESTION_LIMIT,
+): MentionCandidate[] {
+  const q = query.toLowerCase();
+  const scored: Array<{ c: MentionCandidate; rank: number }> = [];
+  for (const c of candidates) {
+    const uname = c.username.toLowerCase();
+    const display = (c.displayName ?? "").toLowerCase();
+    if (q.length === 0) {
+      scored.push({ c, rank: 1 });
+      continue;
+    }
+    if (uname.startsWith(q) || display.startsWith(q)) {
+      scored.push({ c, rank: 0 });
+      continue;
+    }
+    if (uname.includes(q) || display.includes(q)) {
+      scored.push({ c, rank: 1 });
+    }
+  }
+  scored.sort((a, b) =>
+    a.rank !== b.rank
+      ? a.rank - b.rank
+      : a.c.username.localeCompare(b.c.username, undefined, { sensitivity: "base" }),
+  );
+  return scored.slice(0, limit).map((s) => s.c);
+}

--- a/frontend/src/utils/notify.ts
+++ b/frontend/src/utils/notify.ts
@@ -14,7 +14,8 @@ export type Category =
   | 'group_invite'
   | 'enrollment'
   | 'incoming_call'
-  | 'all_mention';
+  | 'all_mention'
+  | 'user_mention';
 
 type CategoryConfig = {
   sound?: 'ping' | 'join' | 'leave';
@@ -56,6 +57,13 @@ const CATEGORIES: Record<Category, CategoryConfig> = {
   // channel_message). Badge is left to the accompanying new_message event so a
   // connected client doesn't double-count unread.
   all_mention:       { sound: 'ping',  osNotif: true,                            cooldownMs: 2500 },
+  // @username in a group (#843) — someone spoke to YOU by name, which is a
+  // personal event, so it is treated like a DM rather than like channel
+  // chatter: ping, OS notification, AND the status-bar alert that names the
+  // sender. It is deliberately louder than `all_mention` (which is addressed
+  // to a room, not to you) — that alert is the difference. Badge is left to
+  // the accompanying new_message event so unread isn't double-counted.
+  user_mention:      { sound: 'ping',  osNotif: true,               alert: true, cooldownMs: 2500 },
 };
 
 export type NotifyPayload = {

--- a/mobile/hooks/useInboxRealtime.ts
+++ b/mobile/hooks/useInboxRealtime.ts
@@ -58,10 +58,12 @@ export function useInboxRealtime() {
             queryKey: groupInviteQueryKeys.pending(userId),
           });
           break;
-        case "all_mention": {
-          // An @all in a group. Arrives on the per-user inbox room so it
-          // reaches members even when they're not in the group's LiveKit
-          // room. Ingest the referenced channel so the message lands, then
+        case "all_mention":
+        case "user_mention": {
+          // An @all or an @username (#843) in a group. Arrives on the per-user
+          // inbox room so it reaches members even when they're not in the
+          // group's LiveKit room. Ingest the referenced channel so the message
+          // lands, then
           // refresh that channel's message cache. (No foreground OS ping —
           // mobile/lib/push exposes no ready local-notification helper, and
           // this task doesn't build new notification infra.)

--- a/mobile/lib/realtime/events.ts
+++ b/mobile/lib/realtime/events.ts
@@ -46,6 +46,16 @@ export type RealtimeEvent =
       sender_username: string | null;
     }
   | {
+      // Per-user @username mention (#843). Same shape as all_mention — the
+      // difference is the audience: the backend publishes this ONLY to the
+      // members the message names.
+      type: "user_mention";
+      group_id: string;
+      channel_id: string;
+      sender_id: string;
+      sender_username: string | null;
+    }
+  | {
       type: "member_role_changed";
       group_id: string;
     }
@@ -74,6 +84,7 @@ const KNOWN_TYPES = new Set<RealtimeEvent["type"]>([
   "dm_created",
   "membership_changed",
   "all_mention",
+  "user_mention",
   "member_role_changed",
   "roster_changed",
   "device_revoked",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
 
   e2e:
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.50.0
+        version: 1.62.1
       dotenv:
         specifier: ^16
         version: 16.6.1
@@ -1010,6 +1013,11 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   '@poppinss/colors@4.1.6':
     resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
 
@@ -1880,6 +1888,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2322,6 +2335,16 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   postcss-import@15.1.0:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
@@ -3515,6 +3538,10 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
+
   '@poppinss/colors@4.1.6':
     dependencies:
       kleur: 4.1.5
@@ -4386,6 +4413,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -4788,6 +4818,14 @@ snapshots:
   pify@2.3.0: {}
 
   pirates@4.0.7: {}
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-import@15.1.0(postcss@8.5.23):
     dependencies:

--- a/pollis-core/src/commands/messages/send.rs
+++ b/pollis-core/src/commands/messages/send.rs
@@ -249,41 +249,76 @@ pub async fn send_message(
         }
     }
 
-    // @all mention: group messages don't raise OS notifications for every
-    // new message, but an explicit `@all` pings every group member's inbox so
-    // they get one. Per-user "notifications off" is enforced client-side in
+    // Mentions (#843). Group messages don't raise OS notifications for every
+    // new message, but a mention does — an explicit `@all` pings every group
+    // member's inbox, and an `@username` pings exactly the members named. Both
+    // resolve against THIS channel's roster, which the sender is already a
+    // member of, so a mention can never address (or probe for) someone outside
+    // the room. Per-user "notifications off" is enforced client-side in
     // notify.ts. Inbox publish (one per member) is fire-and-forget; failures
-    // are logged, never fatal to the send. Only meaningful for group channels.
-    if is_channel && mentions_all(&content) {
-        let member_ids: Vec<String> = {
+    // are logged, never fatal to the send. Only meaningful for group channels;
+    // a DM already notifies its recipient unconditionally.
+    let audience = if is_channel {
+        // `(user_id, username)` for every other member. LEFT JOIN so a member
+        // whose user row is missing still counts for `@all` — it just can't be
+        // named individually.
+        let members: Vec<(String, String)> = {
             let conn = state.remote_db.conn().await?;
             let mut rows = conn.query(
-                "SELECT user_id FROM group_member WHERE group_id = ?1 AND user_id <> ?2",
+                "SELECT gm.user_id, COALESCE(u.username, '')
+                 FROM group_member gm
+                 LEFT JOIN users u ON u.id = gm.user_id
+                 WHERE gm.group_id = ?1 AND gm.user_id <> ?2",
                 libsql::params![mls_group_id.clone(), sender_id.clone()],
             ).await?;
-            let mut ids = Vec::new();
+            let mut out = Vec::new();
             while let Some(row) = rows.next().await? {
-                ids.push(row.get::<String>(0)?);
+                out.push((row.get::<String>(0)?, row.get::<String>(1)?));
             }
-            ids
+            out
         };
-        let payload = serde_json::json!({
-            "type": "all_mention",
-            "group_id": mls_group_id,
-            "channel_id": conversation_id,
-            "sender_id": sender_id,
-            "sender_username": sender_username,
-        });
-        for uid in member_ids {
-            if let Err(e) = crate::commands::livekit::publish_to_user_inbox(
-                state,
-                &uid,
-                payload.clone(),
-            ).await {
-                eprintln!("[realtime] send_message: @all inbox publish to {uid}: {e}");
+        let audience = mention_audience(is_channel, &content, &members);
+
+        // `@all` keeps its exact existing payload and fanout — every member.
+        if mentions_all(&content) {
+            let payload = serde_json::json!({
+                "type": "all_mention",
+                "group_id": mls_group_id,
+                "channel_id": conversation_id,
+                "sender_id": sender_id,
+                "sender_username": sender_username,
+            });
+            for (uid, _) in &members {
+                if let Err(e) = crate::commands::livekit::publish_to_user_inbox(
+                    state,
+                    uid,
+                    payload.clone(),
+                ).await {
+                    eprintln!("[realtime] send_message: @all inbox publish to {uid}: {e}");
+                }
+            }
+        } else if let MentionAudience::Only(ref ids) = audience {
+            let payload = serde_json::json!({
+                "type": "user_mention",
+                "group_id": mls_group_id,
+                "channel_id": conversation_id,
+                "sender_id": sender_id,
+                "sender_username": sender_username,
+            });
+            for uid in ids {
+                if let Err(e) = crate::commands::livekit::publish_to_user_inbox(
+                    state,
+                    uid,
+                    payload.clone(),
+                ).await {
+                    eprintln!("[realtime] send_message: @mention inbox publish to {uid}: {e}");
+                }
             }
         }
-    }
+        audience
+    } else {
+        MentionAudience::Everyone
+    };
 
     // Content-free push to recipients' backgrounded/closed apps (#344).
     // Fire-and-forget: a push relay hiccup must never block or fail the send,
@@ -291,22 +326,32 @@ pub async fn send_message(
     // Desktop runs this too (its users just have no registered tokens), which
     // is what lets a desktop-sent message wake a recipient's phone.
     //
-    // Notification policy mirrors desktop: a DM always notifies its recipient,
-    // but a group channel message only notifies on an explicit `@all` (regular
-    // channel chatter would be far too noisy — desktop raises no per-message
-    // notification for it either; see the @all inbox-ping branch above).
-    let should_push = !is_channel || mentions_all(&content);
-    if should_push {
+    // Notification policy mirrors desktop and is driven by the SAME `audience`
+    // the inbox fanout above used, so the two can't drift: a DM always notifies
+    // its recipient, a channel `@all` notifies every member, a channel
+    // `@username` notifies exactly the members named, and ordinary channel
+    // chatter notifies nobody (it would be far too noisy — desktop raises no
+    // per-message notification for it either).
+    let push_only: Option<Vec<String>> = match audience {
+        MentionAudience::Everyone => Some(Vec::new()),
+        MentionAudience::Only(ids) => Some(ids),
+        MentionAudience::Nobody => None,
+    };
+    if let Some(only) = push_only {
         let state = Arc::clone(state);
         let conversation_id = conversation_id.clone();
         let mls_group_id = mls_group_id.clone();
         let sender_id = sender_id.clone();
         tokio::spawn(async move {
+            // An empty restriction means "every member", which is what
+            // `notify_new_message` does with `None`.
+            let restrict = if only.is_empty() { None } else { Some(only.as_slice()) };
             if let Err(e) = crate::commands::push::notify_new_message(
                 &conversation_id,
                 &mls_group_id,
                 is_channel,
                 &sender_id,
+                restrict,
                 &state,
             )
             .await
@@ -335,4 +380,214 @@ fn mentions_all(content: &str) -> bool {
         w.trim_end_matches(|c: char| !c.is_alphanumeric() && c != '@')
             .eq_ignore_ascii_case("@all")
     })
+}
+
+/// Characters that may appear INSIDE a username after the leading `@`. Kept
+/// deliberately wide (the `users.username` column has no charset constraint)
+/// but closed over the punctuation that normally ends a sentence, so
+/// "@dana." and "@dana," yield the token `dana`.
+fn is_mention_body_char(c: char) -> bool {
+    c.is_alphanumeric() || c == '_' || c == '-' || c == '.'
+}
+
+/// Extract the `@`-prefixed mention tokens from `content`, lowercased and
+/// stripped of the leading `@`.
+///
+/// A token only counts when the `@` starts the string or follows whitespace —
+/// that is what stops "email@allcorp" and "a@b.com" from reading as mentions,
+/// matching the spirit of `mentions_all()` above. Trailing `.`/`-`/`_` are
+/// trimmed so "@dana." mentions `dana`, and `@all` is deliberately excluded:
+/// it is the everyone-mention, handled by `mentions_all()`, never a username.
+///
+/// MIRROR: `mentionTokens()` in `frontend/src/utils/mentions.ts`. The two must
+/// agree or the composer will promise a ping the backend does not send.
+fn mention_tokens(content: &str) -> Vec<String> {
+    let chars: Vec<char> = content.chars().collect();
+    let mut tokens = Vec::new();
+    let mut i = 0;
+    while i < chars.len() {
+        if chars[i] != '@' {
+            i += 1;
+            continue;
+        }
+        // Only a string-initial or whitespace-preceded `@` opens a mention.
+        if i > 0 && !chars[i - 1].is_whitespace() {
+            i += 1;
+            continue;
+        }
+        let mut j = i + 1;
+        while j < chars.len() && is_mention_body_char(chars[j]) {
+            j += 1;
+        }
+        let token: String = chars[i + 1..j]
+            .iter()
+            .collect::<String>()
+            .trim_end_matches(['.', '-', '_'])
+            .to_lowercase();
+        if !token.is_empty() && token != "all" {
+            tokens.push(token);
+        }
+        i = j.max(i + 1);
+    }
+    tokens
+}
+
+/// Who should be woken for a message — i.e. who gets an inbox ping and a
+/// background push, over and above the unread badge every recipient gets.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum MentionAudience {
+    /// Everyone in the conversation except the sender. A DM (always personal)
+    /// or a channel `@all`.
+    Everyone,
+    /// Only these user ids — a channel message that names specific members by
+    /// `@username`. This is the case that lets a mention reach you in a
+    /// channel whose ordinary chatter is badge-only.
+    Only(Vec<String>),
+    /// Nobody — ordinary channel chatter. The accompanying `new_message`
+    /// event still bumps the unread badge.
+    Nobody,
+}
+
+/// Decide the wake-up audience for a message.
+///
+/// `members` is `(user_id, username)` for every OTHER member of the
+/// conversation — the caller reads it from the conversation the sender is
+/// already a member of, which is what keeps mentions from becoming a user
+/// directory: an `@name` that matches nobody in this room resolves to nothing
+/// and reveals nothing. Matching is case-insensitive, and the returned ids
+/// preserve `members` order with duplicates removed.
+pub(crate) fn mention_audience(
+    is_channel: bool,
+    content: &str,
+    members: &[(String, String)],
+) -> MentionAudience {
+    // A DM is personal by construction — every message notifies.
+    if !is_channel {
+        return MentionAudience::Everyone;
+    }
+    if mentions_all(content) {
+        return MentionAudience::Everyone;
+    }
+    let tokens = mention_tokens(content);
+    if tokens.is_empty() {
+        return MentionAudience::Nobody;
+    }
+    let mut ids: Vec<String> = Vec::new();
+    for (user_id, username) in members {
+        let uname = username.to_lowercase();
+        if !uname.is_empty() && tokens.iter().any(|t| *t == uname) && !ids.contains(user_id) {
+            ids.push(user_id.clone());
+        }
+    }
+    if ids.is_empty() {
+        MentionAudience::Nobody
+    } else {
+        MentionAudience::Only(ids)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn members() -> Vec<(String, String)> {
+        vec![
+            ("u_dana".to_string(), "dana".to_string()),
+            ("u_bob".to_string(), "Bob".to_string()),
+            ("u_ann".to_string(), "ann_marie".to_string()),
+        ]
+    }
+
+    // The invariant #843 exists to establish: naming someone in a CHANNEL
+    // wakes them, even though the same channel's ordinary chatter does not.
+    #[test]
+    fn per_user_mention_in_channel_targets_only_the_named_member() {
+        assert_eq!(
+            mention_audience(true, "can you look at this @dana", &members()),
+            MentionAudience::Only(vec!["u_dana".to_string()])
+        );
+    }
+
+    // The other half of the same invariant: a plain channel message wakes
+    // nobody. Regressing this turns every channel into a notification storm.
+    #[test]
+    fn plain_channel_message_wakes_nobody() {
+        assert_eq!(
+            mention_audience(true, "shipping the build now", &members()),
+            MentionAudience::Nobody
+        );
+    }
+
+    #[test]
+    fn mention_matching_is_case_insensitive_and_dedupes() {
+        assert_eq!(
+            mention_audience(true, "@BOB @bob ping", &members()),
+            MentionAudience::Only(vec!["u_bob".to_string()])
+        );
+    }
+
+    #[test]
+    fn multiple_mentions_preserve_member_order() {
+        assert_eq!(
+            mention_audience(true, "@bob and @dana", &members()),
+            MentionAudience::Only(vec!["u_dana".to_string(), "u_bob".to_string()])
+        );
+    }
+
+    // Trailing sentence punctuation must not swallow the mention.
+    #[test]
+    fn trailing_punctuation_is_trimmed() {
+        assert_eq!(
+            mention_audience(true, "thanks @dana.", &members()),
+            MentionAudience::Only(vec!["u_dana".to_string()])
+        );
+        assert_eq!(
+            mention_audience(true, "hey @ann_marie, look", &members()),
+            MentionAudience::Only(vec!["u_ann".to_string()])
+        );
+    }
+
+    // An `@name` nobody in this conversation answers to resolves to nothing.
+    // This is the no-leak property: mentions never reach outside the room.
+    #[test]
+    fn unknown_and_embedded_mentions_resolve_to_nobody() {
+        assert_eq!(
+            mention_audience(true, "@carol are you there", &members()),
+            MentionAudience::Nobody
+        );
+        assert_eq!(
+            mention_audience(true, "mail me at bob@dana.com", &members()),
+            MentionAudience::Nobody
+        );
+    }
+
+    // `@all` keeps its existing everyone-fanout, and never reads as a username.
+    #[test]
+    fn all_mention_still_means_everyone() {
+        assert_eq!(
+            mention_audience(true, "@all standup in 5", &members()),
+            MentionAudience::Everyone
+        );
+        assert_eq!(mention_tokens("@all standup"), Vec::<String>::new());
+    }
+
+    // A DM notifies its recipient whether or not anyone is named.
+    #[test]
+    fn dm_always_notifies_everyone() {
+        assert_eq!(
+            mention_audience(false, "hey", &members()),
+            MentionAudience::Everyone
+        );
+        assert_eq!(
+            mention_audience(false, "hey @dana", &members()),
+            MentionAudience::Everyone
+        );
+    }
+
+    #[test]
+    fn mention_tokens_ignores_bare_at_and_embedded_at() {
+        assert_eq!(mention_tokens("@ hello"), Vec::<String>::new());
+        assert_eq!(mention_tokens("user@example.com"), Vec::<String>::new());
+        assert_eq!(mention_tokens("hi @dana"), vec!["dana".to_string()]);
+    }
 }

--- a/pollis-core/src/commands/push.rs
+++ b/pollis-core/src/commands/push.rs
@@ -53,11 +53,19 @@ pub async fn register_push_token(
 /// effort: resolves recipients → their tokens → one batched Expo POST. Returns
 /// `Ok(())` (after logging) on any relay failure; callers spawn this so it
 /// never blocks or fails the send.
+///
+/// `only` narrows the recipients to a subset of the conversation's members —
+/// used by per-user `@username` mentions (#843), where a channel message must
+/// wake exactly the people named and nobody else. `None` means every member,
+/// the DM / `@all` behaviour. The subset is INTERSECTED with real membership
+/// rather than trusted directly, so it can only ever remove recipients: a
+/// caller cannot use it to push to someone outside the conversation.
 pub async fn notify_new_message(
     conversation_id: &str,
     mls_group_id: &str,
     is_channel: bool,
     sender_id: &str,
+    only: Option<&[String]>,
     state: &Arc<AppState>,
 ) -> Result<()> {
     let conn = state.remote_db.conn().await?;
@@ -85,6 +93,14 @@ pub async fn notify_new_message(
     while let Some(row) = rows.next().await? {
         user_ids.push(row.get::<String>(0)?);
     }
+
+    // Narrow to the named recipients when the caller asked for it. Applied as
+    // an intersection with the membership read above, so `only` can never
+    // widen the audience past the conversation.
+    if let Some(allowed) = only {
+        user_ids.retain(|u| allowed.contains(u));
+    }
+
     if user_ids.is_empty() {
         return Ok(());
     }


### PR DESCRIPTION
Closes #843.

Previously you could ping everyone (`@all`) or nobody, and the person addressed got no notification — channel messages only bump a badge. This adds per-person mentions.

### Composer, per skin — as specified
- **Terminal: no pop-over.** `MentionGhost.tsx` is an absolutely-positioned mirror of the textarea rendering the current value at `visibility:hidden` (which preserves layout exactly) followed by the dimmed completion, so the ghost lands precisely at the caret with no measurement. **Tab** accepts. Offered only when the caret is at end-of-line — the fish / zsh-autosuggestions idiom, not a workaround.
- **Refined: the Slack list.** `absolute bottom-full` inside the composer's own container, never a portal. Arrows move, Enter/Tab accept, Esc dismisses, hover tracks, matched prefix bolded, avatars, `scrollIntoView` on the active row.

### One function decides the audience
`mention_audience(is_channel, content, members) -> Everyone | Only(ids) | Nobody` drives **both** the inbox fanout and the push, so the two cannot drift — which is the bug this shape prevents. `notify_new_message` gained an `only` filter that **intersects** with real membership, so it can only ever remove recipients, never add one. `@all` keeps a byte-identical payload and fanout.

The new `user_mention` notification is deliberately louder than `all_mention` — it adds the status-bar alert naming the sender, because `@all` addresses a room and `@you` addresses you.

### No enumeration
The candidate pool is the roster you can already see, never a lookup — so mentions cannot be used to discover users outside your groups and DMs. An `@name` matching nobody is inert on both sides, asserted in Rust and in e2e.

### Tests — and these were actually run
- `cargo test -p pollis-core --lib messages::send` → **9 passed**, including `per_user_mention_in_channel_targets_only_the_named_member` and `plain_channel_message_wakes_nobody`.
- **Playwright: 8 passed (6.7s), screenshots in `e2e/artifacts/`** — ghost+Tab and absence-of-list in terminal, list+arrows+Enter/Tab/Esc in refined, self-vs-peer token styling in both, unresolvable mention inert in both.

### Incidental fix worth knowing about
The frontend's `VITE_PLAYWRIGHT=true` mock mode was **already broken** before this work: missing module exports failed the dep pre-bundle, several commands had been renamed (`get_channel_messages` → `read_channel_messages`), and `is_current_device_registered` returned `null`, which read as "device revoked" and dead-ended the app on the loading screen. Fixed in its own commit (`18961fbb`) and documented. That is why this PR has runnable UI tests and the sibling feature PRs do not — anyone writing a browser-mode spec should rebase on it.

### Cross-cutting
Applied #854's request for `save-button` + `copy-link-button` in both skin branches of `MessageItem.tsx`. One deliberate deviation: terminal uses its own local toolbar class rather than copying refined's, which would have rendered a permanently-visible, mis-sized button.