### PR TITLE
Port shareable group invite links to mobile (#847 parity)

### DIFF
--- a/mobile/TEST-PLAN.md
+++ b/mobile/TEST-PLAN.md
@@ -73,7 +73,13 @@ capturing **iPhone + iPad + Android** screenshots:
 `auth` · `auth-restore` (keystore unlock) · `enrollment` (+ recovery) · `groups` ·
 `group-members` · `dms` · `messaging` (edit/delete/reactions/reply) · `search` ·
 `profile-prefs` (+ accent + change-email) · `security` (devices/safety-numbers) ·
-`blocking` · `realtime` (two-client live) · `push-tap`.
+`blocking` · `realtime` (two-client live) · `push-tap` · `invite-links` (#847
+parity: mint on the invite screen with expiry/uses presets, one-time card with
+verified copy + share sheet, list/revoke on `group/invite-links`, and
+`pollis://invite/<token>` deep-link redemption on `app/invite/[token]` —
+including a cold-start tap, which expo-router routes via the initial URL; the
+`https://pollis.com/invite/<token>` form additionally needs universal/app-links
+config, deliberately not yet added).
 
 Media flows are **excluded by decision**.
 

--- a/mobile/app/group/invite-links.tsx
+++ b/mobile/app/group/invite-links.tsx
@@ -1,0 +1,183 @@
+import { useState } from "react";
+import { View, Text } from "react-native";
+import { useLocalSearchParams } from "expo-router";
+import { Screen, Crumb, Body, Chip, Ctx } from "../../components/ui";
+import { semantic, type as ty } from "../../theme/tokens";
+import {
+  useUserGroupsWithChannels,
+  useGroupInviteLinks,
+  useRevokeGroupInviteLink,
+  type InviteLinkSummary,
+} from "../../hooks/queries";
+
+// #847 (mobile) — review and revoke a group's shareable invite links.
+//
+// There is deliberately NO copy button anywhere on this screen:
+// `InviteLinkSummary` carries no token because the server stores only
+// `sha256(secret)` and has no token to give back. A link is copyable exactly
+// once, at creation, on the invite screen.
+export default function GroupInviteLinks() {
+  const { groupId } = useLocalSearchParams<{ groupId?: string }>();
+  const id = groupId ?? null;
+
+  const { data: groups = [] } = useUserGroupsWithChannels();
+  const group = groups.find((g) => g.id === id);
+
+  const { data: links = [], isLoading } = useGroupInviteLinks(id);
+  const revokeLink = useRevokeGroupInviteLink(id);
+
+  // Two-tap confirm, same pattern as channel delete in group/settings.
+  const [confirmRevoke, setConfirmRevoke] = useState<string | null>(null);
+
+  const onRevoke = (linkId: string) => {
+    if (confirmRevoke !== linkId) {
+      setConfirmRevoke(linkId);
+      return;
+    }
+    revokeLink.mutate(linkId, {
+      onSettled: () => setConfirmRevoke(null),
+    });
+  };
+
+  const statusOf = (link: InviteLinkSummary): string => {
+    // `is_live` is computed server-side so this badge cannot disagree with
+    // what redemption will actually do.
+    if (link.revoked_at) {
+      return "REVOKED";
+    }
+    if (link.is_live) {
+      return "ACTIVE";
+    }
+    return "EXPIRED";
+  };
+
+  const detailOf = (link: InviteLinkSummary): string => {
+    const uses =
+      link.max_uses != null
+        ? `${link.uses}/${link.max_uses} uses`
+        : link.uses === 1
+          ? "1 use"
+          : `${link.uses} uses`;
+    const expiry = link.expires_at
+      ? `expires ${new Date(link.expires_at).toLocaleDateString()}`
+      : "no expiry";
+    const creator = link.creator_username
+      ? `by ${link.creator_username}`
+      : null;
+    return [uses, expiry, creator].filter(Boolean).join(" · ");
+  };
+
+  return (
+    <Screen testID="screen-group-invite-links" centered>
+      <Crumb
+        segs={[
+          { label: "GROUPS" },
+          { label: group?.name ?? "Group" },
+          { label: "Invite links", leaf: true },
+        ]}
+      />
+      <Body>
+        <Text
+          style={{
+            fontFamily: ty.body.fontFamily,
+            fontSize: 11,
+            color: semantic.mute,
+            lineHeight: 16,
+            paddingHorizontal: 18,
+            paddingTop: 6,
+          }}
+        >
+          Links can't be shown again after creation — the server keeps only a
+          hash. Revoking stops a link immediately for everyone holding it.
+        </Text>
+
+        {links.map((link) => {
+          const armed = confirmRevoke === link.id;
+          const status = statusOf(link);
+          return (
+            <View
+              key={link.id}
+              testID={`row-invite-link-${link.id}`}
+              style={{
+                flexDirection: "row",
+                alignItems: "center",
+                gap: 12,
+                minHeight: 56,
+                paddingVertical: 12,
+                paddingHorizontal: 18,
+                borderBottomWidth: 1,
+                borderBottomColor: semantic.hairSoft,
+              }}
+            >
+              <View style={{ flex: 1, minWidth: 0 }}>
+                <Text
+                  style={{
+                    fontFamily: ty.rowN.fontFamily,
+                    fontSize: 14,
+                    color: link.is_live ? semantic.accent : semantic.mute,
+                  }}
+                >
+                  [{status}]
+                </Text>
+                <Text
+                  numberOfLines={1}
+                  style={{
+                    fontFamily: ty.body.fontFamily,
+                    fontSize: 12,
+                    color: semantic.mute,
+                    marginTop: 2,
+                  }}
+                >
+                  {detailOf(link)}
+                </Text>
+              </View>
+              {link.is_live ? (
+                <Chip
+                  variant={armed ? "on" : "default"}
+                  testID={`btn-revoke-invite-link-${link.id}`}
+                  accessibilityLabel="Revoke invite link"
+                  onPress={() => onRevoke(link.id)}
+                >
+                  {revokeLink.isPending && armed
+                    ? "…"
+                    : armed
+                      ? "Confirm"
+                      : "Revoke"}
+                </Chip>
+              ) : null}
+            </View>
+          );
+        })}
+
+        {!isLoading && links.length === 0 ? (
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 13,
+              color: semantic.mute,
+              paddingHorizontal: 18,
+              paddingTop: 14,
+            }}
+          >
+            No invite links yet. Create one from the Invite screen.
+          </Text>
+        ) : null}
+
+        {revokeLink.isError ? (
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 12,
+              color: semantic.danger,
+              paddingHorizontal: 18,
+              paddingTop: 8,
+            }}
+          >
+            {(revokeLink.error as Error).message || "Couldn't revoke link."}
+          </Text>
+        ) : null}
+      </Body>
+      <Ctx cr={group?.name ?? "GROUP"} name="Invite links" />
+    </Screen>
+  );
+}

