### PR TITLE
mobile: store-ready build config for iOS + Android (no EAS)

### DIFF
--- a/mobile/.env.example
+++ b/mobile/.env.example
@@ -19,9 +19,12 @@ EXPO_PUBLIC_R2_PUBLIC_URL=
 # the DS (POST /v1/livekit/token).
 EXPO_PUBLIC_LIVEKIT_URL=
 
-# Optional (Resend is server-side OTP delivery — mobile doesn't send,
-# only verifies):
-EXPO_PUBLIC_RESEND_API_KEY=
-
 # Delivery Service base URL (dev: https://api-dev.pollis.com, prod: https://api.pollis.com)
+# Store builds MUST point this at https://api.pollis.com.
 EXPO_PUBLIC_POLLIS_DELIVERY_URL="https://api-dev.pollis.com"
+
+# REMOVED in #393 — never re-add (they'd inline into the shipped JS bundle):
+# EXPO_PUBLIC_RESEND_API_KEY, EXPO_PUBLIC_LIVEKIT_API_KEY,
+# EXPO_PUBLIC_LIVEKIT_API_SECRET, EXPO_PUBLIC_R2_ACCESS_KEY_ID,
+# EXPO_PUBLIC_R2_SECRET_ACCESS_KEY. If any of these linger in your local .env,
+# delete them before a store build.

--- a/mobile/CLAUDE.md
+++ b/mobile/CLAUDE.md
@@ -177,6 +177,77 @@ Two things worth knowing:
 now unconditional defaults in SDK 55 / RN 0.83 and were dropped from the config
 schema, so listing them fails doctor's schema check for no behavioural gain.
 
