### PR TITLE
fix(ui): point message-action states at a colour token that exists

### DIFF
--- a/e2e/bookmarks.spec.ts
+++ b/e2e/bookmarks.spec.ts
@@ -366,6 +366,54 @@ for (const skin of SKINS) {
       expect(clipboard).not.toContain("bob");
     });
 
+    test("the copied state is actually painted, not just labelled", async ({
+      page,
+    }) => {
+      // `--c-text-accent` was referenced by every hover, focus-visible and
+      // "copied" state on the message actions and defined NOWHERE, so the
+      // colour half of the affordance silently painted nothing. The glyph and
+      // the accessible name still changed, which is exactly why the existing
+      // tests passed throughout. This asserts the RESOLVED colour moves.
+      //
+      // Only the refined skin fails on the unfixed code: terminal defines
+      // `--c-text` as the same HSL as `--c-accent`, so an element falling back
+      // to inherited text colour lands on the accent by coincidence. That is
+      // why this went unnoticed — in terminal it looked correct. Keep both
+      // skins: in terminal this is a guard, in refined it proves the fix.
+      await boot(page, skin);
+      await gotoChannel(page);
+
+      const message = page.getByTestId(`message-${CHANNEL_MESSAGE_ID}`);
+      await message.getByTestId("message-actions-more").click();
+      const copyButton = message.getByTestId("copy-link-button");
+
+      const colourOf = () =>
+        copyButton.evaluate((el) => getComputedStyle(el).color);
+      const idle = await colourOf();
+
+      await copyButton.click();
+      await expect(copyButton).toHaveAttribute("data-copy-state", "copied");
+      const copied = await colourOf();
+
+      expect(copied).not.toBe(idle);
+      // And it is the accent, not some arbitrary third colour.
+      const accent = await page.evaluate(() =>
+        getComputedStyle(document.documentElement)
+          .getPropertyValue("--c-accent")
+          .trim(),
+      );
+      expect(accent).not.toBe("");
+      const asRgb = await page.evaluate((c) => {
+        const probe = document.createElement("span");
+        probe.style.color = c;
+        document.body.appendChild(probe);
+        const resolved = getComputedStyle(probe).color;
+        probe.remove();
+        return resolved;
+      }, accent);
+      expect(copied).toBe(asRgb);
+    });
+
     test("a successful copy confirms itself on the button", async ({ page }) => {
       await boot(page, skin);
       await gotoChannel(page);

--- a/frontend/src/components/Auth/LoginScreen.tsx
+++ b/frontend/src/components/Auth/LoginScreen.tsx
@@ -90,7 +90,7 @@ export const LoginScreen: React.FC<LoginScreenProps> = ({
             <div className="flex flex-col gap-5">
               <div>
 
-                <p className="text-xs mt-1 font-mono" style={{ color: "var(--c-text-accent)" }}>
+                <p className="text-xs mt-1 font-mono text-accent">
                   {t("login.prompt")}
                 </p>
               </div>

--- a/frontend/src/components/Message/MessageActions.tsx
+++ b/frontend/src/components/Message/MessageActions.tsx
@@ -107,7 +107,7 @@ export const MessageActions: React.FC<MessageActionsProps> = ({
         : t("actions.copyLink");
   const copyLinkTone =
     copyLinkState === "copied"
-      ? "text-[var(--c-text-accent)]"
+      ? "text-accent"
       : copyLinkState === "failed"
         ? "text-danger"
         : "text-dim hover:text-fg";
@@ -125,8 +125,8 @@ export const MessageActions: React.FC<MessageActionsProps> = ({
   // navigation shows the same affordance the pointer would.
   const barBtnClass =
     variant === "refined"
-      ? "p-1 text-[var(--c-text-muted)] hover:text-[var(--c-text-accent)] focus-visible:text-[var(--c-text-accent)] outline-none"
-      : "text-[var(--c-text-muted)] hover:text-[var(--c-text-accent)] focus-visible:text-[var(--c-text-accent)] outline-none";
+      ? "p-1 text-muted hover:text-accent focus-visible:text-accent outline-none"
+      : "text-muted hover:text-accent focus-visible:text-accent outline-none";
 
   // The container owns hover-reveal for both skins; while the menu is open it
   // stays fully visible even if the pointer leaves the row — otherwise the
@@ -183,8 +183,7 @@ export const MessageActions: React.FC<MessageActionsProps> = ({
             aria-label={t("actions.more")}
             aria-expanded={menuOpen}
             aria-haspopup="menu"
-            className={barBtnClass}
-            style={{ color: menuOpen ? "var(--c-text-accent)" : undefined }}
+            className={`${barBtnClass}${menuOpen ? " text-accent" : ""}`}
           >
             <MoreHorizontal size={iconSize} />
           </button>


### PR DESCRIPTION
`--c-text-accent` is referenced by every hover, `focus-visible` and "copied" state on `MessageActions`, and once in `LoginScreen` — and is **defined nowhere**. Every one of those declarations was invalid and painted nothing, so hovering a message action, reaching one by keyboard, and the copy-link confirmation all had no colour response.

Repointed at the semantic `text-accent` / `text-muted` utilities, which is what CLAUDE.md asks for anyway.

**Why nobody noticed:** in the terminal skin `--c-text` is the same HSL as `--c-accent`, so an element falling back to inherited text colour lands on the accent by coincidence and looks right. Only refined is visibly wrong. The new test fails on the unfixed code in refined and passes in terminal — labelled in-file as proof in one skin and a guard in the other, rather than pretending both prove it.

The existing copy-link tests passed throughout because the glyph and the accessible name do change; only the colour was dead. That is the same lesson as the picker-clipping and PTT-idle bugs earlier in this batch — assert resolved appearance, not state names.

Found by #874's style sweep, which flagged it rather than silently repointing it, since choosing a replacement colour is a design decision.

159 e2e passed; tsc clean.