### PR TITLE
feat(mobile): in-app account deletion (App Store 5.1.1(v))

### DIFF
--- a/mobile/TEST-PLAN.md
+++ b/mobile/TEST-PLAN.md
@@ -75,6 +75,11 @@ capturing **iPhone + iPad + Android** screenshots:
 `profile-prefs` (+ accent + change-email) · `security` (devices/safety-numbers) ·
 `blocking` · `realtime` (two-client live) · `push-tap`.
 
+The `security` flow additionally covers the in-app account-deletion entry
+(`row-delete-account` → typed-DELETE confirm screen, `btn-delete-account`
+disabled until armed) — assert the disabled state only; never run the actual
+deletion against a shared seed account.
+
 Media flows are **excluded by decision**.
 
 ### 4. iPadOS adaptive layouts — #622

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -135,6 +135,10 @@ export default function RootLayout() {
                 name="self/change-email"
                 options={{ animation: "slide_from_bottom" }}
               />
+              <Stack.Screen
+                name="self/delete-account"
+                options={{ animation: "slide_from_bottom" }}
+              />
             </Stack>
           </ThemeProvider>
         </QueryClientProvider>

--- a/mobile/app/self/delete-account.tsx
+++ b/mobile/app/self/delete-account.tsx
@@ -1,0 +1,138 @@
+import { useState } from "react";
+import { View, Text } from "react-native";
+import { useRouter } from "expo-router";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  Screen,
+  Crumb,
+  Body,
+  Field,
+  Button,
+  BottomAction,
+  Ctx,
+} from "../../components/ui";
+import { Icon } from "../../components/icons";
+import { semantic, type as ty } from "../../theme/tokens";
+import { useDeleteAccount } from "../../hooks/queries";
+import { appStore } from "../../stores/appStore";
+import { observer } from "mobx-react-lite";
+
+// The word the user must type to arm deletion. Matches desktop's
+// SecurityPage: deliberately a constant, not translatable copy, so the
+// comparison and the instruction can never drift apart.
+const DELETE_CONFIRM_WORD = "DELETE";
+
+function DeleteAccount() {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const currentUser = appStore.currentUser;
+  const [confirmText, setConfirmText] = useState("");
+  const deleteAccount = useDeleteAccount();
+
+  const armed = confirmText === DELETE_CONFIRM_WORD;
+
+  const onDelete = () => {
+    if (!currentUser || !armed || deleteAccount.isPending) {
+      return;
+    }
+    deleteAccount.mutate(currentUser.id, {
+      onSuccess: () => {
+        // The account is gone server-side and this device's data is wiped.
+        // Drop everything the UI still holds (decrypted messages live in the
+        // query cache) and land on the sign-in screen.
+        queryClient.clear();
+        appStore.logout();
+        router.replace("/(auth)/email");
+      },
+    });
+  };
+
+  return (
+    <Screen testID="screen-self-delete-account" centered>
+      <Crumb
+        segs={[
+          { label: "SELF" },
+          { label: "Security" },
+          { label: "Delete account", leaf: true },
+        ]}
+      />
+      <Body>
+        <View style={{ paddingHorizontal: 18, paddingTop: 14, gap: 14 }}>
+          <Text style={[ty.h1, { color: semantic.danger }]}>
+            Delete account
+          </Text>
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 13,
+              lineHeight: 19,
+              color: semantic.mute,
+            }}
+          >
+            This permanently deletes your Pollis account. You are removed from
+            every group and conversation, your devices are unregistered, and
+            your encrypted data on this phone is wiped. Other members keep
+            their own copies of past messages, but nothing sent after deletion
+            can ever be read with your keys.
+          </Text>
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 13,
+              lineHeight: 19,
+              color: semantic.mute,
+            }}
+          >
+            This cannot be undone. There is no grace period and no recovery.
+          </Text>
+
+          <View style={{ gap: 6, paddingTop: 8 }}>
+            <Text style={ty.label}>
+              TYPE {DELETE_CONFIRM_WORD} TO CONFIRM
+            </Text>
+            <Field
+              value={confirmText}
+              onChangeText={setConfirmText}
+              placeholder={DELETE_CONFIRM_WORD}
+              testID="input-delete-confirm"
+              accessibilityLabel={`Type ${DELETE_CONFIRM_WORD} to confirm`}
+              icon={<Icon.shield color={semantic.danger} />}
+            />
+          </View>
+
+          {deleteAccount.isError ? (
+            <Text
+              testID="text-delete-error"
+              style={{
+                fontFamily: ty.body.fontFamily,
+                fontSize: 12,
+                lineHeight: 17,
+                color: semantic.danger,
+              }}
+            >
+              {(deleteAccount.error as Error).message ||
+                "Couldn't delete the account. Nothing was changed — try again."}
+            </Text>
+          ) : null}
+        </View>
+      </Body>
+      <BottomAction>
+        <Button
+          full
+          variant="danger"
+          testID="btn-delete-account"
+          icon={<Icon.exit color={semantic.danger} />}
+          disabled={!armed || deleteAccount.isPending || !currentUser}
+          onPress={onDelete}
+        >
+          {deleteAccount.isPending
+            ? "DELETING ACCOUNT…"
+            : "DELETE ACCOUNT PERMANENTLY"}
+        </Button>
+      </BottomAction>
+      <Ctx cr="SELF · SECURITY" name="Delete account" />
+    </Screen>
+  );
+}
+
+export default observer(DeleteAccount);

