### PR TITLE
fix(voice): report a gate command that returns nothing instead of swallowing a TypeError

### DIFF
--- a/e2e/voice-controls.spec.ts
+++ b/e2e/voice-controls.spec.ts
@@ -108,6 +108,15 @@ async function boot(page: Page, skin: Skin) {
   }, preloadFor(skin));
   await page.goto("/");
   await expect(page.getByTestId("app-ready")).toBeAttached();
+  // The controls use `transition-colors`, so the moment `data-mic-state`
+  // flips the computed colour is still the PREVIOUS state's and only
+  // animates to the new one. Sampling appearance right after the attribute
+  // settles therefore read a stale colour perhaps a third of the time, and
+  // two genuinely different states compared equal. These tests are about
+  // which colour a state lands on, never how it gets there.
+  await page.addStyleTag({
+    content: "*, *::before, *::after { transition: none !important; animation: none !important; }",
+  });
 }
 
 /** Walk into the voice channel and put the session in the joined state. */
@@ -334,14 +343,21 @@ test.describe("push-to-talk + deafen — terminal VoiceBar", () => {
     await expect(mute).toBeVisible();
     await expect(deafen).toBeVisible();
 
-    await setGate(page, LIVE);
-    const live = await appearanceOf(mute);
-    await setGate(page, MUTED);
-    const muted = await appearanceOf(mute);
-    await setGate(page, PTT_IDLE);
-    const pttIdle = await appearanceOf(mute);
+    // Wait for the button to actually reflect each gate BEFORE sampling how it
+    // looks. `setGate` resolves when the command returns, not when React has
+    // re-rendered, so reading the appearance straight after it sampled the
+    // previous frame perhaps a third of the time — and a stale sample makes
+    // two genuinely different states compare equal.
+    const appearanceInState = async (gate: Parameters<typeof setGate>[1], state: string) => {
+      await setGate(page, gate);
+      await expect(mute).toHaveAttribute("data-mic-state", state);
+      return appearanceOf(mute);
+    };
 
-    await expect(mute).toHaveAttribute("data-mic-state", "ptt-idle");
+    const live = await appearanceInState(LIVE, "live");
+    const muted = await appearanceInState(MUTED, "muted");
+    const pttIdle = await appearanceInState(PTT_IDLE, "ptt-idle");
+
     expect(pttIdle).not.toBe(muted);
     expect(pttIdle).not.toBe(live);
 
@@ -354,17 +370,9 @@ test.describe("push-to-talk + deafen — terminal VoiceBar", () => {
 });
 
 /*
- * GAP, deliberately not papered over with a passing test:
- *
- * `SidebarProfilePanel` — the refined skin's persistent voice strip, and the
- * counterpart to the terminal `VoiceBar` above — has no deafen control at all,
- * and its mic button reads the plain `voiceState.micMuted` boolean rather than
- * the four-state indicator. So in refined, push-to-talk idle renders as an
- * ordinary live mic and deafened renders as an ordinary mute, with nothing
- * anywhere in the sidebar to undeafen with. The controls are only complete on
- * the voice-channel stage, which both skins share and which the tests above
- * cover.
- *
- * A test asserting today's sidebar behaviour would be a test that locks the
- * defect in, so there isn't one. It is reported instead.
+ * The gap this file used to record — refined's sidebar strip having no deafen
+ * control and a two-state mic — was #891, and is closed. The strip now carries
+ * the same four-state mic and a deafen toggle in both skins; the tests live in
+ * `voice-sidebar-parity.spec.ts`, which asserts the four states are distinct in
+ * rendered appearance rather than by state name.
  */

--- a/e2e/voice-sidebar-parity.spec.ts
+++ b/e2e/voice-sidebar-parity.spec.ts
@@ -47,8 +47,15 @@ const STRIP = {
 
 type InputMode = "voice_activity" | "push_to_talk";
 
-function preloadState(skin: Skin, inputMode: InputMode) {
+function preloadState(
+  skin: Skin,
+  inputMode: InputMode,
+  nullGateCommands: string[] = [],
+) {
   return {
+    // Commands the mock should answer with nothing instead of a gate
+    // snapshot. Empty for every test but the #888 regression below.
+    nullGateCommands,
     session: USER,
     profile: { id: USER.id, username: USER.username },
     preferences: JSON.stringify({ skin, voice_input_mode: inputMode }),
@@ -80,7 +87,12 @@ function preloadState(skin: Skin, inputMode: InputMode) {
   };
 }
 
-async function boot(page: Page, skin: Skin, inputMode: InputMode = "voice_activity") {
+async function boot(
+  page: Page,
+  skin: Skin,
+  inputMode: InputMode = "voice_activity",
+  nullGateCommands: string[] = [],
+) {
   await page.addInitScript((preload) => {
     (window as unknown as Record<string, unknown>).__POLLIS_PRELOAD__ = preload;
     // `@tauri-apps/api/window` is NOT vite-aliased (only `/core` and `/event`
@@ -98,7 +110,7 @@ async function boot(page: Page, skin: Skin, inputMode: InputMode = "voice_activi
       runCallback: () => {},
       invoke: () => Promise.resolve(null),
     };
-  }, preloadState(skin, inputMode));
+  }, preloadState(skin, inputMode, nullGateCommands));
   await page.goto("/");
   await expect(page.getByTestId("sidebar")).toBeVisible();
 }
@@ -370,3 +382,57 @@ for (const skin of SKINS) {
     });
   });
 }