+## Store builds (no EAS — local `expo prebuild` + native tooling)
+
+Published as a private individual account, Apple team `9JF7WWYMU2`. Version
+bookkeeping is **local and explicit** in `app.json`: `ios.buildNumber` (string)
+and `android.versionCode` (int) — bump both by hand for every store upload
+(stores reject a re-used number), bump `version` for user-facing releases.
+
+**Environment first.** `EXPO_PUBLIC_*` vars inline into the shipped JS bundle,
+so before any store build check `mobile/.env`:
+
+- `EXPO_PUBLIC_POLLIS_DELIVERY_URL` **must** be `https://api.pollis.com` (prod
+  DS), not api-dev.
+- `EXPO_PUBLIC_LIVEKIT_API_KEY` / `EXPO_PUBLIC_LIVEKIT_API_SECRET` /
+  `EXPO_PUBLIC_RESEND_API_KEY` must **not** exist in `.env` — the code stopped
+  reading them in #393, but a stale var would still be inlined into the bundle
+  as plaintext. Delete them.
+
+### iOS
+
+```bash
+cd mobile
+pnpm expo prebuild -p ios
+cd ios && pod install && cd ..
+xcodebuild -workspace ios/Pollis.xcworkspace -scheme Pollis \
+  -configuration Release -destination 'generic/platform=iOS' \
+  archive -archivePath build/Pollis.xcarchive \
+  DEVELOPMENT_TEAM=9JF7WWYMU2 -allowProvisioningUpdates
+xcodebuild -exportArchive -archivePath build/Pollis.xcarchive \
+  -exportOptionsPlist store/ExportOptions.plist -exportPath build/export \
+  -allowProvisioningUpdates
+```
+
+`store/ExportOptions.plist` (committed — `ios/` is generated, so it can't live
+there) sets `method: app-store-connect`, `teamID: 9JF7WWYMU2`,
+`uploadSymbols: true`. Upload the resulting `.ipa` with Xcode Organizer or
+`xcrun altool`/Transporter.
+
+**Encryption export compliance:** `app.json` sets
+`ITSAppUsesNonExemptEncryption: true` deliberately. `false` means "no
+encryption, or only Apple-exempt encryption (auth, DRM, HTTPS-only)" — Pollis
+uses standard-algorithm E2EE (MLS RFC 9420: AES-GCM, ML-DSA-44) for content
+confidentiality in its own protocol, which is **not** on the exempt list, so
+`false` would be a false export declaration. `true` is the honest answer; it
+skips the per-build compliance interruption in App Store Connect and instead
+requires (one-time/annual, operational not code): answering ASC's export
+compliance questions (standard algorithms → mass-market self-classification,
+annual self-classification report to the U.S. BIS by Feb 1), and the French
+encryption declaration to ANSSI if distributing in France. Do not flip this to
+`false` to silence ASC.
+
+### Android
+
+```bash
+cd mobile
+pnpm expo prebuild -p android
+cd android && ./gradlew :app:bundleRelease
+# → android/app/build/outputs/bundle/release/app-release.aab
+```
+
+Release signing is wired by `plugins/withReleaseSigning.js` (registered in
+`app.json`), a local Expo config plugin that patches the generated
+`android/app/build.gradle` at prebuild: `signingConfigs.release` reads
+`POLLIS_UPLOAD_STORE_FILE` / `POLLIS_UPLOAD_STORE_PASSWORD` /
+`POLLIS_UPLOAD_KEY_ALIAS` / `POLLIS_UPLOAD_KEY_PASSWORD` from gradle
+properties (`~/.gradle/gradle.properties`) or the environment, and **falls back
+to the debug keystore when unset** — so CI's `assembleRelease` keeps working
+with zero config. Generate the upload keystore once with
+`scripts/generate-upload-keystore.sh` (RSA-4096 at `~/.pollis/pollis-upload.jks`,
+refuses to overwrite); it prints the gradle.properties lines. Never commit a
+keystore (`*.jks` is gitignored) or its passwords.
+
 ---
 
 ## Rough edges — technical

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -14,12 +14,14 @@
     },
     "ios": {
       "supportsTablet": true,
+      "buildNumber": "1",
       "icon": {
         "light": "./assets/ios-light.png",
         "dark": "./assets/ios-dark.png",
         "tinted": "./assets/ios-tinted.png"
       },
       "infoPlist": {
+        "ITSAppUsesNonExemptEncryption": true,
         "NSCameraUsageDescription": "Pollis needs your camera to scan the pairing QR code from your desktop.",
         "UISupportedInterfaceOrientations": [
           "UIInterfaceOrientationPortrait"
@@ -79,6 +81,7 @@
       },
       "predictiveBackGestureEnabled": false,
       "package": "com.pollis.mobile",
+      "versionCode": 1,
       "permissions": [
         "android.permission.CAMERA"
       ]
@@ -87,6 +90,7 @@
       "favicon": "./assets/favicon.png"
     },
     "plugins": [
+      "./plugins/withReleaseSigning",
       "expo-secure-store",
       "expo-router",
       "expo-image",

--- a/mobile/plugins/withReleaseSigning.js
+++ b/mobile/plugins/withReleaseSigning.js
@@ -1,0 +1,86 @@
+// Expo config plugin: wire a release signingConfig into android/app/build.gradle
+// at prebuild time, without EAS. Reads the upload keystore from gradle/env
+// properties (POLLIS_UPLOAD_STORE_FILE / _STORE_PASSWORD / _KEY_ALIAS /
+// _KEY_PASSWORD — put them in ~/.gradle/gradle.properties, see
+// scripts/generate-upload-keystore.sh) and falls back to the Expo template's
+// debug keystore when unset, so CI release builds keep working unchanged.
+const { withAppBuildGradle } = require('expo/config-plugins');
+
+const RELEASE_SIGNING_CONFIG = `        release {
+            // Injected by plugins/withReleaseSigning.js (upload keystore from
+            // gradle/env properties; debug keystore fallback when unset).
+            def pollisStoreFile = project.findProperty('POLLIS_UPLOAD_STORE_FILE') ?: System.getenv('POLLIS_UPLOAD_STORE_FILE')
+            if (pollisStoreFile) {
+                storeFile file(pollisStoreFile)
+                storePassword project.findProperty('POLLIS_UPLOAD_STORE_PASSWORD') ?: System.getenv('POLLIS_UPLOAD_STORE_PASSWORD')
+                keyAlias project.findProperty('POLLIS_UPLOAD_KEY_ALIAS') ?: System.getenv('POLLIS_UPLOAD_KEY_ALIAS')
+                keyPassword project.findProperty('POLLIS_UPLOAD_KEY_PASSWORD') ?: System.getenv('POLLIS_UPLOAD_KEY_PASSWORD')
+            } else {
+                storeFile file('debug.keystore')
+                storePassword 'android'
+                keyAlias 'androiddebugkey'
+                keyPassword 'android'
+            }
+        }
+`;
+
+function addReleaseSigning(gradle) {
+  // Idempotency: if the block is already present, leave the file alone.
+  if (gradle.includes('POLLIS_UPLOAD_STORE_FILE')) {
+    return gradle;
+  }
+
+  // 1. Add a `release` entry inside `signingConfigs { ... }` (inserting it
+  //    directly after the opening brace keeps this independent of whatever
+  //    else the template puts in there).
+  const signingConfigsRe = /(signingConfigs\s*\{\n)/;
+  if (!signingConfigsRe.test(gradle)) {
+    throw new Error(
+      'withReleaseSigning: could not find `signingConfigs {` in android/app/build.gradle'
+    );
+  }
+  let next = gradle.replace(signingConfigsRe, `$1${RELEASE_SIGNING_CONFIG}`);
+
+  // 2. Point buildTypes.release at signingConfigs.release. The Expo template
+  //    ships `signingConfig signingConfigs.debug` inside the release build
+  //    type; rewrite only the occurrence inside `buildTypes { ... release {`.
+  const buildTypesIdx = next.indexOf('buildTypes');
+  if (buildTypesIdx === -1) {
+    throw new Error(
+      'withReleaseSigning: could not find `buildTypes` in android/app/build.gradle'
+    );
+  }
+  const releaseIdx = next.indexOf('release {', buildTypesIdx);
+  if (releaseIdx === -1) {
+    throw new Error(
+      'withReleaseSigning: could not find the release build type in android/app/build.gradle'
+    );
+  }
+  const debugRefIdx = next.indexOf('signingConfig signingConfigs.debug', releaseIdx);
+  if (debugRefIdx === -1) {
+    // Already pointing somewhere else (e.g. a re-run on a hand-edited file);
+    // the signingConfigs.release block above is still in place.
+    return next;
+  }
+  next =
+    next.slice(0, debugRefIdx) +
+    'signingConfig signingConfigs.release' +
+    next.slice(debugRefIdx + 'signingConfig signingConfigs.debug'.length);
+  return next;
+}
+
+const withReleaseSigning = (config) => {
+  return withAppBuildGradle(config, (config) => {
+    if (config.modResults.language !== 'groovy') {
+      throw new Error(
+        'withReleaseSigning: android/app/build.gradle is not groovy — plugin needs updating'
+      );
+    }
+    config.modResults.contents = addReleaseSigning(config.modResults.contents);
+    return config;
+  });
+};
+
+module.exports = withReleaseSigning;
+// Exported for unit-style verification without running prebuild.
+module.exports.addReleaseSigning = addReleaseSigning;

--- a/mobile/scripts/generate-upload-keystore.sh
+++ b/mobile/scripts/generate-upload-keystore.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Generate the Play upload keystore for Pollis release signing.
+# One-time per developer machine. NEVER commit the keystore or its passwords.
+set -euo pipefail
+
+KEYSTORE="${HOME}/.pollis/pollis-upload.jks"
+ALIAS="pollis-upload"
+
+if ! command -v keytool >/dev/null 2>&1; then
+  echo "error: keytool not found — install a JDK (e.g. 'brew install openjdk@17')" >&2
+  exit 1
+fi
+
+if [ -e "${KEYSTORE}" ]; then
+  echo "error: ${KEYSTORE} already exists — refusing to overwrite." >&2
+  echo "If you really want a new keystore, move the old one aside first." >&2
+  echo "(Losing the upload key means a Play Console key-reset support request.)" >&2
+  exit 1
+fi
+
+mkdir -p "${HOME}/.pollis"
+
+# RSA-4096, ~27 years validity. keytool prompts for the store password and
+# distinguished-name fields interactively; the key password defaults to the
+# store password (press RETURN at the key-password prompt).
+keytool -genkeypair -v \
+  -keystore "${KEYSTORE}" \
+  -alias "${ALIAS}" \
+  -keyalg RSA \
+  -keysize 4096 \
+  -validity 10000
+
+chmod 600 "${KEYSTORE}"
+
+echo
+echo "Keystore created at ${KEYSTORE}"
+echo
+echo "Add these lines to ~/.gradle/gradle.properties (create the file if needed),"
+echo "filling in the password you just chose:"
+echo
+echo "POLLIS_UPLOAD_STORE_FILE=${KEYSTORE}"
+echo "POLLIS_UPLOAD_STORE_PASSWORD=<store password>"
+echo "POLLIS_UPLOAD_KEY_ALIAS=${ALIAS}"
+echo "POLLIS_UPLOAD_KEY_PASSWORD=<key password (same as store password if you pressed RETURN)>"
+echo
+echo "Then 'cd mobile && pnpm expo prebuild -p android' and"
+echo "'./gradlew :app:bundleRelease' will sign with this key."
+echo "Back the keystore up somewhere safe — and never commit it."

--- a/mobile/store/ExportOptions.plist
+++ b/mobile/store/ExportOptions.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>method</key>
+	<string>app-store-connect</string>
+	<key>teamID</key>
+	<string>9JF7WWYMU2</string>
+	<key>uploadSymbols</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
Makes the mobile app's build configuration store-ready for both platforms, publishing as a private individual (Apple team 9JF7WWYMU2), no EAS account.

- app.json: `ITSAppUsesNonExemptEncryption: true` (standard-algorithm E2EE — MLS/AES-GCM/ML-DSA — is not Apple-exempt; `false` would be a false export declaration; reasoning in mobile/CLAUDE.md), explicit local `ios.buildNumber` / `android.versionCode`.
- `plugins/withReleaseSigning.js`: Expo config plugin injecting a release signingConfig into the generated build.gradle from `POLLIS_UPLOAD_*` gradle/env properties, falling back to the debug keystore when unset (CI unchanged). Idempotent; unit-tested against the template shape and verified via real `expo prebuild -p android` (generated gradle identical under set/unset env; release buildType repointed, debug untouched).
- `scripts/generate-upload-keystore.sh`: one-time RSA-4096 upload keystore at ~/.pollis/pollis-upload.jks (refuses overwrite; keystore never committed — *.jks gitignored).
- `store/ExportOptions.plist`: app-store-connect export options (lives outside generated ios/); plutil-linted.
- mobile/CLAUDE.md "Store builds": full iOS archive/export + Android bundleRelease commands, stale-.env warning (dead #393 secret vars must not linger; prod DS URL required); .env.example updated to the post-#393 var set.

Verified: plugin loads via node, `expo/config-plugins` importable, `expo prebuild` for both platforms in a clean tree (Info.plist gets CFBundleVersion=1 + the compliance key). Gradle configure not runnable here (no Android SDK on this machine).