### PR TITLE
fix(messages): tell the user whether copy-link actually copied

### DIFF
--- a/e2e/bookmarks.spec.ts
+++ b/e2e/bookmarks.spec.ts
@@ -101,8 +101,13 @@ function preloadState(skin: Skin, bookmarks: unknown[] = []) {
  * meaningless here — every assertion below navigates through the UI and checks
  * what is RENDERED instead.
  */
-async function boot(page: Page, skin: Skin, bookmarks: unknown[] = []) {
-  const state = preloadState(skin, bookmarks);
+async function boot(
+  page: Page,
+  skin: Skin,
+  bookmarks: unknown[] = [],
+  opts: { failClipboard?: boolean } = {},
+) {
+  const state = { ...preloadState(skin, bookmarks), ...opts };
   await page.addInitScript((preload) => {
     (window as unknown as Record<string, unknown>).__POLLIS_PRELOAD__ = preload;
     // `@tauri-apps/api/window` is NOT vite-aliased (only `/core` and `/event`
@@ -369,6 +374,54 @@ for (const skin of SKINS) {
       expect(clipboard).not.toContain("Acme");
       expect(clipboard).not.toContain("general");
       expect(clipboard).not.toContain("bob");
+    });
+
+    test("a successful copy confirms itself on the button", async ({ page }) => {
+      await boot(page, skin);
+      await gotoChannel(page);
+
+      const copyButton = page
+        .getByTestId(`message-${CHANNEL_MESSAGE_ID}`)
+        .getByTestId("copy-link-button");
+
+      await expect(copyButton).toHaveAttribute("data-copy-state", "idle");
+      await copyButton.click();
+
+      // Every other copy affordance people use confirms itself; a silent
+      // success reads as "the button is broken" (#889).
+      await expect(copyButton).toHaveAttribute("data-copy-state", "copied");
+      await expect(copyButton).toHaveAccessibleName("Link copied");
+
+      // And it goes back on its own rather than sticking.
+      await expect(copyButton).toHaveAttribute("data-copy-state", "idle", {
+        timeout: 5000,
+      });
+    });
+
+    test("a failed copy is distinguishable from a successful one", async ({
+      page,
+    }) => {
+      await boot(page, skin, [], { failClipboard: true });
+      await gotoChannel(page);
+
+      const copyButton = page
+        .getByTestId(`message-${CHANNEL_MESSAGE_ID}`)
+        .getByTestId("copy-link-button");
+
+      await copyButton.click();
+
+      // The whole point of #889: the failure must not look like the success.
+      await expect(copyButton).toHaveAttribute("data-copy-state", "failed");
+      await expect(copyButton).toHaveAccessibleName("Couldn't copy link");
+
+      // Nothing was put on the clipboard, so the user has nothing to paste —
+      // which is exactly why they need to be told.
+      const clipboard = await page.evaluate(
+        () =>
+          (window as unknown as { __tauriMock: { clipboard: string } })
+            .__tauriMock.clipboard,
+      );
+      expect(clipboard).toBe("");
     });
 
     test("saving from the message row lands in the saved list", async ({ page }) => {

--- a/frontend/src/__mocks__/tauri-core.ts
+++ b/frontend/src/__mocks__/tauri-core.ts
@@ -865,6 +865,13 @@ function handleCommand(command: string, args: Record<string, unknown>): unknown 
     }
 
     case 'write_clipboard_text': {
+      // A preload may set `failClipboard` to model an OS clipboard write that
+      // fails — the Rust command returns false rather than throwing, and that
+      // false used to be discarded by the caller (#889). Nothing is written in
+      // that case, so a test can also prove the clipboard was left alone.
+      if (preload.failClipboard) {
+        return false;
+      }
       const { text } = args as { text: string };
       store.clipboard = text;
       return true;

--- a/frontend/src/components/Message/MessageItem.tsx
+++ b/frontend/src/components/Message/MessageItem.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Reply, CornerUpLeft, Edit2, Trash2, MessagesSquare, Bookmark, Link } from "lucide-react";
+import { Reply, CornerUpLeft, Edit2, Trash2, MessagesSquare, Bookmark, Link, Check, AlertCircle } from "lucide-react";
 import { ThreadReplyCount } from "./ThreadReplyCount";
 import { formatTimeOfDay, formatFullTimestamp } from "../../utils/format";
 import { observer } from "mobx-react-lite";
@@ -38,6 +38,9 @@ interface MessageItemProps {
    * pass them the affordances simply don't render. Wired from `MessageList`. */
   onToggleSave?: (messageId: string) => void;
   onCopyLink?: (messageId: string) => void;
+  /** Transient outcome of THIS message's last copy-link click (#889).
+   *  `idle` for every message but the one just acted on. */
+  copyLinkState?: "idle" | "copied" | "failed";
   isSaved?: boolean;
   onPin?: (messageId: string) => void;
   onScrollToReply?: (messageId: string) => void;
@@ -69,6 +72,7 @@ export const MessageItem: React.FC<MessageItemProps> = observer(({
   onDelete,
   onToggleSave,
   onCopyLink,
+  copyLinkState = "idle",
   isSaved = false,
   onScrollToReply,
   receipts,
@@ -79,6 +83,27 @@ export const MessageItem: React.FC<MessageItemProps> = observer(({
   const isOwn = message.sender_id === currentUser?.id;
   const isLightBg = useBackgroundIsLight();
   const skin = useSkin();
+  // Copy-link feedback (#889). A clipboard write that failed used to look
+  // exactly like one that succeeded — both silent — so the affordance read as
+  // broken. Both skins show the same three states; only the glyph size differs.
+  const copyLinkIcon =
+    copyLinkState === "copied"
+      ? Check
+      : copyLinkState === "failed"
+        ? AlertCircle
+        : Link;
+  const copyLinkLabel =
+    copyLinkState === "copied"
+      ? "Link copied"
+      : copyLinkState === "failed"
+        ? "Couldn't copy link"
+        : "Copy link to message";
+  const copyLinkTone =
+    copyLinkState === "copied"
+      ? "text-[var(--c-text-accent)]"
+      : copyLinkState === "failed"
+        ? "text-[var(--c-danger)]"
+        : "text-[var(--c-text-muted)] hover:text-[var(--c-text-accent)]";
 
   // Stable per-user color for non-own, non-admin authors. Key on username
   // when available so the same person keeps the same color across groups
@@ -304,11 +329,13 @@ export const MessageItem: React.FC<MessageItemProps> = observer(({
             {onCopyLink && (
               <button
                 data-testid="copy-link-button"
+                data-copy-state={copyLinkState}
                 onClick={() => onCopyLink(message.id)}
-                aria-label="Copy link to message"
-                className="p-1 text-[var(--c-text-muted)] hover:text-[var(--c-text-accent)]"
+                aria-label={copyLinkLabel}
+                title={copyLinkLabel}
+                className={`p-1 ${copyLinkTone}`}
               >
-                <Link size={16} />
+                {React.createElement(copyLinkIcon, { size: 16 })}
               </button>
             )}
             {isOwn && onEdit && (
@@ -482,11 +509,17 @@ export const MessageItem: React.FC<MessageItemProps> = observer(({
             {onCopyLink && (
               <button
                 data-testid="copy-link-button"
+                data-copy-state={copyLinkState}
                 onClick={() => onCopyLink(message.id)}
-                aria-label="Copy link to message"
-                className="opacity-0 group-hover:opacity-100 text-[var(--c-text-muted)] hover:text-[var(--c-text-accent)]"
+                aria-label={copyLinkLabel}
+                title={copyLinkLabel}
+                className={`${
+                  copyLinkState === "idle"
+                    ? "opacity-0 group-hover:opacity-100"
+                    : "opacity-100"
+                } ${copyLinkTone}`}
               >
-                <Link size={18} />
+                {React.createElement(copyLinkIcon, { size: 18 })}
               </button>
             )}
             {isOwn && onEdit && (

--- a/frontend/src/components/Message/MessageList.tsx
+++ b/frontend/src/components/Message/MessageList.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useLayoutEffect, useRef, useMemo } from "react";
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useMemo, useState } from "react";
 import { MessageItem } from "./MessageItem";
 import "./messageHighlight.css";
 import { useBlockedUsers } from "../../hooks/queries";
@@ -309,6 +309,23 @@ export const MessageList: React.FC<MessageListProps> = observer(({
   const savedMessageIds = useSavedMessageIds();
   const toggleSavedMutation = useToggleSavedMessage();
   const { copyPermalink } = useMessagePermalink();
+  // Which message's copy-link button is currently showing an outcome, and
+  // which outcome (#889). One at a time: the affordance is per-message but the
+  // feedback is about the click that just happened.
+  const [copyLinkState, setCopyLinkState] = useState<{
+    messageId: string;
+    state: "copied" | "failed";
+  } | null>(null);
+
+  // Clear the badge a couple of seconds after it appears, and never leave a
+  // timer behind that would set state on an unmounted list.
+  useEffect(() => {
+    if (!copyLinkState) {
+      return;
+    }
+    const timer = window.setTimeout(() => setCopyLinkState(null), 2000);
+    return () => window.clearTimeout(timer);
+  }, [copyLinkState]);
 
   const handleToggleSave = useCallback(
     (messageId: string) => {
@@ -318,16 +335,20 @@ export const MessageList: React.FC<MessageListProps> = observer(({
   );
 
   const handleCopyLink = useCallback(
-    (messageId: string) => {
+    async (messageId: string) => {
       const message = sortedMessages.find((m) => m.id === messageId);
       // The message's OWN conversation, never the list's `conversationId` prop
       // — that prop is the MLS group id for channels, which would produce a
       // permalink that resolves nowhere.
       const targetConversationId = message?.conversation_id;
       if (!targetConversationId) {
+        // No conversation to link to is itself a failure the user should see,
+        // rather than a click that does nothing at all (#889).
+        setCopyLinkState({ messageId, state: "failed" });
         return;
       }
-      void copyPermalink(targetConversationId, messageId);
+      const ok = await copyPermalink(targetConversationId, messageId);
+      setCopyLinkState({ messageId, state: ok ? "copied" : "failed" });
     },
     [sortedMessages, copyPermalink],
   );
@@ -480,6 +501,11 @@ export const MessageList: React.FC<MessageListProps> = observer(({
             isSaved={savedMessageIds.has(message.id)}
             onToggleSave={handleToggleSave}
             onCopyLink={handleCopyLink}
+            copyLinkState={
+              copyLinkState?.messageId === message.id
+                ? copyLinkState.state
+                : "idle"
+            }
             receipts={receipts}
             peerCount={peerCount}
             isDm={isDm}


### PR DESCRIPTION
Closes #889.

`copyPermalink` returns false when the OS clipboard write fails, and `MessageList.handleCopyLink` threw that away with `void`. A failed copy and a successful one were both completely silent, so the user had no way to know whether they had a link to paste — and the affordance read as broken.

The button now carries its own outcome for a couple of seconds, identically in both skins: check + "Link copied" on success, alert + "Couldn't copy link" on failure, exposed as `data-copy-state` and as the accessible name. In terminal the button is normally hover-revealed; while it is showing an outcome it stays visible, so the feedback doesn't vanish when the pointer moves.

The "no conversation id" early return is treated as a failure too — previously that path was a click that did nothing at all.

Four tests in `bookmarks.spec.ts` (both skins), plus a `failClipboard` preload hook so the mock can model a write that fails rather than throws — the real Rust command returns false, and that shape had no coverage. The failure test also asserts the clipboard was left untouched, which is precisely why the user needs telling. Verified all four fail with the fix reverted.

Full suite 82 passed; typecheck and production build clean.

Note, not fixed here: `CreatedInviteLinkCard` has the same silent-failure shape (catches and only `console.error`s) and reaches `navigator.clipboard` directly instead of the bridge's `writeClipboardText`. Different feature, so it wants its own ticket rather than riding along.