+
+/**
+ * #888 — a gate command that returns nothing must not be mistaken for one that
+ * returned a gate.
+ *
+ * `applyGate` read `gate.transmitting` straight off the resolved value, so a
+ * command returning nothing threw a `TypeError` into its own catch. The catch
+ * logged at warn level and carried on, which made a genuine backend fault
+ * indistinguishable from a successful no-op.
+ *
+ * Asserted on the console rather than on pixels on purpose: leaving the last
+ * good state up is the CORRECT outcome and the screen looks the same either
+ * way, so the only honest signal is whether the failure was reported or
+ * swallowed as a type error.
+ */
+test("a gate command returning nothing is reported, not swallowed as a TypeError", async ({
+  page,
+}) => {
+  const messages: string[] = [];
+  page.on("console", (msg) => {
+    messages.push(`${msg.type()}: ${msg.text()}`);
+  });
+  page.on("pageerror", (err) => {
+    messages.push(`pageerror: ${err.message}`);
+  });
+
+  await boot(page, "terminal", "voice_activity", ["toggle_voice_mute"]);
+  await joinVoice(page, "terminal");
+
+  const before = await readStrip(page, "terminal");
+  await page.getByTestId(STRIP.terminal.mic).click();
+  await expect
+    .poll(() => messages.some((m) => m.includes("toggle_voice_mute")))
+    .toBe(true);
+
+  // The failure is named, not inferred from a stack trace.
+  expect(
+    messages.some(
+      (m) => m.includes("returned no gate state") && m.startsWith("error:"),
+    ),
+  ).toBe(true);
+  // And it is not a deref blowing up inside the handler. Scoped to the gate's
+  // own fields: the browser harness emits unrelated `unregisterListener`
+  // teardown noise that has nothing to do with this path.
+  expect(
+    messages.filter(
+      (m) => m.includes("transmitting") || m.includes("self_muted"),
+    ),
+  ).toEqual([]);
+
+  // An unknown gate must leave the last good state alone rather than write a
+  // half-built one.
+  expect(await readStrip(page, "terminal")).toEqual(before);
+});

--- a/frontend/src/__mocks__/tauri-core.ts
+++ b/frontend/src/__mocks__/tauri-core.ts
@@ -283,8 +283,19 @@ function emojiDataUrl(shortcode: string, contentHash: string): string {
   return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
 }
 
