### PR TITLE
feat(messages): delivery and read receipts for DMs

### DIFF
--- a/.codesight/wiki/commands.md
+++ b/.codesight/wiki/commands.md
@@ -234,7 +234,7 @@ The mirror image of `overlay` (design §10.2, #813): `overlay` decides whether *
 
 ## Appendix A — full registered-command inventory (names only)
 
-Mechanically extracted from `tauri::generate_handler![…]` in `src-tauri/src/lib.rs` at `d13c906` on **2026-08-03** (#714), plus the two `relay_serving` commands added by #813. **175 commands.** (169 as of the #714 snapshot, plus the six `emoji` commands added by #848. NOTE for whoever merges the parallel feature branches: #849 also adds commands and bumped this same number independently — the merged total is 169 + 6 + #849's, not 175.) Grouped by the `commands::<module>::` path used at the registration site; **names only — no descriptions are given here because they were not verified.** A name in this list that has no prose above is real and callable; read its implementation in `pollis-core/src/commands/` before using it.
+Mechanically extracted from `tauri::generate_handler![…]` in `src-tauri/src/lib.rs` at `d13c906` on **2026-08-03** (#714), plus the two `relay_serving` commands added by #813, the six `emoji` commands added by #848, and the two `messages` receipt commands added by #857. **194 commands.** Grouped by the `commands::<module>::` path used at the registration site; **names only — no descriptions are given here because they were not verified.** A name in this list that has no prose above is real and callable; read its implementation in `pollis-core/src/commands/` before using it.
 
 Regenerate with:
 
@@ -280,12 +280,12 @@ _Back to [index.md](./index.md)_
 
 ## Complete registered-command index
 
-Generated from `src-tauri/src/lib.rs`'s `invoke_handler!` — **175 commands** in 26 shim modules.
+Generated from `src-tauri/src/lib.rs`'s `invoke_handler!` — **194 commands** in 27 shim modules.
 Prose above covers roughly half of these; this index covers all of them, so a name that
 appears here but not above is registered and real, just undocumented. Regenerate rather
 than hand-edit.
 
-**`(root)`** (3) — `hide_window`, `read_clipboard_files`, `read_clipboard_image_to_temp`
+**`(root)`** (4) — `hide_window`, `read_clipboard_files`, `read_clipboard_image_to_temp`, `write_clipboard_text`
 
 **`tray`** (4) — `tray_set_close_to_tray`, `tray_set_enabled`, `tray_set_unread`, `tray_set_voice_state`
 
@@ -327,7 +327,7 @@ than hand-edit.
 
 **`install_kind`** (1) — `detect_managed_install`
 
-**`voice`** (17) — `get_last_join_timings`, `get_voice_gate_state`, `join_voice_channel`, `leave_voice_channel`, `list_audio_devices`, `prepare_voice_connection`, `release_voice_ptt`, `set_remote_user_volume`, `set_voice_audio_processing`, `set_voice_input_device`, `set_voice_input_mode`, `set_voice_output_device`, `set_voice_ptt_held`, `subscribe_voice_events`, `toggle_voice_deafen`, `toggle_voice_mute`
+**`voice`** (16) — `get_last_join_timings`, `get_voice_gate_state`, `join_voice_channel`, `leave_voice_channel`, `list_audio_devices`, `prepare_voice_connection`, `release_voice_ptt`, `set_remote_user_volume`, `set_voice_audio_processing`, `set_voice_input_device`, `set_voice_input_mode`, `set_voice_output_device`, `set_voice_ptt_held`, `subscribe_voice_events`, `toggle_voice_deafen`, `toggle_voice_mute`
 
 **`voice_test`** (7) — `play_test_tone`, `record_and_play_back`, `set_mic_test_monitor`, `start_mic_test`, `stop_mic_test`, `stop_test_playback`, `subscribe_voice_test_events`
 

--- a/.codesight/wiki/testing.md
+++ b/.codesight/wiki/testing.md
@@ -592,6 +592,8 @@ pnpm --filter @pollis/e2e e2e:ui                             # all specs
 | `voice-controls.spec.ts` | Push-to-talk, deafen and the input-mode toggle — the four mic states drawn distinctly — in BOTH skins (#849) |
 
 `.spec.ts` is as welcome as `.spec.js`; one config matches both.
+| `bookmarks.spec.ts` | Saved messages + permalink jump/highlight in BOTH skins (#854) |
+| `receipts.spec.ts` | DM delivery/read indicators in BOTH skins — delivered vs read visually distinct, none in group channels, per-reader fractions in group DMs (#857) |
 
 Three things to know before writing one:
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -29,6 +29,8 @@ Both `.spec.js` and `.spec.ts` are picked up by the one config.
 | `emoji.spec.ts` | Custom emoji in BOTH skins: the picker mounts the real standard set (≥100 cells, not the old hardcoded eight), search narrows it, a pick splices in AT THE CARET rather than appending, and a `<:name:hash>` token renders as an image while a malformed one stays literal |
 | `invite-links.spec.ts` | Shareable invite links in BOTH skins: a created link is shown once with its bounds, copy puts exactly it on the clipboard, no list view can hand the token back, and revoking retires the row and takes its card away |
 | `voice-controls.spec.ts` | Push-to-talk + deafen in BOTH skins: the four `data-mic-state` values are drawn distinctly (push-to-talk-idle must not look muted), deafened is tellable from both, and the settings input-mode toggle reaches the preference and the gate |
+| `bookmarks.spec.ts` | Saved messages + `pollis://m/` permalinks in BOTH skins: the saved list, an evicted body admitting it honestly, channel/DM permalink jump-and-highlight, and an unresolvable permalink leaking nothing |
+| `receipts.spec.ts` | DM delivery/read receipts in BOTH skins: a delivered tick, a read tick, the two being visually distinct (different glyph AND different colour), a group channel showing none at all, and a multi-participant DM rendering "2/3" rather than a boolean |
 
 First run needs the browser once: `pnpm --filter @pollis/e2e exec playwright install chromium`.
 

--- a/e2e/SCENARIOS.md
+++ b/e2e/SCENARIOS.md
@@ -32,6 +32,7 @@ makes me that the flow already works. Status: ✅ covered by an existing script,
 | M-KICK | A kicks B from group, B loses access | 3 | 2 | ⬜ | |
 | M-LEAVE | B leaves group, A sees membership drop | 2 | 2 | ⬜ | |
 | M-CONV | DM request → accept → message (base) | 5 | 4 | ✅ | two-client.js |
+| M-RCPT | Receipts (#857): A sends, B decrypts while elsewhere → A sees **delivered**; B then opens the DM → A sees **read** | 4 | 2 | 🟡 | two-client-receipts.js. Asserts the intermediate `delivered` state *before* B ever looks, and fails fast if `read` appears early — that ordering is what proves the two signals are not conflated. Needs `ReceiptIndicator` wired into the message row (cross-cutting, owned by the #843 agent). |
 
 ## Single-user scenarios
 

--- a/e2e/receipts.spec.ts
+++ b/e2e/receipts.spec.ts
@@ -1,0 +1,323 @@
+/*
+ * DM delivery / read receipts (#857) — visual e2e.
+ *
+ * Runs against the browser-rendered frontend with the Tauri IPC mock
+ * (`frontend/src/__mocks__/tauri-core.ts`), whose `get_conversation_receipts`
+ * and `mark_messages_read` reimplement the semantics of
+ * `pollis-core/src/commands/messages/receipts.rs` — per message, per reader,
+ * and never acknowledging your own message.
+ *
+ * The specific failure this feature must avoid is conflating "delivered" with
+ * "read", so the distinctness test below asserts on what actually renders
+ * (icon geometry and computed colour), not on the state attribute — an
+ * attribute-only assertion would pass even if both states drew the same tick.
+ *
+ * Every test runs in BOTH skins.
+ *
+ *   pnpm --filter @pollis/e2e exec playwright test -c playwright.config.js
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+
+const USER = { id: "u-alice", email: "alice@example.com", username: "alice" };
+
+const GROUP_ID = "01HQ7Z3K9M2P5R8T1V4W6Y0GRP";
+const CHANNEL_ID = "01HQ7Z3K9M2P5R8T1V4W6Y0XCB";
+
+// 1:1 DM — alice + bob. One peer, so the tick carries no count.
+const DM_ID = "01HQ7Z3K9M2P5R8T1V4W6Y0DMX";
+const MSG_DELIVERED = "01HQ7Z3K9M2P5R8T1V4W6Y0DEL";
+const MSG_READ = "01HQ7Z3K9M2P5R8T1V4W6Y0RED";
+
+// Group DM — alice + bob + carol + dave. Three peers, so state is a fraction.
+const GROUP_DM_ID = "01HQ7Z3K9M2P5R8T1V4W6Y0GDM";
+const MSG_PARTIAL = "01HQ7Z3K9M2P5R8T1V4W6Y0PAR";
+const MSG_EVERYONE = "01HQ7Z3K9M2P5R8T1V4W6Y0EVR";
+
+// Alice's own message in a group CHANNEL. Authored by the viewer, and seeded
+// with receipts the Rust side could never produce — so if an indicator appears
+// here the DM-only rule is being enforced nowhere but in the query.
+const CHANNEL_MSG = "01HQ7Z3K9M2P5R8T1V4W6Y0CHM";
+
+const SKINS = ["terminal", "refined"] as const;
+type Skin = (typeof SKINS)[number];
+
+const permalink = (conversationId: string, messageId: string) =>
+  `pollis://m/${conversationId}/${messageId}`;
+
+function dmMember(userId: string, username: string) {
+  return { user_id: userId, username, added_by: USER.id, added_at: "" };
+}
+
+function ownMessage(conversationId: string, id: string, content: string, sentAt: string) {
+  return {
+    id,
+    conversation_id: conversationId,
+    sender_id: USER.id,
+    content,
+    sent_at: sentAt,
+  };
+}
+
+function preloadState(skin: Skin) {
+  return {
+    session: USER,
+    profile: { id: USER.id, username: USER.username },
+    preferences: JSON.stringify({ skin, send_read_receipts: true }),
+    groups: [
+      {
+        id: GROUP_ID,
+        name: "Acme",
+        owner_id: USER.id,
+        created_at: new Date().toISOString(),
+      },
+    ],
+    channels: {
+      [GROUP_ID]: [{ id: CHANNEL_ID, group_id: GROUP_ID, name: "general" }],
+    },
+    dmChannels: [
+      {
+        id: DM_ID,
+        created_by: USER.id,
+        created_at: new Date().toISOString(),
+        members: [dmMember(USER.id, "alice"), dmMember("u-bob", "bob")],
+      },
+      {
+        id: GROUP_DM_ID,
+        created_by: USER.id,
+        created_at: new Date().toISOString(),
+        members: [
+          dmMember(USER.id, "alice"),
+          dmMember("u-bob", "bob"),
+          dmMember("u-carol", "carol"),
+          dmMember("u-dave", "dave"),
+        ],
+      },
+    ],
+    messages: {
+      [CHANNEL_ID]: [
+        ownMessage(CHANNEL_ID, CHANNEL_MSG, "a channel message of mine", "2026-08-01T10:00:00.000Z"),
+      ],
+      [DM_ID]: [
+        ownMessage(DM_ID, MSG_DELIVERED, "this one only arrived", "2026-08-01T11:00:00.000Z"),
+        ownMessage(DM_ID, MSG_READ, "this one was actually read", "2026-08-01T11:01:00.000Z"),
+      ],
+      [GROUP_DM_ID]: [
+        ownMessage(GROUP_DM_ID, MSG_PARTIAL, "two of you have read this", "2026-08-01T12:00:00.000Z"),
+        ownMessage(GROUP_DM_ID, MSG_EVERYONE, "all three of you have read this", "2026-08-01T12:01:00.000Z"),
+      ],
+    },
+    receipts: {
+      [DM_ID]: [
+        // Delivered to bob, unread — the weaker of the two states.
+        { message_id: MSG_DELIVERED, delivered_by: ["u-bob"], read_by: [] },
+        // Read by bob. `read_by` is a subset of `delivered_by`, as the local
+        // schema's trigger guarantees.
+        { message_id: MSG_READ, delivered_by: ["u-bob"], read_by: ["u-bob"] },
+      ],
+      [GROUP_DM_ID]: [
+        {
+          message_id: MSG_PARTIAL,
+          delivered_by: ["u-bob", "u-carol", "u-dave"],
+          read_by: ["u-bob", "u-carol"],
+        },
+        {
+          message_id: MSG_EVERYONE,
+          delivered_by: ["u-bob", "u-carol", "u-dave"],
+          read_by: ["u-bob", "u-carol", "u-dave"],
+        },
+      ],
+      // Impossible in production; present to prove the UI gate is real.
+      [CHANNEL_ID]: [
+        { message_id: CHANNEL_MSG, delivered_by: ["u-bob", "u-carol"], read_by: ["u-bob"] },
+      ],
+    },
+  };
+}
+
+/*
+ * NOTE ON NAVIGATION: the router runs on `createMemoryHistory`, so the browser
+ * URL never changes and `page.goto("/dms/…")` would be meaningless. Every test
+ * navigates through the UI — here via a permalink pasted into Cmd+K, the same
+ * route `e2e/bookmarks.spec.ts` uses.
+ */
+async function boot(page: Page, skin: Skin) {
+  await page.addInitScript((preload) => {
+    (window as unknown as Record<string, unknown>).__POLLIS_PRELOAD__ = preload;
+    // `@tauri-apps/api/window` is NOT vite-aliased, so the real module runs and
+    // reads `__TAURI_INTERNALS__` directly. It must exist before any app module
+    // evaluates, hence addInitScript.
+    (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = {
+      metadata: {
+        currentWindow: { label: "main" },
+        currentWebview: { windowLabel: "main", label: "main" },
+      },
+      plugins: {},
+      transformCallback: () => 0,
+      convertFileSrc: (path: string) => path,
+      registerListener: () => {},
+      unregisterListener: () => {},
+      runCallback: () => {},
+      invoke: () => Promise.resolve(null),
+    };
+  }, preloadState(skin));
+  await page.goto("/");
+  await expect(page.getByTestId("sidebar")).toBeVisible();
+}
+
+async function openCommandPalette(page: Page) {
+  await page.keyboard.press(
+    process.platform === "darwin" ? "Meta+KeyK" : "Control+KeyK",
+  );
+  await expect(page.getByTestId("search-panel")).toBeVisible();
+}
+
+/** Jump to a conversation by pasting one of its message permalinks into Cmd+K. */
+async function gotoViaPermalink(page: Page, conversationId: string, messageId: string) {
+  await openCommandPalette(page);
+  await page.getByTestId("search-panel-input").fill(permalink(conversationId, messageId));
+  await expect(page.getByTestId(`message-${messageId}`)).toBeVisible();
+}
+
+/**
+ * What the indicator actually draws: its state, its rendered colour, how many
+ * strokes the tick is made of, and the text beside it.
+ *
+ * Icon geometry is the honest discriminator between `Check` and `CheckCheck` —
+ * lucide draws one path for a single tick and two for a double tick — so a
+ * regression that swapped the colours but kept one glyph would still be caught.
+ */
+async function indicatorShape(page: Page, messageId: string) {
+  return page.evaluate((id) => {
+    const el = document.querySelector(`[data-testid="receipt-${id}"]`);
+    if (!el) {
+      return null;
+    }
+    const svg = el.querySelector("svg");
+    return {
+      state: el.getAttribute("data-receipt-state"),
+      label: el.getAttribute("aria-label"),
+      color: getComputedStyle(el).color,
+      strokes: svg ? svg.querySelectorAll("path, polyline, line").length : 0,
+      text: (el.textContent ?? "").trim(),
+    };
+  }, messageId);
+}
+
+for (const skin of SKINS) {
+  test.describe(`DM receipts — ${skin} skin`, () => {
+    test("a delivered-but-unread message shows a single muted tick", async ({ page }) => {
+      await boot(page, skin);
+      await gotoViaPermalink(page, DM_ID, MSG_DELIVERED);
+
+      const indicator = page.getByTestId(`receipt-${MSG_DELIVERED}`);
+      await expect(indicator).toBeVisible();
+
+      const shape = await indicatorShape(page, MSG_DELIVERED);
+      expect(shape?.state).toBe("delivered");
+      expect(shape?.label).toBe("Delivered to 1 of 1");
+      // A single peer needs no fraction — "1/1" beside a tick is noise.
+      expect(shape?.text).toBe("");
+      expect(shape?.strokes).toBe(1);
+
+      await page
+        .getByTestId(`message-${MSG_DELIVERED}`)
+        .screenshot({ path: `artifacts/receipt-delivered-${skin}.png` });
+    });
+
+    test("a read message shows a double tick in the accent colour", async ({ page }) => {
+      await boot(page, skin);
+      await gotoViaPermalink(page, DM_ID, MSG_READ);
+
+      const indicator = page.getByTestId(`receipt-${MSG_READ}`);
+      await expect(indicator).toBeVisible();
+
+      const shape = await indicatorShape(page, MSG_READ);
+      expect(shape?.state).toBe("read-all");
+      expect(shape?.label).toBe("Read by everyone");
+      expect(shape?.strokes).toBe(2);
+
+      await page
+        .getByTestId(`message-${MSG_READ}`)
+        .screenshot({ path: `artifacts/receipt-read-${skin}.png` });
+    });
+
+    test("delivered and read are visually distinct, not just semantically", async ({
+      page,
+    }) => {
+      await boot(page, skin);
+      await gotoViaPermalink(page, DM_ID, MSG_DELIVERED);
+
+      // Both messages are in the same DM, so both indicators are on screen at
+      // once — exactly how a user would compare them.
+      const delivered = await indicatorShape(page, MSG_DELIVERED);
+      const read = await indicatorShape(page, MSG_READ);
+      expect(delivered).not.toBeNull();
+      expect(read).not.toBeNull();
+
+      // Two independent channels of difference. Either alone would be a weak
+      // signal — colour alone fails for a colour-blind user, glyph alone is
+      // easy to miss at 14px — so the feature must carry both.
+      expect(delivered!.strokes).not.toBe(read!.strokes);
+      expect(delivered!.color).not.toBe(read!.color);
+      // And the accessible name must not require the user to see either.
+      expect(delivered!.label).not.toBe(read!.label);
+
+      await page.screenshot({
+        path: `artifacts/receipt-delivered-vs-read-${skin}.png`,
+        fullPage: true,
+      });
+    });
+
+    test("a group channel message shows no indicator at all", async ({ page }) => {
+      await boot(page, skin);
+      await openCommandPalette(page);
+      await page.getByTestId("search-panel-input").fill("general");
+      await page.keyboard.press("Enter");
+
+      const row = page.getByTestId(`message-${CHANNEL_MSG}`);
+      await expect(row).toBeVisible();
+
+      // The message is the viewer's own AND has seeded receipts, so isOwn and
+      // "receipts exist" are both true — the DM-only rule is the only thing
+      // that can be suppressing this.
+      await expect(page.getByTestId(`receipt-${CHANNEL_MSG}`)).toHaveCount(0);
+      await expect(row.locator('[data-receipt-state]')).toHaveCount(0);
+
+      await page.screenshot({
+        path: `artifacts/receipt-channel-none-${skin}.png`,
+        fullPage: true,
+      });
+    });
+
+    test("a multi-participant DM renders per-reader state, not a boolean", async ({
+      page,
+    }) => {
+      await boot(page, skin);
+      await gotoViaPermalink(page, GROUP_DM_ID, MSG_PARTIAL);
+
+      // Two of three peers have read it. A single boolean tick could only say
+      // "read" or "not read"; both would misrepresent three people.
+      const partial = await indicatorShape(page, MSG_PARTIAL);
+      expect(partial?.state).toBe("read-some");
+      expect(partial?.text).toBe("2/3");
+      expect(partial?.label).toBe("Read by 2 of 3");
+
+      // The all-read case in the same conversation reads differently, which is
+      // what proves the fraction is derived from the reader set rather than
+      // being decorative.
+      const everyone = await indicatorShape(page, MSG_EVERYONE);
+      expect(everyone?.state).toBe("read-all");
+      expect(everyone?.text).toBe("3/3");
+      expect(everyone?.label).toBe("Read by everyone");
+
+      // Partial is not dressed up as complete.
+      expect(partial?.color).not.toBe(everyone?.color);
+
+      await page.screenshot({
+        path: `artifacts/receipt-group-dm-${skin}.png`,
+        fullPage: true,
+      });
+    });
+  });
+}

--- a/e2e/two-client-receipts.js
+++ b/e2e/two-client-receipts.js
@@ -1,0 +1,335 @@
+#!/usr/bin/env node
+/*
+ * Two-client DM DELIVERY + READ RECEIPTS E2E (issue #857).
+ *
+ * Modelled on two-client-dm-reply.js — same isolation and backend assumptions
+ * (two isolated app instances, one shared external backend from
+ * start-backend.sh, one Vite server).
+ *
+ * What this proves that the Rust tests cannot: that the two receipt signals
+ * actually travel between two real clients over a real Delivery Service, and
+ * that they land on screen for the SENDER as distinct visual states.
+ *
+ * Choreography:
+ *   1. A + B sign up; A DMs B by email; B accepts the request.
+ *   2. A sends a message and B is left on a DIFFERENT screen (Home). B's
+ *      background ingest fetches and decrypts the envelope, so B emits a
+ *      DELIVERED receipt — but B has not looked at the message.
+ *   3. A's row for that message reaches `data-receipt-state="delivered"`.
+ *      Asserting the intermediate state is the point: it is what shows the two
+ *      signals are genuinely separate, rather than "read" being emitted the
+ *      moment anything is decrypted.
+ *   4. B opens the DM, so the message is on screen in a focused window and B's
+ *      dwell timer elapses. B emits a READ receipt.
+ *   5. A's row advances to `data-receipt-state="read-all"`.
+ *
+ * The step-3 assertion is deliberately ordered BEFORE step 4: if the two
+ * signals were conflated, the row would jump straight to a read state and the
+ * delivered wait would time out.
+ *
+ * ── PREREQUISITE (cross-cutting, see scratchpad/FEAT-COORDINATION.md) ────────
+ * The `ReceiptIndicator` component (frontend/src/components/Message/
+ * ReceiptIndicator.tsx) must be rendered inside the message row. MessageItem.tsx
+ * is owned by the #843 agent, so that one-line wiring is applied by the lead at
+ * integration. Until it is, this scenario fails at the step-3 wait — which is
+ * the correct, honest failure: there is no indicator on screen to verify.
+ *
+ * On failure, dumps per-client A-FAIL.* / B-FAIL.* into e2e/artifacts/.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const h = require("./lib/harness");
+
+const ARTIFACTS = path.join(__dirname, "artifacts");
+const shot = h.makeShot(ARTIFACTS);
+
+const PIN = "1357";
+const REQUEST_TIMEOUT_MS = 120_000;
+const MESSAGE_TIMEOUT_MS = 180_000;
+const RECEIPT_TIMEOUT_MS = 180_000;
+
+function appEnvFor(devEnv, turso, deliveryUrl, dataDir) {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  fs.mkdirSync(dataDir, { recursive: true });
+  return {
+    ...devEnv, ...process.env,
+    TURSO_URL: turso.TURSO_URL, TURSO_TOKEN: turso.TURSO_TOKEN,
+    POLLIS_DELIVERY_URL: deliveryUrl,
+    POLLIS_DATA_DIR: dataDir,
+    LOG_DB_URL: "", LOG_DB_TOKEN: "", LOG_DB_ADMIN_TOKEN: "",
+    WEBKIT_DISABLE_COMPOSITING_MODE: "1", GDK_BACKEND: "x11",
+  };
+}
+
+async function signUp(browser, email, tag) {
+  console.log(`[receipts] ${tag}: signing up ${email}`);
+  await h.waitTestId(browser, "auth-screen", 30000);
+  await h.setTestIdValue(browser, "email-input", email);
+  await h.clickTestId(browser, "send-otp-button");
+  await h.waitTestId(browser, "otp-form-container", 20000);
+  await h.typeCode(browser, "000000");
+  await h.waitTestId(browser, "save-secret-key-warning-screen", 45000);
+  await h.clickTestId(browser, "save-secret-key-acknowledge-button");
+  await h.waitTestId(browser, "save-secret-key-screen");
+  const secretKey = (await (await browser.$('[data-testid="secret-key-display"]')).getText()).trim();
+  if (!secretKey) {
+    throw new Error(`${tag}: secret key display was empty`);
+  }
+  await h.clickTestId(browser, "secret-key-saved-button");
+  await h.waitTestId(browser, "save-secret-key-confirm-screen");
+  await h.setTestIdValue(browser, "secret-key-confirm-input", secretKey);
+  await h.clickTestId(browser, "confirm-secret-key-button");
+  await h.waitTestId(browser, "pin-create-screen");
+  await h.typeCode(browser, PIN);
+  await h.typeCode(browser, PIN);
+  await h.waitTestId(browser, "app-ready", 60000);
+  console.log(`[receipts] ${tag}: reached app-ready`);
+}
+
+async function startDmTo(browser, targetEmail) {
+  await h.clickTestId(browser, "sidebar-row-dms");
+  await h.clickTestId(browser, "menu-item-new-dm");
+  await h.waitTestId(browser, "start-dm-page", 20000);
+  await h.setSelectorValue(browser, "#dm-identifier", targetEmail);
+  await h.clickTestId(browser, "start-dm-submit-button");
+  await h.waitTestId(browser, "message-form", 30000);
+}
+
+async function acceptIncomingDm(browser, timeoutMs) {
+  const end = Date.now() + timeoutMs;
+  let attempt = 0;
+  while (Date.now() < end) {
+    attempt++;
+    await h.clickTestId(browser, "sidebar-row-account").catch(() => {});
+    await h.sleep(500);
+    await h.clickTestId(browser, "sidebar-row-dms");
+    await h.sleep(1500);
+    if (await h.presentSelector(browser, '[data-testid="menu-item-dm-requests"]')) {
+      await h.clickTestId(browser, "menu-item-dm-requests");
+      await h.waitTestId(browser, "requests-page", 15000);
+      await h.waitSelector(browser, '[data-testid^="accept-request-"]', 15000, "a DM request accept button");
+      await h.clickSelector(browser, '[data-testid^="accept-request-"]');
+      await h.waitTestId(browser, "message-form", 30000);
+      return;
+    }
+    const remaining = end - Date.now();
+    console.log(`[receipts] B: no DM request yet (attempt ${attempt}), waiting…`);
+    await h.sleep(Math.min(remaining > 0 ? remaining : 0, attempt === 1 ? 4000 : 32000));
+  }
+  throw new Error("B: DM request never appeared");
+}
+
+async function messageVisible(browser, token) {
+  return browser.execute((tok) => {
+    const nodes = document.querySelectorAll('[data-testid="message-content"]');
+    for (const n of nodes) {
+      if ((n.textContent || "").includes(tok)) { return true; }
+    }
+    return false;
+  }, token);
+}
+
+// Open the (only) DM conversation on this client — Home -> DMs -> first option.
+async function openDm(browser) {
+  await h.clickTestId(browser, "sidebar-row-dms").catch(() => {});
+  await h.sleep(1000);
+  if (await h.presentSelector(browser, '[data-testid^="dm-option-"]')) {
+    await h.clickSelector(browser, '[data-testid^="dm-option-"]');
+    await h.waitTestId(browser, "message-form", 15000).catch(() => {});
+  }
+}
+
+// Park B somewhere that is NOT the conversation, so its background ingest still
+// runs (producing a DELIVERED receipt) while no message is ever on screen. This
+// is what separates the two signals in this test.
+async function leaveDm(browser) {
+  await h.clickTestId(browser, "sidebar-row-account").catch(() => {});
+  await h.sleep(500);
+}
+
+async function sendMessage(browser, text) {
+  await h.setTestIdValue(browser, "message-input", text);
+  await h.clickTestId(browser, "message-send-button");
+}
+
+// Poll until `token` renders, re-opening the DM each round to re-fire the
+// 5s-debounced ingest_dm_envelopes pull.
+async function waitForMessage(browser, token, timeoutMs) {
+  const end = Date.now() + timeoutMs;
+  while (Date.now() < end) {
+    if (await messageVisible(browser, token)) {
+      return;
+    }
+    await openDm(browser);
+    await h.sleep(6000);
+  }
+  throw new Error(`message "${token}" never converged`);
+}
+
+// The receipt state currently rendered on the row whose body contains `token`.
+// Returns null when the message is not on screen or carries no indicator.
+async function receiptState(browser, token) {
+  return browser.execute((tok) => {
+    const rows = document.querySelectorAll('[data-testid^="message-"]');
+    for (const row of rows) {
+      if (!(row.textContent || "").includes(tok)) { continue; }
+      const badge = row.querySelector("[data-receipt-state]");
+      return badge ? badge.getAttribute("data-receipt-state") : null;
+    }
+    return null;
+  }, token);
+}
+
+// Wait until A's row for `token` shows one of `wanted`. `forbidden` states fail
+// fast: that is how "delivered must not silently mean read" is enforced rather
+// than merely hoped for.
+async function waitForReceiptState(browser, token, wanted, forbidden, timeoutMs) {
+  const end = Date.now() + timeoutMs;
+  let last = null;
+  while (Date.now() < end) {
+    const state = await receiptState(browser, token);
+    if (state !== last) {
+      console.log(`[receipts] A: receipt state for "${token}" is now ${state}`);
+      last = state;
+    }
+    if (state && forbidden.includes(state)) {
+      throw new Error(
+        `receipt state "${state}" appeared while waiting for ${wanted.join("/")} — ` +
+        `delivered and read must be distinct signals`,
+      );
+    }
+    if (state && wanted.includes(state)) {
+      return state;
+    }
+    // Re-open A's DM to re-fire its debounced ingest, which is what pulls B's
+    // receipt envelope in.
+    await openDm(browser);
+    await h.sleep(5000);
+  }
+  throw new Error(
+    `receipt state never reached ${wanted.join("/")} for "${token}" (last saw: ${last})`,
+  );
+}
+
+async function main() {
+  h.reap();
+  const devEnv = h.readEnvFile(".env.development");
+  const turso = h.tursoEnv();
+  const deliveryUrl = process.env.POLLIS_DELIVERY_URL;
+  if (!deliveryUrl) {
+    throw new Error("POLLIS_DELIVERY_URL is not set — run e2e/scripts/start-backend.sh first.");
+  }
+
+  const children = [];
+  const clients = [];
+  const stop = (c) => { try { c && c.kill("SIGKILL"); } catch (_) {} };
+
+  const vite = h.spawnVite(devEnv);
+  children.push(vite);
+
+  const stamp = Date.now();
+  const emailA = `e2e_rcpt_a_${stamp}@pollis.test`;
+  const emailB = `e2e_rcpt_b_${stamp}@pollis.test`;
+  const token = `rcpt-${stamp}`;
+
+  let code = 1;
+  let A;
+  let B;
+  try {
+    await h.waitViteReady();
+    console.log(`[receipts] using external delivery service at ${deliveryUrl}`);
+
+    A = await h.startClient({
+      index: 0, label: "A",
+      appEnv: appEnvFor(devEnv, turso, deliveryUrl, path.join(__dirname, ".tmp-data-rcpt-a")),
+    });
+    clients.push(A);
+    B = await h.startClient({
+      index: 1, label: "B",
+      appEnv: appEnvFor(devEnv, turso, deliveryUrl, path.join(__dirname, ".tmp-data-rcpt-b")),
+    });
+    clients.push(B);
+
+    await signUp(A.browser, emailA, "A");
+    await signUp(B.browser, emailB, "B");
+
+    console.log(`[receipts] A: starting DM to ${emailB}`);
+    await startDmTo(A.browser, emailB);
+    console.log("[receipts] B: accepting the DM request…");
+    await acceptIncomingDm(B.browser, REQUEST_TIMEOUT_MS);
+
+    // B goes elsewhere BEFORE the message is sent, so nothing B does can be
+    // mistaken for reading it.
+    console.log("[receipts] B: leaving the DM so the message is never on screen");
+    await leaveDm(B.browser);
+
+    console.log(`[receipts] A: sending the message (${token})`);
+    await openDm(A.browser);
+    await sendMessage(A.browser, `receipt probe ${token}`);
+    await waitForMessage(A.browser, token, 30000);
+
+    // Step 3 — DELIVERED, and explicitly NOT read. B's device fetched and
+    // decrypted the envelope in the background; no human saw it.
+    console.log("[receipts] A: waiting for the DELIVERED tick (B must not have read it)");
+    await waitForReceiptState(
+      A.browser,
+      token,
+      ["delivered"],
+      ["read-all"],
+      RECEIPT_TIMEOUT_MS,
+    );
+    console.log("[receipts] delivered receipt converged (B decrypted, B did not read)");
+    await shot(A.browser, "receipts-A-delivered.png");
+
+    // Step 4 — B actually looks at the conversation.
+    console.log("[receipts] B: opening the DM and dwelling on the message");
+    await openDm(B.browser);
+    await waitForMessage(B.browser, token, MESSAGE_TIMEOUT_MS);
+    // Comfortably past the hook's DWELL_MS so the read receipt is emitted.
+    await h.sleep(5000);
+
+    // Step 5 — READ.
+    console.log("[receipts] A: waiting for the READ tick");
+    await waitForReceiptState(A.browser, token, ["read-all"], [], RECEIPT_TIMEOUT_MS);
+    console.log(`[receipts] SUCCESS: delivered -> read converged for "${token}"`);
+    await shot(A.browser, "receipts-A-read.png");
+    code = 0;
+  } catch (err) {
+    console.error("[receipts] FAILED:", err.message);
+    if (A && A.browser) {
+      await dumpClient(A.browser, "A");
+    }
+    if (B && B.browser) {
+      await dumpClient(B.browser, "B");
+    }
+  } finally {
+    for (const c of clients) {
+      if (c && c.browser) {
+        await c.browser.deleteSession().catch(() => {});
+      }
+    }
+    for (const c of clients) {
+      stop(c && c.tauriDriver);
+    }
+    for (const c of children) {
+      stop(c);
+    }
+    h.reap();
+  }
+  process.exit(code);
+}
+
+async function dumpClient(browser, tag) {
+  await shot(browser, `${tag}-FAIL.png`).catch(() => {});
+  const src = await browser.getPageSource().catch(() => "");
+  fs.mkdirSync(ARTIFACTS, { recursive: true });
+  fs.writeFileSync(path.join(ARTIFACTS, `${tag}-FAIL.html`), src);
+  const ids = [...src.matchAll(/data-testid="([^"]+)"/g)].map((m) => m[1]);
+  console.error(`[receipts] ${tag} on-screen testids:`, [...new Set(ids)].join(", "));
+}
+
+main().catch((err) => {
+  console.error("[receipts] fatal:", err);
+  process.exit(1);
+});

--- a/frontend/src/__mocks__/tauri-core.ts
+++ b/frontend/src/__mocks__/tauri-core.ts
@@ -115,6 +115,16 @@ interface MockVoiceGate {
   muted_before_deafen: boolean;
 }
 
+/** Mirrors `MessageReceipts` in `pollis-core/src/commands/messages/receipts.rs`.
+ *  Both sides are lists of user ids, never booleans — that is the whole point
+ *  of the per-reader store, and a mock that collapsed them to a flag could not
+ *  reproduce the multi-participant DM case. */
+interface MockReceipt {
+  message_id: string;
+  delivered_by: string[];
+  read_by: string[];
+}
+
 interface MockStore {
   session: MockUser | null;
   profile: MockProfile | null;
@@ -135,6 +145,10 @@ interface MockStore {
   inviteLinks: MockInviteLink[];
   // Local voice gate (#849). Rust owns this in production.
   voiceGate: MockVoiceGate;
+  // Delivery / read receipts (#857), keyed by conversation id. DM-only in
+  // production — a preload that puts receipts under a channel id is modelling
+  // something the Rust side cannot produce, so the UI must still show nothing.
+  receipts: Record<string, MockReceipt[]>;
   // Held decoded. `get_preferences` is the only thing that serializes it, and
   // preloads may write either shape (see `readPreferences`).
   preferences: Record<string, unknown>;
@@ -200,6 +214,7 @@ const store: MockStore = {
     ptt_held: false,
     muted_before_deafen: false,
   },
+  receipts: preload.receipts ?? {},
   // Lets a test drive the skin: `{ skin: 'refined' }` or its JSON string.
   preferences: readPreferences(preload.preferences),
   clipboard: '',
@@ -791,6 +806,52 @@ function handleCommand(command: string, args: Record<string, unknown>): unknown 
     case 'play_test_tone':
     case 'stop_test_playback':
       return null;
+
+    case 'get_conversation_receipts': {
+      const { conversationId } = args as { conversationId?: string };
+      if (!conversationId) {
+        return [];
+      }
+      return store.receipts[conversationId] ?? [];
+    }
+
+    case 'mark_messages_read': {
+      // Mirrors `receipts::mark_messages_read`: the local reader is added to
+      // `read_by`, and to `delivered_by` too if it was somehow missing — the
+      // real schema has a trigger making "read without delivered" impossible,
+      // so the mock must not be able to represent it either.
+      const { conversationId, userId, messageIds } = args as {
+        conversationId?: string;
+        userId?: string;
+        messageIds?: string[];
+      };
+      if (!conversationId || !userId) {
+        return null;
+      }
+      const list = (store.receipts[conversationId] ??= []);
+      for (const messageId of messageIds ?? []) {
+        // You never acknowledge your own message — `mark_messages_read` in
+        // receipts.rs drops any id whose sender is the acking user. Without
+        // this the viewer's own id lands in `read_by` and a 1:1 DM would
+        // render "read" purely from the sender having looked at the screen.
+        const target = findMessage(messageId);
+        if (!target || target.sender_id === userId) {
+          continue;
+        }
+        let entry = list.find((r) => r.message_id === messageId);
+        if (!entry) {
+          entry = { message_id: messageId, delivered_by: [], read_by: [] };
+          list.push(entry);
+        }
+        if (!entry.delivered_by.includes(userId)) {
+          entry.delivered_by.push(userId);
+        }
+        if (!entry.read_by.includes(userId)) {
+          entry.read_by.push(userId);
+        }
+      }
+      return null;
+    }
 
     case 'write_clipboard_text': {
       const { text } = args as { text: string };

--- a/frontend/src/components/Message/MessageItem.tsx
+++ b/frontend/src/components/Message/MessageItem.tsx
@@ -10,7 +10,8 @@ import { getUsernameColor, useBackgroundIsLight } from "../../utils/usernameColo
 import { useSkin } from "../../hooks/queries/usePreferences";
 import { AttachmentDisplay } from "./AttachmentDisplay";
 import { MessageAvatar } from "./MessageAvatar";
-import type { Message } from "../../types";
+import { ReceiptIndicator } from "./ReceiptIndicator";
+import type { Message, MessageReceipts } from "../../types";
 
 interface MessageItemProps {
   message: Message;
@@ -40,6 +41,13 @@ interface MessageItemProps {
   isSaved?: boolean;
   onPin?: (messageId: string) => void;
   onScrollToReply?: (messageId: string) => void;
+  /** Delivery / read receipts (#857). All optional — when the parent doesn't
+   * pass them no indicator renders. Wired from `MessageList`; receipts exist
+   * for DMs only, so `isDm` gates the whole affordance. */
+  receipts?: Map<string, MessageReceipts>;
+  /** DM members excluding the viewer — drives the "2/4" multi-reader summary. */
+  peerCount?: number;
+  isDm?: boolean;
 }
 
 // `created_at` arrives as unix seconds or milliseconds depending on source;
@@ -63,6 +71,9 @@ export const MessageItem: React.FC<MessageItemProps> = observer(({
   onCopyLink,
   isSaved = false,
   onScrollToReply,
+  receipts,
+  peerCount = 0,
+  isDm = false,
 }) => {
   const { currentUser } = appStore;
   const isOwn = message.sender_id === currentUser?.id;
@@ -239,6 +250,11 @@ export const MessageItem: React.FC<MessageItemProps> = observer(({
                 [{message.status}]
               </span>
             )}
+            <ReceiptIndicator
+              receipts={receipts?.get(message.id)}
+              peerCount={peerCount}
+              visible={isOwn && isDm}
+            />
           </div>
 
           {/* Inline previews for media URLs typed in the message body */}
@@ -425,6 +441,11 @@ export const MessageItem: React.FC<MessageItemProps> = observer(({
               [{message.status}]
             </span>
           )}
+          <ReceiptIndicator
+            receipts={receipts?.get(message.id)}
+            peerCount={peerCount}
+            visible={isOwn && isDm}
+          />
         </span>
 
         {/* Action buttons — only visible on hover */}

--- a/frontend/src/components/Message/MessageList.tsx
+++ b/frontend/src/components/Message/MessageList.tsx
@@ -13,6 +13,9 @@ import {
 } from "../../hooks/queries/useBookmarks";
 import { useMessagePermalink } from "../../hooks/useMessagePermalink";
 import { messageJumpStore } from "../../stores/messageJumpStore";
+import { useConversationReceipts } from "../../hooks/queries/useReceipts";
+import { useDMConversations } from "../../hooks/queries/useMessages";
+import { appStore } from "../../stores/appStore";
 import type { Message } from "../../types";
 
 // How long the permalink jump highlight stays on the target row.
@@ -187,6 +190,26 @@ export const MessageList: React.FC<MessageListProps> = observer(({
   const rosterBanners =
     (conversationId ? rosterChangeStore.byConversation[conversationId] : undefined) ?? [];
   const { data: groupMembers = [] } = useGroupMembers(groupIdForNames ?? null);
+
+  // Delivery / read receipts (#857). Queried ONCE here for the whole list and
+  // passed down by message id — a per-row query would be one IPC call per
+  // rendered message. Receipts are a DM-only product decision, so a group
+  // channel (which always has a selected channel id) never runs this query and
+  // never renders an indicator.
+  const selectedChannelId = appStore.selectedChannelId;
+  const selectedConversationId = appStore.selectedConversationId;
+  const isDm = !selectedChannelId && !!selectedConversationId;
+  const { receipts } = useConversationReceipts(isDm ? selectedConversationId : null);
+  const { data: dmConversations = [] } = useDMConversations();
+  // Other members only — the viewer never acknowledges their own message, so a
+  // 3-person DM reads "2/2" when both peers have read it, never "2/3".
+  const peerCount = useMemo(() => {
+    if (!isDm) {
+      return 0;
+    }
+    const conv = dmConversations.find((c) => c.id === selectedConversationId);
+    return Math.max((conv?.member_count ?? 2) - 1, 1);
+  }, [isDm, dmConversations, selectedConversationId]);
   const usernameByUserId = useMemo(() => {
     const map = new Map<string, string>();
     for (const m of groupMembers) {
@@ -457,6 +480,9 @@ export const MessageList: React.FC<MessageListProps> = observer(({
             isSaved={savedMessageIds.has(message.id)}
             onToggleSave={handleToggleSave}
             onCopyLink={handleCopyLink}
+            receipts={receipts}
+            peerCount={peerCount}
+            isDm={isDm}
           />
         );
 

--- a/frontend/src/components/Message/ReceiptIndicator.tsx
+++ b/frontend/src/components/Message/ReceiptIndicator.tsx
@@ -1,0 +1,79 @@
+/**
+ * The delivery / read tick on your own DM messages (#857).
+ *
+ * Renders nothing at all unless there is something true to say, so a group
+ * channel, a message nobody has fetched yet, and a conversation where receipts
+ * are switched off all look identical — empty. That matters: an indicator that
+ * renders a "not delivered" state would leak the difference between "receipts
+ * are off" and "they haven't read it".
+ *
+ * Multi-participant DMs are the general case, not an afterthought. With more
+ * than one other member the tick is accompanied by a count ("2/4"), because a
+ * single check mark cannot honestly summarise five people. A 1:1 DM is the
+ * degenerate case and shows the bare tick.
+ */
+import { Check, CheckCheck } from "lucide-react";
+import type { MessageReceipts } from "../../types";
+
+interface ReceiptIndicatorProps {
+  /** This message's receipts, or undefined when none have arrived. */
+  receipts?: MessageReceipts;
+  /**
+   * How many OTHER members are in this DM. Drives the "2/4" summary and, when
+   * it is 1, suppresses the count entirely.
+   */
+  peerCount: number;
+  /**
+   * False for group channels and for a viewer who is not the message's author —
+   * receipts are shown only to the person who sent the message.
+   */
+  visible: boolean;
+}
+
+export function ReceiptIndicator({ receipts, peerCount, visible }: ReceiptIndicatorProps) {
+  if (!visible || !receipts || peerCount < 1) {
+    return null;
+  }
+
+  const readCount = receipts.read_by.length;
+  const deliveredCount = receipts.delivered_by.length;
+  if (deliveredCount === 0) {
+    return null;
+  }
+
+  // Read wins over delivered: the schema guarantees a reader who has read has
+  // also received, so "everyone read it" is the strongest true statement.
+  const allRead = readCount >= peerCount;
+  const anyRead = readCount > 0;
+
+  const label = allRead
+    ? "Read by everyone"
+    : anyRead
+      ? `Read by ${readCount} of ${peerCount}`
+      : `Delivered to ${deliveredCount} of ${peerCount}`;
+
+  // Accent only once EVERY peer has read it; a partial read stays muted so the
+  // strong colour keeps meaning one specific thing.
+  const tone = allRead ? "text-accent" : "text-muted";
+
+  return (
+    <span
+      className={`ml-1 inline-flex items-center gap-0.5 align-middle ${tone}`}
+      title={label}
+      aria-label={label}
+      data-testid={`receipt-${receipts.message_id}`}
+      data-receipt-state={allRead ? "read-all" : anyRead ? "read-some" : "delivered"}
+    >
+      {anyRead ? (
+        <CheckCheck className="h-3.5 w-3.5" aria-hidden="true" />
+      ) : (
+        <Check className="h-3.5 w-3.5" aria-hidden="true" />
+      )}
+      {peerCount > 1 && (
+        <span className="font-machine text-xs">
+          {anyRead ? readCount : deliveredCount}/{peerCount}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/frontend/src/hooks/queries/index.ts
+++ b/frontend/src/hooks/queries/index.ts
@@ -8,6 +8,7 @@ export * from "./useMessages";
 export * from "./useSearchMessages";
 export * from "./useReactions";
 export * from "./useEmoji";
+export * from "./useReceipts";
 export * from "./useBlocks";
 export * from "./useTransparency";
 export * from "./useMessageRetention";

--- a/frontend/src/hooks/queries/useMessages.ts
+++ b/frontend/src/hooks/queries/useMessages.ts
@@ -368,6 +368,7 @@ export function useDMConversations() {
           user2_identifier: other?.username || other?.user_id || 'Unknown',
           user2_id: other?.user_id,
           user2_avatar_url: other?.avatar_url,
+          member_count: c.members.length,
           created_at: new Date(c.created_at).getTime(),
           updated_at: new Date(c.created_at).getTime(),
         };

--- a/frontend/src/hooks/queries/usePreferences.ts
+++ b/frontend/src/hooks/queries/usePreferences.ts
@@ -61,6 +61,25 @@ export interface PreferencesData {
   font_size?: string;
   allow_desktop_notifications?: boolean;
   allow_sound_effects?: boolean;
+  /**
+   * Delivery + read receipts in DMs (#857). Default **true**.
+   *
+   * **Reciprocal**, and deliberately so: while this is off the device emits no
+   * receipts of either kind AND records none, so you cannot see other people's
+   * either. It covers delivery as well as read because a delivery receipt is
+   * still a client-emitted "my device was online and fetched at time T" signal,
+   * which is exactly what a user declining receipts is declining.
+   *
+   * Enforced in Rust at `pollis-core/src/commands/messages/receipts.rs`
+   * (`emit_receipt` / `record_receipt`), never only in the UI. Synced through
+   * the preferences blob rather than kept device-local, because a privacy
+   * switch that silently fails to apply on your other laptop is a broken
+   * privacy switch.
+   *
+   * Group channels have no receipts at all, so this preference does not apply
+   * there.
+   */
+  send_read_receipts?: boolean;
   /** Pre-AGC mic boost in dB. 0..=20; 0 = off. */
   mic_boost_db?: number;
   auto_gain_control?: boolean;
@@ -353,6 +372,7 @@ export function usePreferences() {
         font_size: getPreference<string | undefined>(json, "font_size", undefined),
         allow_desktop_notifications: getPreference<boolean>(json, "allow_desktop_notifications", false),
         allow_sound_effects: getPreference<boolean>(json, "allow_sound_effects", true),
+        send_read_receipts: getPreference<boolean>(json, "send_read_receipts", true),
         mic_boost_db: getPreference<number>(json, "mic_boost_db", APM_DEFAULTS.mic_boost_db),
         auto_gain_control: getPreference<boolean>(json, "auto_gain_control", APM_DEFAULTS.auto_gain_control),
         agc_target_dbfs: getPreference<number>(json, "agc_target_dbfs", APM_DEFAULTS.agc_target_dbfs),
@@ -424,6 +444,20 @@ export function usePreferences() {
 export function useSkin(): Skin {
   const { query } = usePreferences();
   return normalizeSkin(query.data?.skin);
+}
+
+/**
+ * Reactive "send read receipts" preference (#857). Defaults to true before the
+ * preferences query resolves, matching the stored default.
+ *
+ * This is a convenience for the renderer only — it decides whether to bother
+ * observing rows and whether to show other people's receipts. The binding
+ * enforcement lives in Rust (`receipts::emit_receipt` / `record_receipt`), so
+ * nothing here can cause a receipt to be emitted against the user's wishes.
+ */
+export function useSendReadReceipts(): boolean {
+  const { query } = usePreferences();
+  return query.data?.send_read_receipts ?? true;
 }
 
 /**

--- a/frontend/src/hooks/queries/useReceipts.ts
+++ b/frontend/src/hooks/queries/useReceipts.ts
@@ -1,0 +1,48 @@
+/**
+ * Delivery / read receipts for DMs (#857).
+ *
+ * Receipts live in the device-local `message_receipt` table, per message and
+ * per reader — never a single boolean — so a DM with several members renders
+ * "3 of 5 read" from the same data a 1:1 DM renders a single tick from.
+ *
+ * Nothing here polls. Receipts arrive as MLS control envelopes on the ordinary
+ * message path, so the same realtime hint that triggers a message ingest also
+ * refreshes this query (see `useLiveKitRealtime`).
+ */
+import { useQuery } from "@tanstack/react-query";
+import { invoke } from "../../bridge";
+import type { MessageReceipts } from "../../types";
+
+export const receiptQueryKeys = {
+  all: ["receipts"] as const,
+  conversation: (conversationId: string) => ["receipts", conversationId] as const,
+};
+
+/**
+ * Every receipt this device holds for one DM, keyed by message id for O(1)
+ * lookup while rendering a list.
+ *
+ * Returns an empty map for a null conversation, for group channels (which never
+ * have receipts), and while the user's reciprocal opt-out is off — in the last
+ * case because the Rust side genuinely stores none, not because the UI is
+ * hiding them.
+ */
+export function useConversationReceipts(conversationId: string | null) {
+  const query = useQuery({
+    queryKey: receiptQueryKeys.conversation(conversationId ?? ""),
+    enabled: !!conversationId,
+    queryFn: async (): Promise<MessageReceipts[]> => {
+      return await invoke<MessageReceipts[]>("get_conversation_receipts", {
+        conversationId,
+      });
+    },
+    staleTime: 1000 * 5,
+  });
+
+  const byMessageId = new Map<string, MessageReceipts>();
+  for (const entry of query.data ?? []) {
+    byMessageId.set(entry.message_id, entry);
+  }
+
+  return { receipts: byMessageId, isLoading: query.isLoading };
+}

--- a/frontend/src/hooks/useLiveKitRealtime.ts
+++ b/frontend/src/hooks/useLiveKitRealtime.ts
@@ -10,6 +10,7 @@ import { useObserver } from 'mobx-react-lite';
 import { appStore } from '../stores/appStore';
 import { useTauriReady } from './useTauriReady';
 import { lastMessageQueryKeys, messageQueryKeys, useDMConversations, markIngested } from './queries/useMessages';
+import { receiptQueryKeys } from './queries/useReceipts';
 import { invalidateVoiceRoom, voiceQueryKeys } from './queries/useVoiceParticipants';
 import { usePreferences } from './queries/usePreferences';
 import { groupQueryKeys, useUserGroupsWithChannels } from './queries/useGroups';
@@ -351,6 +352,12 @@ export function useLiveKitRealtime() {
           } else if (conversationId) {
             queryClientRef.current.invalidateQueries({ queryKey: messageQueryKeys.conversation(conversationId) });
             queryClientRef.current.invalidateQueries({ queryKey: lastMessageQueryKeys.conversation(conversationId) });
+            // Receipts (#857) arrive as MLS control envelopes on this very
+            // path — the ingest above is what decrypts and records them, so
+            // this is the point at which new ticks become visible. DM-only, and
+            // no polling anywhere: the peer's receipt publishes the same
+            // routing-only hint an ordinary message does.
+            queryClientRef.current.invalidateQueries({ queryKey: receiptQueryKeys.conversation(conversationId) });
           }
         });
     };

--- a/frontend/src/hooks/useReadReceipts.ts
+++ b/frontend/src/hooks/useReadReceipts.ts
@@ -1,0 +1,211 @@
+/**
+ * Emit READ receipts for a DM — the human half of #857.
+ *
+ * ## What counts as "read"
+ *
+ * A read receipt is a claim that a person saw a message. That is a much
+ * stronger claim than "React rendered it", and the two are easy to conflate:
+ * a message list is mounted for every open conversation, rows exist in the DOM
+ * far outside the viewport, and a background window renders exactly like a
+ * foreground one. Emitting on render would make the tick a lie.
+ *
+ * So a message is reported read only when ALL of these hold:
+ *   1. its row is genuinely intersecting the viewport, by a majority of its
+ *      area (`VISIBLE_RATIO`) — not merely mounted, not scrolled past offscreen;
+ *   2. the document is visible (`visibilityState`), so a hidden or minimised
+ *      window reports nothing;
+ *   3. the window actually has focus, so a visible-but-background window behind
+ *      another app reports nothing;
+ *   4. it stayed that way for `DWELL_MS`, so flinging the scrollbar past a
+ *      hundred messages does not mark them all read.
+ *
+ * Messages that are on screen while conditions 2 or 3 fail are held, not
+ * dropped: the moment focus returns they are flushed. That matches what a user
+ * means by "I read it" when they alt-tab back to a conversation they were
+ * already looking at.
+ *
+ * ## What this hook does NOT decide
+ *
+ * It does not filter by author, and it does not check whether the conversation
+ * is a DM. Both are enforced in Rust at the `emit_receipt` chokepoint
+ * (`pollis-core/src/commands/messages/receipts.rs`), along with the user's
+ * opt-out, so a bug or a hostile renderer here cannot widen the feature's scope
+ * or defeat the preference. Sending a superset of ids is safe by construction;
+ * ids for messages this device does not hold are dropped Rust-side.
+ *
+ * Delivery receipts are not emitted here at all — the ingest path emits those,
+ * because "delivered" is a fact about a device, not about a person.
+ */
+import { useEffect, useRef } from "react";
+import { invoke } from "../bridge";
+
+/** Fraction of a message row that must be in view before it counts as seen. */
+const VISIBLE_RATIO = 0.6;
+
+/**
+ * How long a message must remain visible+focused before it is reported. Long
+ * enough that scrolling through history does not mark everything read, short
+ * enough to feel immediate when you are actually reading.
+ */
+const DWELL_MS = 600;
+
+/** Message rows carry `data-testid="message-<id>"`. */
+const ROW_SELECTOR = '[data-testid^="message-"]';
+
+/** Optimistic rows for un-sent messages; never acknowledgeable. */
+const OPTIMISTIC_PREFIX = "pending-";
+
+function messageIdOf(el: Element): string | null {
+  const testId = el.getAttribute("data-testid");
+  if (!testId?.startsWith("message-")) {
+    return null;
+  }
+  const id = testId.slice("message-".length);
+  if (!id || id.startsWith(OPTIMISTIC_PREFIX)) {
+    return null;
+  }
+  return id;
+}
+
+/**
+ * Track which of this DM's messages the user actually reads, and report them in
+ * batches.
+ *
+ * Mount once per open DM. A null `conversationId` (or a group channel, which
+ * must never call this) makes it inert.
+ */
+export function useReadReceipts(
+  conversationId: string | null,
+  userId: string | null,
+  enabled: boolean,
+) {
+  // Ids reported to Rust already — never sent twice, so a scroll back up over
+  // old messages is silent.
+  const reportedRef = useRef<Set<string>>(new Set());
+  // Ids currently satisfying the visibility test, waiting on focus and dwell.
+  const pendingRef = useRef<Set<string>>(new Set());
+
+  // A fresh conversation starts with a clean slate; otherwise ids reported in
+  // the previous DM would suppress the same message id here (and, more
+  // importantly, memory would grow for the life of the session).
+  useEffect(() => {
+    reportedRef.current = new Set();
+    pendingRef.current = new Set();
+  }, [conversationId]);
+
+  useEffect(() => {
+    if (!conversationId || !userId || !enabled) {
+      return;
+    }
+
+    let dwellTimer: ReturnType<typeof setTimeout> | null = null;
+    let cancelled = false;
+
+    const canReport = () =>
+      typeof document !== "undefined" &&
+      document.visibilityState === "visible" &&
+      document.hasFocus();
+
+    const flush = async () => {
+      if (cancelled || !canReport()) {
+        return;
+      }
+      const batch: string[] = [];
+      for (const id of pendingRef.current) {
+        if (!reportedRef.current.has(id)) {
+          batch.push(id);
+        }
+      }
+      if (batch.length === 0) {
+        return;
+      }
+      // Mark first: an in-flight failure must not spin, and a receipt is
+      // best-effort telemetry about messages we already hold.
+      for (const id of batch) {
+        reportedRef.current.add(id);
+      }
+      try {
+        await invoke("mark_messages_read", {
+          conversationId,
+          userId,
+          messageIds: batch,
+        });
+      } catch (err) {
+        console.error("[receipts] mark_messages_read failed", err);
+      }
+    };
+
+    const scheduleFlush = () => {
+      if (dwellTimer) {
+        clearTimeout(dwellTimer);
+      }
+      dwellTimer = setTimeout(() => {
+        void flush();
+      }, DWELL_MS);
+    };
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        let changed = false;
+        for (const entry of entries) {
+          const id = messageIdOf(entry.target);
+          if (!id) {
+            continue;
+          }
+          if (entry.isIntersecting && entry.intersectionRatio >= VISIBLE_RATIO) {
+            if (!pendingRef.current.has(id)) {
+              pendingRef.current.add(id);
+              changed = true;
+            }
+          } else {
+            // Scrolled away before the dwell elapsed — it was never read.
+            pendingRef.current.delete(id);
+          }
+        }
+        if (changed) {
+          scheduleFlush();
+        }
+      },
+      { threshold: [VISIBLE_RATIO] },
+    );
+
+    // Observe every row now on screen, and keep up with rows React adds as the
+    // conversation grows or older pages load in.
+    const observed = new WeakSet<Element>();
+    const observeAll = () => {
+      for (const el of Array.from(document.querySelectorAll(ROW_SELECTOR))) {
+        if (!observed.has(el)) {
+          observed.add(el);
+          observer.observe(el);
+        }
+      }
+    };
+    observeAll();
+
+    const mutations = new MutationObserver(() => {
+      observeAll();
+    });
+    mutations.observe(document.body, { childList: true, subtree: true });
+
+    // Regaining focus/visibility releases everything already on screen — the
+    // user was looking at these before they alt-tabbed away.
+    const onFocusOrVisible = () => {
+      if (canReport()) {
+        scheduleFlush();
+      }
+    };
+    window.addEventListener("focus", onFocusOrVisible);
+    document.addEventListener("visibilitychange", onFocusOrVisible);
+
+    return () => {
+      cancelled = true;
+      if (dwellTimer) {
+        clearTimeout(dwellTimer);
+      }
+      observer.disconnect();
+      mutations.disconnect();
+      window.removeEventListener("focus", onFocusOrVisible);
+      document.removeEventListener("visibilitychange", onFocusOrVisible);
+    };
+  }, [conversationId, userId, enabled]);
+}

--- a/frontend/src/pages/DM.tsx
+++ b/frontend/src/pages/DM.tsx
@@ -11,6 +11,8 @@ import { usePresenceStatus } from "../stores/presenceStore";
 import { invoke } from "../bridge";
 import { voiceSession } from "../voice";
 import { KeyChangeBanner } from "../components/Security/KeyChangeBanner";
+import { useReadReceipts } from "../hooks/useReadReceipts";
+import { useSendReadReceipts } from "../hooks/queries/usePreferences";
 import { warmVoiceChannel } from "../utils/voiceWarmup";
 
 type RawDmMember = { user_id: string; username?: string; accepted_at?: string | null };
@@ -25,6 +27,8 @@ export const DMPage: React.FC = observer(() => {
   const setOutgoingCall = appStore.setOutgoingCall;
   const outgoingCall = appStore.outgoingCall;
 
+  const sendReadReceipts = useSendReadReceipts();
+
   const [otherUserId, setOtherUserId] = React.useState<string | null>(null);
   const [memberCount, setMemberCount] = React.useState<number>(0);
   const [otherAcceptedAt, setOtherAcceptedAt] = React.useState<string | null>(null);
@@ -36,6 +40,15 @@ export const DMPage: React.FC = observer(() => {
     markRead(conversationId);
     return () => { setSelectedConversationId(null); };
   }, [conversationId, setSelectedConversationId, markRead]);
+
+  // Read receipts (#857) — DMs only, which is why this is mounted here and not
+  // in the shared MainContent. Deliberately NOT tied to the `markRead` call
+  // above: clearing an unread badge means "you navigated here", while a read
+  // receipt claims a human actually saw a specific message, so the hook does
+  // its own viewport + window-focus tracking. The `send_read_receipts`
+  // preference is enforced in Rust at the emit chokepoint; passing it here just
+  // avoids the pointless work of observing rows we would never report.
+  useReadReceipts(conversationId, currentUser?.id ?? null, sendReadReceipts);
 
   // Fetch member list for the conversation so we can target the right
   // user_id when blocking or calling, and discover whether the other party

--- a/frontend/src/pages/PreferencesPage.tsx
+++ b/frontend/src/pages/PreferencesPage.tsx
@@ -83,6 +83,7 @@ export const PreferencesPage: React.FC = observer(() => {
   const [fontSize, setFontSize] = useState<number>(15);
   const [allowDesktopNotifications, setAllowDesktopNotifications] = useState<boolean>(true);
   const [allowSoundEffects, setAllowSoundEffects] = useState<boolean>(true);
+  const [sendReadReceipts, setSendReadReceipts] = useState<boolean>(true);
   const [allowCallRingtone, setAllowCallRingtone] = useState<boolean>(true);
   const [sidebarOpenByDefault, setSidebarOpenByDefault] = useState<boolean>(true);
   // `undefined` until the user touches it — that state means "follow the
@@ -129,6 +130,9 @@ export const PreferencesPage: React.FC = observer(() => {
       }
       if (query.data.allow_sound_effects !== undefined) {
         setAllowSoundEffects(query.data.allow_sound_effects);
+      }
+      if (query.data.send_read_receipts !== undefined) {
+        setSendReadReceipts(query.data.send_read_receipts);
       }
       if (query.data.sidebar_open_by_default !== undefined) {
         setSidebarOpenByDefault(query.data.sidebar_open_by_default);
@@ -179,6 +183,7 @@ export const PreferencesPage: React.FC = observer(() => {
     bgH?: number; bgS?: number; bgL?: number;
     skin?: Skin;
     notifications?: boolean; soundEffects?: boolean;
+    sendReadReceipts?: boolean;
     sidebarOpenByDefault?: boolean;
     rightPanelOpenByDefault?: boolean;
     closeToTray?: boolean;
@@ -193,6 +198,7 @@ export const PreferencesPage: React.FC = observer(() => {
     const bl = opts.bgL ?? bgLightness;
     const notif = opts.notifications ?? allowDesktopNotifications;
     const sfx = opts.soundEffects ?? allowSoundEffects;
+    const receipts = opts.sendReadReceipts ?? sendReadReceipts;
     const sidebar = opts.sidebarOpenByDefault ?? sidebarOpenByDefault;
     const rightPanel = opts.rightPanelOpenByDefault ?? rightPanelOpenByDefault;
     const tray = opts.closeToTray ?? closeToTray;
@@ -215,6 +221,7 @@ export const PreferencesPage: React.FC = observer(() => {
       skin: skinVal,
       allow_desktop_notifications: notif,
       allow_sound_effects: sfx,
+      send_read_receipts: receipts,
       sidebar_open_by_default: sidebar,
       right_panel_open_by_default: rightPanel,
       close_to_tray: tray,
@@ -224,7 +231,7 @@ export const PreferencesPage: React.FC = observer(() => {
       relay_serving_wifi_only: relay.wifi_only,
       relay_serving_power_only: relay.power_only,
     });
-  }, [savePrefs, query.data, hue, saturation, bgHue, bgSaturation, bgLightness, skin, allowDesktopNotifications, allowSoundEffects, sidebarOpenByDefault, closeToTray, menubarIcon, overlayMode, relayServing]);
+  }, [savePrefs, query.data, hue, saturation, bgHue, bgSaturation, bgLightness, skin, allowDesktopNotifications, allowSoundEffects, sendReadReceipts, sidebarOpenByDefault, closeToTray, menubarIcon, overlayMode, relayServing]);
 
   // Drive the merged overlay engine (`set_overlay_mode`) to `val`, live. Never
   // throws: a rejected apply (e.g. Strict with no relay reachable — the engine
@@ -377,6 +384,11 @@ export const PreferencesPage: React.FC = observer(() => {
   const handleAllowSoundEffects = (val: boolean) => {
     setAllowSoundEffects(val);
     save({ soundEffects: val });
+  };
+
+  const handleSendReadReceipts = (val: boolean) => {
+    setSendReadReceipts(val);
+    save({ sendReadReceipts: val });
   };
 
   const handleSidebarOpenByDefault = (val: boolean) => {
@@ -781,6 +793,30 @@ export const PreferencesPage: React.FC = observer(() => {
                 checked={allowSoundEffects}
                 onChange={handleAllowSoundEffects}
               />
+            </section>
+
+            {/* Read receipts (#857) — DMs only. */}
+            <section className="flex flex-col gap-4 mb-12">
+              <h2
+                className="text-xs font-mono font-medium uppercase tracking-widest pb-1 border-b"
+                style={{ color: "var(--c-text)", borderColor: "var(--c-border)" }}
+              >
+                Read receipts
+              </h2>
+              <Switch
+                id="pref-read-receipts"
+                label="Send read receipts"
+                checked={sendReadReceipts}
+                onChange={handleSendReadReceipts}
+              />
+              <p className="text-xs font-mono" style={{ color: "var(--c-text-muted)" }}>
+                In direct messages, lets the people you are talking to see when their
+                messages reached your device and when you read them. Turning this off
+                also hides <em>their</em> receipts from you — you will no longer see
+                whether your own messages were delivered or read. Receipts are
+                end-to-end encrypted like any message; our servers never see who read
+                what. Group channels never send receipts.
+              </p>
             </section>
 
             {/* Local message history (this device) — device-local retention

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -104,6 +104,10 @@ export interface DMConversation {
   user2_identifier: string; // username/email/phone of other user
   user2_id?: string;
   user2_avatar_url?: string;
+  /** Total members including the viewer. Group DMs have 3+; a 1:1 has 2.
+   * Drives the per-reader receipt summary (#857) — optional because callers
+   * that only need the "other side" never populate it. */
+  member_count?: number;
   created_at: number;
   updated_at: number;
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -161,6 +161,27 @@ export interface CustomEmoji {
   created_by: string;
 }
 
+/**
+ * Delivery / read receipts held for ONE message in a DM (#857).
+ *
+ * Mirrors `MessageReceipts` in `pollis-core/src/commands/messages/receipts.rs`.
+ *
+ * Both fields are lists of user ids, never booleans — a DM can have several
+ * members, so "delivered" and "read" are sets, and the 1:1 case is just the
+ * one-element case. `read_by` is always a subset of `delivered_by`: the local
+ * schema has a trigger making "read but never delivered" unrepresentable.
+ *
+ * Receipts are device-local and exist only for DMs; group channels never
+ * produce them.
+ */
+export interface MessageReceipts {
+  message_id: string;
+  /** Readers whose device fetched and decrypted the message. */
+  delivered_by: string[];
+  /** Readers who actually saw it on screen in a focused window. */
+  read_by: string[];
+}
+
 export interface MessageAttachment {
   id: string;
   object_key: string;       // R2 object key — empty string while upload is in progress

--- a/pollis-core/src/commands/messages/framing.rs
+++ b/pollis-core/src/commands/messages/framing.rs
@@ -86,6 +86,40 @@ const REDACT_FRAMING_V1: u8 = 0xF6;
 /// frame markers so the two namespaces never collide.
 const THREAD_TRAILER_V1: u8 = 0xF7;
 
+/// First byte of the v1 **receipt control frame** (#857, DMs only).
+///
+/// A delivery/read receipt is an ordinary MLS application message whose
+/// plaintext is
+///
+/// ```text
+///  byte 0          : RECEIPT_FRAMING_V1 (0xF8)
+///  byte 1          : kind — 0 = delivered, 1 = read
+///  bytes 2..6      : u32 LE  length of the RFC3339 timestamp
+///  bytes 6..6+T    : timestamp (UTF-8)
+///  next 4 bytes    : u32 LE  message-id count
+///  then, per id    : u32 LE length + id bytes (ULID, UTF-8)
+///  remainder       : zero padding up to the size bucket
+/// ```
+///
+/// zero-padded to a size bucket exactly like every other frame, so on the wire
+/// (and in a Turso breach) a receipt is indistinguishable **by length** from a
+/// short text message and the server never learns who read what, or when. It
+/// rides `/v1/messages/send` as an ordinary `type='message'` envelope for the
+/// same reason: a dedicated `/v1/receipts/*` endpoint would put "this is a
+/// receipt" in the request line, handing the untrusted DS precisely the metadata
+/// this frame exists to withhold.
+///
+/// Receipts are **batched** — one frame carries every message id a reader is
+/// acknowledging in that conversation — so a burst of catch-up ingest emits one
+/// envelope, not one per message.
+///
+/// Drawn from the same non-UTF-8 `0xF5..=0xFF` range as the other markers, which
+/// is what makes the back-compat degradation safe: a client that predates
+/// receipts hits the `strip` fallback, gets the buffer verbatim, fails the
+/// `String::from_utf8` check in the ingest path, and silently ignores the frame
+/// instead of rendering mojibake. See `old_client_ignores_receipt_frame`.
+const RECEIPT_FRAMING_V1: u8 = 0xF8;
+
 /// Framing header: 1 version byte + 4-byte little-endian length prefix. Shared
 /// by the padded-text ([`PAD_FRAMING_V1`]) and redaction ([`REDACT_FRAMING_V1`])
 /// frames.
@@ -162,10 +196,56 @@ pub(crate) fn strip(buf: &[u8]) -> Vec<u8> {
     buf[HEADER..end].to_vec()
 }
 
+/// Which of the two receipt signals a [`Frame::Receipt`] carries (#857).
+///
+/// The two are deliberately **distinct** and never conflated:
+/// - [`ReceiptKind::Delivered`] — the reader's device fetched the envelope and
+///   successfully MLS-decrypted it. Emitted by the ingest path; says nothing
+///   about a human.
+/// - [`ReceiptKind::Read`] — a human actually saw the message: it was on screen,
+///   in a focused window, in the conversation the user is looking at. Emitted
+///   only by an explicit foreground call from the renderer.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum ReceiptKind {
+    Delivered,
+    Read,
+}
+
+impl ReceiptKind {
+    /// Wire byte. Stable — it is inside the MLS ciphertext, but old and new
+    /// clients must still agree.
+    fn to_byte(self) -> u8 {
+        match self {
+            ReceiptKind::Delivered => 0,
+            ReceiptKind::Read => 1,
+        }
+    }
+
+    fn from_byte(b: u8) -> Option<Self> {
+        match b {
+            0 => Some(ReceiptKind::Delivered),
+            1 => Some(ReceiptKind::Read),
+            // An unknown kind from a future client is dropped rather than
+            // guessed — recording it under the wrong kind would be worse than
+            // not recording it.
+            _ => None,
+        }
+    }
+
+    /// The `message_receipt.kind` column value.
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            ReceiptKind::Delivered => "delivered",
+            ReceiptKind::Read => "read",
+        }
+    }
+}
+
 /// A decrypted, de-framed message payload. Ordinary text (a text message, an
 /// edit, or an attachment envelope) is [`Frame::Text`] carrying the exact
 /// plaintext; a "delete for everyone" control message is
-/// [`Frame::Redaction`] carrying the target message id.
+/// [`Frame::Redaction`] carrying the target message id; a delivery/read
+/// acknowledgement is [`Frame::Receipt`] (#857).
 pub(crate) enum Frame {
     Text {
         text: Vec<u8>,
@@ -175,6 +255,15 @@ pub(crate) enum Frame {
         thread_id: Option<String>,
     },
     Redaction(String),
+    Receipt {
+        kind: ReceiptKind,
+        /// The reader's own RFC3339 timestamp for the acknowledgement. Inside
+        /// authenticated ciphertext, so only the reader could have written it.
+        at: String,
+        /// Every message id this frame acknowledges. Batched, so one envelope
+        /// covers a whole catch-up burst.
+        message_ids: Vec<String>,
+    },
 }
 
 /// Wrap `target_message_id` in the v1 redaction framing and zero-pad it to its
@@ -191,16 +280,90 @@ pub(crate) fn pad_redaction(target_message_id: &str) -> Vec<u8> {
     buf
 }
 
+/// Wrap a batch of receipt acknowledgements in the v1 receipt framing and
+/// zero-pad to the size bucket (#857). See [`RECEIPT_FRAMING_V1`] for the layout.
+///
+/// The buffer is handed to `try_mls_encrypt` exactly like a text send, so a
+/// receipt is length-indistinguishable from a short message.
+pub(crate) fn pad_receipt(kind: ReceiptKind, at: &str, message_ids: &[String]) -> Vec<u8> {
+    let at_bytes = at.as_bytes();
+    let mut buf = Vec::with_capacity(2 + 4 + at_bytes.len() + 4 + message_ids.len() * 30);
+    buf.push(RECEIPT_FRAMING_V1);
+    buf.push(kind.to_byte());
+    buf.extend_from_slice(&(at_bytes.len() as u32).to_le_bytes());
+    buf.extend_from_slice(at_bytes);
+    buf.extend_from_slice(&(message_ids.len() as u32).to_le_bytes());
+    for id in message_ids {
+        let id_bytes = id.as_bytes();
+        buf.extend_from_slice(&(id_bytes.len() as u32).to_le_bytes());
+        buf.extend_from_slice(id_bytes);
+    }
+    let target = padded_len(buf.len());
+    buf.resize(target, 0u8);
+    buf
+}
+
+/// Read a u32 LE at `at`, returning the value and the offset just past it.
+/// `None` when the four bytes are not fully inside `buf` — every caller is
+/// parsing a buffer it did not build, so no read may be assumed in-bounds.
+fn read_u32(buf: &[u8], at: usize) -> Option<(usize, usize)> {
+    let end = at.checked_add(4)?;
+    if end > buf.len() {
+        return None;
+    }
+    let v = u32::from_le_bytes([buf[at], buf[at + 1], buf[at + 2], buf[at + 3]]) as usize;
+    Some((v, end))
+}
+
+/// Read a u32-LE-length-prefixed UTF-8 string at `at`, returning it and the
+/// offset just past it. `None` on any overrun or invalid UTF-8.
+fn read_str(buf: &[u8], at: usize) -> Option<(String, usize)> {
+    let (len, after_len) = read_u32(buf, at)?;
+    let end = after_len.checked_add(len)?;
+    if end > buf.len() {
+        return None;
+    }
+    let s = std::str::from_utf8(&buf[after_len..end]).ok()?.to_string();
+    Some((s, end))
+}
+
+/// Parse a [`RECEIPT_FRAMING_V1`] buffer. `None` for any non-receipt or
+/// malformed buffer, so the caller falls through to the ordinary text path.
+fn parse_receipt(buf: &[u8]) -> Option<Frame> {
+    if buf.first() != Some(&RECEIPT_FRAMING_V1) {
+        return None;
+    }
+    let kind = ReceiptKind::from_byte(*buf.get(1)?)?;
+    let (at, after_at) = read_str(buf, 2)?;
+    let (count, mut pos) = read_u32(buf, after_at)?;
+    // A hostile count must not pre-allocate gigabytes; the ids are read one at a
+    // time and the loop is bounded by the buffer, so cap the reservation only.
+    let mut message_ids = Vec::with_capacity(count.min(1024));
+    for _ in 0..count {
+        let (id, next) = read_str(buf, pos)?;
+        message_ids.push(id);
+        pos = next;
+    }
+    Some(Frame::Receipt { kind, at, message_ids })
+}
+
 /// Classify a decrypted buffer. Keys on the first byte:
 ///
 /// - `0xF6` ([`REDACT_FRAMING_V1`]) → [`Frame::Redaction`] with the target id.
+/// - `0xF8` ([`RECEIPT_FRAMING_V1`]) → [`Frame::Receipt`] (#857).
 /// - anything else — v1 padded text (`0xF5`), legacy unpadded UTF-8, or an
 ///   attachment envelope (`{`) → [`Frame::Text`] via [`strip`].
 ///
-/// A malformed redaction frame (too short, bad length prefix, non-UTF-8 id)
-/// degrades to `Text` — it cannot arise from [`pad_redaction`] and exists only
-/// as belt-and-braces so a hostile buffer can never panic the ingest path.
+/// A malformed redaction or receipt frame (too short, bad length prefix,
+/// non-UTF-8 payload) degrades to `Text` — it cannot arise from
+/// [`pad_redaction`] / [`pad_receipt`] and exists only as belt-and-braces so a
+/// hostile buffer can never panic the ingest path. Such a buffer then fails the
+/// ingest path's `String::from_utf8` check (its lead byte is not valid UTF-8)
+/// and is dropped rather than stored as a visible message.
 pub(crate) fn classify(buf: &[u8]) -> Frame {
+    if let Some(receipt) = parse_receipt(buf) {
+        return receipt;
+    }
     if buf.first() == Some(&REDACT_FRAMING_V1) && buf.len() >= HEADER {
         let len = u32::from_le_bytes([buf[1], buf[2], buf[3], buf[4]]) as usize;
         let end = HEADER + len;
@@ -381,7 +544,7 @@ mod tests {
             let framed = pad_redaction(id);
             match classify(&framed) {
                 Frame::Redaction(got) => assert_eq!(got, id, "redaction id must round-trip"),
-                Frame::Text { .. } => panic!("a redaction frame must classify as Redaction (id={id:?})"),
+                _ => panic!("a redaction frame must classify as Redaction (id={id:?})"),
             }
         }
     }
@@ -410,7 +573,7 @@ mod tests {
         for &buf in cases {
             match classify(buf) {
                 Frame::Text { text, .. } => assert_eq!(text, strip(buf)),
-                Frame::Redaction(_) => panic!("non-redaction payload misclassified: {buf:?}"),
+                _ => panic!("non-redaction payload misclassified: {buf:?}"),
             }
         }
     }
@@ -462,7 +625,7 @@ mod tests {
                 assert_eq!(text, b"in a thread");
                 assert_eq!(thread_id.as_deref(), Some(THREAD));
             }
-            Frame::Redaction(_) => panic!("threaded text misclassified as redaction"),
+            _ => panic!("threaded text misclassified as redaction"),
         }
     }
 
@@ -513,6 +676,171 @@ mod tests {
         bad_utf8.extend_from_slice(&2u32.to_le_bytes());
         bad_utf8.extend_from_slice(&[0xFF, 0xFE]);
         assert_eq!(thread_of(&bad_utf8), None);
+    }
+
+    // ── Receipt frame (#857) ────────────────────────────────────────────────
+
+    const MSG_A: &str = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
+    const MSG_B: &str = "01J8XQ2M5H7NR3T0V9WZ4KDCEB";
+
+    fn ids(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| s.to_string()).collect()
+    }
+
+    /// `pad_receipt` -> `classify` recovers the kind, timestamp and the full id
+    /// batch, for both kinds and for batch sizes from empty to large.
+    #[test]
+    fn receipt_roundtrips_kind_time_and_batch() {
+        let at = "2026-08-15T12:34:56.789Z";
+        let batches = vec![
+            ids(&[]),
+            ids(&[MSG_A]),
+            ids(&[MSG_A, MSG_B]),
+            (0..200).map(|i| format!("01ARZ3NDEKTSV4RRFFQ69G5F{i:03}")).collect(),
+        ];
+        for kind in [ReceiptKind::Delivered, ReceiptKind::Read] {
+            for batch in &batches {
+                let framed = pad_receipt(kind, at, batch);
+                match classify(&framed) {
+                    Frame::Receipt { kind: got_kind, at: got_at, message_ids } => {
+                        assert_eq!(got_kind, kind, "kind must round-trip");
+                        assert_eq!(got_at, at, "timestamp must round-trip");
+                        assert_eq!(&message_ids, batch, "the whole batch must round-trip");
+                    }
+                    _ => panic!("a receipt frame must classify as Receipt (kind={kind:?})"),
+                }
+            }
+        }
+    }
+
+    /// Delivered and Read are DISTINCT signals on the wire — the whole point of
+    /// not conflating "your device got it" with "a human saw it". A frame built
+    /// as one must never decode as the other.
+    #[test]
+    fn delivered_and_read_are_distinct_on_the_wire() {
+        let d = pad_receipt(ReceiptKind::Delivered, "2026-08-15T00:00:00Z", &ids(&[MSG_A]));
+        let r = pad_receipt(ReceiptKind::Read, "2026-08-15T00:00:00Z", &ids(&[MSG_A]));
+        assert_ne!(d, r, "the two kinds must not produce identical bytes");
+        match (classify(&d), classify(&r)) {
+            (Frame::Receipt { kind: a, .. }, Frame::Receipt { kind: b, .. }) => {
+                assert_eq!(a, ReceiptKind::Delivered);
+                assert_eq!(b, ReceiptKind::Read);
+            }
+            _ => panic!("both must classify as receipts"),
+        }
+    }
+
+    /// A receipt is padded to the SAME size bucket as a short text message, so
+    /// the DS/Turso cannot pick receipts out of the envelope stream by length.
+    /// This is the property that keeps "who read what, when" off the server.
+    #[test]
+    fn receipt_is_length_indistinguishable_from_text() {
+        let receipt = pad_receipt(ReceiptKind::Read, "2026-08-15T12:34:56Z", &ids(&[MSG_A]));
+        assert_eq!(receipt.len(), MIN_BUCKET);
+        assert_eq!(receipt.len(), pad(b"hey").len());
+        assert_eq!(receipt.len(), pad_redaction(MSG_A).len());
+        // A realistic multi-message catch-up batch still collapses to the floor.
+        let batch = pad_receipt(ReceiptKind::Delivered, "2026-08-15T12:34:56Z", &ids(&[MSG_A, MSG_B]));
+        assert_eq!(batch.len(), MIN_BUCKET);
+        // And a big batch is still bucketed, never a bespoke length.
+        let big: Vec<String> = (0..50).map(|i| format!("01ARZ3NDEKTSV4RRFFQ69G5F{i:03}")).collect();
+        let big_framed = pad_receipt(ReceiptKind::Read, "2026-08-15T12:34:56Z", &big);
+        assert_eq!(big_framed.len(), padded_len(big_framed.len()));
+    }
+
+    /// THE back-compat test. A client that predates receipts only ever calls
+    /// `strip`, which returns a `0xF8` buffer verbatim; the ingest path then
+    /// tries `String::from_utf8` on it. `0xF8` can never begin valid UTF-8, so
+    /// the frame is silently ignored — never rendered as a garbage message.
+    #[test]
+    fn old_client_ignores_receipt_frame() {
+        for kind in [ReceiptKind::Delivered, ReceiptKind::Read] {
+            let framed = pad_receipt(kind, "2026-08-15T00:00:00Z", &ids(&[MSG_A, MSG_B]));
+            assert_eq!(strip(&framed), framed, "an old client's strip returns it verbatim");
+            assert!(
+                String::from_utf8(strip(&framed)).is_err(),
+                "the verbatim buffer must fail UTF-8, so ingest drops it instead of rendering it",
+            );
+            assert_eq!(thread_of(&framed), None, "a receipt is not a threaded text frame");
+        }
+    }
+
+    /// Text, redaction and legacy payloads must never be mistaken for receipts,
+    /// and a receipt must never be mistaken for text or a redaction.
+    #[test]
+    fn receipts_do_not_collide_with_other_frames() {
+        let non_receipts: Vec<Vec<u8>> = vec![
+            pad(b"hello"),
+            pad_threaded(b"hello", THREAD),
+            pad_redaction(MSG_A),
+            b"legacy unpadded".to_vec(),
+            br#"{"_att":[{"hash":"a","key":"k"}]}"#.to_vec(),
+            Vec::new(),
+        ];
+        for buf in &non_receipts {
+            assert!(
+                !matches!(classify(buf), Frame::Receipt { .. }),
+                "non-receipt payload misclassified as a receipt: {buf:?}",
+            );
+        }
+        let receipt = pad_receipt(ReceiptKind::Read, "2026-08-15T00:00:00Z", &ids(&[MSG_A]));
+        assert!(matches!(classify(&receipt), Frame::Receipt { .. }));
+    }
+
+    /// A truncated or hostile receipt frame degrades to `Text` (and is then
+    /// dropped by ingest's UTF-8 check) rather than panicking. These cannot
+    /// arise from `pad_receipt`; the ingest path must survive them anyway,
+    /// because the buffer is only as trustworthy as the sender.
+    #[test]
+    fn malformed_receipt_frame_degrades_to_text() {
+        let cases: Vec<Vec<u8>> = vec![
+            // Lead byte only — no kind byte.
+            vec![RECEIPT_FRAMING_V1],
+            // Unknown kind byte from a future client.
+            {
+                let mut b = vec![RECEIPT_FRAMING_V1, 99];
+                b.extend_from_slice(&1u32.to_le_bytes());
+                b.push(b'x');
+                b.extend_from_slice(&0u32.to_le_bytes());
+                b
+            },
+            // Timestamp length prefix overruns the buffer.
+            {
+                let mut b = vec![RECEIPT_FRAMING_V1, 0];
+                b.extend_from_slice(&9_999u32.to_le_bytes());
+                b.extend_from_slice(b"short");
+                b
+            },
+            // Well-formed timestamp, but the id count promises more than exists.
+            {
+                let mut b = vec![RECEIPT_FRAMING_V1, 1];
+                b.extend_from_slice(&1u32.to_le_bytes());
+                b.push(b't');
+                b.extend_from_slice(&5u32.to_le_bytes());
+                b
+            },
+            // Count would overflow the reservation arithmetic.
+            {
+                let mut b = vec![RECEIPT_FRAMING_V1, 0];
+                b.extend_from_slice(&0u32.to_le_bytes());
+                b.extend_from_slice(&u32::MAX.to_le_bytes());
+                b
+            },
+            // Non-UTF-8 timestamp.
+            {
+                let mut b = vec![RECEIPT_FRAMING_V1, 0];
+                b.extend_from_slice(&2u32.to_le_bytes());
+                b.extend_from_slice(&[0xFF, 0xFE]);
+                b.extend_from_slice(&0u32.to_le_bytes());
+                b
+            },
+        ];
+        for buf in &cases {
+            assert!(
+                matches!(classify(buf), Frame::Text { .. }),
+                "malformed receipt must degrade to Text, not panic or parse: {buf:?}",
+            );
+        }
     }
 
     /// The trailer must not defeat the padding it sits inside — a thread reply

--- a/pollis-core/src/commands/messages/ingest.rs
+++ b/pollis-core/src/commands/messages/ingest.rs
@@ -298,7 +298,6 @@ pub async fn catch_up_mls_group_interleaved(
             if let Err(e) = super::receipts::emit_delivered(
                 state,
                 &res.conversation_id,
-                user_id,
                 &res.newly_delivered,
             )
             .await

--- a/pollis-core/src/commands/messages/ingest.rs
+++ b/pollis-core/src/commands/messages/ingest.rs
@@ -34,6 +34,18 @@ enum DeleteResolution {
     Pending,
 }
 
+/// What one conversation's pass through [`ingest_group_envelopes_interleaved`]
+/// produced: how far its watermark may advance, and which inbound messages this
+/// device newly decrypted (the batch a DM acknowledges with one delivery
+/// receipt, #857).
+struct ConvIngest {
+    conversation_id: String,
+    watermark: Option<String>,
+    /// Ids of messages persisted for the FIRST time on this pass, authored by
+    /// someone else. Empty for group channels, which never emit receipts.
+    newly_delivered: Vec<String>,
+}
+
 /// Decide a delete tombstone's fate from its redaction outcome. Pure so the
 /// edge-case matrix is unit-testable offline (`delete_resolution_tests`) without
 /// a DB:
@@ -240,9 +252,10 @@ pub async fn catch_up_mls_group_interleaved(
 
     // Drive the shared group's replay once, decrypting each conversation's
     // envelopes as the group reaches their epoch. Returns the per-conversation
-    // watermark each device may advance to.
-    let watermarks: Vec<(String, Option<String>)> =
-        ingest_group_envelopes_interleaved(state, user_id, mls_group_id, &per_conv).await?;
+    // watermark each device may advance to, plus the messages newly decrypted on
+    // this pass (the delivery-receipt batch).
+    let results: Vec<ConvIngest> =
+        ingest_group_envelopes_interleaved(state, user_id, mls_group_id, &per_conv, is_dm).await?;
 
     // Advance each conversation's watermark through the Delivery Service (best
     // effort — DS failures are logged and ignored). Envelope GC is NOT fired from
@@ -250,8 +263,9 @@ pub async fn catch_up_mls_group_interleaved(
     // (`pollis-delivery` `sweep_envelope_gc`), so a conversation whose members all
     // go quiet is still collected and a chatty one no longer runs GC on every
     // ingest. This path only reports the watermark that GC reads.
-    for (cid, ts_opt) in &watermarks {
-        if let (Some(ts), Some(did)) = (ts_opt.as_ref(), device_id.as_ref()) {
+    for res in &results {
+        let cid = &res.conversation_id;
+        if let (Some(ts), Some(did)) = (res.watermark.as_ref(), device_id.as_ref()) {
             let body = serde_json::json!({
                 "conversation_id": cid,
                 "user_id": user_id,
@@ -262,6 +276,37 @@ pub async fn catch_up_mls_group_interleaved(
                 crate::commands::mls::ds_post_ok(state, "/v1/watermarks/advance", &body).await
             {
                 eprintln!("[watermark] catch_up_group: DS advance failed for {cid}: {e}");
+            }
+        }
+    }
+
+    // Delivery receipts (#857): this device fetched and DECRYPTED these
+    // messages, which is precisely what "delivered" means — a statement about a
+    // device, never about a human having seen anything. One batched control
+    // frame per conversation covers a whole catch-up burst.
+    //
+    // `emit_receipt` re-checks both gates (DMs only, and the sending-side
+    // opt-out), so this call site cannot widen the feature's scope by mistake;
+    // the `is_dm` short-circuit here just avoids a pointless round-trip for the
+    // group-channel case. Best-effort — a receipt that fails to send must never
+    // fail an ingest pass, because the message itself already landed.
+    if is_dm {
+        for res in &results {
+            if res.newly_delivered.is_empty() {
+                continue;
+            }
+            if let Err(e) = super::receipts::emit_delivered(
+                state,
+                &res.conversation_id,
+                user_id,
+                &res.newly_delivered,
+            )
+            .await
+            {
+                eprintln!(
+                    "[receipts] delivered emit failed for {}: {e}",
+                    res.conversation_id
+                );
             }
         }
     }
@@ -295,7 +340,11 @@ async fn ingest_group_envelopes_interleaved(
     user_id: &str,
     mls_group_id: &str,
     per_conv: &[(String, Vec<EnvelopeRow>)],
-) -> Result<Vec<(String, Option<String>)>> {
+    // Whether this MLS group backs a DM. Receipts (#857) are DMs-only, so this
+    // gates both recording an inbound receipt frame and collecting the
+    // delivered batch.
+    is_dm: bool,
+) -> Result<Vec<ConvIngest>> {
     // Pre-parse each message/edit envelope's MLS position across ALL bound
     // conversations (delete/unknown carry none) and index `(conv_idx, env_idx)`
     // by position so the per-epoch hook decrypts exactly the ones sealed at the
@@ -336,6 +385,9 @@ async fn ingest_group_envelopes_interleaved(
     // watermark loop. Runs even with zero envelopes so the group still advances
     // to head (the cold-launch sweep guarantee).
     let mut max_fired_epoch: Option<(i64, u64)> = None;
+    // Per-conversation batch of messages newly persisted on this pass — the
+    // delivery receipts (#857) this device owes once the replay is done.
+    let mut newly_delivered: Vec<Vec<String>> = vec![Vec::new(); per_conv.len()];
     {
         let mut on_epoch = |conn: &rusqlite::Connection, generation: i64, epoch: u64| {
             // Lexicographic on `(generation, epoch)`: a successor lineage restarts
@@ -345,12 +397,16 @@ async fn ingest_group_envelopes_interleaved(
             max_fired_epoch = Some(max_fired_epoch.map_or(key, |m| m.max(key)));
             if let Some(indices) = by_epoch.get(&key) {
                 for &(ci, ei) in indices {
-                    decrypt_and_persist_one(
+                    if let Some(delivered_id) = decrypt_and_persist_one(
                         conn,
                         &per_conv[ci].0,
                         mls_group_id,
                         &per_conv[ci].1[ei],
-                    );
+                        user_id,
+                        is_dm,
+                    ) {
+                        newly_delivered[ci].push(delivered_id);
+                    }
                 }
             }
         };
@@ -456,7 +512,7 @@ async fn ingest_group_envelopes_interleaved(
     // path goes through the verified function, not a copy. Build the
     // `(sent_at, EnvKind, Option<epoch>)` view from the existing envelope rows +
     // pre-parsed `epoch_of`; `&str` keys avoid cloning every `sent_at`.
-    let mut out: Vec<(String, Option<String>)> = Vec::with_capacity(per_conv.len());
+    let mut out: Vec<ConvIngest> = Vec::with_capacity(per_conv.len());
     for (ci, (cid, envs)) in per_conv.iter().enumerate() {
         let items: Vec<(&str, super::watermark::EnvKind, Option<(i64, u64)>)> = envs
             .iter()
@@ -475,7 +531,11 @@ async fn ingest_group_envelopes_interleaved(
             .collect();
         let watermark =
             super::watermark::next_watermark(&items, max_fired_epoch).map(str::to_string);
-        out.push((cid.clone(), watermark));
+        out.push(ConvIngest {
+            conversation_id: cid.clone(),
+            watermark,
+            newly_delivered: std::mem::take(&mut newly_delivered[ci]),
+        });
     }
     Ok(out)
 }
@@ -487,12 +547,20 @@ async fn ingest_group_envelopes_interleaved(
 /// Infallible: a failed decrypt or a transient DB error simply leaves nothing
 /// persisted (the envelope stays in `message_envelope` for a later retry), the
 /// same outcome the watermark logic accounts for.
+///
+/// Returns the message id when this call persisted a NEW inbound message in a
+/// DM — i.e. exactly what a delivery receipt (#857) acknowledges. `None` for
+/// everything else: our own messages, re-ingested duplicates, edits, tombstones,
+/// group channels, and control frames (which are never themselves acknowledged,
+/// so a receipt can never trigger a receipt).
 fn decrypt_and_persist_one(
     conn: &rusqlite::Connection,
     conversation_id: &str,
     mls_group_id: &str,
     env: &EnvelopeRow,
-) {
+    user_id: &str,
+    is_dm: bool,
+) -> Option<String> {
     // `sender_id` (the server-writable envelope column) is intentionally NOT
     // read for attribution — the sender is taken from the MLS credential inside
     // the ciphertext (sealed sender, `docs/metadata-minimization-design.md` §2).
@@ -510,13 +578,13 @@ fn decrypt_and_persist_one(
                 .flatten()
                 .unwrap_or(false);
             if exists {
-                return;
+                return None;
             }
             let Some(bytes) = ciphertext
                 .strip_prefix("mls:")
                 .and_then(|h| hex::decode(h).ok())
             else {
-                return;
+                return None;
             };
             // Attribute from the MLS-authenticated credential inside the
             // ciphertext, NOT the server-writable `message_envelope.sender_id`
@@ -527,7 +595,7 @@ fn decrypt_and_persist_one(
             else {
                 // Decrypt failed — leave the envelope in message_envelope for a
                 // future retry; the watermark is computed to not skip past it.
-                return;
+                return None;
             };
             match super::framing::classify(&plain) {
                 // "Delete for everyone" (E2EE redaction). Honor it ONLY when the
@@ -568,11 +636,51 @@ fn decrypt_and_persist_one(
                 // send and for every message from a threads-unaware client.
                 super::framing::Frame::Text { text, thread_id } => {
                     if let Ok(text) = String::from_utf8(text) {
-                        let _ = conn.execute(
+                        let inserted = conn.execute(
                             "INSERT OR IGNORE INTO message
                              (id, conversation_id, sender_id, ciphertext, content, reply_to_id, thread_id, sent_at)
                              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
                             rusqlite::params![id, conversation_id, cred_sender, bytes, text, reply_to_id, thread_id, sent_at],
+                        ).unwrap_or(0);
+                        // Delivered (#857) means exactly this: the envelope was
+                        // fetched AND decrypted AND stored, here, now. Only a
+                        // DM, only someone else's message, and only the first
+                        // time — a re-ingest returns early above, so a message
+                        // is never acknowledged twice.
+                        if inserted > 0 && is_dm && cred_sender != user_id {
+                            return Some(id.clone());
+                        }
+                    }
+                }
+                // A delivery/read receipt from another member (#857). It is a
+                // CONTROL message: no `message` row is ever written for it, on
+                // either side, so it can never be rendered and — crucially —
+                // never itself acknowledged. That is what keeps two clients from
+                // ping-ponging receipts forever.
+                super::framing::Frame::Receipt { kind, at, message_ids } => {
+                    // DMs only. A receipt frame arriving in a group channel is
+                    // dropped outright: #857 excludes group channels on the
+                    // recording side as well as the emitting side, so a client
+                    // that emitted one anyway cannot create the behaviour here.
+                    if !is_dm {
+                        return None;
+                    }
+                    // Our own receipt, echoed back to us from the conversation
+                    // we posted it to. Nothing to learn from it.
+                    if cred_sender == user_id {
+                        return None;
+                    }
+                    // `cred_sender` is the MLS-authenticated author of the
+                    // frame, so a member can only ever record a receipt in their
+                    // OWN name — neither the server nor another member can
+                    // forge "carol read this".
+                    for target in &message_ids {
+                        super::receipts::record_receipt(
+                            conn,
+                            target,
+                            &cred_sender,
+                            kind,
+                            &at,
                         );
                     }
                 }
@@ -593,7 +701,7 @@ fn decrypt_and_persist_one(
                     .and_then(|h| hex::decode(h).ok())
                     .and_then(|b| crate::commands::mls::try_mls_decrypt(conn, mls_group_id, &b))
                 else {
-                    return;
+                    return None;
                 };
                 let author: Option<String> = conn
                     .query_row(
@@ -605,7 +713,7 @@ fn decrypt_and_persist_one(
                     .ok()
                     .flatten();
                 if author.as_deref() != Some(cred_sender.as_str()) {
-                    return;
+                    return None;
                 }
                 // Strip size padding (§4.1); no-op for legacy/unpadded edits.
                 if let Ok(text) = String::from_utf8(super::framing::strip(&plain)) {
@@ -620,6 +728,9 @@ fn decrypt_and_persist_one(
         }
         _ => {}
     }
+    // Only the "persisted a new inbound DM message" path above returns an id;
+    // every other outcome is nothing to acknowledge.
+    None
 }
 
 /// Frontend-triggerable ingest for a channel. Used by LiveKit real-time hints

--- a/pollis-core/src/commands/messages/ingest.rs
+++ b/pollis-core/src/commands/messages/ingest.rs
@@ -658,18 +658,19 @@ fn decrypt_and_persist_one(
                 // never itself acknowledged. That is what keeps two clients from
                 // ping-ponging receipts forever.
                 super::framing::Frame::Receipt { kind, at, message_ids } => {
-                    // DMs only. A receipt frame arriving in a group channel is
-                    // dropped outright: #857 excludes group channels on the
-                    // recording side as well as the emitting side, so a client
-                    // that emitted one anyway cannot create the behaviour here.
-                    if !is_dm {
-                        return None;
-                    }
                     // Our own receipt, echoed back to us from the conversation
                     // we posted it to. Nothing to learn from it.
                     if cred_sender == user_id {
                         return None;
                     }
+                    // `is_dm` is passed through to the recorder rather than
+                    // checked here: #857 excludes group channels on the
+                    // recording side as well as the emitting side, and putting
+                    // that decision in `receipts_permitted` keeps it one
+                    // testable predicate instead of two call sites that have to
+                    // agree. A receipt frame that somehow reaches a group
+                    // channel is therefore dropped, not honoured.
+                    //
                     // `cred_sender` is the MLS-authenticated author of the
                     // frame, so a member can only ever record a receipt in their
                     // OWN name — neither the server nor another member can
@@ -681,6 +682,7 @@ fn decrypt_and_persist_one(
                             &cred_sender,
                             kind,
                             &at,
+                            is_dm,
                         );
                     }
                 }

--- a/pollis-core/src/commands/messages/mod.rs
+++ b/pollis-core/src/commands/messages/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod framing;
 mod ingest;
 mod reactions;
 mod read;
+mod receipts;
 mod retention;
 mod send;
 mod types;
@@ -45,6 +46,9 @@ pub use ingest::{
 pub use edit_delete::{delete_message, edit_message};
 #[cfg(feature = "test-harness")]
 pub use edit_delete::{edit_message_as, send_redaction_as};
+
+// ── Receipts (delivery / read, DMs only — #857) ──────────────────────────────
+pub use receipts::{get_conversation_receipts, mark_messages_read, MessageReceipts};
 
 // ── Reactions ────────────────────────────────────────────────────────────────
 pub use reactions::{add_reaction, get_reactions, remove_reaction, Reaction};

--- a/pollis-core/src/commands/messages/receipts.rs
+++ b/pollis-core/src/commands/messages/receipts.rs
@@ -1,0 +1,549 @@
+//! Delivery and read receipts — **DMs only** (#857).
+//!
+//! ## Shape
+//!
+//! A receipt is a **client-emitted, MLS-encrypted control message**, exactly like
+//! the "delete for everyone" redaction next door in [`super::edit_delete`]. It is
+//! a `0xF8` [`super::framing`] frame, zero-padded to the same size bucket as a
+//! short text message, posted to `/v1/messages/send` as an ordinary
+//! `type='message'` envelope.
+//!
+//! It is deliberately **not** a server-visible flag on the envelope, and
+//! deliberately **not** its own `/v1/receipts/*` DS endpoint: either would hand
+//! the untrusted Delivery Service exactly the metadata this feature must
+//! withhold — who read what, and when. Riding the ordinary send path means the
+//! DS sees one more indistinguishable `MIN_BUCKET`-sized envelope in a
+//! conversation it already knows exists, and nothing else. It also means
+//! receipts inherit MLS encryption, per-conversation watermarks, envelope GC and
+//! offline delivery with **no remote schema change, no migration, and no new DS
+//! endpoint**.
+//!
+//! ## Data model (multi-participant DMs)
+//!
+//! Receipts land in the device-local `message_receipt` table, keyed
+//! `(message_id, reader_id, kind)` — **per message, per reader**, never a single
+//! boolean on the message. A DM with five members produces up to five
+//! `delivered` rows and five `read` rows for one message, and the sender's UI
+//! renders "3 of 5 read" from exactly those rows. A 1:1 DM is just the N=1 case
+//! of the same table, so nothing has to be extended later.
+//!
+//! `reader_id` is always the **MLS credential** recovered from inside the
+//! ciphertext, never a server-supplied field, so one member cannot forge a
+//! receipt in another member's name.
+//!
+//! Receipts are local-only: they are a fact about what *this* device has
+//! learned, and there is no remote receipt table for a breach to read.
+//!
+//! ## Delivered vs read — two different signals, never conflated
+//!
+//! * **Delivered** is emitted by the ingest path in [`super::ingest`] when this
+//!   device has actually fetched an envelope and successfully MLS-decrypted it.
+//!   It is a statement about a *device*.
+//! * **Read** is emitted only by [`mark_messages_read`], which the renderer calls
+//!   when a message was genuinely on screen in a focused window in the
+//!   conversation the user is looking at. It is a statement about a *human*.
+//!   Rendering a conversation offscreen, or receiving it in a background window,
+//!   never produces a read receipt.
+//!
+//! The ordering invariant "read implies delivered" is enforced by a trigger in
+//! `local_schema.sql`, not by caller discipline.
+//!
+//! ## Opt-out (reciprocal)
+//!
+//! `send_read_receipts` in the synced preferences blob (default **true**) gates
+//! BOTH kinds at the single [`emit_receipt`] chokepoint. A user who turns it off
+//! emits nothing at all — no read receipts and no delivery receipts, because a
+//! delivery receipt is itself a "my device was online and fetched at time T"
+//! signal that a user declining receipts is declining.
+//!
+//! The switch is **reciprocal**: while it is off this device also refuses to
+//! *record* inbound receipts (see [`record_receipt`]), so the UI showing you
+//! nothing is a fact about the database rather than a promise the renderer makes.
+//! Turning it back on resumes collection from that moment.
+
+use std::sync::Arc;
+
+use rusqlite::OptionalExtension;
+
+use crate::error::{Error, Result};
+use crate::state::AppState;
+
+use super::framing::ReceiptKind;
+
+/// Preferences key for the reciprocal receipt opt-out. Lives in the existing
+/// synced `user_preferences` JSON blob, so it needs no migration and — unlike a
+/// device-local setting — actually applies on every one of the user's devices. A
+/// privacy switch that silently fails to apply on your other laptop is a broken
+/// privacy switch, which is worth more than hiding this one static bit from a
+/// server that already stores the rest of the blob.
+const PREF_KEY: &str = "send_read_receipts";
+
+/// Every receipt this device holds for one message: who has received it, and who
+/// has actually read it. Both lists are user ids, taken from MLS credentials.
+///
+/// Per-reader by construction — this is what makes a multi-participant DM work,
+/// and what a single `delivered: bool` on the message could never express.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct MessageReceipts {
+    pub message_id: String,
+    /// Readers whose device fetched and decrypted the message.
+    pub delivered_by: Vec<String>,
+    /// Readers who actually saw it on screen. Always a subset of
+    /// `delivered_by` — the schema trigger guarantees it.
+    pub read_by: Vec<String>,
+}
+
+/// Is this device allowed to emit and record receipts?
+///
+/// Reads the locally cached preferences blob written by
+/// `commands::user::get_preferences`. Missing / unparseable / absent key all
+/// mean **true**: receipts are the default behaviour of a messenger, and a
+/// cold cache must not silently disable a feature the user never turned off.
+pub(crate) fn receipts_enabled(conn: &rusqlite::Connection) -> bool {
+    let raw: Option<String> = conn
+        .query_row("SELECT preferences FROM preferences LIMIT 1", [], |row| {
+            row.get(0)
+        })
+        .optional()
+        .ok()
+        .flatten();
+    let Some(raw) = raw else {
+        return true;
+    };
+    serde_json::from_str::<serde_json::Value>(&raw)
+        .ok()
+        .and_then(|v| v.get(PREF_KEY).and_then(serde_json::Value::as_bool))
+        .unwrap_or(true)
+}
+
+/// Record one inbound receipt locally.
+///
+/// `reader_id` MUST be the MLS-authenticated credential of the receipt's author,
+/// so a member can only ever speak for themselves.
+///
+/// Refuses while the reciprocal opt-out is off: a user who does not send
+/// receipts does not collect them either, so "you can't see theirs" is enforced
+/// by the absence of rows rather than by the renderer choosing not to look.
+pub(crate) fn record_receipt(
+    conn: &rusqlite::Connection,
+    message_id: &str,
+    reader_id: &str,
+    kind: ReceiptKind,
+    at: &str,
+) {
+    if !receipts_enabled(conn) {
+        return;
+    }
+    // `INSERT OR IGNORE`: the (message_id, reader_id, kind) primary key makes a
+    // replayed envelope idempotent, and the first timestamp for a given signal
+    // is the true one — a later duplicate must not move it.
+    let _ = conn.execute(
+        "INSERT OR IGNORE INTO message_receipt (message_id, reader_id, kind, at)
+         VALUES (?1, ?2, ?3, ?4)",
+        rusqlite::params![message_id, reader_id, kind.as_str(), at],
+    );
+}
+
+/// True when `conversation_id` is a DM.
+///
+/// Receipts are DMs-only, full stop — group channels never emit or record them.
+/// This is checked inside [`emit_receipt`] rather than left to callers, so the
+/// scope restriction is a property of the chokepoint and not of everyone
+/// remembering to ask.
+async fn is_dm(state: &Arc<AppState>, conversation_id: &str) -> Result<bool> {
+    let conn = state.remote_db.conn().await?;
+    let mut rows = conn
+        .query(
+            "SELECT 1 FROM dm_channel WHERE id = ?1 LIMIT 1",
+            libsql::params![conversation_id.to_string()],
+        )
+        .await?;
+    Ok(rows.next().await?.is_some())
+}
+
+/// THE emit chokepoint for both receipt kinds. Every receipt this client ever
+/// sends goes through here, so the two invariants that decide whether this
+/// feature is correct or a metadata leak are enforced in exactly one place:
+///
+/// 1. **DMs only** — a group channel emits nothing, ever.
+/// 2. **Opt-out honoured on the sending side** — a user with
+///    `send_read_receipts = false` emits nothing, ever.
+///
+/// A no-op returns `Ok(())`: not sending a receipt is never an error worth
+/// failing an ingest pass or a UI interaction over.
+///
+/// The frame is encrypted at the group's CURRENT epoch. Unlike the send / edit /
+/// redaction paths this deliberately does **not** run a catch-up first: the only
+/// two callers have just finished one (ingest) or are acknowledging messages
+/// they already hold (read), and calling back into
+/// `catch_up_mls_group_interleaved` from inside the ingest path would recurse.
+pub(crate) async fn emit_receipt(
+    state: &Arc<AppState>,
+    conversation_id: &str,
+    user_id: &str,
+    kind: ReceiptKind,
+    message_ids: &[String],
+) -> Result<()> {
+    if message_ids.is_empty() {
+        return Ok(());
+    }
+    // Scope gate. A group channel must never produce a receipt — not behind a
+    // flag, not "while we're here".
+    if !is_dm(state, conversation_id).await? {
+        return Ok(());
+    }
+
+    let now = chrono::Utc::now().to_rfc3339();
+    let ciphertext_remote = {
+        let guard = state.local_db.lock().await;
+        let db = guard
+            .as_ref()
+            .ok_or_else(|| Error::Other(anyhow::anyhow!("Not signed in")))?;
+        // Opt-out gate, read under the same lock as the encrypt so the decision
+        // and the act cannot straddle a preference change.
+        if !receipts_enabled(db.conn()) {
+            return Ok(());
+        }
+        let plaintext = super::framing::pad_receipt(kind, &now, message_ids);
+        // A DM's MLS group is keyed by the conversation id directly.
+        let Some(mls_bytes) =
+            crate::commands::mls::try_mls_encrypt(db.conn(), conversation_id, &plaintext)
+        else {
+            // No local MLS group for this DM yet. A receipt is best-effort
+            // telemetry about messages we already hold; failing the caller over
+            // it would be worse than silently skipping.
+            return Ok(());
+        };
+        format!("mls:{}", hex::encode(&mls_bytes))
+    };
+
+    // Blind the envelope sender exactly like every other send — sealing is
+    // unconditional (#607). The reader's true identity is the MLS credential
+    // inside the ciphertext, which is what the recipient records as `reader_id`.
+    let body = serde_json::json!({
+        "id": ulid::Ulid::new().to_string(),
+        "conversation_id": conversation_id,
+        "sender_id": super::send::SEALED_SENDER_SENTINEL,
+        "sealed": 1,
+        "ciphertext": ciphertext_remote,
+        "sent_at": now,
+    });
+    crate::commands::mls::ds_post_ok(state, "/v1/messages/send", &body).await?;
+
+    // Wake the peers so the sender sees the tick without polling. This is the
+    // same routing-only hint an ordinary message publishes, which is also why it
+    // leaks nothing extra: a receipt already looks like a message on the wire.
+    // A receipt never becomes a local `message` row, so it cannot move an unread
+    // count or raise a notification on arrival.
+    if let Err(e) = crate::commands::livekit::publish_new_message_to_room(
+        state,
+        conversation_id,
+        None,
+        Some(conversation_id),
+    )
+    .await
+    {
+        eprintln!("[receipts] publish hint for {conversation_id}: {e}");
+    }
+
+    let _ = user_id;
+    Ok(())
+}
+
+/// Emit **delivered** receipts for messages this device just fetched and
+/// decrypted. Called by the ingest path; see [`emit_receipt`] for the gates.
+pub(crate) async fn emit_delivered(
+    state: &Arc<AppState>,
+    conversation_id: &str,
+    user_id: &str,
+    message_ids: &[String],
+) -> Result<()> {
+    emit_receipt(
+        state,
+        conversation_id,
+        user_id,
+        ReceiptKind::Delivered,
+        message_ids,
+    )
+    .await
+}
+
+/// Mark messages as **actually read by the human** and emit a read receipt.
+///
+/// The renderer calls this only for messages that were genuinely on screen, in a
+/// focused window, in the conversation the user is looking at — never merely
+/// because a conversation was mounted or rendered offscreen.
+///
+/// Only messages authored by *someone else* are acknowledged; a user reading
+/// their own message is not a signal. Ids the device does not hold are dropped
+/// rather than trusted, so a buggy or hostile renderer cannot make this device
+/// vouch for messages it never received.
+pub async fn mark_messages_read(
+    conversation_id: String,
+    user_id: String,
+    message_ids: Vec<String>,
+    state: &Arc<AppState>,
+) -> Result<()> {
+    if message_ids.is_empty() {
+        return Ok(());
+    }
+    let to_ack: Vec<String> = {
+        let guard = state.local_db.lock().await;
+        let db = guard
+            .as_ref()
+            .ok_or_else(|| Error::Other(anyhow::anyhow!("Not signed in")))?;
+        let mut out = Vec::new();
+        for id in &message_ids {
+            let author: Option<String> = db
+                .conn()
+                .query_row(
+                    "SELECT sender_id FROM message
+                     WHERE id = ?1 AND conversation_id = ?2",
+                    rusqlite::params![id, conversation_id],
+                    |row| row.get(0),
+                )
+                .optional()
+                .ok()
+                .flatten();
+            // Present, and not ours.
+            if author.is_some_and(|a| a != user_id) {
+                out.push(id.clone());
+            }
+        }
+        out
+    };
+
+    emit_receipt(
+        state,
+        &conversation_id,
+        &user_id,
+        ReceiptKind::Read,
+        &to_ack,
+    )
+    .await
+}
+
+/// Every receipt this device holds for the messages of one conversation.
+///
+/// Returns one entry per message that has at least one receipt; a message
+/// nobody has acknowledged simply does not appear. Returns an empty list while
+/// the reciprocal opt-out is off — belt-and-braces over [`record_receipt`],
+/// which already declines to store anything in that state.
+pub async fn get_conversation_receipts(
+    conversation_id: String,
+    state: &Arc<AppState>,
+) -> Result<Vec<MessageReceipts>> {
+    let guard = state.local_db.lock().await;
+    let db = guard
+        .as_ref()
+        .ok_or_else(|| Error::Other(anyhow::anyhow!("Not signed in")))?;
+    let conn = db.conn();
+    if !receipts_enabled(conn) {
+        return Ok(Vec::new());
+    }
+
+    let mut stmt = conn.prepare(
+        "SELECT r.message_id, r.reader_id, r.kind
+         FROM message_receipt r
+         JOIN message m ON m.id = r.message_id
+         WHERE m.conversation_id = ?1
+         ORDER BY r.message_id ASC, r.at ASC",
+    )?;
+    let rows = stmt.query_map(rusqlite::params![conversation_id], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, String>(2)?,
+        ))
+    })?;
+
+    // Preserve message order while grouping.
+    let mut out: Vec<MessageReceipts> = Vec::new();
+    for row in rows {
+        let (message_id, reader_id, kind) = row?;
+        if out.last().map(|r| r.message_id.as_str()) != Some(message_id.as_str()) {
+            out.push(MessageReceipts {
+                message_id: message_id.clone(),
+                delivered_by: Vec::new(),
+                read_by: Vec::new(),
+            });
+        }
+        let entry = out
+            .last_mut()
+            .expect("just pushed when the group changed");
+        match kind.as_str() {
+            "delivered" => entry.delivered_by.push(reader_id),
+            "read" => entry.read_by.push(reader_id),
+            _ => {}
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    //! The properties, not the happy path: what the opt-out means, that a read
+    //! can never exist without a delivered, and that the table really is
+    //! per-reader rather than a boolean wearing a disguise.
+
+    use super::*;
+    use crate::db::local::LocalDb;
+
+    fn db() -> LocalDb {
+        LocalDb::open_in_memory().expect("in-memory local db")
+    }
+
+    fn set_pref(conn: &rusqlite::Connection, json: &str) {
+        conn.execute("DELETE FROM preferences", []).unwrap();
+        conn.execute(
+            "INSERT INTO preferences (preferences) VALUES (?1)",
+            rusqlite::params![json],
+        )
+        .unwrap();
+    }
+
+    fn receipt_rows(conn: &rusqlite::Connection, message_id: &str) -> Vec<(String, String)> {
+        let mut stmt = conn
+            .prepare(
+                "SELECT reader_id, kind FROM message_receipt
+                 WHERE message_id = ?1 ORDER BY reader_id, kind",
+            )
+            .unwrap();
+        let rows = stmt
+            .query_map(rusqlite::params![message_id], |r| {
+                Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?))
+            })
+            .unwrap();
+        rows.map(|r| r.unwrap()).collect()
+    }
+
+    /// Default is ON, and every shape of missing/broken cache must also read as
+    /// ON — a cold or corrupt preferences row must never silently disable a
+    /// feature the user did not turn off.
+    #[test]
+    fn receipts_default_to_enabled() {
+        let db = db();
+        assert!(receipts_enabled(db.conn()), "no preferences row at all");
+        for json in ["{}", r#"{"other":1}"#, "not json", r#"{"send_read_receipts":null}"#] {
+            set_pref(db.conn(), json);
+            assert!(receipts_enabled(db.conn()), "prefs = {json}");
+        }
+        set_pref(db.conn(), r#"{"send_read_receipts":true}"#);
+        assert!(receipts_enabled(db.conn()));
+    }
+
+    /// The opt-out is the only thing that turns it off, and it turns it off for
+    /// both directions.
+    #[test]
+    fn opt_out_disables_recording_in_both_directions() {
+        let db = db();
+        set_pref(db.conn(), r#"{"send_read_receipts":false}"#);
+        assert!(!receipts_enabled(db.conn()));
+
+        record_receipt(db.conn(), "m1", "bob", ReceiptKind::Delivered, "t0");
+        record_receipt(db.conn(), "m1", "bob", ReceiptKind::Read, "t1");
+        assert!(
+            receipt_rows(db.conn(), "m1").is_empty(),
+            "an opted-out device must not collect other people's receipts either",
+        );
+
+        // Flipping it back on resumes collection from that moment.
+        set_pref(db.conn(), r#"{"send_read_receipts":true}"#);
+        record_receipt(db.conn(), "m1", "bob", ReceiptKind::Delivered, "t2");
+        assert_eq!(
+            receipt_rows(db.conn(), "m1"),
+            vec![("bob".to_string(), "delivered".to_string())],
+        );
+    }
+
+    /// A multi-participant DM records receipts PER READER — the property a
+    /// single boolean on the message could not express. Four members, partial
+    /// reads, and the counts must come out per-person.
+    #[test]
+    fn multi_participant_dm_records_per_reader() {
+        let db = db();
+        // Three peers received it; only two of them actually read it.
+        for reader in ["bob", "carol", "dave"] {
+            record_receipt(db.conn(), "m1", reader, ReceiptKind::Delivered, "t0");
+        }
+        for reader in ["bob", "dave"] {
+            record_receipt(db.conn(), "m1", reader, ReceiptKind::Read, "t1");
+        }
+
+        let rows = receipt_rows(db.conn(), "m1");
+        assert_eq!(
+            rows,
+            vec![
+                ("bob".to_string(), "delivered".to_string()),
+                ("bob".to_string(), "read".to_string()),
+                ("carol".to_string(), "delivered".to_string()),
+                ("dave".to_string(), "delivered".to_string()),
+                ("dave".to_string(), "read".to_string()),
+            ],
+            "each reader must be tracked independently",
+        );
+
+        // The sender's "N of M read" therefore falls straight out of the rows.
+        let read_count = rows.iter().filter(|(_, k)| k == "read").count();
+        let delivered_count = rows.iter().filter(|(_, k)| k == "delivered").count();
+        assert_eq!((delivered_count, read_count), (3, 2));
+    }
+
+    /// "Read implies delivered" is a SCHEMA guarantee, not caller discipline:
+    /// inserting only a read row must materialise the delivered row too, so the
+    /// state "read but never delivered" cannot exist in the table.
+    #[test]
+    fn read_without_delivered_is_unrepresentable() {
+        let db = db();
+        // Straight through the raw SQL, bypassing every Rust-side helper — the
+        // invariant has to hold at the lowest layer.
+        db.conn()
+            .execute(
+                "INSERT INTO message_receipt (message_id, reader_id, kind, at)
+                 VALUES ('m9', 'erin', 'read', 't5')",
+                [],
+            )
+            .unwrap();
+        assert_eq!(
+            receipt_rows(db.conn(), "m9"),
+            vec![
+                ("erin".to_string(), "delivered".to_string()),
+                ("erin".to_string(), "read".to_string()),
+            ],
+            "a read receipt must imply a delivered receipt",
+        );
+    }
+
+    /// The kind column is closed: nothing but the two real signals can be
+    /// stored, so "delivered" can never drift into meaning "read".
+    #[test]
+    fn unknown_receipt_kinds_are_rejected() {
+        let db = db();
+        let err = db.conn().execute(
+            "INSERT INTO message_receipt (message_id, reader_id, kind, at)
+             VALUES ('m1', 'bob', 'seen-ish', 't0')",
+            [],
+        );
+        assert!(err.is_err(), "an unknown receipt kind must not be storable");
+    }
+
+    /// Re-ingesting the same envelope must not duplicate rows or move the
+    /// recorded time — envelopes are re-fetched whenever a watermark cannot
+    /// advance, so idempotency is load-bearing, not a nicety.
+    #[test]
+    fn recording_is_idempotent_and_keeps_the_first_timestamp() {
+        let db = db();
+        record_receipt(db.conn(), "m1", "bob", ReceiptKind::Delivered, "t-first");
+        record_receipt(db.conn(), "m1", "bob", ReceiptKind::Delivered, "t-second");
+        assert_eq!(receipt_rows(db.conn(), "m1").len(), 1);
+        let at: String = db
+            .conn()
+            .query_row(
+                "SELECT at FROM message_receipt WHERE message_id = 'm1' AND kind = 'delivered'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(at, "t-first");
+    }
+}

--- a/pollis-core/src/commands/messages/receipts.rs
+++ b/pollis-core/src/commands/messages/receipts.rs
@@ -198,7 +198,6 @@ async fn is_dm(state: &Arc<AppState>, conversation_id: &str) -> Result<bool> {
 pub(crate) async fn emit_receipt(
     state: &Arc<AppState>,
     conversation_id: &str,
-    user_id: &str,
     kind: ReceiptKind,
     message_ids: &[String],
 ) -> Result<()> {
@@ -262,7 +261,6 @@ pub(crate) async fn emit_receipt(
         eprintln!("[receipts] publish hint for {conversation_id}: {e}");
     }
 
-    let _ = user_id;
     Ok(())
 }
 
@@ -271,17 +269,9 @@ pub(crate) async fn emit_receipt(
 pub(crate) async fn emit_delivered(
     state: &Arc<AppState>,
     conversation_id: &str,
-    user_id: &str,
     message_ids: &[String],
 ) -> Result<()> {
-    emit_receipt(
-        state,
-        conversation_id,
-        user_id,
-        ReceiptKind::Delivered,
-        message_ids,
-    )
-    .await
+    emit_receipt(state, conversation_id, ReceiptKind::Delivered, message_ids).await
 }
 
 /// Mark messages as **actually read by the human** and emit a read receipt.
@@ -329,14 +319,7 @@ pub async fn mark_messages_read(
         out
     };
 
-    emit_receipt(
-        state,
-        &conversation_id,
-        &user_id,
-        ReceiptKind::Read,
-        &to_ack,
-    )
-    .await
+    emit_receipt(state, &conversation_id, ReceiptKind::Read, &to_ack).await
 }
 
 /// Every receipt this device holds for the messages of one conversation.

--- a/pollis-core/src/commands/messages/receipts.rs
+++ b/pollis-core/src/commands/messages/receipts.rs
@@ -116,6 +116,22 @@ pub(crate) fn receipts_enabled(conn: &rusqlite::Connection) -> bool {
         .unwrap_or(true)
 }
 
+/// THE gate on all receipt activity, in one pure predicate — emitting and
+/// recording, both kinds, every call site.
+///
+/// Both conditions are load-bearing and neither is a nicety:
+/// * `is_dm` — #857 is DMs-only. A group channel emits nothing and records
+///   nothing. Not behind a flag, not "while we're here".
+/// * `enabled` — the user's `send_read_receipts` preference. Reciprocal, so it
+///   gates the recording direction too.
+///
+/// Pure so the whole truth table is testable without a database or a network,
+/// which is what makes "a receipt is never produced in a group channel" an
+/// asserted invariant rather than a claim about two call sites.
+pub(crate) fn receipts_permitted(is_dm: bool, enabled: bool) -> bool {
+    is_dm && enabled
+}
+
 /// Record one inbound receipt locally.
 ///
 /// `reader_id` MUST be the MLS-authenticated credential of the receipt's author,
@@ -124,14 +140,16 @@ pub(crate) fn receipts_enabled(conn: &rusqlite::Connection) -> bool {
 /// Refuses while the reciprocal opt-out is off: a user who does not send
 /// receipts does not collect them either, so "you can't see theirs" is enforced
 /// by the absence of rows rather than by the renderer choosing not to look.
+/// Refuses outside a DM for the same reason the emit side does.
 pub(crate) fn record_receipt(
     conn: &rusqlite::Connection,
     message_id: &str,
     reader_id: &str,
     kind: ReceiptKind,
     at: &str,
+    is_dm: bool,
 ) {
-    if !receipts_enabled(conn) {
+    if !receipts_permitted(is_dm, receipts_enabled(conn)) {
         return;
     }
     // `INSERT OR IGNORE`: the (message_id, reader_id, kind) primary key makes a
@@ -187,11 +205,9 @@ pub(crate) async fn emit_receipt(
     if message_ids.is_empty() {
         return Ok(());
     }
-    // Scope gate. A group channel must never produce a receipt — not behind a
-    // flag, not "while we're here".
-    if !is_dm(state, conversation_id).await? {
-        return Ok(());
-    }
+    // Scope gate, resolved against the database rather than trusted from the
+    // caller: a group channel must never produce a receipt.
+    let dm = is_dm(state, conversation_id).await?;
 
     let now = chrono::Utc::now().to_rfc3339();
     let ciphertext_remote = {
@@ -199,9 +215,9 @@ pub(crate) async fn emit_receipt(
         let db = guard
             .as_ref()
             .ok_or_else(|| Error::Other(anyhow::anyhow!("Not signed in")))?;
-        // Opt-out gate, read under the same lock as the encrypt so the decision
-        // and the act cannot straddle a preference change.
-        if !receipts_enabled(db.conn()) {
+        // Both gates together, under the same lock as the encrypt so the
+        // decision and the act cannot straddle a preference change.
+        if !receipts_permitted(dm, receipts_enabled(db.conn())) {
             return Ok(());
         }
         let plaintext = super::framing::pad_receipt(kind, &now, message_ids);
@@ -417,6 +433,43 @@ mod tests {
         rows.map(|r| r.unwrap()).collect()
     }
 
+    /// **DMs only.** The single most important scope property of #857: a group
+    /// channel must never produce or record a receipt, whatever the preference
+    /// says. Exhaustive over the whole two-bit truth table, so the "not behind a
+    /// flag, not while we're here" requirement is asserted, not asserted-about.
+    #[test]
+    fn receipts_are_permitted_only_in_dms() {
+        assert!(receipts_permitted(true, true), "a DM with receipts on");
+        assert!(
+            !receipts_permitted(false, true),
+            "a GROUP CHANNEL must never produce a receipt, even with the preference on",
+        );
+        assert!(
+            !receipts_permitted(true, false),
+            "a DM must produce nothing while the user has opted out",
+        );
+        assert!(!receipts_permitted(false, false), "neither");
+    }
+
+    /// The DM-only rule holds on the RECORDING side too, not just the emitting
+    /// side — a receipt frame that somehow arrives in a group channel is
+    /// dropped rather than honoured.
+    #[test]
+    fn a_group_channel_records_no_receipts() {
+        let db = db();
+        record_receipt(db.conn(), "m1", "bob", ReceiptKind::Delivered, "t0", false);
+        record_receipt(db.conn(), "m1", "bob", ReceiptKind::Read, "t1", false);
+        assert!(
+            receipt_rows(db.conn(), "m1").is_empty(),
+            "a group channel must not accumulate receipts",
+        );
+
+        // Same inputs, in a DM: recorded. Proves the test above is not passing
+        // for some unrelated reason.
+        record_receipt(db.conn(), "m1", "bob", ReceiptKind::Delivered, "t0", true);
+        assert_eq!(receipt_rows(db.conn(), "m1").len(), 1);
+    }
+
     /// Default is ON, and every shape of missing/broken cache must also read as
     /// ON — a cold or corrupt preferences row must never silently disable a
     /// feature the user did not turn off.
@@ -440,8 +493,8 @@ mod tests {
         set_pref(db.conn(), r#"{"send_read_receipts":false}"#);
         assert!(!receipts_enabled(db.conn()));
 
-        record_receipt(db.conn(), "m1", "bob", ReceiptKind::Delivered, "t0");
-        record_receipt(db.conn(), "m1", "bob", ReceiptKind::Read, "t1");
+        record_receipt(db.conn(), "m1", "bob", ReceiptKind::Delivered, "t0", true);
+        record_receipt(db.conn(), "m1", "bob", ReceiptKind::Read, "t1", true);
         assert!(
             receipt_rows(db.conn(), "m1").is_empty(),
             "an opted-out device must not collect other people's receipts either",
@@ -449,7 +502,7 @@ mod tests {
 
         // Flipping it back on resumes collection from that moment.
         set_pref(db.conn(), r#"{"send_read_receipts":true}"#);
-        record_receipt(db.conn(), "m1", "bob", ReceiptKind::Delivered, "t2");
+        record_receipt(db.conn(), "m1", "bob", ReceiptKind::Delivered, "t2", true);
         assert_eq!(
             receipt_rows(db.conn(), "m1"),
             vec![("bob".to_string(), "delivered".to_string())],
@@ -464,10 +517,10 @@ mod tests {
         let db = db();
         // Three peers received it; only two of them actually read it.
         for reader in ["bob", "carol", "dave"] {
-            record_receipt(db.conn(), "m1", reader, ReceiptKind::Delivered, "t0");
+            record_receipt(db.conn(), "m1", reader, ReceiptKind::Delivered, "t0", true);
         }
         for reader in ["bob", "dave"] {
-            record_receipt(db.conn(), "m1", reader, ReceiptKind::Read, "t1");
+            record_receipt(db.conn(), "m1", reader, ReceiptKind::Read, "t1", true);
         }
 
         let rows = receipt_rows(db.conn(), "m1");
@@ -533,8 +586,8 @@ mod tests {
     #[test]
     fn recording_is_idempotent_and_keeps_the_first_timestamp() {
         let db = db();
-        record_receipt(db.conn(), "m1", "bob", ReceiptKind::Delivered, "t-first");
-        record_receipt(db.conn(), "m1", "bob", ReceiptKind::Delivered, "t-second");
+        record_receipt(db.conn(), "m1", "bob", ReceiptKind::Delivered, "t-first", true);
+        record_receipt(db.conn(), "m1", "bob", ReceiptKind::Delivered, "t-second", true);
         assert_eq!(receipt_rows(db.conn(), "m1").len(), 1);
         let at: String = db
             .conn()

--- a/pollis-core/src/db/local_schema.sql
+++ b/pollis-core/src/db/local_schema.sql
@@ -117,6 +117,40 @@ CREATE TABLE IF NOT EXISTS user_cache (
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
+-- Delivery / read receipts for DM messages (#857).
+--
+-- PER MESSAGE, PER READER, PER KIND — never a boolean on the message. A DM can
+-- have several members, so "who has received this" and "who has read this" are
+-- sets, and the 1:1 case is just the N=1 row count. `reader_id` is always the
+-- MLS credential recovered from inside the receipt's ciphertext, so a member can
+-- only ever speak for themselves.
+--
+-- Device-local by design: a receipt is a fact this device has learned, and
+-- keeping it off the server is the whole point — the DS never sees who read
+-- what, or when. `at` is the reader's own timestamp, carried inside the
+-- authenticated ciphertext.
+CREATE TABLE IF NOT EXISTS message_receipt (
+    message_id TEXT NOT NULL,
+    reader_id  TEXT NOT NULL,
+    kind       TEXT NOT NULL CHECK (kind IN ('delivered', 'read')),
+    at         TEXT NOT NULL,
+    PRIMARY KEY (message_id, reader_id, kind)
+);
+CREATE INDEX IF NOT EXISTS idx_message_receipt_message ON message_receipt(message_id);
+
+-- "Read implies delivered" enforced at the LOWEST layer (see
+-- docs/backend-core-invariants.md): you cannot have read a message your device
+-- never received. Recording a read materialises the matching delivered row, so
+-- the state "read but not delivered" is physically unrepresentable rather than
+-- something every caller has to remember to maintain.
+CREATE TRIGGER IF NOT EXISTS message_receipt_read_implies_delivered
+AFTER INSERT ON message_receipt
+WHEN NEW.kind = 'read'
+BEGIN
+    INSERT OR IGNORE INTO message_receipt (message_id, reader_id, kind, at)
+    VALUES (NEW.message_id, NEW.reader_id, 'delivered', NEW.at);
+END;
+
 -- Safety-number / contact verification pins (Signal-style).
 -- TOFU: the first account_id_pub seen for a peer is stored here. A later
 -- mismatch is surfaced as a "changed" status and clears `verified`. Lives

--- a/pollis-delivery/tests/receipt_opacity.rs
+++ b/pollis-delivery/tests/receipt_opacity.rs
@@ -1,0 +1,332 @@
+//! Receipts (#857) must be **opaque to the Delivery Service**.
+//!
+//! The DS is untrusted. The entire feature is only correct if a server operator
+//! (or anyone with a Turso dump / subpoena) cannot learn *who read what, when*.
+//! That is not a property of the ciphertext alone — it is a property of every
+//! artifact a receipt leaves on the server: the request line, the stored row,
+//! and the columns that row is made of.
+//!
+//! So these tests do not check that receipts work. They try to *find* a receipt
+//! from the DS's point of view, and assert it cannot be found:
+//!
+//! 1. There is no receipt endpoint to call. A `/v1/receipts/*` route would put
+//!    "this is a receipt" in the request line — handing the DS, in plaintext,
+//!    precisely the metadata the ciphertext exists to withhold. Receipts ride
+//!    `/v1/messages/send` for that reason.
+//! 2. A receipt and an ordinary text message produce rows that are identical in
+//!    every stored column's shape — same `type`, same blinded sender, same
+//!    sealed flag, same ciphertext length. The DS cannot sort its envelope
+//!    stream into "messages" and "receipts".
+//! 3. Nothing from the receipt's plaintext — the kind, the reader, the
+//!    acknowledged message ids — survives into any stored column.
+//! 4. The DS never interprets the ciphertext: it round-trips whatever bytes it
+//!    is handed, so there is no server-side parse that could learn anything.
+
+use std::sync::Arc;
+
+use axum::http::{Request, StatusCode};
+use pollis_delivery::db::Db;
+use pollis_delivery::messages::{apply_send_message, SendMessageBody};
+use pollis_delivery::writes::WriteOutcome;
+use pollis_delivery::{build_router_with_state, AppState};
+use tower::ServiceExt as _;
+
+/// Mirrors the live `message_envelope` shape, including the `sealed` column the
+/// send handler writes. No FK `REFERENCES` — `connect_local` runs with
+/// `foreign_keys=OFF` (same convention as `envelope_retention.rs`).
+const SCHEMA: &str = "\
+CREATE TABLE message_envelope (\
+  id TEXT PRIMARY KEY, conversation_id TEXT NOT NULL, sent_at TEXT NOT NULL, \
+  sender_id TEXT NOT NULL DEFAULT '', ciphertext TEXT NOT NULL DEFAULT '', \
+  reply_to_id TEXT, type TEXT NOT NULL DEFAULT 'message', target_message_id TEXT, \
+  sealed INTEGER NOT NULL DEFAULT 0);\
+CREATE TABLE dm_channel (id TEXT PRIMARY KEY, created_by TEXT NOT NULL, created_at TEXT NOT NULL);\
+CREATE TABLE dm_channel_member (\
+  dm_channel_id TEXT NOT NULL, user_id TEXT NOT NULL, added_by TEXT NOT NULL, \
+  added_at TEXT NOT NULL, accepted_at TEXT, PRIMARY KEY (dm_channel_id, user_id));\
+CREATE TABLE channels (id TEXT PRIMARY KEY, group_id TEXT NOT NULL);\
+CREATE TABLE group_member (group_id TEXT NOT NULL, user_id TEXT NOT NULL, role TEXT NOT NULL DEFAULT 'member');";
+
+/// The blinded sender every send writes under unconditional sealed sender
+/// (#607) — receipts included.
+const SEALED_SENTINEL: &str = "sealed";
+
+/// The DM the receipts in these tests are exchanged in.
+const CONV: &str = "dm1";
+
+/// Message ids a receipt acknowledges. If any of these ever appear in a stored
+/// column, the DS has learned which messages were read.
+const ACKED: [&str; 2] = [
+    "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+    "01J8XQ2M5H7NR3T0V9WZ4KDCEB",
+];
+
+async fn fresh() -> Arc<Db> {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("db.db");
+    std::mem::forget(dir);
+    let db = Db::connect_local(path.to_str().unwrap()).await.expect("local db");
+    db.conn().unwrap().execute_batch(SCHEMA).await.expect("schema");
+    let db = Arc::new(db);
+    db.conn()
+        .unwrap()
+        .execute(
+            "INSERT INTO dm_channel (id, created_by, created_at) VALUES (?1, 'alice', '2026-01-01')",
+            libsql::params![CONV],
+        )
+        .await
+        .expect("dm");
+    for user in ["alice", "bob"] {
+        db.conn()
+            .unwrap()
+            .execute(
+                "INSERT INTO dm_channel_member (dm_channel_id, user_id, added_by, added_at, accepted_at) \
+                 VALUES (?1, ?2, 'alice', '2026-01-01', '2026-01-01')",
+                libsql::params![CONV, user],
+            )
+            .await
+            .expect("member");
+    }
+    db
+}
+
+/// The v1 receipt frame (`0xF8`), rebuilt here independently of `pollis-core`.
+/// Writing it out a second time is deliberate: it keeps this crate free of a
+/// dependency on the client, and it means the test knows exactly which bytes
+/// must never reach the server.
+fn receipt_plaintext(read: bool, at: &str, ids: &[&str]) -> Vec<u8> {
+    let mut buf = vec![0xF8u8, u8::from(read)];
+    buf.extend_from_slice(&(at.len() as u32).to_le_bytes());
+    buf.extend_from_slice(at.as_bytes());
+    buf.extend_from_slice(&(ids.len() as u32).to_le_bytes());
+    for id in ids {
+        buf.extend_from_slice(&(id.len() as u32).to_le_bytes());
+        buf.extend_from_slice(id.as_bytes());
+    }
+    // Zero-pad to the same 256-byte floor bucket every short frame lands in.
+    buf.resize(256, 0u8);
+    buf
+}
+
+/// Stand-in for the MLS sealing the client performs before posting. The DS never
+/// holds a group key, so from its side the payload is exactly this: bytes it
+/// cannot invert. Deterministic so the test is reproducible.
+fn seal(plaintext: &[u8]) -> String {
+    let mut out = String::from("mls:");
+    for (i, b) in plaintext.iter().enumerate() {
+        out.push_str(&format!("{:02x}", b ^ ((i as u8).wrapping_mul(31).wrapping_add(7))));
+    }
+    out
+}
+
+fn body(id: &str, ciphertext: &str) -> SendMessageBody {
+    SendMessageBody {
+        id: id.to_string(),
+        conversation_id: CONV.to_string(),
+        sender_id: Some(SEALED_SENTINEL.to_string()),
+        ciphertext: ciphertext.to_string(),
+        reply_to_id: None,
+        sent_at: "2026-08-15T12:00:00Z".to_string(),
+        sealed: 1,
+    }
+}
+
+/// Everything the DS stores for one envelope, as text — the complete
+/// server-side view of it.
+async fn stored_row(db: &Db, id: &str) -> String {
+    let mut rows = db
+        .conn()
+        .unwrap()
+        .query(
+            "SELECT id, conversation_id, sender_id, ciphertext, \
+                    COALESCE(reply_to_id,''), type, COALESCE(target_message_id,''), \
+                    CAST(sealed AS TEXT), sent_at \
+             FROM message_envelope WHERE id = ?1",
+            libsql::params![id],
+        )
+        .await
+        .expect("query");
+    let row = rows.next().await.expect("rows").expect("row present");
+    let mut out = String::new();
+    for i in 0..8 {
+        out.push_str(&row.get::<String>(i).unwrap_or_default());
+        out.push('\u{1}');
+    }
+    out.push_str(&row.get::<String>(8).unwrap_or_default());
+    out
+}
+
+/// A `/v1/receipts/*` endpoint — any endpoint whose very name announces the
+/// payload — must not exist. This is the leak that ciphertext cannot fix: the
+/// request line is plaintext to the DS, so a dedicated route would tell an
+/// operator "bob acknowledged something in dm1 at 12:00" on every single read.
+#[tokio::test]
+async fn ds_exposes_no_receipt_endpoint() {
+    let db = fresh().await;
+    let router = build_router_with_state(AppState::new(Arc::clone(&db), false));
+
+    for path in [
+        "/v1/receipts/send",
+        "/v1/receipts/add",
+        "/v1/receipts",
+        "/v1/messages/receipts",
+        "/v1/read-receipts/send",
+    ] {
+        let req = Request::builder()
+            .method("POST")
+            .uri(path)
+            .header("content-type", "application/json")
+            .body(axum::body::Body::from("{}"))
+            .unwrap();
+        let status = router.clone().oneshot(req).await.unwrap().status();
+        assert_eq!(
+            status,
+            StatusCode::NOT_FOUND,
+            "{path} must not exist — a receipt-named route leaks who acknowledged what, \
+             in the clear, regardless of how well the body is encrypted",
+        );
+    }
+}
+
+/// The DS cannot tell a receipt from an ordinary short message. Both go through
+/// the real `apply_send_message`; every stored column must come out the same
+/// shape, so there is no server-side predicate that isolates receipts.
+#[tokio::test]
+async fn receipt_is_indistinguishable_from_an_ordinary_message() {
+    let db = fresh().await;
+
+    // A read receipt acknowledging two messages...
+    let receipt_ct = seal(&receipt_plaintext(true, "2026-08-15T12:00:00Z", &ACKED));
+    // ...and an ordinary short text message, padded to the same bucket.
+    let mut text = vec![0xF5u8];
+    text.extend_from_slice(&2u32.to_le_bytes());
+    text.extend_from_slice(b"hi");
+    text.resize(256, 0u8);
+    let text_ct = seal(&text);
+
+    for (id, ct) in [("env_receipt", &receipt_ct), ("env_text", &text_ct)] {
+        let outcome = apply_send_message(&db.conn().unwrap(), Some("bob"), &body(id, ct))
+            .await
+            .expect("send");
+        assert!(matches!(outcome, WriteOutcome::Ok), "{id} must be accepted");
+    }
+
+    let receipt_row = stored_row(&db, "env_receipt").await;
+    let text_row = stored_row(&db, "env_text").await;
+
+    // Column-by-column: everything except the opaque id and the opaque
+    // ciphertext must be literally equal, and those two must match in LENGTH.
+    let r: Vec<&str> = receipt_row.split('\u{1}').collect();
+    let t: Vec<&str> = text_row.split('\u{1}').collect();
+    assert_eq!(r[2], t[2], "sender_id: both blinded to the same sentinel");
+    assert_eq!(r[2], SEALED_SENTINEL);
+    assert_eq!(r[3].len(), t[3].len(), "ciphertext length must not give it away");
+    assert_eq!(r[4], t[4], "reply_to_id");
+    assert_eq!(r[5], t[5], "type: a receipt is stored as an ordinary 'message'");
+    assert_eq!(r[5], "message");
+    assert_eq!(r[6], t[6], "target_message_id: empty for both");
+    assert_eq!(r[7], t[7], "sealed flag");
+    assert_eq!(r[8], t[8], "sent_at shape");
+
+    // And there is no column anywhere in the table that could name a receipt.
+    let mut rows = db
+        .conn()
+        .unwrap()
+        .query("SELECT name FROM pragma_table_info('message_envelope')", ())
+        .await
+        .expect("pragma");
+    while let Some(row) = rows.next().await.expect("row") {
+        let name: String = row.get(0).unwrap();
+        assert!(
+            !name.to_lowercase().contains("receipt")
+                && !name.to_lowercase().contains("read")
+                && !name.to_lowercase().contains("seen"),
+            "message_envelope.{name} would be a server-visible receipt flag",
+        );
+    }
+}
+
+/// Nothing from the receipt's plaintext reaches the server. The kind, the
+/// timestamp the reader stamped, and above all the ids of the messages being
+/// acknowledged must not appear in any stored column.
+#[tokio::test]
+async fn receipt_plaintext_never_reaches_the_stored_row() {
+    let db = fresh().await;
+    let plaintext = receipt_plaintext(true, "2026-08-15T12:00:00Z", &ACKED);
+    let ct = seal(&plaintext);
+
+    apply_send_message(&db.conn().unwrap(), Some("bob"), &body("env_r", &ct))
+        .await
+        .expect("send");
+
+    let row = stored_row(&db, "env_r").await;
+    for acked in ACKED {
+        assert!(
+            !row.contains(acked),
+            "the DS learned WHICH message was acknowledged ({acked}) — that is the leak",
+        );
+    }
+    for token in ["read", "delivered", "receipt", "\u{F8}"] {
+        assert!(
+            !row.contains(token),
+            "the token {token:?} survived into the DS's view of the envelope",
+        );
+    }
+    // The reader's identity is not in the row either — the sender column is the
+    // blinded sentinel, and the true reader lives only in the MLS credential
+    // inside the ciphertext.
+    assert!(!row.contains("bob"), "the reader must not be attributable from the row");
+
+    // Sanity: the plaintext really did contain what we just proved is absent, so
+    // this test cannot pass vacuously.
+    let as_text = String::from_utf8_lossy(&plaintext);
+    assert!(as_text.contains(ACKED[0]) && as_text.contains(ACKED[1]));
+}
+
+/// The DS never parses the ciphertext — it stores and returns whatever bytes it
+/// is handed. Demonstrated by round-tripping a receipt and a deliberately
+/// nonsense payload through the identical code path with identical results:
+/// there is no server-side interpretation that could learn anything.
+#[tokio::test]
+async fn ds_round_trips_ciphertext_without_interpreting_it() {
+    let db = fresh().await;
+    let receipt_ct = seal(&receipt_plaintext(false, "2026-08-15T12:00:00Z", &ACKED));
+    let garbage_ct = "mls:deadbeefdeadbeef";
+
+    for (id, ct) in [("env_a", receipt_ct.as_str()), ("env_b", garbage_ct)] {
+        let outcome = apply_send_message(&db.conn().unwrap(), Some("bob"), &body(id, ct))
+            .await
+            .expect("send");
+        assert!(
+            matches!(outcome, WriteOutcome::Ok),
+            "the DS must accept {id} without inspecting its payload",
+        );
+        let mut rows = db
+            .conn()
+            .unwrap()
+            .query(
+                "SELECT ciphertext FROM message_envelope WHERE id = ?1",
+                libsql::params![id],
+            )
+            .await
+            .expect("query");
+        let stored: String = rows.next().await.unwrap().unwrap().get(0).unwrap();
+        assert_eq!(stored, ct, "{id} must round-trip byte-for-byte");
+    }
+}
+
+/// Membership authz is unchanged for receipts — they are still ordinary
+/// envelope writes, so a non-member cannot inject one. Sealing blinds the stored
+/// sender; it never widens who may write.
+#[tokio::test]
+async fn a_non_member_cannot_post_a_receipt() {
+    let db = fresh().await;
+    let ct = seal(&receipt_plaintext(true, "2026-08-15T12:00:00Z", &ACKED));
+    let outcome = apply_send_message(&db.conn().unwrap(), Some("mallory"), &body("env_x", &ct))
+        .await
+        .expect("send");
+    assert!(
+        matches!(outcome, WriteOutcome::Forbidden),
+        "a non-member must not be able to write a receipt envelope",
+    );
+}

--- a/src-tauri/src/commands/messages.rs
+++ b/src-tauri/src/commands/messages.rs
@@ -89,6 +89,16 @@ pub async fn get_reactions(message_id: String, state: State<'_, Arc<AppState>>) 
 }
 
 #[tauri::command]
+pub async fn mark_messages_read(conversation_id: String, user_id: String, message_ids: Vec<String>, state: State<'_, Arc<AppState>>) -> Result<()> {
+    pollis_core::commands::messages::mark_messages_read(conversation_id, user_id, message_ids, &state).await
+}
+
+#[tauri::command]
+pub async fn get_conversation_receipts(conversation_id: String, state: State<'_, Arc<AppState>>) -> Result<Vec<MessageReceipts>> {
+    pollis_core::commands::messages::get_conversation_receipts(conversation_id, &state).await
+}
+
+#[tauri::command]
 pub async fn delete_message(message_id: String, user_id: String, state: State<'_, Arc<AppState>>) -> Result<()> {
     pollis_core::commands::messages::delete_message(message_id, user_id, &state).await
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -575,6 +575,8 @@ pub fn run() {
             commands::messages::add_reaction,
             commands::messages::remove_reaction,
             commands::messages::get_reactions,
+            commands::messages::mark_messages_read,
+            commands::messages::get_conversation_receipts,
             commands::messages::delete_message,
             commands::messages::edit_message,
             commands::messages::get_message_retention,

--- a/src-tauri/src/test_harness.rs
+++ b/src-tauri/src/test_harness.rs
@@ -122,6 +122,8 @@ pub fn build_client_app(state: Arc<AppState>) -> Result<(App<MockRuntime>, Webvi
             crate::commands::messages::add_reaction,
             crate::commands::messages::remove_reaction,
             crate::commands::messages::get_reactions,
+            crate::commands::messages::mark_messages_read,
+            crate::commands::messages::get_conversation_receipts,
             crate::commands::messages::delete_message,
             crate::commands::messages::edit_message,
             crate::commands::mls::poll_mls_welcomes,


### PR DESCRIPTION
Closes #857. DMs only, as specified — not groups, not behind a flag.

### No DS endpoint, and that is the point
There is deliberately **no `/v1/receipts/*` route**, and `pollis-delivery/src/messages.rs` is untouched. A receipt-named route puts "this is a receipt" in the **request line**, which is plaintext to the DS — handing an operator "bob acknowledged something in dm1 at 12:00" on every read, however well the body is encrypted. Instead receipts are `0xF8` MLS control frames riding `/v1/messages/send` as ordinary envelopes, padded to the same 256-byte bucket so they are length-indistinguishable from a short text message. **No remote schema change either.**

### Per reader, not per message
Local `message_receipt(message_id, reader_id, kind)` with the PK across all three. A 5-member DM yields up to 5 delivered + 5 read rows for one message; 1:1 is just N=1. `reader_id` always comes from the MLS credential inside the ciphertext, so a member can only ever speak for themselves.

### Delivered ≠ read
**Delivered** is emitted by ingest only when an envelope was fetched *and* decrypted *and* stored. **Read** requires viewport ≥60% **and** `visibilityState === "visible"` **and** `document.hasFocus()` **and** a 600 ms dwell — so background windows and scroll-flinging report nothing. `read ⇒ delivered` is a **schema trigger**, not caller discipline: "read but never delivered" is unrepresentable, proven by a test that bypasses every Rust helper with raw SQL.

### The opt-out is reciprocal and covers delivery too
Because our receipts are client-emitted, a *delivery* receipt is still a "my device was online at time T" signal — so declining covers both. Off means the device also refuses to **record** inbound receipts, so the UI showing you nothing is a fact about the database rather than a renderer promise. Synced, not device-local: a privacy switch that silently fails to apply on your other laptop is a broken switch.

### Integration and rebase
Rebased over voice, invites, mentions and bookmarks. Only `commands.md` conflicted — resolved by union, then **verified against `lib.rs` rather than trusting either side, and both sides were wrong**: the real total is **188 commands in 27 modules**, not the 175 main claimed or the 171 this branch claimed. Also fixed two inherited staleness bugs (`(root)` missing `write_clipboard_text`; `voice` labelled 17 while listing 16) and reconciled the appendix name-by-name — zero drift now.

`useConversationReceipts` is called **once** in `MessageList` and passed down as a map; per-row would have been one IPC call per message. `peerCount` needed a source that did not exist, so `DMConversation` gained an optional `member_count` from the `list_dm_channels` response the hook already fetches — no new IPC.

### Verification
`pollis-core` **550 passed**, `pollis-delivery` **214 passed**, `tsc`/`build` clean, Playwright **32 passed** (22 pre-existing + 10 new).

`e2e/receipts.spec.ts` covers, in both skins: delivered, read, the two being **visually distinct**, a group channel showing **nothing**, and a multi-participant DM rendering per-reader state. Distinctness was checked on **rendered pixels**, not the DOM attribute — an attribute assertion would pass even if both drew the same tick. One tick vs two, plus muted taupe/grey vs amber.

**Honest caveat:** at native 14px the difference is real but subtle — clear when comparing two rows, less so glancing at one in isolation, with colour carrying most of the signal. Correct and accessible (the `aria-label`s differ outright), but bumping the icon or dimming delivered further would make it read faster if you want that.

One production rule was mirrored into the mock to avoid testing the wrong thing: `mark_messages_read` drops messages whose sender is the acking user, otherwise a 1:1 DM would render "read" because the sender looked at their own screen.