### PR TITLE
fix(dms): show a DM's members instead of a roster nothing ever filled

### DIFF
--- a/e2e/right-panel-persistence.spec.ts
+++ b/e2e/right-panel-persistence.spec.ts
@@ -373,5 +373,27 @@ for (const skin of SKINS) {
       await expect(panel(page).getByRole("heading", { name: "Members — 3" })).toBeVisible();
       await expect(panel(page).getByRole("button", { name: /carol$/ })).toBeVisible();
     });
+
+    test("a DM's panel names its members instead of reporting none", async ({
+      page,
+    }) => {
+      // #906. `MembersPanel` read `appStore.dmConversations`, which nothing
+      // ever wrote — its two setters had zero call sites — so every DM showed
+      // "Members — 0" and the roster was empty. The channel case above passed
+      // throughout, because that path reads a React Query hook; only the DM
+      // branch touched the dead store.
+      await boot(page, skin, { rightPanelOpenByDefault: true });
+
+      await navigateTo(page, DM_PEER);
+      await expectOpen(page, "the preference asked for an open panel");
+
+      // Two people in this DM: alice (the viewer) and dave.
+      await expect(
+        panel(page).getByRole("heading", { name: "Members — 2" }),
+      ).toBeVisible();
+      await expect(
+        panel(page).getByRole("button", { name: new RegExp(`${DM_PEER}$`) }),
+      ).toBeVisible();
+    });
   });
 }

--- a/frontend/src/components/Layout/RightPanel/MembersPanel.tsx
+++ b/frontend/src/components/Layout/RightPanel/MembersPanel.tsx
@@ -5,7 +5,7 @@ import { appStore } from "../../../stores/appStore";
 import { presenceStore } from "../../../stores/presenceStore";
 import { useSkin } from "../../../hooks/queries/usePreferences";
 import { useGroupMembers } from "../../../hooks/queries/useGroups";
-import { useMessages } from "../../../hooks/queries/useMessages";
+import { useMessages, useDMConversations } from "../../../hooks/queries/useMessages";
 import { MemberRow } from "./MemberRow";
 import { MediaGrid } from "./MediaGrid";
 import type { MessageAttachment } from "../../../types";
@@ -50,7 +50,11 @@ export const MembersPanel: React.FC<MembersPanelProps> = observer(
     const { messages } = useMessages(channelId, conversationId);
     const isTerminal = useSkin() === "terminal";
     const currentUser = appStore.currentUser;
-    const dmConversations = appStore.dmConversations;
+    // React Query, not the MobX store: `appStore.dmConversations` was never
+    // written — its two setters had no call sites — so this panel saw an empty
+    // list in every DM and reported "Members — 0" (#906). The query hook is
+    // the source of truth for remote data everywhere else in the app.
+    const { data: dmConversations = [] } = useDMConversations();
     const hasContext = Boolean(groupId || channelId || conversationId);
 
     // Online first, then alphabetical. Reading `presenceStore.isOnline` here

--- a/frontend/src/stores/appStore.ts
+++ b/frontend/src/stores/appStore.ts
@@ -29,7 +29,6 @@ class AppStore implements AppState {
   // ── Data (messages managed by React Query, not here) ───────────────────
   groups: Group[] = [];
   channels: Record<string, Channel[]> = {};
-  dmConversations: DMConversation[] = [];
   messageQueue: MessageQueueItem[] = [];
 
   // ── UI state ───────────────────────────────────────────────────────────
@@ -168,13 +167,7 @@ class AppStore implements AppState {
     };
   }
 
-  setDMConversations(conversations: DMConversation[]) {
-    this.dmConversations = conversations;
-  }
 
-  addDMConversation(conversation: DMConversation) {
-    this.dmConversations = [...this.dmConversations, conversation];
-  }
 
   setMessageQueue(queue: MessageQueueItem[]) {
     this.messageQueue = queue;
@@ -542,7 +535,6 @@ class AppStore implements AppState {
     this.selectedConversationId = null;
     this.groups = [];
     this.channels = {};
-    this.dmConversations = [];
     this.messageQueue = [];
     this.replyToMessageId = null;
     this.showThreadId = null;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -378,10 +378,9 @@ export interface AppState {
   selectedChannelId: string | null;
   selectedConversationId: string | null; // For DMs
 
-  // Data (messages managed by React Query, not Zustand)
+  // Data (messages and DM conversations managed by React Query, not the store)
   groups: Group[];
   channels: Record<string, Channel[]>; // group_id -> channels
-  dmConversations: DMConversation[];
 
   // Message queue
   messageQueue: MessageQueueItem[];


### PR DESCRIPTION
Closes #906.

`MembersPanel` read `appStore.dmConversations`. Nothing ever wrote it — `setDMConversations` and `addDMConversation` had zero call sites — so every DM rendered **"Members — 0"** with an empty roster, and the no-conversation roster (which uses the DM list as its only peer directory) could not name anyone either.

Reads `useDMConversations()`, the React Query hook that is already the source of truth for this data everywhere else in the app, and deletes the dead field, both setters, its reset line, and its `AppState` slot.

The channel path was never affected, which is why this survived: it reads a hook. Only the DM branch touched the dead store.

Test in `right-panel-persistence.spec.ts` (both skins) asserting a DM panel reports "Members — 2" and names the peer. **Verified it fails with the fix reverted**, in both skins.

149 e2e passed (baseline 147); tsc clean.

Found while fixing #904.