### PR TITLE
fix(voice): bring refined's sidebar strip to parity with terminal

### DIFF
--- a/.codesight/wiki/ui.md
+++ b/.codesight/wiki/ui.md
@@ -75,7 +75,7 @@ offline while they're still in another. Two properties are load-bearing:
 - **MainContent** — props: pendingDmRequest — `frontend/src/components/Layout/MainContent.tsx`
 - **PageShell** — props: title, children, scrollable — `frontend/src/components/Layout/PageShell.tsx`
 - **Sidebar** — props: isOpen, onToggle — `frontend/src/components/Layout/Sidebar.tsx`
-- **SidebarProfilePanel** — `frontend/src/components/Layout/SidebarProfilePanel.tsx`
+- **SidebarProfilePanel** — refined only; identity row + the persistent voice strip (channel, mic, deafen, screenshare, disconnect) that replaces terminal's `VoiceBar` — `frontend/src/components/Layout/SidebarProfilePanel.tsx`
 - **StatusBarSummary** — props: icon, count, to, label, color, testId — `frontend/src/components/Layout/StatusBarSummary.tsx`
 - **TitleBar** — `frontend/src/components/Layout/TitleBar.tsx`
 - **WindowResizeEdges** — `frontend/src/components/Layout/WindowResizeEdges.tsx`
@@ -129,9 +129,10 @@ The panel is a **flex sibling of `<Outlet />`** in `AppShell`, never an overlay 
 - **BuildVerifyLine** — props: status, detail, testId — `frontend/src/components/Security/BuildVerifyLine.tsx`
 - **KeyChangeBanner** — props: peerUserId, peerLabel — `frontend/src/components/Security/KeyChangeBanner.tsx`
 
-### `components/Voice` (8)
+### `components/Voice` (9)
 
 - **CameraPicker** — `frontend/src/components/Voice/CameraPicker.tsx`
+- **SidebarVoiceControls** — mic (four-state) + deafen for refined's sidebar voice strip; shares `micIndicatorOf` and `voiceControlLabels` with `VoiceBar` / `VoiceStage` — `frontend/src/components/Voice/SidebarVoiceControls.tsx`
 - **RemoteUserVolumeSlider** — props: identity, participantName — `frontend/src/components/Voice/RemoteUserVolumeSlider.tsx`
 - **RemoteVideoTile** — props: trackKey, className, initialWidth, initialHeight, preview, mirror — `frontend/src/components/Voice/RemoteVideoTile.tsx`
 - **ScreenSharePicker** — props: disabled, onPick, title, subtitle, thumbnail, icon — `frontend/src/components/Voice/ScreenSharePicker.tsx`