--- a/mobile/app/group/invite.tsx
+++ b/mobile/app/group/invite.tsx
@@ -8,14 +8,36 @@ import {
   Field,
   Button,
   BottomAction,
+  Chip,
+  SectionTitle,
+  ListRow,
   Ctx,
 } from "../../components/ui";
 import { Icon } from "../../components/icons";
 import { semantic, type as ty } from "../../theme/tokens";
+import { CreatedInviteLinkCard } from "../../components/CreatedInviteLinkCard";
 import {
   useSendGroupInvite,
   useUserGroupsWithChannels,
+  useCreateGroupInviteLink,
+  type CreatedInviteLink,
 } from "../../hooks/queries";
+
+// Expiry presets, mirroring desktop's InviteLinkManager (#847). A fixed list
+// rather than a date picker on purpose — every preset here is one a person
+// actually asks for.
+const EXPIRY_OPTIONS: { id: string; label: string; hours: number | null }[] = [
+  { id: "24h", label: "24 HOURS", hours: 24 },
+  { id: "7d", label: "7 DAYS", hours: 24 * 7 },
+  { id: "30d", label: "30 DAYS", hours: 24 * 30 },
+  { id: "never", label: "NEVER", hours: null },
+];
+
+const USES_OPTIONS: { id: string; label: string; uses: number | null }[] = [
+  { id: "1", label: "1 USE", uses: 1 },
+  { id: "10", label: "10 USES", uses: 10 },
+  { id: "unlimited", label: "UNLIMITED", uses: null },
+];
 
 export default function InviteToGroup() {
   const router = useRouter();
@@ -24,6 +46,12 @@ export default function InviteToGroup() {
   const sendInvite = useSendGroupInvite(groupId ?? null);
   const { data: groups = [] } = useUserGroupsWithChannels();
   const group = groups.find((g) => g.id === groupId);
+
+  // ── #847 shareable link mint state ──────────────────────────────────
+  const [expiryHours, setExpiryHours] = useState<number | null>(24 * 7);
+  const [maxUses, setMaxUses] = useState<number | null>(null);
+  const [created, setCreated] = useState<CreatedInviteLink | null>(null);
+  const createLink = useCreateGroupInviteLink(groupId ?? null);
 
   const onSend = () => {
     const trimmed = identifier.trim();
@@ -36,6 +64,15 @@ export default function InviteToGroup() {
         router.back();
       },
     });
+  };
+
+  const onCreateLink = () => {
+    createLink.mutate(
+      { expiresInHours: expiryHours, maxUses },
+      {
+        onSuccess: (link) => setCreated(link),
+      },
+    );
   };
 
   return (
@@ -95,6 +132,93 @@ export default function InviteToGroup() {
             </Text>
           ) : null}
         </View>