--- a/mobile/app/self/security.tsx
+++ b/mobile/app/self/security.tsx
@@ -267,6 +267,27 @@ export default function Security() {
           </Text>
         </View>
 
+        <SectionTitle>ACCOUNT</SectionTitle>
+        <ListRow
+          testID="row-delete-account"
+          minHeight={48}
+          glyph={<Icon.shield color={semantic.danger} />}
+          name={
+            <Text
+              style={{
+                fontFamily: ty.body.fontFamily,
+                fontSize: 14,
+                color: semantic.danger,
+              }}
+            >
+              Delete account
+            </Text>
+          }
+          sub="Permanently delete your account and wipe this device"
+          onPress={() => router.push("/self/delete-account")}
+          end={<Icon.fwd color={semantic.mute} />}
+        />
+
         <View style={{ paddingHorizontal: 18, paddingTop: 18 }}>
           <Button
             full

--- a/mobile/hooks/queries/index.ts
+++ b/mobile/hooks/queries/index.ts
@@ -10,6 +10,7 @@ export * from "./useAuth";
 export * from "./useUserSearch";
 export * from "./usePreferences";
 export * from "./useDevices";
+export * from "./useAccount";
 export * from "./useGroupInvites";
 export * from "./useEnrollment";
 export * from "./useSearch";

--- a/mobile/hooks/queries/useAccount.ts
+++ b/mobile/hooks/queries/useAccount.ts
@@ -1,0 +1,29 @@
+// Account-deletion hook for the Delete Account screen. Backed by
+// `delete_account` (server-side wipe via the DS + local cleanup) and
+// `wipe_local_data` (belt-and-suspenders local wipe).
+//
+// Failure semantics mirror `pollis-core/src/commands/auth.rs`:
+//   - `delete_account` errors out BEFORE any local cleanup if the remote
+//     (DS) delete fails — the user stays signed in and we surface the error.
+//   - Once the remote delete succeeds, core's local cleanup is best-effort;
+//     the follow-up `wipe_local_data` here is too. A local-wipe failure must
+//     NOT strand the user signed-in to a deleted account, so it is logged
+//     and swallowed — the caller always proceeds to sign-out.
+
+import { useMutation } from "@tanstack/react-query";
+import { invoke } from "../../lib/native";
+
+export function useDeleteAccount() {
+  return useMutation({
+    mutationFn: async (userId: string) => {
+      // Remote + primary local wipe. Throws (and aborts) on server failure.
+      await invoke("delete_account", { userId });
+      try {
+        // Sweep any remaining local state (other-account remnants, data dir).
+        await invoke("wipe_local_data");
+      } catch (e) {
+        console.warn("[account] wipe_local_data after delete failed (ignored):", e);
+      }
+    },
+  });
+}


### PR DESCRIPTION
Base: main.

Mobile had no in-app account deletion — an App Store guideline 5.1.1(v) blocker. Desktop PR #959 made deletion real server-side; this wires the mobile flow against the same core commands.

- New full-screen confirmation route `mobile/app/self/delete-account.tsx` (native mobile pattern, typed-DELETE confirmation mirroring desktop's SecurityPage), entered from a new ACCOUNT row on Self → Security.
- `useDeleteAccount` (`mobile/hooks/queries/useAccount.ts`): `invoke("delete_account", { userId })` then best-effort `invoke("wipe_local_data")`. Failure semantics follow core (`pollis-core/src/commands/auth.rs`): a DS/remote failure aborts before any local cleanup — user stays signed in with the error shown; once the remote delete succeeds, local wipe failures are logged and swallowed so the user is never stranded signed-in to a deleted account.
- On success: `queryClient.clear()` + `appStore.logout()` + `router.replace("/(auth)/email")`.
- TEST-PLAN note for the security Maestro flow (assert disabled-until-armed only; never run a real deletion against shared seed).

Depends on the `delete_account` / `wipe_local_data` arms landing in `pollis-core/src/bridge.rs` (being added concurrently; names/args match the desktop `invoke()` surface).

Gate: `pnpm typecheck` clean.