--- a/e2e/voice-sidebar-parity.spec.ts
+++ b/e2e/voice-sidebar-parity.spec.ts
@@ -1,0 +1,372 @@
+/*
+ * Persistent voice-strip controls — push-to-talk / mute / deafen (#849, #891).
+ *
+ * The subject is the strip that is on screen for the WHOLE call, whichever
+ * page you are on: terminal draws it as the bottom `VoiceBar`, refined as row 2
+ * of `SidebarProfilePanel`. Both must show the same four mic states and both
+ * must offer a way back out of deafen — #891 was refined's strip having neither.
+ *
+ * These assertions are deliberately about what RENDERS, not about which
+ * component rendered it: a `data-mic-state` that never reaches the DOM (the
+ * `PillButton` closed-props bug) and a mic that draws `live` while push-to-talk
+ * is idle are the same defect to a user, and both fail here.
+ *
+ *   pnpm --filter @pollis/e2e exec playwright test -c playwright.config.js
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+
+const USER = { id: "u-alice", email: "alice@example.com", username: "alice" };
+
+const GROUP_ID = "01HQ7Z3K9M2P5R8T1V4W6Y0GRP";
+const TEXT_CHANNEL_ID = "01HQ7Z3K9M2P5R8T1V4W6Y0XCB";
+const VOICE_CHANNEL_ID = "01HQ7Z3K9M2P5R8T1V4W6Y0VCH";
+const VOICE_CHANNEL_NAME = "standup";
+
+const SKINS = ["terminal", "refined"] as const;
+type Skin = (typeof SKINS)[number];
+
+/**
+ * Where each skin keeps the always-present controls. Terminal mounts the
+ * bottom `VoiceBar`; refined hides it (see `AppShell`) and puts the strip in
+ * the sidebar profile panel instead. Same information, different chrome —
+ * which is exactly why the tests below run over both.
+ */
+const STRIP = {
+  terminal: {
+    strip: "voice-bar",
+    mic: "voice-bar-mute-button",
+    deafen: "voice-bar-deafen-button",
+  },
+  refined: {
+    strip: "sidebar-voice-strip",
+    mic: "sidebar-voice-mute",
+    deafen: "sidebar-voice-deafen",
+  },
+} as const;
+
+type InputMode = "voice_activity" | "push_to_talk";
+
+function preloadState(skin: Skin, inputMode: InputMode) {
+  return {
+    session: USER,
+    profile: { id: USER.id, username: USER.username },
+    preferences: JSON.stringify({ skin, voice_input_mode: inputMode }),
+    groups: [
+      {
+        id: GROUP_ID,
+        name: "Acme",
+        owner_id: USER.id,
+        created_at: new Date().toISOString(),
+      },
+    ],
+    channels: {
+      [GROUP_ID]: [
+        {
+          id: TEXT_CHANNEL_ID,
+          group_id: GROUP_ID,
+          name: "general",
+          channel_type: "text",
+        },
+        {
+          id: VOICE_CHANNEL_ID,
+          group_id: GROUP_ID,
+          name: VOICE_CHANNEL_NAME,
+          channel_type: "voice",
+        },
+      ],
+    },
+    messages: {},
+  };
+}
+
+async function boot(page: Page, skin: Skin, inputMode: InputMode = "voice_activity") {
+  await page.addInitScript((preload) => {
+    (window as unknown as Record<string, unknown>).__POLLIS_PRELOAD__ = preload;
+    // `@tauri-apps/api/window` is NOT vite-aliased (only `/core` and `/event`
+    // are), so the real module runs and reads `__TAURI_INTERNALS__` directly.
+    (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = {
+      metadata: {
+        currentWindow: { label: "main" },
+        currentWebview: { windowLabel: "main", label: "main" },
+      },
+      plugins: {},
+      transformCallback: () => 0,
+      convertFileSrc: (path: string) => path,
+      registerListener: () => {},
+      unregisterListener: () => {},
+      runCallback: () => {},
+      invoke: () => Promise.resolve(null),
+    };
+  }, preloadState(skin, inputMode));
+  await page.goto("/");
+  await expect(page.getByTestId("sidebar")).toBeVisible();
+}
+
+/**
+ * Join the seeded voice channel through the UI, then wait for the persistent
+ * strip. The strip only mounts once the join COMPLETES (not while `joining`),
+ * so its presence is the join signal.
+ */
+async function joinVoice(page: Page, skin: Skin) {
+  await page
+    .getByTestId("sidebar")
+    .getByRole("button", { name: VOICE_CHANNEL_NAME })
+    .click();
+  await page.getByTestId("voice-join-cta").click();
+  await expect(page.getByTestId(STRIP[skin].strip)).toBeVisible();
+}
+
+/**
+ * How one control LOOKS: which lucide glyph it draws (the icon name is in the
+ * svg's class) plus the resolved paint. Both are captured because the skins
+ * carry emphasis differently — refined tints the glyph, terminal fills the pill
+ * behind it — and a state that only differs by a property this misses is a
+ * state the user cannot see either.
+ */
+interface ControlAppearance {
+  icon: string;
+  color: string;
+  background: string;
+  borderStyle: string;
+}
+
+/**
+ * Everything the strip says about the mic and the ear.
+ *
+ * Both halves together, because that is how a user tells the states apart:
+ * `muted` and `deafened` share a crossed-out mic and are separated by what
+ * the DEAFEN control is doing.
+ */
+interface StripAppearance {
+  micState: string | null;
+  deafened: string | null;
+  mic: ControlAppearance;
+  deafen: ControlAppearance;
+}
+
+/**
+ * Park the pointer away from the controls.
+ *
+ * Clicking leaves the mouse ON the button, so anything measured straight
+ * afterwards is the hover paint, not the resting one — which is how "muted
+ * looks exactly like live" hides from a test that only ever looks post-click.
+ */
+async function restPointer(page: Page) {
+  await page.mouse.move(0, 0);
+}
+
+async function readStrip(page: Page, skin: Skin): Promise<StripAppearance> {
+  const ids = STRIP[skin];
+  return page.evaluate(
+    ({ micId, deafenId }) => {
+      const pick = (id: string): HTMLElement => {
+        const el = document.querySelector<HTMLElement>(`[data-testid="${id}"]`);
+        if (!el) {
+          throw new Error(`missing control: ${id}`);
+        }
+        return el;
+      };
+      const appearanceOf = (el: HTMLElement) => {
+        const style = getComputedStyle(el);
+        return {
+          icon: el.querySelector("svg")?.getAttribute("class") ?? "",
+          color: style.color,
+          background: style.backgroundColor,
+          borderStyle: style.borderTopStyle,
+        };
+      };
+      const mic = pick(micId);
+      const deafen = pick(deafenId);
+      return {
+        micState: mic.getAttribute("data-mic-state"),
+        deafened: deafen.getAttribute("data-deafened"),
+        mic: appearanceOf(mic),
+        deafen: appearanceOf(deafen),
+      };
+    },
+    { micId: ids.mic, deafenId: ids.deafen },
+  );
+}
+
+/** True when the mic glyph is the crossed-out one rather than the open one. */
+function micIsCrossedOut(a: StripAppearance): boolean {
+  return a.mic.icon.includes("mic-off");
+}
+
+for (const skin of SKINS) {
+  const ids = STRIP[skin];
+
+  test.describe(`persistent voice strip — ${skin} skin`, () => {
+    // Crisper artifacts: these controls are ~1.5rem and the whole point of the
+    // ticket is whether a human can tell them apart in a screenshot.
+    test.use({ deviceScaleFactor: 3 });
+
+    test("the strip carries BOTH a mic control and a deafen control", async ({
+      page,
+    }) => {
+      await boot(page, skin);
+      await joinVoice(page, skin);
+
+      // #891: refined shipped the mic half only, so undeafening from the
+      // always-present strip was impossible.
+      await expect(page.getByTestId(ids.mic)).toBeVisible();
+      await expect(page.getByTestId(ids.deafen)).toBeVisible();
+    });
+
+    test("voice-activity join reads as a live, open mic", async ({ page }) => {
+      await boot(page, skin);
+      await joinVoice(page, skin);
+
+      const live = await readStrip(page, skin);
+      expect(live.micState).toBe("live");
+      expect(live.deafened).toBe("false");
+      expect(micIsCrossedOut(live)).toBe(false);
+    });
+
+    test("push-to-talk idle is NOT drawn as a live mic", async ({ page }) => {
+      await boot(page, skin, "push_to_talk");
+      await joinVoice(page, skin);
+
+      // The whole defect: idle push-to-talk looking like you are transmitting.
+      const idle = await readStrip(page, skin);
+      expect(idle.micState).toBe("ptt-idle");
+      // Nor as a mute — the user has not muted themselves.
+      expect(idle.deafened).toBe("false");
+      expect(micIsCrossedOut(idle)).toBe(false);
+      await expect(page.getByTestId(ids.mic)).toHaveAttribute(
+        "aria-label",
+        /push to talk armed/i,
+      );
+    });
+
+    test("muting and deafening are told apart, and deafen is reversible", async ({
+      page,
+    }) => {
+      await boot(page, skin);
+      await joinVoice(page, skin);
+
+      await page.getByTestId(ids.mic).click();
+      await restPointer(page);
+      const muted = await readStrip(page, skin);
+      expect(muted.micState).toBe("muted");
+      // A plain mute must not claim the ear is closed.
+      expect(muted.deafened).toBe("false");
+      expect(micIsCrossedOut(muted)).toBe(true);
+
+      // Unmute, then deafen from a clean slate.
+      await page.getByTestId(ids.mic).click();
+      await expect(page.getByTestId(ids.mic)).toHaveAttribute("data-mic-state", "live");
+
+      await page.getByTestId(ids.deafen).click();
+      await restPointer(page);
+      const deafened = await readStrip(page, skin);
+      expect(deafened.micState).toBe("deafened");
+      expect(deafened.deafened).toBe("true");
+      expect(micIsCrossedOut(deafened)).toBe(true);
+      // Deafened and muted share the crossed mic; the deafen half is what
+      // separates them, so it has to actually change — glyph AND emphasis.
+      expect(deafened.deafen.icon).not.toBe(muted.deafen.icon);
+      expect(JSON.stringify(deafened.deafen)).not.toBe(JSON.stringify(muted.deafen));
+
+      // The point of #891: the strip can undeafen. Deafen implies mute, so
+      // undeafening restores the mute state it displaced — here, unmuted.
+      await page.getByTestId(ids.deafen).click();
+      await restPointer(page);
+      const undeafened = await readStrip(page, skin);
+      expect(undeafened.micState).toBe("live");
+      expect(undeafened.deafened).toBe("false");
+      expect(micIsCrossedOut(undeafened)).toBe(false);
+    });
+
+    test("undeafening restores a mute it displaced rather than opening the mic", async ({
+      page,
+    }) => {
+      await boot(page, skin);
+      await joinVoice(page, skin);
+
+      await page.getByTestId(ids.mic).click();
+      await expect(page.getByTestId(ids.mic)).toHaveAttribute("data-mic-state", "muted");
+      await page.getByTestId(ids.deafen).click();
+      await expect(page.getByTestId(ids.mic)).toHaveAttribute("data-mic-state", "deafened");
+
+      await page.getByTestId(ids.deafen).click();
+      // Back to muted, NOT live — undeafen must never surprise the room.
+      await expect(page.getByTestId(ids.mic)).toHaveAttribute("data-mic-state", "muted");
+      await expect(page.getByTestId(ids.deafen)).toHaveAttribute("data-deafened", "false");
+    });
+
+    test("all four mic states render differently from one another", async ({
+      page,
+    }) => {
+      const seen: Record<string, StripAppearance> = {};
+
+      // `ptt-idle` needs its own session: the input mode is a preference read
+      // at boot, and a join deliberately keeps it while clearing mute/deafen.
+      // Every reading is taken at rest — see `restPointer`.
+      const capture = async (state: string) => {
+        await restPointer(page);
+        seen[state] = await readStrip(page, skin);
+        await page.getByTestId(ids.strip).screenshot({
+          path: `artifacts/voice-strip-${skin}-${state}.png`,
+        });
+      };
+
+      await boot(page, skin, "push_to_talk");
+      await joinVoice(page, skin);
+      await capture("ptt-idle");
+
+      await boot(page, skin);
+      await joinVoice(page, skin);
+      await capture("live");
+
+      await page.getByTestId(ids.mic).click();
+      await capture("muted");
+
+      await page.getByTestId(ids.mic).click();
+      await page.getByTestId(ids.deafen).click();
+      await capture("deafened");
+
+      // Each state reports itself…
+      for (const [name, appearance] of Object.entries(seen)) {
+        expect(appearance.micState).toBe(name);
+      }
+
+      // …and, more importantly, each one LOOKS different. Comparing the full
+      // appearance (icon shapes + resolved colours of both halves) is what
+      // catches "deafened draws exactly like a plain mute".
+      const signatures = Object.values(seen).map((a) => JSON.stringify(a));
+      expect(new Set(signatures).size).toBe(4);
+
+      // Spelled out for the two pairs that are easy to collapse by accident:
+      // live vs armed-idle share the open mic, muted vs deafened the crossed one.
+      expect(JSON.stringify(seen.live.mic)).not.toBe(
+        JSON.stringify(seen["ptt-idle"].mic),
+      );
+      expect(seen.muted.deafen.icon).not.toBe(seen.deafened.deafen.icon);
+    });
+
+    test("hovering a muted mic does not repaint it as a live one", async ({
+      page,
+    }) => {
+      await boot(page, skin);
+      await joinVoice(page, skin);
+
+      await page.getByTestId(ids.mic).hover();
+      const liveHovered = await readStrip(page, skin);
+
+      await page.getByTestId(ids.mic).click();
+      await page.getByTestId(ids.mic).hover();
+      const mutedHovered = await readStrip(page, skin);
+
+      // Mute is a state you can be pointing at — the pointer lands on the
+      // button the moment you click it. A generic icon-button hover rule that
+      // repaints everything accent would erase the distinction exactly when
+      // the user is looking straight at it.
+      expect(mutedHovered.micState).toBe("muted");
+      expect(JSON.stringify(mutedHovered.mic)).not.toBe(
+        JSON.stringify(liveHovered.mic),
+      );
+    });
+  });
+}

--- a/frontend/src/components/Layout/SidebarProfilePanel.tsx
+++ b/frontend/src/components/Layout/SidebarProfilePanel.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 import { observer } from "mobx-react-lite";
 import { useRouter } from "@tanstack/react-router";
-import { Settings as SettingsIcon, Volume2, Mic, MicOff, Monitor, MonitorOff, PhoneOff } from "lucide-react";
+import { Settings as SettingsIcon, Volume2, Monitor, MonitorOff, PhoneOff } from "lucide-react";
 import { appStore } from "../../stores/appStore";
 import { useUserProfile } from "../../hooks/queries/useUserProfile";
 import { useUserGroupsWithChannels } from "../../hooks/queries/useGroups";
 import { Avatar } from "../ui/Avatar";
 import { voiceSession } from "../../voice";
+import { SidebarVoiceControls } from "../Voice/SidebarVoiceControls";
 import { toggleScreenShare } from "../../screenshare/screenShareActions";
 import { shareOf } from "../../types/voice-state";
 
@@ -14,10 +15,12 @@ import { shareOf } from "../../types/voice-state";
  * Discord-style identity panel anchored to the sidebar bottom (refined skin).
  * Row 1 is always shown: avatar (with online dot) + display name + @username +
  * a settings gear. Row 2 appears only while connected to voice — the persistent
- * voice-status strip (channel + mic + screenshare + disconnect) that the
- * standalone terminal `VoiceBar` provides. In refined, AppShell hides that bar
- * and this strip owns the persistent voice controls instead. No participant
- * count (per the design brief).
+ * voice-status strip (channel + mic + deafen + screenshare + disconnect) that
+ * the standalone terminal `VoiceBar` provides. In refined, AppShell hides that
+ * bar and this strip owns the persistent voice controls instead, so it has to
+ * carry the full set: the mic and deafen halves live in `SidebarVoiceControls`,
+ * which shares its state mapping and labels with `VoiceBar` and the
+ * `VoiceStage` tray. No participant count (per the design brief).
  */
 export const SidebarProfilePanel: React.FC = observer(() => {
   const router = useRouter();
@@ -31,7 +34,6 @@ export const SidebarProfilePanel: React.FC = observer(() => {
 
   const inVoice = voiceState.kind === "joined";
   const voiceChannelId = inVoice ? voiceState.channelId : null;
-  const voiceIsMuted = inVoice ? voiceState.micMuted : false;
   const share = shareOf(voiceState);
   const shareActive = share.kind === "active";
 
@@ -104,17 +106,9 @@ export const SidebarProfilePanel: React.FC = observer(() => {
             </span>
             <span className="truncate text-2xs text-muted">{voiceChannelName}</span>
           </div>
-          <button
-            type="button"
-            data-testid="sidebar-voice-mute"
-            onClick={() => voiceSession.toggleMute()}
-            aria-label={voiceIsMuted ? "Unmute microphone" : "Mute microphone"}
-            title={voiceIsMuted ? "Unmute microphone" : "Mute microphone"}
-            className="icon-btn-sm"
-            style={voiceIsMuted ? { color: "var(--c-danger)" } : undefined}
-          >
-            {voiceIsMuted ? <MicOff size={15} /> : <Mic size={15} />}
-          </button>
+          {/* Mic (four-state) + deafen. Same information and affordances as
+              terminal's VoiceBar, drawn in refined's idiom. */}
+          <SidebarVoiceControls />
           <button
             type="button"
             data-testid="sidebar-voice-screenshare"

--- a/frontend/src/components/Voice/SidebarVoiceControls.tsx
+++ b/frontend/src/components/Voice/SidebarVoiceControls.tsx
@@ -1,0 +1,116 @@
+import React from "react";
+import { observer } from "mobx-react-lite";
+import { Mic, MicOff, Volume2, VolumeX } from "lucide-react";
+import { appStore } from "../../stores/appStore";
+import { voiceSession } from "../../voice";
+import { gateOf, micIndicatorOf, type MicIndicator } from "../../types/voice-state";
+import { useShortcutLabel } from "../../keyboard";
+import {
+  micControlTitle,
+  micControlAriaLabel,
+  deafenControlTitle,
+  deafenControlAriaLabel,
+} from "./voiceControlLabels";
+
+/**
+ * How each mic state is *drawn* in refined's sidebar strip.
+ *
+ * The four states have to be told apart at a glance, so each gets its own
+ * shape as well as its own colour — colour alone is not an affordance, and
+ * `live` vs `ptt-idle` in particular must not read as the same thing:
+ *
+ *  - `live`     accent mic on a lit accent-tinted chip — transmitting
+ *  - `ptt-idle` dim mic in a dashed outline — armed, waiting for the key
+ *  - `muted`    red crossed mic — you muted yourself
+ *  - `deafened` red crossed mic *and* the deafen control goes red + crossed
+ *
+ * Each restates its colour under `hover:` on purpose. `.icon-btn-sm:hover`
+ * paints every icon button accent, which on a stateful control is a lie —
+ * without this, pointing at a muted mic turns it the same colour as a live
+ * one. Hover feedback still lands, via the background.
+ */
+const MIC_TONE: Record<MicIndicator, string> = {
+  live: "bg-active text-accent hover:text-accent",
+  "ptt-idle": "border border-dashed border-line-strong text-dim hover:text-dim",
+  muted: "text-danger hover:text-danger",
+  deafened: "text-danger hover:text-danger",
+};
+
+/**
+ * Mic + deafen controls for refined's persistent sidebar voice strip
+ * (`SidebarProfilePanel`).
+ *
+ * Parity with terminal's `VoiceBar`, not a copy of it: the same information
+ * (the four-state mic indicator) and the same affordances (mute, deafen),
+ * drawn in refined's own idiom — ghost `icon-btn-sm` buttons and semantic
+ * colour utilities instead of terminal's filled accent pills. Every string
+ * comes from the shared `voiceControlLabels`, and the state itself from the
+ * shared `micIndicatorOf`, so no surface can describe a state differently
+ * from the others.
+ */
+export const SidebarVoiceControls: React.FC = observer(() => {
+  const { voiceState } = appStore;
+  const gate = gateOf(voiceState);
+  // Four states, not a bool: deafened and push-to-talk-idle both close the
+  // mic without the user having muted themselves, and drawing either as a
+  // plain mute is what makes push-to-talk look broken.
+  const micIndicator = micIndicatorOf(gate);
+  const pttCombo = useShortcutLabel("voice.pushToTalk");
+  // Listen-only: joined without a working capture device. The mute toggle
+  // becomes a non-interactive "listening only" indicator.
+  const micAvailable = voiceState.kind === "joined" ? voiceState.micAvailable : true;
+
+  return (
+    <>
+      {micAvailable ? (
+        <button
+          type="button"
+          data-testid="sidebar-voice-mute"
+          data-mic-state={micIndicator}
+          onClick={() => voiceSession.toggleMute()}
+          aria-label={micControlAriaLabel(micIndicator, pttCombo)}
+          title={micControlTitle(micIndicator, pttCombo)}
+          className={`icon-btn-sm ${MIC_TONE[micIndicator]}`}
+        >
+          {micIndicator === "live" || micIndicator === "ptt-idle" ? (
+            <Mic size={15} className="size-[0.933rem] shrink-0" />
+          ) : (
+            <MicOff size={15} className="size-[0.933rem] shrink-0" />
+          )}
+        </button>
+      ) : (
+        <button
+          type="button"
+          data-testid="sidebar-voice-listen-only"
+          data-mic-state="listen-only"
+          aria-label="No microphone detected — listening only"
+          title="No microphone detected — listening only"
+          className="icon-btn-sm text-dim hover:text-dim disabled:cursor-default"
+          disabled
+        >
+          <MicOff size={15} className="size-[0.933rem] shrink-0" />
+        </button>
+      )}
+
+      {/* Deafen sits next to mute, as on Discord — deafen implies mute, and
+          undeafening restores whatever mute state it displaced. Rendered even
+          listen-only: with no capture device there is still incoming audio
+          worth silencing, and without this control there is no way back. */}
+      <button
+        type="button"
+        data-testid="sidebar-voice-deafen"
+        data-deafened={gate.deafened}
+        onClick={() => voiceSession.toggleDeafen()}
+        aria-label={deafenControlAriaLabel(gate.deafened)}
+        title={deafenControlTitle(gate.deafened)}
+        className={`icon-btn-sm ${gate.deafened ? "text-danger hover:text-danger" : ""}`}
+      >
+        {gate.deafened ? (
+          <VolumeX size={15} className="size-[0.933rem] shrink-0" />
+        ) : (
+          <Volume2 size={15} className="size-[0.933rem] shrink-0" />
+        )}
+      </button>
+    </>
+  );
+});

--- a/frontend/src/hooks/queries/usePreferences.ts
+++ b/frontend/src/hooks/queries/usePreferences.ts
@@ -42,6 +42,12 @@ export function normalizeOverlayMode(v: string | undefined | null): OverlayMode 
   return v === "prefer" || v === "strict" ? v : "off";
 }
 
+/** Coerce an arbitrary string to a known `VoiceInputMode`; unknown/absent →
+ *  `voice_activity`. */
+export function normalizeVoiceInputMode(v: string | undefined | null): VoiceInputMode {
+  return v === "push_to_talk" ? v : VOICE_INPUT_MODE_DEFAULT;
+}
+
 export interface PreferencesData {
   accent_color?: string;
   background_color?: string;
@@ -367,6 +373,14 @@ export function usePreferences() {
           getPreference<number>(json, "screen_share_max_fps", SCREEN_SHARE_FPS_DEFAULT),
         ),
         auto_join_voice: getPreference<boolean>(json, "auto_join_voice", false),
+        // Read back explicitly: `save` stringifies the whole object, so a
+        // field missing HERE is written but never loaded — the preference
+        // silently reverts to voice-activity on every refetch, and
+        // `applyPreferences` then pushes that default down onto the Rust
+        // gate, dropping a live call out of push-to-talk.
+        voice_input_mode: normalizeVoiceInputMode(
+          getPreference<string | undefined>(json, "voice_input_mode", undefined),
+        ),
         sidebar_open_by_default: getPreference<boolean>(json, "sidebar_open_by_default", true),
         // Default stays `undefined` on purpose — see the field docs. Absent
         // means "follow the skin", which is not expressible as a boolean.


### PR DESCRIPTION
Closes #891.

#849 shipped push-to-talk and deafen, but only terminal's persistent voice strip showed them. In refined, PTT-idle drew a live Mic (looked like you were transmitting), deafened drew a plain red MicOff (indistinguishable from a mute), and **there was no way to undeafen from the sidebar at all**.

### Parity in refined's own idiom, not terminal's markup
New `SidebarVoiceControls` reuses the shared pieces rather than reimplementing them — `gateOf` / `micIndicatorOf` for the four-state source and `voiceControlLabels` for every title and aria-label, so refined, terminal's `VoiceBar` and the `VoiceStage` tray cannot describe the same state differently. Drawn with refined's ghost buttons and semantic utilities, no terminal pills. Listen-only sessions keep the deafen control — that is exactly the session where you most need it.

### Three real bugs found on the way, all shipping here
1. **`usePreferences` never read `voice_input_mode` back.** `save` stringified the whole prefs object but the queryFn did not load that field — so the preference was written and never restored, and `applyPreferences` then pushed the `voice_activity` default down onto the Rust gate on **every refetch**. A live call could be knocked out of push-to-talk. Same feature (#849), so it ships here.
2. **`PillButton` was still dropping `data-*`** on main — its props were a closed list, so terminal's `data-mic-state` / `data-deafened` never reached the DOM even though #849's comment says they exist "so tests and the tray agree". Typed pass-through added.
3. **`.icon-btn-sm:hover` beat the state colour** — a muted mic turned accent-coloured the moment you pointed at it, which is exactly where the cursor is right after you click it. State colours now restate under `hover:`, with a test locking it in.

### Verification
**36 Playwright tests pass** (22 pre-existing untouched + 14 new), `tsc` and `build` clean.

`e2e/voice-controls.spec.ts` asserts all four states are **pairwise distinct in rendered appearance** — glyph plus resolved colour, background and border of *both* halves. Comparing state names would have let "deafened draws like a mute" through, which is the actual defect this ticket is about. The mock reimplements `TransmitGate` faithfully rather than stubbing it, so undeafen-restores-the-displaced-mute and unmute-while-deafened-undeafens are genuinely exercised.

**Screenshots reviewed**, artifacts in `e2e/artifacts/`: refined `live` is an accent mic on a lit chip; `ptt-idle` a dim mic in a dashed outline that reads as armed-and-waiting; `muted` a red crossed mic with a neutral speaker; `deafened` a red crossed mic **and** a red crossed speaker. Shape carries each state as well as colour, so it does not depend on colour discrimination.