### PR TITLE
Auto-lock the app after a period of inactivity

### DIFF
--- a/.codesight/wiki/commands.md
+++ b/.codesight/wiki/commands.md
@@ -45,6 +45,19 @@ PIN is cryptographically load-bearing — see `pin-design.md`.
 - `lock()` — drop `AppState.unlock` and close the local DB. Until the next `unlock`, every DB-touching command fails with "Not signed in".
 - `get_unlock_state()` → `{ last_active_user, is_unlocked, pin_set }` — frontend uses this to route between pin-entry, pin-create, and the main app.
 
+## autolock (`commands/autolock.rs`)
+Idle auto-lock (#851) — the timer that was missing from `pin::lock`. Rust owns the deadline **and** the timer; the renderer only reports activity and reacts to the resulting event.
+- `set_auto_lock_timeout(minutes?)` — install this device's idle window, or `null` for Off (the default). Rejects anything outside `AUTO_LOCK_OPTIONS_MINUTES` (`1, 5, 15, 60`), so a window the UI could never produce is unrepresentable. Resets the deadline and re-arms; changing the setting counts as activity.
+- `report_user_activity()` — "a human touched this machine". One lock + one field write; the renderer throttles to at most one call per 15s.
+
+**Why the deadline is not in the renderer.** A WebView throttles (and on some platforms suspends) its own timers once the window is hidden or minimized — exactly when an auto-lock most needs to fire, so a JS `setTimeout` would be reliable only in the case that doesn't matter.
+
+**Not polling.** One task sleeps until the current deadline and re-evaluates on wake; reported activity moves the deadline rather than starting a new timer. A generation counter retires the previous task on every reconfigure, so two timers can never race. `Off` spawns nothing at all.
+
+**An active voice session suppresses it** (`VoiceState.room.is_some() || joining`): `pin::lock` closes the local DB, so locking mid-call would leave the call UI unable to read anything while audio kept flowing. The call is treated as continuous activity and the idle clock resumes when it ends.
+
+**Frontend surface:** Security → "Auto-lock" (`SecurityPage.tsx`), next to PIN because it is the same gate reached without pressing anything. The choice is **device-local** (`localStorage`, keyed by user id — see `frontend/src/utils/autoLock.ts`), like font size and the call ringtone: it describes where a machine physically sits, so syncing it would force one answer onto every device. `useAutoLock` (mounted in `AppShell`) pushes the stored value on mount, feeds throttled activity, and disarms on unmount, so the timer is live exactly while there is decrypted content to protect. On expiry Rust locks, then emits the global `auto-lock` event; `App.tsx` routes it through the **same** `handleLock` Cmd/Ctrl+L uses. That handler's transition into `pin-entry` also calls `queryClient.clear()` — without it every message body the user had read would stay decrypted in the module-level React Query cache, which outlives the unmounted shell.
+
 ## user (`commands/user.rs`)
 - `get_user_profile(user_id)` → `User`
 - `update_user_profile(user_id, username?, email?, phone?)` → `User`
@@ -234,7 +247,7 @@ The mirror image of `overlay` (design §10.2, #813): `overlay` decides whether *
 
 ## Appendix A — full registered-command inventory (names only)
 
-Mechanically extracted from `tauri::generate_handler![…]` in `src-tauri/src/lib.rs` at `d13c906` on **2026-08-03** (#714), plus the two `relay_serving` commands added by #813, the six `emoji` commands added by #848, and the two `messages` receipt commands added by #857. **194 commands.** Grouped by the `commands::<module>::` path used at the registration site; **names only — no descriptions are given here because they were not verified.** A name in this list that has no prose above is real and callable; read its implementation in `pollis-core/src/commands/` before using it.
+Mechanically extracted from `tauri::generate_handler![…]` in `src-tauri/src/lib.rs` at `d13c906` on **2026-08-03** (#714), plus the two `relay_serving` commands added by #813, the six `emoji` commands added by #848, the two `messages` receipt commands added by #857, and the two `autolock` commands added by #851. **196 commands.** Grouped by the `commands::<module>::` path used at the registration site; **names only — no descriptions are given here because they were not verified.** A name in this list that has no prose above is real and callable; read its implementation in `pollis-core/src/commands/` before using it.
 
 Regenerate with:
 
@@ -243,6 +256,7 @@ sed -n '/generate_handler!\[/,/^\s*\]) *$/p' src-tauri/src/lib.rs
 ```
 
 - **`(lib.rs, no module)`** — `hide_window`, `read_clipboard_files`, `read_clipboard_image_to_temp`
+- **`autolock`** — `report_user_activity`, `set_auto_lock_timeout`
 - **`auth`** — `delete_account`, `dev_login`, `get_identity`, `get_session`, `initialize_identity`, `is_current_device_registered`, `list_known_accounts`, `list_user_devices`, `logout`, `request_email_change_otp`, `request_otp`, `revoke_device`, `verify_email_change`, `verify_otp`, `wipe_local_data`
 - **`blocks`** — `block_user`, `list_blocked_users`, `unblock_user`
 - **`bookmarks`** — `list_saved_messages`, `resolve_message_permalink`, `save_message`, `toggle_saved_message`, `unsave_message`
@@ -280,7 +294,7 @@ _Back to [index.md](./index.md)_
 
 ## Complete registered-command index
 
-Generated from `src-tauri/src/lib.rs`'s `invoke_handler!` — **194 commands** in 27 shim modules.
+Generated from `src-tauri/src/lib.rs`'s `invoke_handler!` — **196 commands** in 28 shim modules.
 Prose above covers roughly half of these; this index covers all of them, so a name that
 appears here but not above is registered and real, just undocumented. Regenerate rather
 than hand-edit.
@@ -294,6 +308,8 @@ than hand-edit.
 **`auth`** (15) — `delete_account`, `dev_login`, `get_identity`, `get_session`, `initialize_identity`, `is_current_device_registered`, `list_known_accounts`, `list_user_devices`, `logout`, `request_email_change_otp`, `request_otp`, `revoke_device`, `verify_email_change`, `verify_otp`, `wipe_local_data`
 
 **`pin`** (4) — `get_unlock_state`, `lock`, `set_pin`, `unlock`
+
+**`autolock`** (2) — `report_user_activity`, `set_auto_lock_timeout`
 
 **`device_enrollment`** (9) — `approve_device_enrollment`, `finalize_device_enrollment`, `list_pending_enrollment_requests`, `list_security_events`, `poll_enrollment_status`, `recover_with_secret_key`, `reject_device_enrollment`, `reset_identity_and_recover`, `start_device_enrollment`
 

--- a/.codesight/wiki/pin-design.md
+++ b/.codesight/wiki/pin-design.md
@@ -241,6 +241,7 @@ Dispatched by the `#[tauri::command]` shim under `src-tauri/src/commands/pin.rs`
 - `unlock(user_id: String, pin: String) -> Result<UserProfile>`
   - Replaces the keystore-read path in today's `get_session` (auth.rs:333-351). Returns the same `UserProfile` shape, reconstructed from `accounts.json` + Turso verification + freshly-recomputed `enrollment_required`.
 - `lock() -> Result<()>`
+  - Since #851 it also has a **timer** caller: `commands/autolock.rs` drives it after a device-local idle window (Off by default; 1 / 5 / 15 / 60 min). The deadline lives in Rust, not the renderer, because a WebView throttles its own timers exactly when the window is hidden. An active voice session suppresses it. See the `autolock` section of `commands.md`.
   - Drops `AppState.unlock` and calls `state.unload_user_db()`. Does not touch `accounts.json` — `last_active_user` persists so the login screen can still offer the "continue as X" chip. This is what current `logout(delete_data=false)` becomes (auth.rs:623-665 loses its session-slot delete and its `clear_last_active_user` call).
 - `get_unlock_state() -> Result<UnlockStateSnapshot>`
   - Replaces `get_session`. Returns `{ last_active_user_id, is_unlocked, user_profile }` where `user_profile` is only populated if unlocked. Frontend uses this to decide between "PIN entry for user X," "PIN setup flow," or "full login screen." Never blocks on keystore reads — only reads `accounts.json` and in-memory state.

--- a/.codesight/wiki/testing.md
+++ b/.codesight/wiki/testing.md
@@ -590,12 +590,13 @@ pnpm --filter @pollis/e2e e2e:ui                             # all specs
 | `emoji.spec.ts` | The custom-emoji picker (full standard set, search, caret-accurate insertion) and `<:name:hash>` rendering, in BOTH skins (#848) |
 | `invite-links.spec.ts` | Invite-link create / one-time copy / revoke, in BOTH skins (#847) |
 | `voice-controls.spec.ts` | Push-to-talk, deafen and the input-mode toggle — the four mic states drawn distinctly — in BOTH skins (#849) |
+| `autolock.spec.ts` | Idle auto-lock: the window is chosen, reaches the backend and survives a restart; the shell reports activity; a backend lock drops to the PIN gate **and empties the query cache**, in BOTH skins (#851) |
 
 `.spec.ts` is as welcome as `.spec.js`; one config matches both.
 | `bookmarks.spec.ts` | Saved messages + permalink jump/highlight in BOTH skins (#854) |
 | `receipts.spec.ts` | DM delivery/read indicators in BOTH skins — delivered vs read visually distinct, none in group channels, per-reader fractions in group DMs (#857) |
 
-Three things to know before writing one:
+Four things to know before writing one:
 
 - **Fixtures go in `window.__POLLIS_PRELOAD__`** via `page.addInitScript`, read
   once by the mock on load. Extend `MockStore` in `frontend/src/__mocks__/tauri-core.ts`
@@ -609,3 +610,9 @@ Three things to know before writing one:
   catch it and the page dies in an error boundary. When a Rust command is renamed
   (`get_channel_messages` → `read_channel_messages`) the mock silently rots until
   someone runs these specs.
+- **Backend-pushed events are drivable.** `frontend/src/__mocks__/tauri-event.ts`
+  keeps a listener registry and exposes `window.__tauriEmit(name, payload)`, so a
+  spec can stand in for the shell's `AppHandle::emit` (`autolock.spec.ts` fires
+  `auto-lock` this way). It used to drop every handler on the floor, which made
+  that whole class of behaviour untestable in this tier. `bridge/invoke.ts`
+  unwraps `e.payload`, so the registry delivers `{ payload }`, as real Tauri does.

--- a/e2e/autolock.spec.ts
+++ b/e2e/autolock.spec.ts
@@ -1,0 +1,260 @@
+/*
+ * Idle auto-lock (#851) — the renderer's half, in both skins.
+ *
+ * The deadline itself is owned by Rust (`pollis-core/src/commands/autolock.rs`,
+ * unit-tested there) because a WebView throttles its own timers exactly when the
+ * window is hidden — the case auto-lock exists for. There is therefore nothing
+ * to *time* in this tier. What these tests pin down is the contract between the
+ * two halves, which is where a regression would actually hide:
+ *
+ *   1. the setting renders, applies, and survives a restart of this device,
+ *   2. picking a window reaches the backend (`set_auto_lock_timeout`),
+ *   3. the shell reports activity so the deadline can be reset at all, and
+ *   4. when the backend says "locked", the app drops to the PIN gate with no
+ *      decrypted content left rendered — the same place Cmd/Ctrl+L lands.
+ *
+ * (4) is the security property the ticket exists for, so it asserts on the
+ * absence of the message body, not just on the presence of the PIN screen.
+ *
+ *   pnpm --filter @pollis/e2e playwright
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+
+const USER = { id: "u-alice", email: "alice@example.com", username: "alice" };
+
+const GROUP_ID = "01HQ7Z3K9M2P5R8T1V4W6Y0GRP";
+const CHANNEL_ID = "01HQ7Z3K9M2P5R8T1V4W6Y0XCB";
+const MESSAGE_ID = "01HQ7Z3K9M2P5R8T1V4W6Y0MSG";
+const SECRET = "the decrypted history an unattended laptop would leak";
+
+const SKINS = ["terminal", "refined"] as const;
+type Skin = (typeof SKINS)[number];
+
+function preloadState(skin: Skin) {
+  return {
+    session: USER,
+    profile: { id: USER.id, username: USER.username },
+    preferences: JSON.stringify({ skin }),
+    groups: [
+      {
+        id: GROUP_ID,
+        name: "Acme",
+        owner_id: USER.id,
+        created_at: new Date().toISOString(),
+      },
+    ],
+    channels: {
+      [GROUP_ID]: [{ id: CHANNEL_ID, group_id: GROUP_ID, name: "general" }],
+    },
+    messages: {
+      [CHANNEL_ID]: [
+        {
+          id: MESSAGE_ID,
+          conversation_id: CHANNEL_ID,
+          sender_id: "u-bob",
+          content: SECRET,
+          sent_at: "2026-08-01T10:05:00.000Z",
+        },
+      ],
+    },
+  };
+}
+
+/*
+ * NOTE ON NAVIGATION: the router runs on `createMemoryHistory` (see
+ * `frontend/src/router.tsx`), so the browser URL never changes. Everything
+ * below navigates through the UI and asserts on what is RENDERED.
+ */
+async function boot(page: Page, skin: Skin) {
+  await page.addInitScript((preload) => {
+    (window as unknown as Record<string, unknown>).__POLLIS_PRELOAD__ = preload;
+    // `@tauri-apps/api/window` is NOT vite-aliased (only `/core` and `/event`
+    // are), so the real module runs and reads `__TAURI_INTERNALS__` directly.
+    (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = {
+      metadata: {
+        currentWindow: { label: "main" },
+        currentWebview: { windowLabel: "main", label: "main" },
+      },
+      plugins: {},
+      transformCallback: () => 0,
+      convertFileSrc: (path: string) => path,
+      registerListener: () => {},
+      unregisterListener: () => {},
+      runCallback: () => {},
+      invoke: () => Promise.resolve(null),
+    };
+  }, preloadState(skin));
+  await page.goto("/");
+  // The sidebar is the signal that the app got past auth/PIN into the shell.
+  await expect(page.getByTestId("sidebar")).toBeVisible();
+}
+
+async function openCommandPalette(page: Page) {
+  await page.keyboard.press(
+    process.platform === "darwin" ? "Meta+KeyK" : "Control+KeyK",
+  );
+  await expect(page.getByTestId("search-panel")).toBeVisible();
+}
+
+/**
+ * Navigate to Security through Cmd+K, which also proves the page is reachable
+ * from the palette. The exact row is clicked rather than Enter-ing the first
+ * hit: "security" is also a keyword on the Settings hub, so the top result for
+ * that query is not the Security page.
+ */
+async function gotoSecurity(page: Page) {
+  await openCommandPalette(page);
+  await page.getByTestId("search-panel-input").fill("Security");
+  await page
+    .getByTestId("search-panel-result-item")
+    .filter({ hasText: "/security" })
+    .first()
+    .click();
+  await expect(page.getByTestId("security-page")).toBeVisible();
+}
+
+/** Navigate to the seeded channel so a decrypted message body is on screen. */
+async function gotoChannel(page: Page) {
+  await openCommandPalette(page);
+  await page.getByTestId("search-panel-input").fill("general");
+  await page.keyboard.press("Enter");
+  await expect(page.getByTestId(`message-${MESSAGE_ID}`)).toBeVisible();
+}
+
+/**
+ * Every string sitting in the React Query cache. This is where decrypted
+ * message bodies actually live — the cache is module-level, so it outlives the
+ * shell and a DOM-only assertion would pass on an unmount alone.
+ */
+async function cachedData(page: Page): Promise<string> {
+  return page.evaluate(() =>
+    JSON.stringify(
+      (
+        window as unknown as {
+          __pollisQueryClient: {
+            getQueryCache: () => { getAll: () => { state: unknown }[] };
+          };
+        }
+      ).__pollisQueryClient
+        .getQueryCache()
+        .getAll()
+        .map((q) => q.state),
+    ),
+  );
+}
+
+/** What the renderer last pushed to the backend (null = Off). */
+async function pushedTimeout(page: Page): Promise<number | null> {
+  return page.evaluate(
+    () =>
+      (window as unknown as { __tauriMock: { autoLockMinutes: number | null } })
+        .__tauriMock.autoLockMinutes,
+  );
+}
+
+for (const skin of SKINS) {
+  test.describe(`auto-lock — ${skin} skin`, () => {
+    test("the window can be chosen, reaches the backend, and survives a restart", async ({
+      page,
+    }) => {
+      await boot(page, skin);
+      await gotoSecurity(page);
+
+      const section = page.getByTestId("auto-lock-section");
+      await expect(section).toBeVisible();
+
+      // Off is the default: nothing locks until the user asks for it.
+      await expect(page.getByTestId("auto-lock-off")).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+      expect(await pushedTimeout(page)).toBeNull();
+
+      // Every offered window is present, and only those.
+      for (const value of ["off", "1", "5", "15", "60"]) {
+        await expect(page.getByTestId(`auto-lock-${value}`)).toBeVisible();
+      }
+
+      await page.getByTestId("auto-lock-15").click();
+      // The choice is only real once the backend — which owns the deadline —
+      // has been told about it.
+      await expect
+        .poll(() => pushedTimeout(page))
+        .toBe(15);
+
+      await page.screenshot({
+        path: `artifacts/auto-lock-${skin}.png`,
+        fullPage: true,
+      });
+
+      // Restart this device. The setting is device-local (localStorage, like
+      // font size), so it must come back — and must be re-pushed to a backend
+      // that starts every process with no idea what it was.
+      await page.reload();
+      await expect(page.getByTestId("sidebar")).toBeVisible();
+      await expect.poll(() => pushedTimeout(page)).toBe(15);
+
+      await gotoSecurity(page);
+      await expect(page.getByTestId("auto-lock-15")).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+      await expect(page.getByTestId("auto-lock-off")).toHaveAttribute(
+        "aria-pressed",
+        "false",
+      );
+    });
+
+    test("the shell reports activity so the deadline can be reset", async ({
+      page,
+    }) => {
+      await boot(page, skin);
+      await page.getByTestId("sidebar").click();
+      await page.keyboard.press("KeyA");
+      await expect
+        .poll(() =>
+          page.evaluate(
+            () =>
+              (window as unknown as { __tauriMock: { activityReports: number } })
+                .__tauriMock.activityReports,
+          ),
+        )
+        .toBeGreaterThan(0);
+    });
+
+    test("a backend lock drops to the PIN gate with no decrypted content left", async ({
+      page,
+    }) => {
+      await boot(page, skin);
+      await gotoChannel(page);
+      await expect(page.getByText(SECRET)).toBeVisible();
+      // Precondition: the plaintext really is cached, so the assertion after
+      // the lock is testing something that was there to begin with.
+      expect(await cachedData(page)).toContain(SECRET);
+
+      // Stand in for the Rust shell's `AppHandle::emit` when the idle deadline
+      // expires. Nothing about this path is auto-lock-specific on the renderer
+      // side — it is the same `handleLock` Cmd/Ctrl+L runs.
+      await page.evaluate(() => {
+        (
+          window as unknown as { __tauriEmit: (e: string, p?: unknown) => void }
+        ).__tauriEmit("auto-lock");
+      });
+
+      await expect(page.getByTestId("pin-entry-screen")).toBeVisible();
+      await expect(page.getByTestId("sidebar")).toHaveCount(0);
+      await expect(page.getByText(SECRET)).toHaveCount(0);
+      // The actual security property this ticket exists for: the decrypted
+      // body is gone from memory, not merely unmounted. Without the cache
+      // purge in App.tsx the two assertions above still pass and the plaintext
+      // is still one heap snapshot away.
+      await expect.poll(() => cachedData(page)).not.toContain(SECRET);
+
+      await page.screenshot({
+        path: `artifacts/auto-lock-locked-${skin}.png`,
+        fullPage: true,
+      });
+    });
+  });
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,7 +4,7 @@ import React, {
   useCallback,
   useRef,
 } from "react";
-import { invoke } from "./bridge";
+import { invoke, listen } from "./bridge";
 import { observer } from "mobx-react-lite";
 import { appStore } from "./stores/appStore";
 import { LoginScreen } from "./components/Auth/LoginScreen";
@@ -28,6 +28,7 @@ import { Button } from "./components/ui/Button";
 import { useQueryClient } from "@tanstack/react-query";
 import { installTrayVoiceBridge, installVoiceBridge } from "./voice";
 import { clearAllDrafts } from "./utils/drafts";
+import { AUTO_LOCK_EVENT } from "./utils/autoLock";
 
 type AppState =
   | "initializing"
@@ -271,6 +272,23 @@ function MainApp() {
     clearAllDrafts();
   }, [currentUser?.id]);
 
+  // Locking has to empty the React Query cache, not just stop rendering it.
+  // `pin::lock` drops the keys and closes the local DB, but every message body
+  // the user had already read stays decrypted in the query cache — which is
+  // module-level and outlives AppShell — so without this the plaintext this
+  // feature exists to protect is still sitting in the heap, one devtools
+  // snapshot or one bug that re-renders a stale list away from being readable.
+  //
+  // Keyed on the transition into "pin-entry" so it covers Cmd/Ctrl+L, the
+  // idle auto-lock (#851), and the boot-time PIN gate alike. It runs after
+  // React has committed the pin-entry tree, so AppShell is already unmounted
+  // and no observer is left to refetch against a locked backend.
+  useEffect(() => {
+    if (appState === "pin-entry") {
+      queryClient.clear();
+    }
+  }, [appState, queryClient]);
+
   const handleAuthSuccess = useCallback(async (result: api.AuthResult) => {
     // Branch 1: first-device signup. Show the Secret Key screen and gate
     // navigation until the user types it back to confirm they saved it.
@@ -431,6 +449,28 @@ function MainApp() {
     setPendingPinUser(currentUser);
     setAppState("pin-entry");
   }, [currentUser]);
+
+  // Idle auto-lock (#851): Rust owns the deadline and has already locked by the
+  // time this fires — all that is left is to leave the unlocked UI. Routed
+  // through the very same `handleLock` Cmd/Ctrl+L uses so there is one lock
+  // path, not two that can drift apart.
+  useEffect(() => {
+    let unlisten: (() => void) | null = null;
+    let disposed = false;
+    void listen(AUTO_LOCK_EVENT, () => {
+      void handleLock();
+    }).then((fn) => {
+      if (disposed) {
+        fn();
+      } else {
+        unlisten = fn;
+      }
+    });
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+  }, [handleLock]);
 
   // After delete_account succeeds in Settings, transition to auth screen.
   // Zustand logout() is called in Settings.tsx before this fires.

--- a/frontend/src/__mocks__/tauri-core.ts
+++ b/frontend/src/__mocks__/tauri-core.ts
@@ -153,6 +153,12 @@ interface MockStore {
   // preloads may write either shape (see `readPreferences`).
   preferences: Record<string, unknown>;
   clipboard: string;
+  // Idle auto-lock (#851): the last window the renderer pushed (null = Off)
+  // and how many activity reports it has sent. Nothing here times anything —
+  // Rust owns the deadline — these exist so a spec can prove the renderer's
+  // half of the contract.
+  autoLockMinutes: number | null;
+  activityReports: number;
 }
 
 // Only `@tauri-apps/api/core` and `/event` are vite-aliased to these mocks.
@@ -218,6 +224,8 @@ const store: MockStore = {
   // Lets a test drive the skin: `{ skin: 'refined' }` or its JSON string.
   preferences: readPreferences(preload.preferences),
   clipboard: '',
+  autoLockMinutes: null,
+  activityReports: 0,
 };
 
 // Expose for test inspection via page.evaluate(() => window.__tauriMock)
@@ -328,6 +336,20 @@ function handleCommand(command: string, args: Record<string, unknown>): unknown 
     case 'set_pin':
     case 'unlock':
     case 'lock':
+      return null;
+
+    // Idle auto-lock (#851). The real deadline and timer live in Rust
+    // (`pollis-core/src/commands/autolock.rs`); in the browser tier there is
+    // nothing to time, so these just record the last window the renderer
+    // pushed. A spec asserts on `__tauriMock.autoLockMinutes` to prove the
+    // setting reached the backend, and fires the lock itself with
+    // `window.__tauriEmit('auto-lock')`.
+    case 'set_auto_lock_timeout':
+      store.autoLockMinutes = (args.minutes as number | null) ?? null;
+      return null;
+
+    case 'report_user_activity':
+      store.activityReports += 1;
       return null;
 
     case 'initialize_identity':

--- a/frontend/src/__mocks__/tauri-event.ts
+++ b/frontend/src/__mocks__/tauri-event.ts
@@ -1,24 +1,70 @@
 /**
  * Browser-side mock for @tauri-apps/api/event used when VITE_PLAYWRIGHT=true.
- * Returns a no-op unlisten function so event listeners don't error in test mode.
+ *
+ * Listeners used to be dropped on the floor, which made every backend-pushed
+ * event untestable in the browser tier. They are now kept in a registry and
+ * `window.__tauriEmit(name, payload)` delivers to them, so a spec can drive a
+ * Rust-originated event (the idle auto-lock, #851) the same way the real shell
+ * would. Registering a handler is still side-effect-free, so existing specs
+ * that never emit behave exactly as before.
  */
 
 type UnlistenFn = () => void;
+type Handler = (event: { payload: unknown }) => void;
+
+const listeners = new Map<string, Set<Handler>>();
+
+function add(event: string, handler: Handler): UnlistenFn {
+  let set = listeners.get(event);
+  if (!set) {
+    set = new Set();
+    listeners.set(event, set);
+  }
+  set.add(handler);
+  return () => {
+    set?.delete(handler);
+  };
+}
 
 export function listen(
-  _event: string,
-  _handler: (event: unknown) => void,
+  event: string,
+  handler: (event: { payload: unknown }) => void,
 ): Promise<UnlistenFn> {
-  return Promise.resolve(() => {});
+  return Promise.resolve(add(event, handler));
 }
 
 export function once(
-  _event: string,
-  _handler: (event: unknown) => void,
+  event: string,
+  handler: (event: { payload: unknown }) => void,
 ): Promise<UnlistenFn> {
-  return Promise.resolve(() => {});
+  const unlisten = add(event, (e) => {
+    unlisten();
+    handler(e);
+  });
+  return Promise.resolve(unlisten);
 }
 
-export function emit(_event: string, _payload?: unknown): Promise<void> {
+/**
+ * Deliver an event to everything currently listening. Note the
+ * `{ payload }` envelope: `bridge/invoke.ts` unwraps `e.payload` before
+ * handing the value to app code, exactly as real Tauri does.
+ */
+function deliver(event: string, payload?: unknown): void {
+  const set = listeners.get(event);
+  if (!set) {
+    return;
+  }
+  // Snapshot: a handler is allowed to unlisten itself (see `once`).
+  for (const handler of [...set]) {
+    handler({ payload: payload ?? null });
+  }
+}
+
+export function emit(event: string, payload?: unknown): Promise<void> {
+  deliver(event, payload);
   return Promise.resolve();
 }
+
+// The test-side entry point. Specs call this from `page.evaluate` to stand in
+// for the Rust shell's `AppHandle::emit`.
+(window as unknown as Record<string, unknown>).__tauriEmit = deliver;

--- a/frontend/src/components/Layout/AppShell.tsx
+++ b/frontend/src/components/Layout/AppShell.tsx
@@ -26,6 +26,7 @@ import { isDropTargetActive } from "../../stores/dropTargetStore";
 import { useUserGroupsWithChannels } from "../../hooks/queries/useGroups";
 import { useLiveKitRealtime } from "../../hooks/useLiveKitRealtime";
 import { useBadge } from "../../hooks/useBadge";
+import { useAutoLock } from "../../hooks/useAutoLock";
 import { AlertTriangle, Download, Mail, Phone, X } from "lucide-react";
 import { startUpdatePolling, stopUpdatePolling } from "../../services/updatePoller";
 import { loadDeviceCallRingtone } from "../../utils/notify";
@@ -295,6 +296,11 @@ export const AppShell: React.FC = observer(() => {
 
   // Sync unread count to OS dock/taskbar badge
   useBadge();
+
+  // Idle auto-lock (#851). Armed for exactly as long as this shell — the only
+  // thing that renders decrypted content — is mounted. The deadline lives in
+  // Rust; this only pushes the device-local window and throttled activity.
+  useAutoLock(currentUser?.id ?? null);
 
   // Sync groups+channels into the store once loaded
   useEffect(() => {

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -20,6 +20,13 @@ interface ButtonProps {
   onKeyDown?: (e: React.KeyboardEvent<HTMLButtonElement>) => void;
   autoFocus?: boolean;
   "aria-label"?: string;
+  /**
+   * Selected state for a button acting as a toggle — e.g. one option in a
+   * group of mutually exclusive choices. Without it a "selected" option is
+   * announced identically to an unselected one, since the distinction is
+   * carried only by the `primary` variant's colour.
+   */
+  "aria-pressed"?: boolean;
   "data-testid"?: string;
 }
 
@@ -36,6 +43,7 @@ export const Button: React.FC<ButtonProps> = ({
   onKeyDown,
   autoFocus,
   "aria-label": ariaLabel,
+  "aria-pressed": ariaPressed,
   "data-testid": testId,
 }) => {
   const isPrimary = variant === "primary";
@@ -58,6 +66,7 @@ export const Button: React.FC<ButtonProps> = ({
       onKeyDown={onKeyDown}
       autoFocus={autoFocus}
       aria-label={ariaLabel}
+      aria-pressed={ariaPressed}
       data-testid={testId}
       className={`inline-flex items-center justify-center gap-2 font-mono font-medium rounded-[var(--radius-control)] tracking-[0.5px] cursor-pointer transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-4 focus:ring-[var(--c-accent)] focus:ring-offset-2 focus:ring-offset-black ${variantClass} ${size === "xs" ? "px-1.5 py-0.5 text-[10px]" : size === "sm" ? "px-2.5 py-1 text-[11px]" : "px-4 py-2 text-xs"} ${className}`}
     >

--- a/frontend/src/hooks/useAutoLock.ts
+++ b/frontend/src/hooks/useAutoLock.ts
@@ -1,0 +1,88 @@
+import { useEffect } from "react";
+import * as api from "../services/api";
+import {
+  ACTIVITY_REPORT_THROTTLE_MS,
+  loadDeviceAutoLockMinutes,
+} from "../utils/autoLock";
+
+/**
+ * Events that count as "a human is at this machine". Deliberately the same set
+ * an OS screensaver watches: pointer movement and clicks, keys, scrolling, and
+ * the app regaining focus. All passive and captured, so nothing here can
+ * interfere with a component's own handling of the event.
+ */
+const ACTIVITY_EVENTS = [
+  "pointerdown",
+  "pointermove",
+  "keydown",
+  "wheel",
+  "focus",
+] as const;
+
+/**
+ * Arms the backend idle auto-lock (#851) for as long as the unlocked shell is
+ * mounted, and feeds it throttled activity reports.
+ *
+ * The deadline itself is owned by Rust — see `utils/autoLock.ts` for why a
+ * renderer-side timer would be unreliable in precisely the cases that matter.
+ * All this hook does is:
+ *
+ * 1. push the device-local window on mount (covers cold start and every
+ *    unlock, since the shell remounts after the PIN gate),
+ * 2. report activity at most once every {@link ACTIVITY_REPORT_THROTTLE_MS} so
+ *    typing doesn't become one IPC call per keystroke, and
+ * 3. disarm on unmount, so the timer is live exactly while there is decrypted
+ *    content to protect.
+ *
+ * Changing the setting re-pushes immediately from the Security page rather than
+ * waiting for a remount.
+ */
+export function useAutoLock(userId: string | null | undefined): void {
+  useEffect(() => {
+    let disposed = false;
+
+    api
+      .setAutoLockTimeout(loadDeviceAutoLockMinutes(userId))
+      .catch((err) => console.warn("[autolock] failed to arm:", err));
+
+    // Throttle on the leading edge: the first event after a quiet gap reports
+    // straight away, and everything inside the gap is dropped. No trailing
+    // timer, so there is no `setTimeout` left dangling on unmount and nothing
+    // runs on a cadence.
+    // Starts at 0, not `Date.now()`: the very first interaction after the
+    // shell mounts should report, rather than being swallowed by a throttle
+    // window the user never saw.
+    let lastReport = 0;
+    const report = () => {
+      const now = Date.now();
+      if (now - lastReport < ACTIVITY_REPORT_THROTTLE_MS) {
+        return;
+      }
+      lastReport = now;
+      if (disposed) {
+        return;
+      }
+      api
+        .reportUserActivity()
+        .catch((err) => console.warn("[autolock] activity report failed:", err));
+    };
+
+    for (const name of ACTIVITY_EVENTS) {
+      window.addEventListener(name, report, { passive: true, capture: true });
+    }
+
+    return () => {
+      disposed = true;
+      for (const name of ACTIVITY_EVENTS) {
+        window.removeEventListener(name, report, { capture: true });
+      }
+      // The shell is going away — either the app locked (the timer has already
+      // fired and stopped) or the user logged out. Either way, leaving a timer
+      // armed against a session that no longer exists is a state worth not
+      // having.
+      api
+        .setAutoLockTimeout(null)
+        .catch((err) => console.warn("[autolock] failed to disarm:", err));
+    };
+  }, [userId]);
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -43,6 +43,14 @@ const queryClient = new QueryClient({
   },
 });
 
+// Same rationale as `__pollisStore` above: the query cache is where decrypted
+// message plaintext actually lives, so a test asserting that locking empties it
+// (#851) needs to see the cache, not just the rendered tree — a DOM assertion
+// would pass on an unmount alone and prove nothing about the heap.
+if (import.meta.env.VITE_PLAYWRIGHT === 'true') {
+  (window as any).__pollisQueryClient = queryClient;
+}
+
 const root = createRoot(container!);
 
 root.render(

--- a/frontend/src/pages/SecurityPage.tsx
+++ b/frontend/src/pages/SecurityPage.tsx
@@ -23,6 +23,12 @@ import {
 import { invoke } from "../bridge";
 import { isMac, isLinux, isWindows } from "../utils/platform";
 import { formatDateTime } from "../utils/format";
+import { useShortcutLabel } from "../keyboard";
+import {
+  AUTO_LOCK_OPTIONS,
+  loadDeviceAutoLockMinutes,
+  saveDeviceAutoLockMinutes,
+} from "../utils/autoLock";
 
 // The plain-language explainer for everything on this page — what a root is,
 // what an inclusion tick means, and the difference between "couldn't check" and
@@ -138,6 +144,27 @@ export const SecurityPage: React.FC = observer(() => {
   const revokeMedia = useRevokeMediaPermissions();
   const [revokeMediaOnExit, setRevokeMediaOnExit] = useState<boolean>(false);
   const [confirmingRevoke, setConfirmingRevoke] = useState<boolean>(false);
+
+  // Idle auto-lock (#851). Device-local, like font size and the call ringtone:
+  // it describes where this machine physically sits, so it deliberately does
+  // not sync. Seeded from localStorage once the active user is known.
+  const [autoLockMinutes, setAutoLockMinutes] = useState<number | null>(null);
+  const lockLabel = useShortcutLabel("app.lock");
+
+  useEffect(() => {
+    setAutoLockMinutes(loadDeviceAutoLockMinutes(currentUser?.id));
+  }, [currentUser?.id]);
+
+  const handleAutoLock = (minutes: number | null) => {
+    setAutoLockMinutes(minutes);
+    saveDeviceAutoLockMinutes(currentUser?.id, minutes);
+    // Push straight away rather than waiting for the shell to remount — the
+    // backend owns the deadline, so until it hears about the change nothing
+    // has actually changed.
+    void api.setAutoLockTimeout(minutes).catch((err) => {
+      console.warn("[autolock] failed to apply timeout:", err);
+    });
+  };
 
   useEffect(() => {
     if (prefsQuery.data?.revoke_media_on_exit !== undefined) {
@@ -387,6 +414,61 @@ export const SecurityPage: React.FC = observer(() => {
                 Change PIN
               </Button>
             </div>
+          </section>
+
+          {/* Auto-lock (#851) — sits with PIN because it is the same gate,
+              just reached without pressing anything. Device-local: the answer
+              depends on where this machine physically sits, so it deliberately
+              does not sync to your other devices. */}
+          <section className="flex flex-col gap-4 mb-12" data-testid="auto-lock-section">
+            <h2 className={sectionHeaderClass} style={sectionHeaderStyle}>
+              Auto-lock
+            </h2>
+            <p className="text-xs" style={{ color: "var(--c-text-muted)", lineHeight: 1.5 }}>
+              Lock Pollis back to the PIN screen after a period with no mouse or
+              keyboard activity, so walking away from this machine doesn't leave
+              your decrypted conversations on screen. You can always lock
+              immediately with {lockLabel}.
+            </p>
+            {/* A group of toggle buttons rather than the `role="radiogroup"`
+                the neighbouring selectors use: without `role="radio"` +
+                `aria-checked` on the children (which would also commit us to
+                arrow-key traversal) a radiogroup announces every option as
+                unselected. `aria-pressed` states the selection honestly, and
+                renders identically. */}
+            <div
+              role="group"
+              aria-label="Auto-lock after inactivity"
+              className="flex gap-2 flex-wrap"
+            >
+              {AUTO_LOCK_OPTIONS.map((option) => {
+                const selected = autoLockMinutes === option.minutes;
+                return (
+                  <Button
+                    key={option.label}
+                    variant={selected ? "primary" : "secondary"}
+                    size="sm"
+                    aria-label={option.label}
+                    aria-pressed={selected}
+                    data-testid={`auto-lock-${option.minutes ?? "off"}`}
+                    onClick={() => {
+                      if (selected) {
+                        return;
+                      }
+                      handleAutoLock(option.minutes);
+                    }}
+                  >
+                    {option.label}
+                  </Button>
+                );
+              })}
+            </div>
+            <p className="text-xs" style={{ color: "var(--c-text-muted)", lineHeight: 1.5 }}>
+              Applies to this device only. A call in progress keeps Pollis
+              unlocked — locking would close the local database out from under
+              the call. Nothing is lost when it locks: your messages are on
+              disk, and entering your PIN brings you straight back.
+            </p>
           </section>
 
           {/* Devices */}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -89,6 +89,19 @@ export async function lockUnlock(): Promise<void> {
   await invoke('lock');
 }
 
+/// Push this device's idle auto-lock window (#851) to the backend, which owns
+/// the deadline and the timer. `null` turns auto-lock off. Rust rejects any
+/// value the UI doesn't offer — see `AUTO_LOCK_OPTIONS` in `utils/autoLock.ts`.
+export async function setAutoLockTimeout(minutes: number | null): Promise<void> {
+  await invoke('set_auto_lock_timeout', { minutes });
+}
+
+/// Tell the backend a human just interacted with this device, resetting the
+/// idle deadline. Throttled by the caller — never call this per keystroke.
+export async function reportUserActivity(): Promise<void> {
+  await invoke('report_user_activity');
+}
+
 export async function getSession(): Promise<AuthResult | null> {
   const profile = await invoke<RawUserProfile | null>('get_session');
   if (!profile) {

--- a/frontend/src/utils/autoLock.ts
+++ b/frontend/src/utils/autoLock.ts
@@ -1,0 +1,90 @@
+/**
+ * Idle auto-lock (#851) — the renderer's half.
+ *
+ * The deadline itself lives in Rust (`pollis-core/src/commands/autolock.rs`)
+ * because a WebView throttles its own timers once the window is hidden or
+ * minimized, which is exactly when an auto-lock most needs to fire. This module
+ * owns only the *choice*: which window the user picked on this device, and the
+ * throttle that keeps activity reporting off the IPC hot path.
+ *
+ * The choice is deliberately **device-local**, like font size and the call
+ * ringtone — auto-lock describes where a machine physically sits (a laptop in a
+ * cafe wants 1 minute; a desktop in a locked room wants Off), so syncing it
+ * would force one answer onto every device.
+ */
+
+/** The global event Rust emits when the idle deadline expires. Must match
+ *  `AUTO_LOCK_EVENT` in `pollis-core/src/commands/autolock.rs`. */
+export const AUTO_LOCK_EVENT = "auto-lock";
+
+export interface AutoLockOption {
+  /** Minutes of inactivity, or `null` for "never lock". */
+  minutes: number | null;
+  label: string;
+}
+
+/**
+ * The offered windows. Rust validates against the same list
+ * (`AUTO_LOCK_OPTIONS_MINUTES`), so a value that isn't here can't be installed
+ * even by a caller that bypasses this UI.
+ */
+export const AUTO_LOCK_OPTIONS: readonly AutoLockOption[] = [
+  { minutes: null, label: "Off" },
+  { minutes: 1, label: "1 min" },
+  { minutes: 5, label: "5 min" },
+  { minutes: 15, label: "15 min" },
+  { minutes: 60, label: "1 hour" },
+] as const;
+
+/**
+ * Smallest gap between two activity reports. Typing must not turn into one IPC
+ * call per keystroke; 15s is far below every offered window (the shortest is
+ * 60s), so the deadline can never expire inside one throttle gap.
+ */
+export const ACTIVITY_REPORT_THROTTLE_MS = 15_000;
+
+const AUTO_LOCK_KEY_PREFIX = "pollis-auto-lock:";
+
+function autoLockKey(userId: string | null | undefined): string {
+  return `${AUTO_LOCK_KEY_PREFIX}${userId ?? "anon"}`;
+}
+
+/**
+ * The device-local auto-lock window for this user in minutes, or `null` for
+ * Off. Off is also the default: an unset, unreadable, or corrupt entry all mean
+ * "the user has not asked for this", and silently locking someone out of their
+ * own app is worse than not locking.
+ */
+export function loadDeviceAutoLockMinutes(
+  userId: string | null | undefined,
+): number | null {
+  try {
+    const raw = localStorage.getItem(autoLockKey(userId));
+    if (!raw) {
+      return null;
+    }
+    const minutes = parseInt(raw, 10);
+    if (!AUTO_LOCK_OPTIONS.some((o) => o.minutes === minutes)) {
+      return null;
+    }
+    return minutes;
+  } catch {
+    return null;
+  }
+}
+
+/** Persist the device-local auto-lock window. `null` clears it (Off). */
+export function saveDeviceAutoLockMinutes(
+  userId: string | null | undefined,
+  minutes: number | null,
+): void {
+  try {
+    if (minutes === null) {
+      localStorage.removeItem(autoLockKey(userId));
+      return;
+    }
+    localStorage.setItem(autoLockKey(userId), String(minutes));
+  } catch {
+    // localStorage unavailable / quota exceeded — fall through silently
+  }
+}

--- a/pollis-core/src/commands/autolock.rs
+++ b/pollis-core/src/commands/autolock.rs
@@ -1,0 +1,507 @@
+//! Idle auto-lock (#851).
+//!
+//! The PIN is cryptographically load-bearing and `pin::lock` already exists,
+//! but nothing ever called it on a timer — walk away from an unlocked laptop
+//! and the whole decrypted history stays on screen. This module owns the idle
+//! deadline and drives `pin::lock` when it expires.
+//!
+//! **Why the deadline lives here and not in the renderer.** A WebView throttles
+//! (and on some platforms suspends) its timers once the window is hidden or
+//! minimized — exactly the states in which an auto-lock most needs to fire. A
+//! `setTimeout` in JS would therefore be reliable only while the user is
+//! looking at the app, which is the case that does not matter. Rust holds
+//! `last_activity` and a **single** sleeping task that wakes at the deadline;
+//! the renderer's only job is to report that a human touched the machine.
+//!
+//! That single resettable timer is deliberately not polling (CLAUDE.md bans
+//! `setInterval`-style keepalives): the task sleeps exactly until the current
+//! deadline, and a reported activity simply moves the deadline so the next wake
+//! re-evaluates and sleeps again. Nothing runs on a fixed cadence.
+//!
+//! **Voice suppresses it.** `pin::lock` closes the local DB, so locking mid-call
+//! would leave the call UI unable to read anything while audio kept flowing —
+//! a confusing half-state, not a security win. An active session is therefore
+//! treated as continuous activity: the deadline keeps sliding while the call is
+//! up, and the idle clock resumes the moment it ends.
+//!
+//! The chosen timeout is **device-local** and owned by the renderer (see
+//! `frontend/src/utils/autoLock.ts`) — it describes where a machine physically
+//! sits, so syncing it would force one answer onto every device. The renderer
+//! pushes it in via [`set_auto_lock_timeout`] at startup and on every change;
+//! nothing here is persisted.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock, Weak};
+use std::time::Duration;
+
+use tokio::time::Instant;
+
+use crate::error::{Error, Result};
+use crate::sink::EventSink;
+use crate::state::AppState;
+
+/// The global event name the renderer listens on to drop to the PIN gate. Must
+/// match `AUTO_LOCK_EVENT` in `frontend/src/utils/autoLock.ts`.
+pub const AUTO_LOCK_EVENT: &str = "auto-lock";
+
+/// The only timeouts the UI offers, in minutes. `None` (Off) is the default and
+/// is not in this list. Kept here rather than only in the renderer so
+/// [`set_auto_lock_timeout`] can reject anything else at the IPC chokepoint —
+/// a 1-second auto-lock is an invalid state, not a user preference.
+pub const AUTO_LOCK_OPTIONS_MINUTES: &[u32] = &[1, 5, 15, 60];
+
+/// What the timer task should do the instant it asks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Decision {
+    /// Auto-lock is off. No timer should exist at all.
+    Disabled,
+    /// The idle window has elapsed — lock now.
+    Fire,
+    /// Not idle yet (or held open by a call). Sleep this long, then re-ask.
+    Sleep(Duration),
+}
+
+/// The pure deadline rule, factored out of the timer task so it can be tested
+/// without a clock, a runtime, or an [`AppState`].
+///
+/// * `timeout` — the configured idle window, or `None` when auto-lock is off.
+/// * `idle_for` — how long since the last reported user activity.
+/// * `voice_active` — whether a voice session is up right now.
+pub fn decide(timeout: Option<Duration>, idle_for: Duration, voice_active: bool) -> Decision {
+    let Some(timeout) = timeout else {
+        return Decision::Disabled;
+    };
+    // A live call counts as continuous activity, so the deadline is pushed a
+    // full window out rather than being allowed to expire underneath it.
+    if voice_active {
+        return Decision::Sleep(timeout);
+    }
+    match timeout.checked_sub(idle_for) {
+        Some(remaining) if !remaining.is_zero() => Decision::Sleep(remaining),
+        _ => Decision::Fire,
+    }
+}
+
+/// The two things the timer needs from the rest of the app. A trait rather than
+/// a bare `Arc<AppState>` so the loop can be unit-tested: building a real
+/// `AppState` requires a live remote DB connection.
+#[async_trait::async_trait]
+pub trait AutoLockHost: Send + Sync + 'static {
+    /// Whether a voice session is up right now.
+    async fn voice_active(&self) -> bool;
+    /// Perform the lock. Must be idempotent — the renderer routes the resulting
+    /// event through the same handler Cmd/Ctrl+L uses, which locks again.
+    async fn lock(&self);
+}
+
+struct Inner {
+    timeout: Option<Duration>,
+    last_activity: Instant,
+}
+
+/// Owns the idle deadline and the one task that waits on it.
+pub struct AutoLockManager {
+    /// A `std::sync::Mutex`, not tokio's: every path that touches it does a
+    /// couple of field writes with no `.await` held. Activity reporting is on
+    /// the IPC hot path and must never park a task.
+    inner: Mutex<Inner>,
+    /// Bumped by every [`AutoLockManager::configure_duration`]. A timer task
+    /// carries the generation it was spawned under and exits as soon as it no
+    /// longer matches, so a settings change can never leave two timers racing.
+    generation: AtomicU64,
+    sink: Mutex<Option<Arc<dyn EventSink<()>>>>,
+    host: Mutex<Option<Arc<dyn AutoLockHost>>>,
+    /// A handle back to the `Arc` this manager lives in, so `configure` can
+    /// hand an owned reference to the task it spawns.
+    me: OnceLock<Weak<AutoLockManager>>,
+}
+
+static MANAGER: OnceLock<Arc<AutoLockManager>> = OnceLock::new();
+
+/// The process-wide manager.
+pub fn manager() -> &'static Arc<AutoLockManager> {
+    MANAGER.get_or_init(AutoLockManager::new)
+}
+
+/// Install the sink the [`AUTO_LOCK_EVENT`] event is pushed through. The
+/// desktop shell wires this to `AppHandle::emit` at setup. Without a sink the
+/// backend still locks — the renderer just wouldn't know to leave the unlocked
+/// UI, so this is required, not decorative.
+pub fn set_event_sink(sink: Arc<dyn EventSink<()>>) {
+    manager().set_sink(sink);
+}
+
+impl AutoLockManager {
+    pub fn new() -> Arc<AutoLockManager> {
+        let manager = Arc::new(AutoLockManager {
+            inner: Mutex::new(Inner {
+                timeout: None,
+                last_activity: Instant::now(),
+            }),
+            generation: AtomicU64::new(0),
+            sink: Mutex::new(None),
+            host: Mutex::new(None),
+            me: OnceLock::new(),
+        });
+        let _ = manager.me.set(Arc::downgrade(&manager));
+        manager
+    }
+
+    pub fn set_sink(&self, sink: Arc<dyn EventSink<()>>) {
+        *self.sink.lock().unwrap() = Some(sink);
+    }
+
+    pub fn set_host(&self, host: Arc<dyn AutoLockHost>) {
+        *self.host.lock().unwrap() = Some(host);
+    }
+
+    /// The configured idle window, or `None` when auto-lock is off.
+    pub fn timeout(&self) -> Option<Duration> {
+        self.inner.lock().unwrap().timeout
+    }
+
+    /// Mark "a human touched this machine just now". Cheap by construction —
+    /// one uncontended lock and one field write — because the renderer calls it
+    /// from real input events.
+    pub fn report_activity(&self) {
+        self.inner.lock().unwrap().last_activity = Instant::now();
+    }
+
+    /// Apply a new idle window (`None` = off) and re-arm. Also counts as
+    /// activity: changing the setting is itself a user action, and without the
+    /// reset a device that had been idle for an hour would lock the instant
+    /// someone picked "60 minutes".
+    pub fn configure_duration(&self, timeout: Option<Duration>) {
+        {
+            let mut inner = self.inner.lock().unwrap();
+            inner.timeout = timeout;
+            inner.last_activity = Instant::now();
+        }
+        let generation = self.generation.fetch_add(1, Ordering::AcqRel) + 1;
+        if timeout.is_none() {
+            // Off: the generation bump alone retires the running task. Spawning
+            // nothing is what makes "Off" cost exactly zero.
+            return;
+        }
+        let Some(me) = self.me.get().and_then(Weak::upgrade) else {
+            return;
+        };
+        // No runtime (a sync test, a host that hasn't started tokio) means no
+        // timer. The setting is still recorded, so a later `configure` on a
+        // runtime arms it.
+        let Ok(handle) = tokio::runtime::Handle::try_current() else {
+            return;
+        };
+        handle.spawn(async move {
+            me.run(generation).await;
+        });
+    }
+
+    /// Convenience wrapper over [`AutoLockManager::configure_duration`] for the
+    /// minute-granularity values the UI deals in.
+    pub fn configure_minutes(&self, minutes: Option<u32>) {
+        self.configure_duration(minutes.map(|m| Duration::from_secs(u64::from(m) * 60)));
+    }
+
+    /// What the timer should do right now.
+    pub async fn evaluate(&self) -> Decision {
+        let (timeout, idle_for) = {
+            let inner = self.inner.lock().unwrap();
+            (
+                inner.timeout,
+                Instant::now().saturating_duration_since(inner.last_activity),
+            )
+        };
+        // Skip the (async) voice read entirely when auto-lock is off, so a
+        // disabled timer never touches the voice mutex.
+        if timeout.is_none() {
+            return Decision::Disabled;
+        }
+        let voice_active = match self.host() {
+            Some(host) => host.voice_active().await,
+            None => false,
+        };
+        decide(timeout, idle_for, voice_active)
+    }
+
+    fn host(&self) -> Option<Arc<dyn AutoLockHost>> {
+        self.host.lock().unwrap().clone()
+    }
+
+    fn sink(&self) -> Option<Arc<dyn EventSink<()>>> {
+        self.sink.lock().unwrap().clone()
+    }
+
+    /// The whole timer. One task, one sleep at a time, always sleeping until a
+    /// real deadline rather than on a fixed cadence.
+    async fn run(self: Arc<Self>, generation: u64) {
+        loop {
+            if self.generation.load(Ordering::Acquire) != generation {
+                return;
+            }
+            match self.evaluate().await {
+                Decision::Disabled => return,
+                Decision::Sleep(remaining) => tokio::time::sleep(remaining).await,
+                Decision::Fire => {
+                    // Re-check after the last sleep: a `configure` that landed
+                    // while we were asleep must win over a stale decision.
+                    if self.generation.load(Ordering::Acquire) != generation {
+                        return;
+                    }
+                    self.fire().await;
+                    return;
+                }
+            }
+        }
+    }
+
+    async fn fire(&self) {
+        if let Some(host) = self.host() {
+            host.lock().await;
+        }
+        // Locked first, told second: if the sink is missing or the renderer is
+        // gone, the keys are already out of memory.
+        if let Some(sink) = self.sink() {
+            let _ = sink.send(());
+        }
+        // A fresh baseline so the next `configure` (which the renderer issues
+        // after a successful unlock) starts from now rather than from an idle
+        // window that has already elapsed.
+        self.report_activity();
+    }
+}
+
+/// Bridges the process-wide manager to the running app.
+struct AppStateHost(Arc<AppState>);
+
+#[async_trait::async_trait]
+impl AutoLockHost for AppStateHost {
+    async fn voice_active(&self) -> bool {
+        // `VoiceState.room` is `Some` between a successful join and
+        // `release_voice_resources` — the authoritative "in a call" signal.
+        // `joining` covers the in-flight join so a lock can't land in the gap
+        // between "user clicked join" and "room is up".
+        #[cfg(feature = "media")]
+        {
+            let voice = self.0.voice.lock().await;
+            voice.room.is_some() || voice.joining.load(Ordering::Relaxed)
+        }
+        #[cfg(not(feature = "media"))]
+        {
+            false
+        }
+    }
+
+    async fn lock(&self) {
+        if let Err(e) = crate::commands::pin::lock(&self.0).await {
+            eprintln!("[autolock] lock failed: {e}");
+        }
+    }
+}
+
+// ── Commands ─────────────────────────────────────────────────────────
+
+/// Reject any window the UI could never have produced. `None` (Off) is always
+/// valid; everything else must be one of [`AUTO_LOCK_OPTIONS_MINUTES`].
+///
+/// This is the chokepoint that keeps a 0-minute (lock instantly, unusable) or
+/// 10-year (indistinguishable from off, but pretending otherwise) window
+/// unrepresentable — the IPC boundary is the lowest layer available, since the
+/// setting is device-local and never touches a schema.
+pub fn validate_timeout(minutes: Option<u32>) -> Result<()> {
+    match minutes {
+        None => Ok(()),
+        Some(m) if AUTO_LOCK_OPTIONS_MINUTES.contains(&m) => Ok(()),
+        Some(m) => Err(Error::Other(anyhow::anyhow!(
+            "unsupported auto-lock timeout: {m} minutes"
+        ))),
+    }
+}
+
+/// Set (or clear) the idle auto-lock window for this device.
+///
+/// `None` turns auto-lock off. See [`validate_timeout`] for what else is
+/// accepted.
+pub async fn set_auto_lock_timeout(state: &Arc<AppState>, minutes: Option<u32>) -> Result<()> {
+    validate_timeout(minutes)?;
+    let manager = manager();
+    manager.set_host(Arc::new(AppStateHost(Arc::clone(state))));
+    manager.configure_minutes(minutes);
+    Ok(())
+}
+
+/// Report that a human interacted with this device. The renderer throttles
+/// these, so this is a handful of calls per minute at worst.
+pub async fn report_user_activity() -> Result<()> {
+    manager().report_activity();
+    Ok(())
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, AtomicUsize};
+
+    const MIN: Duration = Duration::from_secs(60);
+
+    // ── The pure rule ────────────────────────────────────────────────
+
+    #[test]
+    fn off_is_disabled_however_idle_the_device_is() {
+        assert_eq!(
+            decide(None, Duration::from_secs(60 * 60 * 24), false),
+            Decision::Disabled
+        );
+    }
+
+    #[test]
+    fn fires_once_the_idle_window_has_elapsed() {
+        assert_eq!(decide(Some(MIN), MIN, false), Decision::Fire);
+        assert_eq!(
+            decide(Some(MIN), MIN + Duration::from_secs(1), false),
+            Decision::Fire
+        );
+    }
+
+    #[test]
+    fn sleeps_the_remaining_window_when_not_yet_idle() {
+        assert_eq!(
+            decide(Some(MIN), Duration::from_secs(20), false),
+            Decision::Sleep(Duration::from_secs(40))
+        );
+    }
+
+    #[test]
+    fn an_active_call_suppresses_the_fire() {
+        // Idle far past the window, but a call is up: hold, do not lock.
+        assert_eq!(
+            decide(Some(MIN), Duration::from_secs(60 * 60), true),
+            Decision::Sleep(MIN)
+        );
+    }
+
+    // ── The timer loop ───────────────────────────────────────────────
+    //
+    // Real (millisecond) sleeps rather than a paused clock: tokio's paused
+    // clock auto-advances whenever the runtime goes idle, which is precisely
+    // what a "did it wait?" assertion needs it not to do.
+
+    #[derive(Default)]
+    struct TestHost {
+        voice_active: AtomicBool,
+        locks: AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl AutoLockHost for TestHost {
+        async fn voice_active(&self) -> bool {
+            self.voice_active.load(Ordering::SeqCst)
+        }
+        async fn lock(&self) {
+            self.locks.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    fn armed(timeout: Option<Duration>) -> (Arc<AutoLockManager>, Arc<TestHost>) {
+        let manager = AutoLockManager::new();
+        let host = Arc::new(TestHost::default());
+        manager.set_host(Arc::clone(&host) as Arc<dyn AutoLockHost>);
+        manager.configure_duration(timeout);
+        (manager, host)
+    }
+
+    async fn sleep_ms(ms: u64) {
+        tokio::time::sleep(Duration::from_millis(ms)).await;
+    }
+
+    #[tokio::test]
+    async fn timer_locks_after_the_idle_window() {
+        let (_manager, host) = armed(Some(Duration::from_millis(80)));
+        assert_eq!(host.locks.load(Ordering::SeqCst), 0);
+        sleep_ms(200).await;
+        assert_eq!(host.locks.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn activity_resets_the_deadline() {
+        let (manager, host) = armed(Some(Duration::from_millis(200)));
+        // Keep reporting activity across more than two full windows.
+        for _ in 0..6 {
+            sleep_ms(80).await;
+            manager.report_activity();
+        }
+        assert_eq!(
+            host.locks.load(Ordering::SeqCst),
+            0,
+            "a device in continuous use must never auto-lock"
+        );
+        // Stop touching it and it locks.
+        sleep_ms(400).await;
+        assert_eq!(host.locks.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn off_never_locks() {
+        let (_manager, host) = armed(None);
+        sleep_ms(300).await;
+        assert_eq!(host.locks.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn switching_to_off_retires_a_running_timer() {
+        let (manager, host) = armed(Some(Duration::from_millis(80)));
+        manager.configure_duration(None);
+        sleep_ms(300).await;
+        assert_eq!(host.locks.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn an_active_voice_session_suppresses_the_timer() {
+        let (_manager, host) = armed(Some(Duration::from_millis(80)));
+        host.voice_active.store(true, Ordering::SeqCst);
+        sleep_ms(400).await;
+        assert_eq!(
+            host.locks.load(Ordering::SeqCst),
+            0,
+            "locking mid-call closes the DB under the live call UI"
+        );
+        // Ending the call hands the device straight back to the idle clock —
+        // it has been idle far longer than the window, so the next wake fires.
+        host.voice_active.store(false, Ordering::SeqCst);
+        sleep_ms(200).await;
+        assert_eq!(host.locks.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn reconfiguring_never_leaves_two_timers_running() {
+        let (manager, host) = armed(Some(Duration::from_millis(80)));
+        for _ in 0..5 {
+            manager.configure_duration(Some(Duration::from_millis(80)));
+        }
+        sleep_ms(400).await;
+        assert_eq!(
+            host.locks.load(Ordering::SeqCst),
+            1,
+            "each configure must retire the previous timer"
+        );
+    }
+
+    #[test]
+    fn only_the_offered_windows_are_representable() {
+        assert!(validate_timeout(None).is_ok());
+        for m in AUTO_LOCK_OPTIONS_MINUTES {
+            assert!(validate_timeout(Some(*m)).is_ok(), "{m} should be offered");
+        }
+        // A zero window would lock the instant the app opened; the rest are
+        // simply not offered, and a caller inventing one is a bug, not a
+        // preference.
+        for m in [0u32, 2, 7, 1440, u32::MAX] {
+            assert!(
+                validate_timeout(Some(m)).is_err(),
+                "{m} minutes must be rejected"
+            );
+        }
+    }
+}

--- a/pollis-core/src/commands/mod.rs
+++ b/pollis-core/src/commands/mod.rs
@@ -1,6 +1,9 @@
 pub mod account_identity;
 pub mod auth;
 pub mod pin;
+// Idle auto-lock (#851): the deadline + the single resettable timer that
+// drives `pin::lock`. Pure tokio, so it compiles on every target.
+pub mod autolock;
 pub mod blocks;
 // Saved messages + local permalink resolution (#854). Pure rusqlite against the
 // device-local DB — no DS, no Turso, compiles on every target.

--- a/src-tauri/src/commands/autolock.rs
+++ b/src-tauri/src/commands/autolock.rs
@@ -1,0 +1,56 @@
+// Generated shim file. Each #[tauri::command] forwards to
+// pollis_core::commands::autolock::*. Edit pollis-core, not here.
+//
+// The one thing that is NOT a forward is the lock sink: pollis-core stays
+// Tauri-runtime-free (`pollis_core::sink::EventSink`), so the adapter that turns
+// "the idle deadline expired" into a global `AppHandle::emit` lives on this side.
+
+#![allow(unused_imports)]
+use std::sync::Arc;
+use tauri::State;
+
+#[cfg(feature = "native-shell")]
+use tauri::{AppHandle, Emitter};
+
+use crate::error::Result;
+use crate::state::AppState;
+pub use pollis_core::commands::autolock::*;
+use pollis_core::sink::EventSink;
+
+#[tauri::command]
+pub async fn set_auto_lock_timeout(
+    state: State<'_, Arc<AppState>>,
+    minutes: Option<u32>,
+) -> Result<()> {
+    pollis_core::commands::autolock::set_auto_lock_timeout(&state, minutes).await
+}
+
+#[tauri::command]
+pub async fn report_user_activity() -> Result<()> {
+    pollis_core::commands::autolock::report_user_activity().await
+}
+
+/// Pushes the lock to every window as the global `auto-lock` event.
+///
+/// Gated on the native shell for the same reason as the relay-serving sink:
+/// `AppHandle` defaults to the `Wry` runtime, which a headless
+/// (`--no-default-features`) build does not compile. The two commands above stay
+/// ungated — without a sink the backend still locks, the renderer just isn't
+/// told, which is why installing this is required rather than optional.
+#[cfg(feature = "native-shell")]
+struct AppHandleSink(AppHandle);
+
+#[cfg(feature = "native-shell")]
+impl EventSink<()> for AppHandleSink {
+    fn send(&self, _event: ()) -> std::result::Result<(), String> {
+        self.0
+            .emit(AUTO_LOCK_EVENT, ())
+            .map_err(|e| e.to_string())
+    }
+}
+
+/// Wire the auto-lock event to the app handle. Called once during setup.
+#[cfg(feature = "native-shell")]
+pub fn install_auto_lock_sink(app: AppHandle) {
+    set_event_sink(Arc::new(AppHandleSink(app)));
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,6 +1,8 @@
 // Shim modules. Each forwards #[tauri::command]s to pollis_core::commands::*.
 // install_kind stays in src-tauri because it inspects Tauri's bundle metadata.
 pub mod auth;
+// Idle auto-lock (#851).
+pub mod autolock;
 pub mod blocks;
 pub mod bookmarks;
 pub mod device_enrollment;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -438,6 +438,12 @@ pub fn run() {
             // refresh when Preferences remounts.
             commands::relay_serving::install_status_sink(tray_handle.clone());
 
+            // Push the idle auto-lock to the renderer as a global event (#851).
+            // The deadline is owned by Rust because a WebView throttles its own
+            // timers exactly when the window is hidden — the case auto-lock
+            // exists for.
+            commands::autolock::install_auto_lock_sink(tray_handle.clone());
+
             // Holds the "revoke media permissions on quit" preference so the
             // ExitRequested hook can read it synchronously at shutdown.
             tray_handle.manage(commands::media_permissions::MediaPermissionsState::default());
@@ -486,6 +492,8 @@ pub fn run() {
             commands::pin::unlock,
             commands::pin::lock,
             commands::pin::get_unlock_state,
+            commands::autolock::set_auto_lock_timeout,
+            commands::autolock::report_user_activity,
             commands::auth::list_user_devices,
             commands::auth::revoke_device,
             commands::auth::is_current_device_registered,


### PR DESCRIPTION
Closes #851.

`pin::lock` existed and was bound to Cmd/Ctrl+L, but nothing ever called it on a timer. Now something does.

**The deadline lives in Rust** (`pollis-core/src/commands/autolock.rs`), not the renderer: a WebView throttles its own timers once the window is hidden or minimized, which is exactly when an auto-lock needs to fire. One task sleeps until the current deadline and re-evaluates on wake — reported activity moves the deadline rather than starting a new timer, and `Off` spawns nothing. A generation counter retires the previous task on reconfigure, so two timers can't race. An active voice session suppresses the lock (locking closes the local DB out from under a live call).

Two new commands (`set_auto_lock_timeout`, `report_user_activity`), which reject any window the UI doesn't offer. 196 commands in 28 shim modules.

**The setting is device-local** (localStorage, like font size / call ringtone) — it describes where a machine physically sits, so syncing it would force one answer onto every device. Options: Off (default), 1, 5, 15, 60 min, on the Security page next to PIN.

**Auto-lock and Cmd+L are one path**, not two: Rust locks, emits `auto-lock`, and `App.tsx` routes it through the same `handleLock`.

**Fixed along the way:** the manual lock left every message body the user had read decrypted in the module-level React Query cache, which outlives the unmounted shell. Locking now calls `queryClient.clear()`, and the e2e asserts on the cache rather than only on the DOM — a DOM assertion passes on an unmount alone and proves nothing about the heap.

### Tests
- 11 new Rust unit tests (`cargo test -p pollis-core`: 574 pass, was 563)
- 6 new Playwright tests in both skins (`e2e`: 88 pass, was 82)
- Every new test was re-run with its fix reverted and confirmed to fail.

Also: `tauri-event.ts` used to drop every listener on the floor, making backend-pushed events untestable in the browser tier. It now keeps a registry and exposes `window.__tauriEmit`.