+
+        <SectionTitle>SHAREABLE LINK</SectionTitle>
+        <View style={{ paddingHorizontal: 18, paddingTop: 6, gap: 8 }}>
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 11,
+              color: semantic.mute,
+              lineHeight: 16,
+            }}
+          >
+            Anyone with the link can join directly — no approval step. The
+            link is shown exactly once, right after you create it.
+          </Text>
+
+          <Text style={[ty.label, { paddingTop: 6 }]}>EXPIRES AFTER</Text>
+          <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 6 }}>
+            {EXPIRY_OPTIONS.map((opt) => (
+              <Chip
+                key={opt.id}
+                variant={expiryHours === opt.hours ? "on" : "default"}
+                testID={`chip-expiry-${opt.id}`}
+                onPress={() => setExpiryHours(opt.hours)}
+              >
+                {opt.label}
+              </Chip>
+            ))}
+          </View>
+
+          <Text style={[ty.label, { paddingTop: 6 }]}>MAXIMUM USES</Text>
+          <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 6 }}>
+            {USES_OPTIONS.map((opt) => (
+              <Chip
+                key={opt.id}
+                variant={maxUses === opt.uses ? "on" : "default"}
+                testID={`chip-uses-${opt.id}`}
+                onPress={() => setMaxUses(opt.uses)}
+              >
+                {opt.label}
+              </Chip>
+            ))}
+          </View>
+
+          <View style={{ paddingTop: 8 }}>
+            <Button
+              full
+              testID="btn-create-invite-link"
+              onPress={onCreateLink}
+              disabled={createLink.isPending}
+              icon={<Icon.link color={semantic.ink} />}
+            >
+              {createLink.isPending ? "CREATING…" : "CREATE INVITE LINK"}
+            </Button>
+          </View>
+
+          {createLink.isError ? (
+            <Text
+              style={{
+                fontFamily: ty.body.fontFamily,
+                fontSize: 12,
+                color: semantic.danger,
+              }}
+            >
+              {(createLink.error as Error).message ||
+                "Couldn't create invite link."}
+            </Text>
+          ) : null}
+
+          {created ? <CreatedInviteLinkCard link={created} /> : null}
+        </View>
+
+        <ListRow
+          testID="row-manage-invite-links"
+          minHeight={48}
+          glyph={<Icon.link color={semantic.mute} />}
+          name="Manage invite links"
+          nameStyle={{ fontSize: 14, fontFamily: ty.body.fontFamily }}
+          sub="Review and revoke existing links"
+          onPress={() =>
+            groupId &&
+            router.push({
+              pathname: "/group/invite-links",
+              params: { groupId },
+            })
+          }
+          end={<Icon.fwd color={semantic.mute} />}
+        />
       </Body>
       <Ctx cr={group?.name ?? "GROUP"} name="Invite a member" />
       <BottomAction>