-/** Snapshot the gate exactly as `TransmitGate::snapshot` does. */
-function gateSnapshot(): Record<string, unknown> {
+/**
+ * Snapshot the gate exactly as `TransmitGate::snapshot` does.
+ *
+ * A preload may set `nullGateCommands` to a list of command names that should
+ * resolve to nothing instead of a snapshot. That is not a shape Rust produces
+ * today; it exists so a test can reproduce #888 — a gate command returning
+ * nothing, which used to throw a TypeError into `applyGate`'s catch and read
+ * as a silent no-op.
+ */
+function gateSnapshot(command?: string): Record<string, unknown> | null {
+  if (command && (preload.nullGateCommands ?? []).includes(command)) {
+    return null;
+  }
   const gate = store.voiceGate;
   // Derived in Rust, never recomputed by the UI — so it is derived here too.
   const transmitting = gate.self_muted
@@ -748,7 +759,7 @@ function handleCommand(command: string, args: Record<string, unknown>): unknown 
       if (gate.deafened) {
         gate.muted_before_deafen = muted;
       }
-      return gateSnapshot();
+      return gateSnapshot(command);
     }
 
     case 'toggle_voice_deafen': {
@@ -763,7 +774,7 @@ function handleCommand(command: string, args: Record<string, unknown>): unknown 
         gate.self_muted = true;
         gate.ptt_held = false;
       }
-      return gateSnapshot();
+      return gateSnapshot(command);
     }
 
     case 'set_voice_input_mode': {
@@ -771,22 +782,22 @@ function handleCommand(command: string, args: Record<string, unknown>): unknown 
       store.voiceGate.mode = mode;
       // Switching mode always drops a held latch, in either direction.
       store.voiceGate.ptt_held = false;
-      return gateSnapshot();
+      return gateSnapshot(command);
     }
 
     case 'set_voice_ptt_held': {
       const { held } = args as { held: boolean };
       store.voiceGate.ptt_held = held;
-      return gateSnapshot();
+      return gateSnapshot(command);
     }
 
     case 'release_voice_ptt': {
       store.voiceGate.ptt_held = false;
-      return gateSnapshot();
+      return gateSnapshot(command);
     }
 
     case 'get_voice_gate_state':
-      return gateSnapshot();
+      return gateSnapshot(command);
 
     // Voice room observation, device enumeration and the mic-test rig. There
     // is no audio hardware behind the browser build, so these are inert.

--- a/frontend/src/voice/VoiceSessionManager.ts
+++ b/frontend/src/voice/VoiceSessionManager.ts
@@ -371,7 +371,17 @@ class VoiceSessionManager {
       return;
     }
     try {
-      const gate = await invoke<VoiceGateState>(command, args);
+      // Typed nullable deliberately: `invoke` resolves to whatever the command
+      // actually returned, and a gate command that returns nothing used to make
+      // the reads below throw a TypeError straight into the catch — turning a
+      // real backend fault into a silent no-op (#888). Mirroring an unknown
+      // gate is not possible, so bail loudly and leave the last good state up
+      // rather than writing a half-built one.
+      const gate = await invoke<VoiceGateState | null>(command, args);
+      if (!gate) {
+        console.error(`[voice] ${command} returned no gate state; leaving the previous gate in place`);
+        return;
+      }
       const localIdentity = this.localIdentity;
       // The local tile follows what the room sees: not transmitting reads
       // as muted to everyone else, so it should look muted to us too. The


### PR DESCRIPTION
Closes #888.

`applyGate` read `gate.transmitting` and `gate.self_muted` straight off the resolved value. A gate command returning nothing threw a `TypeError` into `applyGate`'s own catch, which logged at warn level and carried on — so a genuine backend fault was indistinguishable from a successful no-op.

Types the result `VoiceGateState | null` and bails explicitly, at error level, leaving the last good gate up. Mirroring an unknown gate isn't possible, so the honest options are 'report it' or 'write a half-built state'; this picks the former.

Regression test in `voice-sidebar-parity.spec.ts`, with a mock hook (`nullGateCommands`) letting a preload make a named gate command resolve to nothing. It asserts on the console rather than on pixels deliberately: leaving the previous state up is the *correct* outcome and the screen looks identical either way, so the only honest signal is whether the failure was named or swallowed as a deref.

Verified it fails without the guard and passes with it. Full suite 78 passed.

Stacked on #895 (the transition-sampling flake), without which the suite is unreliable.