### PR TITLE
ci(cli): install dbus headers so the Linux CLI can link the OS keystore

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -71,7 +71,8 @@ jobs:
             libssl-dev \
             pkg-config \
             build-essential \
-            perl
+            perl \
+            libdbus-1-dev
 
       - name: Load production secrets
         run: |


### PR DESCRIPTION
Closes #881.

#879 turned on the `os-keystore` feature for `pollis-tui` (the shipped CLI was otherwise writing keys to a plaintext file). That pulls `keyring` → `libdbus-sys`, which needs `libdbus-1-dev` at build time.

`cli-release.yml` is the **only** workflow building the TUI that lacks it — `kani.yml`, `rebuild-verify.yml`, `mls-tests.yml` and `desktop-release.yml` all install it already. So every CLI release since has failed at `build-cli-linux` (`pkg_config failed` → `explicit panic` in the `libdbus-sys` build script), and **the published CLI has been stale since 2026-08-13** — missing the keystore fix itself, auto-lock, and all of #875.

Found while running the post-merge checklist for #875: the CLI is a downstream target of `pollis-core`, and checking it rather than assuming it was fine is what surfaced this.