--- a/mobile/app/invite/[token].tsx
+++ b/mobile/app/invite/[token].tsx
@@ -1,0 +1,139 @@
+import { useEffect, useRef, useState } from "react";
+import { View, Text, ActivityIndicator } from "react-native";
+import { useRouter, useLocalSearchParams } from "expo-router";
+import { useQueryClient } from "@tanstack/react-query";
+import { Screen, Crumb, Body, Button, BottomAction, Ctx } from "../../components/ui";
+import { semantic, type as ty } from "../../theme/tokens";
+import { invoke } from "../../lib/native";
+import { restoreSession } from "../../hooks/queries/useAuth";
+import { appStore } from "../../stores/appStore";
+import { groupQueryKeys, type RedeemedInvite } from "../../hooks/queries";
+
+interface UnlockStateSnapshot {
+  pin_set: boolean;
+  is_unlocked: boolean;
+  last_active_user: string | null;
+}
+
+type Phase = "working" | "signedOut" | "locked" | "failed";
+
+// #847 (mobile) — where a shared invite link lands.
+//
+// expo-router maps `pollis://invite/<token>` here on warm AND cold starts (it
+// wires `Linking.getInitialURL()` into the navigation container itself, so a
+// link tapped while the app is killed still arrives as this route's initial
+// screen). The desktop-rendered `https://pollis.com/invite/<token>` form needs
+// iOS universal links / Android app links (associated-domains + server files)
+// before it opens the app — deliberately not configured here.
+//
+// On failure this renders ONE opaque message for every cause. The Delivery
+// Service deliberately cannot tell us whether a token was wrong, expired,
+// revoked or used up — distinguishing them would confirm to an attacker that
+// a token was real but stale.
+export default function InviteLanding() {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { token } = useLocalSearchParams<{ token?: string }>();
+  const [phase, setPhase] = useState<Phase>("working");
+
+  // Cold-start arrival bypasses the boot router in app/index.tsx, so this
+  // screen restores the session itself before redeeming. Runs once.
+  const ran = useRef(false);
+  useEffect(() => {
+    if (ran.current) {
+      return;
+    }
+    ran.current = true;
+    (async () => {
+      const trimmed = (token ?? "").trim();
+      if (!trimmed) {
+        setPhase("failed");
+        return;
+      }
+      try {
+        let userId = appStore.currentUser?.id ?? null;
+        if (!userId) {
+          const profile = await restoreSession();
+          if (!profile) {
+            setPhase("signedOut");
+            return;
+          }
+          const snap = await invoke<UnlockStateSnapshot>("get_unlock_state");
+          if (!snap.is_unlocked) {
+            setPhase("locked");
+            return;
+          }
+          userId = profile.id;
+        }
+        const result = await invoke<RedeemedInvite>(
+          "redeem_group_invite_link",
+          { token: trimmed, userId },
+        );
+        // The redeemer just crossed into a group they could not see before —
+        // invalidate broadly, like desktop's useRedeemGroupInviteLink.
+        queryClient.invalidateQueries({ queryKey: groupQueryKeys.all });
+        router.replace({
+          pathname: "/group/[id]",
+          params: { id: result.group_id },
+        });
+      } catch (e) {
+        console.warn("[invite] redeem failed:", e);
+        setPhase("failed");
+      }
+    })();
+  }, [token, router, queryClient]);
+
+  const message =
+    phase === "working"
+      ? "Checking your invite…"
+      : phase === "signedOut"
+        ? "Sign in to Pollis first, then open the invite link again."
+        : phase === "locked"
+          ? "Unlock Pollis first, then open the invite link again."
+          : "This invite link can't be used. It may be invalid, expired, revoked, or already used up — ask for a new link.";
+
+  return (
+    <Screen testID="screen-invite-landing" centered>
+      <Crumb segs={[{ label: "POLLIS" }, { label: "Invite", leaf: true }]} />
+      <Body>
+        <View
+          style={{
+            paddingHorizontal: 18,
+            paddingTop: 24,
+            gap: 12,
+            alignItems: "center",
+          }}
+        >
+          {phase === "working" ? (
+            <ActivityIndicator color={semantic.accent} />
+          ) : null}
+          <Text
+            testID="invite-landing-message"
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 13,
+              color: phase === "failed" ? semantic.danger : semantic.ink2,
+              lineHeight: 19,
+              textAlign: "center",
+            }}
+          >
+            {message}
+          </Text>
+        </View>
+      </Body>
+      <Ctx cr="POLLIS" name="Group invite" hideBack />
+      {phase !== "working" ? (
+        <BottomAction>
+          <Button
+            full
+            testID="btn-invite-continue"
+            variant="primary"
+            onPress={() => router.replace("/")}
+          >
+            {phase === "failed" ? "BACK TO POLLIS" : "OPEN POLLIS"}
+          </Button>
+        </BottomAction>
+      ) : null}
+    </Screen>
+  );
+}

--- a/mobile/components/CreatedInviteLinkCard.tsx
+++ b/mobile/components/CreatedInviteLinkCard.tsx
@@ -1,0 +1,153 @@
+// #847 (mobile) — the one and only view of a freshly minted invite link.
+//
+// The server stores only `sha256(secret)`, so unlike Slack or Discord — which
+// keep the code in plaintext and let you re-open it forever — this link
+// genuinely cannot be shown again by anyone, including us. The card says so
+// out loud instead of hiding it behind a support question later.
+//
+// Copy is VERIFIED (#897/#958 semantics): `Clipboard.setStringAsync` resolves
+// to a boolean, and a rejected or false write surfaces as a visible failed
+// state — a link that is only ever shown once and was never actually copied is
+// the worst possible thing to report as a success. We deliberately do NOT
+// read the clipboard back to double-check: on iOS 14+ a clipboard read fires
+// the system "pasted from Pollis" banner on every tap.
+
+import { useEffect, useRef, useState } from "react";
+import { View, Text, Share } from "react-native";
+import * as Clipboard from "expo-clipboard";
+import { Card, Button } from "./ui";
+import { Icon } from "./icons";
+import { palette, semantic, type as ty } from "../theme/tokens";
+import type { CreatedInviteLink } from "../hooks/queries";
+
+type CopyState = "idle" | "copied" | "failed";
+
+// How long an outcome stays on the button before it returns to idle.
+const COPY_FEEDBACK_MS = 2000;
+
+export function CreatedInviteLinkCard({ link }: { link: CreatedInviteLink }) {
+  const [copyState, setCopyState] = useState<CopyState>("idle");
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clear the outcome a couple of seconds after it appears, and never leave a
+  // timer behind that would set state on an unmounted card.
+  useEffect(() => {
+    if (copyState === "idle") {
+      return;
+    }
+    timer.current = setTimeout(() => setCopyState("idle"), COPY_FEEDBACK_MS);
+    return () => {
+      if (timer.current) {
+        clearTimeout(timer.current);
+      }
+    };
+  }, [copyState]);
+
+  const onCopy = async () => {
+    // Back to idle first so a second tap on an already-failed button is a
+    // visible state change, and so the feedback timer restarts.
+    setCopyState("idle");
+    const copied = await Clipboard.setStringAsync(link.url).catch(() => false);
+    setCopyState(copied ? "copied" : "failed");
+  };
+
+  const onShare = () => {
+    // Native share sheet. Failures (user dismissed) are not an error state.
+    Share.share({ message: link.url }).catch(() => {});
+  };
+
+  const bounds: string[] = [];
+  if (link.max_uses != null) {
+    bounds.push(link.max_uses === 1 ? "1 use" : `${link.max_uses} uses`);
+  }
+  if (link.expires_at) {
+    bounds.push(`expires ${new Date(link.expires_at).toLocaleString()}`);
+  }
+  const boundsLabel =
+    bounds.length > 0 ? bounds.join(" · ") : "No expiry · unlimited uses";
+
+  return (
+    <Card style={{ gap: 10 }}>
+      <Text style={[ty.label, { color: semantic.accent }]}>
+        LINK CREATED — COPY IT NOW
+      </Text>
+      <Text
+        style={{
+          fontFamily: ty.body.fontFamily,
+          fontSize: 11,
+          color: semantic.mute,
+          lineHeight: 16,
+        }}
+      >
+        This is the only time this link can be shown. Nobody — including you —
+        can view it again. To share it later, create a new one.
+      </Text>
+      <View
+        style={{
+          borderWidth: 1,
+          borderColor: semantic.hairStrong,
+          backgroundColor: palette.bg,
+          paddingVertical: 8,
+          paddingHorizontal: 10,
+          borderRadius: 3,
+        }}
+      >
+        <Text
+          testID="created-invite-link-url"
+          selectable
+          style={{
+            fontFamily: ty.mono.fontFamily,
+            fontSize: 11,
+            color: semantic.ink,
+          }}
+        >
+          {link.url}
+        </Text>
+      </View>
+      <View style={{ flexDirection: "row", gap: 8 }}>
+        <View style={{ flex: 1 }}>
+          <Button
+            full
+            testID="btn-copy-invite-link"
+            variant={copyState === "failed" ? "danger" : "primary"}
+            onPress={onCopy}
+            icon={
+              copyState === "copied" ? (
+                <Icon.check color={palette.bg} />
+              ) : copyState === "failed" ? (
+                <Icon.alert color={semantic.danger} />
+              ) : (
+                <Icon.copy color={palette.bg} />
+              )
+            }
+          >
+            {copyState === "copied"
+              ? "COPIED"
+              : copyState === "failed"
+                ? "COPY FAILED"
+                : "COPY"}
+          </Button>
+        </View>
+        <View style={{ flex: 1 }}>
+          <Button
+            full
+            testID="btn-share-invite-link"
+            onPress={onShare}
+            icon={<Icon.share color={semantic.ink} />}
+          >
+            SHARE
+          </Button>
+        </View>
+      </View>
+      <Text
+        style={{
+          fontFamily: ty.body.fontFamily,
+          fontSize: 11,
+          color: semantic.mute,
+        }}
+      >
+        {boundsLabel}
+      </Text>
+    </Card>
+  );
+}

--- a/mobile/components/icons.tsx
+++ b/mobile/components/icons.tsx
@@ -27,6 +27,10 @@ import {
   Smartphone,
   ChevronLeft,
   ChevronRight,
+  Copy,
+  Link2,
+  Share2,
+  AlertCircle,
   ArrowLeft,
   ArrowRight,
   Diamond,
@@ -75,6 +79,10 @@ export const Icon = {
   mail: wrap(Mail),
   key: wrap(Key),
   device: wrap(Smartphone),
+  copy: wrap(Copy),
+  link: wrap(Link2),
+  share: wrap(Share2),
+  alert: wrap(AlertCircle),
   diamond: wrap(Diamond, 16),
 };
 

--- a/mobile/hooks/queries/useGroupInvites.ts
+++ b/mobile/hooks/queries/useGroupInvites.ts
@@ -427,6 +427,130 @@ export function useGroupBySlug(slug: string | null) {
   });
 }
 
+// ── #847 shareable invite links (desktop parity: frontend useGroups.ts) ──────
+
+// A freshly minted invite link. Mirrors `CreatedInviteLink` in
+// `pollis-core/src/commands/groups/types.rs`. `token`/`url` arrive exactly
+// once, from the create call — the server stores only `sha256(secret)`, so
+// once this value is discarded the link can never be displayed again.
+export interface CreatedInviteLink {
+  id: string;
+  token: string;
+  url: string;
+  expires_at?: string | null;
+  max_uses?: number | null;
+}
+
+// An existing link as shown in the management list. Mirrors
+// `InviteLinkSummary` — deliberately has no token field; the server has no
+// token to give back.
+export interface InviteLinkSummary {
+  id: string;
+  created_at: string;
+  creator_username?: string | null;
+  expires_at?: string | null;
+  max_uses?: number | null;
+  uses: number;
+  revoked_at?: string | null;
+  is_live: boolean;
+}
+
+// Mirrors `RedeemedInvite`.
+export interface RedeemedInvite {
+  group_id: string;
+  group_name?: string | null;
+}
+
+export const inviteLinkQueryKeys = {
+  byGroup: (groupId: string | null) =>
+    ["group-invite-links", groupId] as const,
+};
+
+export function useGroupInviteLinks(groupId: string | null) {
+  const currentUser = useObserver(() => appStore.currentUser);
+  return useQuery({
+    queryKey: inviteLinkQueryKeys.byGroup(groupId),
+    queryFn: async (): Promise<InviteLinkSummary[]> => {
+      if (!currentUser || !groupId) {
+        return [];
+      }
+      return await invoke<InviteLinkSummary[]>("list_group_invite_links", {
+        groupId,
+        userId: currentUser.id,
+      });
+    },
+    enabled: !!(currentUser && groupId),
+  });
+}
+
+export function useCreateGroupInviteLink(groupId: string | null) {
+  const queryClient = useQueryClient();
+  const currentUser = useObserver(() => appStore.currentUser);
+  return useMutation({
+    mutationFn: async (vars: {
+      expiresInHours: number | null;
+      maxUses: number | null;
+    }): Promise<CreatedInviteLink> => {
+      if (!currentUser || !groupId) {
+        throw new Error("No active group");
+      }
+      return await invoke<CreatedInviteLink>("create_group_invite_link", {
+        groupId,
+        creatorId: currentUser.id,
+        expiresInHours: vars.expiresInHours,
+        maxUses: vars.maxUses,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: inviteLinkQueryKeys.byGroup(groupId),
+      });
+    },
+  });
+}
+
+export function useRevokeGroupInviteLink(groupId: string | null) {
+  const queryClient = useQueryClient();
+  const currentUser = useObserver(() => appStore.currentUser);
+  return useMutation({
+    mutationFn: async (linkId: string) => {
+      if (!currentUser) {
+        throw new Error("No current user");
+      }
+      await invoke("revoke_group_invite_link", {
+        linkId,
+        userId: currentUser.id,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: inviteLinkQueryKeys.byGroup(groupId),
+      });
+    },
+  });
+}
+
+export function useRedeemGroupInviteLink() {
+  const queryClient = useQueryClient();
+  const currentUser = useObserver(() => appStore.currentUser);
+  return useMutation({
+    mutationFn: async (token: string): Promise<RedeemedInvite> => {
+      if (!currentUser) {
+        throw new Error("No current user");
+      }
+      return await invoke<RedeemedInvite>("redeem_group_invite_link", {
+        token,
+        userId: currentUser.id,
+      });
+    },
+    onSuccess: () => {
+      // The redeemer just crossed into a group they could not see before, so
+      // most group-scoped caches are stale. Invalidate broadly, like desktop.
+      queryClient.invalidateQueries({ queryKey: groupQueryKeys.all });
+    },
+  });
+}
+
 export function useLeaveGroup() {
   const queryClient = useQueryClient();
   const currentUser = useObserver(() => appStore.currentUser);

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -21,6 +21,7 @@
     "expo": "~55.0.29",
     "expo-build-properties": "~55.0.17",
     "expo-camera": "~55.0.22",
+    "expo-clipboard": "~55.0.16",
     "expo-constants": "~55.0.17",
     "expo-dev-client": "~55.0.38",
     "expo-file-system": "~55.0.25",

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       expo-camera:
         specifier: ~55.0.22
         version: 55.0.22(@types/emscripten@1.41.5)(expo@55.0.29)(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.0))(react@19.2.0)
+      expo-clipboard:
+        specifier: ~55.0.16
+        version: 55.0.16(expo@55.0.29)(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.0))(react@19.2.0)
       expo-constants:
         specifier: ~55.0.17
         version: 55.0.17(expo@55.0.29)(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.0))
@@ -2047,6 +2050,13 @@ packages:
     peerDependenciesMeta:
       react-native-web:
         optional: true
+
+  expo-clipboard@55.0.16:
+    resolution: {integrity: sha512-MI61Fboym8MYHSGpPg51O+KN1zLlsOVwx30Ou7ygVqmUOQaQ4ZVMeCRiCziudZoMe8fohcSBt7XaCAjdTnacRQ==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
+      react-native: '*'
 
   expo-constants@55.0.17:
     resolution: {integrity: sha512-t0SNWmXTjXPCHzjNsv1Okjaj8SpXQcUjDPtYDqvofDS+BhAsvlKNmwaaWXvduBjjmmmJWNH8q1/x9IWQ+upg8g==}
@@ -6325,6 +6335,12 @@ snapshots:
       react-native: 0.83.6(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.0)
     transitivePeerDependencies:
       - '@types/emscripten'
+
+  expo-clipboard@55.0.16(expo@55.0.29)(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.0))(react@19.2.0):
+    dependencies:
+      expo: 55.0.29(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.0(react@19.2.0))(react-native-worklets@0.7.4(@babel/core@7.29.7)(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      react: 19.2.0
+      react-native: 0.83.6(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.0)
 
   expo-constants@55.0.17(expo@55.0.29)(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.0)):
     dependencies:


### PR DESCRIPTION
Mobile port of desktop's shareable invite links (PR #885 + the #958 verified-copy semantics).

- Mint UI on `app/group/invite.tsx`: expiry presets (24h/7d/30d/never) + max-uses presets (1/10/unlimited), matching desktop's choices. Created link shown exactly once (`CreatedInviteLinkCard`) with a verified `expo-clipboard` copy (false/rejected write surfaces as COPY FAILED; no clipboard read-back, to avoid the iOS paste banner) and the native share sheet.
- Admin list + revoke on `app/group/invite-links.tsx` (summaries only — no token exists server-side to re-copy; two-tap confirm revoke).
- Deep-link redemption on `app/invite/[token].tsx`: `pollis://invite/<token>` (scheme is `pollis`), handles cold start via expo-router's initial-URL routing, restores the session itself, calls `redeem_group_invite_link`, navigates into the group on success, one opaque failure state for every error. The desktop-rendered `https://pollis.com/invite/<token>` form needs iOS universal-links / Android app-links config (associated domains + server files) — deliberately not added here.
- Hooks mirror desktop's `useGroups.ts` invite-link section byte-for-byte on command names/args (`create_group_invite_link {groupId, creatorId, expiresInHours, maxUses}`, `list_group_invite_links {groupId, userId}`, `revoke_group_invite_link {linkId, userId}`, `redeem_group_invite_link {token, userId}`) — the bridge arms are landing concurrently.

Gate: `pnpm typecheck` clean.