### PR TITLE
feat(mobile): auto-lock after inactivity (#899)

### DIFF
--- a/mobile/TEST-PLAN.md
+++ b/mobile/TEST-PLAN.md
@@ -78,7 +78,10 @@ capturing **iPhone + iPad + Android** screenshots:
 The `security` flow additionally covers the in-app account-deletion entry
 (`row-delete-account` → typed-DELETE confirm screen, `btn-delete-account`
 disabled until armed) — assert the disabled state only; never run the actual
-deletion against a shared seed account.
+deletion against a shared seed account. It also covers auto-lock (#899):
+select a window via `chip-autolock-1`, tap `row-lock-now`, assert the PIN
+unlock screen appears, unlock with the fixed PIN, and assert the app restores
+to Security.
 
 Media flows are **excluded by decision**.
 

--- a/mobile/TEST-PLAN.md
+++ b/mobile/TEST-PLAN.md
@@ -75,6 +75,11 @@ capturing **iPhone + iPad + Android** screenshots:
 `profile-prefs` (+ accent + change-email) · `security` (devices/safety-numbers) ·
 `blocking` · `realtime` (two-client live) · `push-tap`.
 
+The `security` flow additionally covers the in-app account-deletion entry
+(`row-delete-account` → typed-DELETE confirm screen, `btn-delete-account`
+disabled until armed) — assert the disabled state only; never run the actual
+deletion against a shared seed account.
+
 Media flows are **excluded by decision**.
 
 ### 4. iPadOS adaptive layouts — #622

--- a/mobile/app/(auth)/pin.tsx
+++ b/mobile/app/(auth)/pin.tsx
@@ -31,6 +31,12 @@ function AuthPIN() {
   useEffect(() => {
     unlockState.mutate(undefined, {
       onSuccess: (snapshot) => {
+        // Keep the store's lock flag honest for the auto-lock engine
+        // (lib/autolock.tsx): landing here needing an unlock means locked,
+        // whether we arrived via auto-lock or a cold start.
+        if (snapshot.pin_set && !snapshot.is_unlocked) {
+          appStore.setLocked(true);
+        }
         setStage(snapshot.pin_set ? "unlock" : "create-first");
       },
       onError: () => {
@@ -74,7 +80,10 @@ function AuthPIN() {
       unlockMutation.mutate(
         { userId: currentUser.id, pin: entered },
         {
-          onSuccess: () => router.replace("/(auth)/initializing"),
+          onSuccess: () => {
+            appStore.setLocked(false);
+            router.replace("/(auth)/initializing");
+          },
           onError: (e) => {
             setError((e as Error).message || "Invalid PIN.");
             setPin("");
@@ -101,6 +110,7 @@ function AuthPIN() {
         { newPin: entered },
         {
           onSuccess: () => {
+            appStore.setLocked(false);
             // First-device signup has a one-time recovery key stashed in
             // the store by `verify_otp`. Show it before initializing so
             // the user can save it before we drop it from memory.

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -135,6 +135,10 @@ export default function RootLayout() {
                 name="self/change-email"
                 options={{ animation: "slide_from_bottom" }}
               />
+              <Stack.Screen
+                name="self/delete-account"
+                options={{ animation: "slide_from_bottom" }}
+              />
             </Stack>
           </ThemeProvider>
         </QueryClientProvider>

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -18,6 +18,7 @@ import { queryClient } from "../lib/queryClient";
 import { initializeNativeBridge } from "../lib/native";
 import { usePushNotifications } from "../hooks/usePushNotifications";
 import { useInboxRealtime } from "../hooks/useInboxRealtime";
+import { AutoLockProvider } from "../lib/autolock";
 
 SplashScreen.preventAutoHideAsync();
 
@@ -84,6 +85,9 @@ export default function RootLayout() {
           <ThemeProvider>
             <StatusBar style="light" />
             <SignedInServicesGate />
+            {/* Auto-lock (#899): captures touch starts to refresh the idle
+                deadline and locks on background-elapsed / foreground-idle. */}
+            <AutoLockProvider>
             <Stack
               screenOptions={{
                 headerShown: false,
@@ -140,6 +144,7 @@ export default function RootLayout() {
                 options={{ animation: "slide_from_bottom" }}
               />
             </Stack>
+            </AutoLockProvider>
           </ThemeProvider>
         </QueryClientProvider>
       </SafeAreaProvider>

--- a/mobile/app/self/delete-account.tsx
+++ b/mobile/app/self/delete-account.tsx
@@ -1,0 +1,138 @@
+import { useState } from "react";
+import { View, Text } from "react-native";
+import { useRouter } from "expo-router";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  Screen,
+  Crumb,
+  Body,
+  Field,
+  Button,
+  BottomAction,
+  Ctx,
+} from "../../components/ui";
+import { Icon } from "../../components/icons";
+import { semantic, type as ty } from "../../theme/tokens";
+import { useDeleteAccount } from "../../hooks/queries";
+import { appStore } from "../../stores/appStore";
+import { observer } from "mobx-react-lite";
+
+// The word the user must type to arm deletion. Matches desktop's
+// SecurityPage: deliberately a constant, not translatable copy, so the
+// comparison and the instruction can never drift apart.
+const DELETE_CONFIRM_WORD = "DELETE";
+
+function DeleteAccount() {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const currentUser = appStore.currentUser;
+  const [confirmText, setConfirmText] = useState("");
+  const deleteAccount = useDeleteAccount();
+
+  const armed = confirmText === DELETE_CONFIRM_WORD;
+
+  const onDelete = () => {
+    if (!currentUser || !armed || deleteAccount.isPending) {
+      return;
+    }
+    deleteAccount.mutate(currentUser.id, {
+      onSuccess: () => {
+        // The account is gone server-side and this device's data is wiped.
+        // Drop everything the UI still holds (decrypted messages live in the
+        // query cache) and land on the sign-in screen.
+        queryClient.clear();
+        appStore.logout();
+        router.replace("/(auth)/email");
+      },
+    });
+  };
+
+  return (
+    <Screen testID="screen-self-delete-account" centered>
+      <Crumb
+        segs={[
+          { label: "SELF" },
+          { label: "Security" },
+          { label: "Delete account", leaf: true },
+        ]}
+      />
+      <Body>
+        <View style={{ paddingHorizontal: 18, paddingTop: 14, gap: 14 }}>
+          <Text style={[ty.h1, { color: semantic.danger }]}>
+            Delete account
+          </Text>
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 13,
+              lineHeight: 19,
+              color: semantic.mute,
+            }}
+          >
+            This permanently deletes your Pollis account. You are removed from
+            every group and conversation, your devices are unregistered, and
+            your encrypted data on this phone is wiped. Other members keep
+            their own copies of past messages, but nothing sent after deletion
+            can ever be read with your keys.
+          </Text>
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 13,
+              lineHeight: 19,
+              color: semantic.mute,
+            }}
+          >
+            This cannot be undone. There is no grace period and no recovery.
+          </Text>
+
+          <View style={{ gap: 6, paddingTop: 8 }}>
+            <Text style={ty.label}>
+              TYPE {DELETE_CONFIRM_WORD} TO CONFIRM
+            </Text>
+            <Field
+              value={confirmText}
+              onChangeText={setConfirmText}
+              placeholder={DELETE_CONFIRM_WORD}
+              testID="input-delete-confirm"
+              accessibilityLabel={`Type ${DELETE_CONFIRM_WORD} to confirm`}
+              icon={<Icon.shield color={semantic.danger} />}
+            />
+          </View>
+
+          {deleteAccount.isError ? (
+            <Text
+              testID="text-delete-error"
+              style={{
+                fontFamily: ty.body.fontFamily,
+                fontSize: 12,
+                lineHeight: 17,
+                color: semantic.danger,
+              }}
+            >
+              {(deleteAccount.error as Error).message ||
+                "Couldn't delete the account. Nothing was changed — try again."}
+            </Text>
+          ) : null}
+        </View>
+      </Body>
+      <BottomAction>
+        <Button
+          full
+          variant="danger"
+          testID="btn-delete-account"
+          icon={<Icon.exit color={semantic.danger} />}
+          disabled={!armed || deleteAccount.isPending || !currentUser}
+          onPress={onDelete}
+        >
+          {deleteAccount.isPending
+            ? "DELETING ACCOUNT…"
+            : "DELETE ACCOUNT PERMANENTLY"}
+        </Button>
+      </BottomAction>
+      <Ctx cr="SELF · SECURITY" name="Delete account" />
+    </Screen>
+  );
+}
+
+export default observer(DeleteAccount);

--- a/mobile/app/self/security.tsx
+++ b/mobile/app/self/security.tsx
@@ -21,6 +21,12 @@ import {
   useApproveEnrollment,
   useRejectEnrollment,
 } from "../../hooks/queries";
+import {
+  AUTO_LOCK_OPTIONS_MINUTES,
+  autoLockLabel,
+  useAutoLockMinutes,
+  useLockNow,
+} from "../../lib/autolock";
 
 function formatRelative(iso: string): string {
   const d = new Date(iso);
@@ -56,6 +62,9 @@ export default function Security() {
   const approveEnrollment = useApproveEnrollment();
   const rejectEnrollment = useRejectEnrollment();
   const [confirmRevoke, setConfirmRevoke] = useState<string | null>(null);
+  const { minutes: autoLockMinutes, setMinutes: setAutoLockMinutes } =
+    useAutoLockMinutes();
+  const lockNow = useLockNow();
 
   const onRevoke = (deviceId: string) => {
     if (confirmRevoke !== deviceId) {
@@ -248,6 +257,44 @@ export default function Security() {
           name="Blocked users"
           nameStyle={{ fontSize: 14, fontFamily: ty.body.fontFamily }}
           onPress={() => router.push("/self/blocked")}
+          end={<Icon.fwd color={semantic.mute} />}
+        />
+
+        <SectionTitle>AUTO-LOCK</SectionTitle>
+        <View style={{ paddingHorizontal: 18, paddingTop: 6, gap: 10 }}>
+          <Text
+            style={{
+              fontFamily: ty.body.fontFamily,
+              fontSize: 12,
+              color: semantic.mute,
+              lineHeight: 17,
+            }}
+          >
+            Lock Pollis behind your device PIN after a period of inactivity.
+            This setting stays on this phone.
+          </Text>
+          <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 8 }}>
+            {AUTO_LOCK_OPTIONS_MINUTES.map((opt) => (
+              <Chip
+                key={opt === null ? "off" : String(opt)}
+                testID={`chip-autolock-${opt === null ? "off" : opt}`}
+                accessibilityLabel={`Auto-lock ${autoLockLabel(opt)}`}
+                variant={autoLockMinutes === opt ? "on" : "default"}
+                onPress={() => setAutoLockMinutes(opt)}
+              >
+                {autoLockLabel(opt)}
+              </Chip>
+            ))}
+          </View>
+        </View>
+        <ListRow
+          testID="row-lock-now"
+          minHeight={48}
+          glyph={<Icon.lock color={semantic.mute} />}
+          name="Lock now"
+          nameStyle={{ fontSize: 14, fontFamily: ty.body.fontFamily }}
+          sub="Require your PIN to reopen Pollis"
+          onPress={() => void lockNow()}
           end={<Icon.fwd color={semantic.mute} />}
         />
 

--- a/mobile/app/self/security.tsx
+++ b/mobile/app/self/security.tsx
@@ -267,6 +267,27 @@ export default function Security() {
           </Text>
         </View>
 
+        <SectionTitle>ACCOUNT</SectionTitle>
+        <ListRow
+          testID="row-delete-account"
+          minHeight={48}
+          glyph={<Icon.shield color={semantic.danger} />}
+          name={
+            <Text
+              style={{
+                fontFamily: ty.body.fontFamily,
+                fontSize: 14,
+                color: semantic.danger,
+              }}
+            >
+              Delete account
+            </Text>
+          }
+          sub="Permanently delete your account and wipe this device"
+          onPress={() => router.push("/self/delete-account")}
+          end={<Icon.fwd color={semantic.mute} />}
+        />
+
         <View style={{ paddingHorizontal: 18, paddingTop: 18 }}>
           <Button
             full

--- a/mobile/hooks/queries/index.ts
+++ b/mobile/hooks/queries/index.ts
@@ -10,6 +10,7 @@ export * from "./useAuth";
 export * from "./useUserSearch";
 export * from "./usePreferences";
 export * from "./useDevices";
+export * from "./useAccount";
 export * from "./useGroupInvites";
 export * from "./useEnrollment";
 export * from "./useSearch";

--- a/mobile/hooks/queries/useAccount.ts
+++ b/mobile/hooks/queries/useAccount.ts
@@ -1,0 +1,29 @@
+// Account-deletion hook for the Delete Account screen. Backed by
+// `delete_account` (server-side wipe via the DS + local cleanup) and
+// `wipe_local_data` (belt-and-suspenders local wipe).
+//
+// Failure semantics mirror `pollis-core/src/commands/auth.rs`:
+//   - `delete_account` errors out BEFORE any local cleanup if the remote
+//     (DS) delete fails — the user stays signed in and we surface the error.
+//   - Once the remote delete succeeds, core's local cleanup is best-effort;
+//     the follow-up `wipe_local_data` here is too. A local-wipe failure must
+//     NOT strand the user signed-in to a deleted account, so it is logged
+//     and swallowed — the caller always proceeds to sign-out.
+
+import { useMutation } from "@tanstack/react-query";
+import { invoke } from "../../lib/native";
+
+export function useDeleteAccount() {
+  return useMutation({
+    mutationFn: async (userId: string) => {
+      // Remote + primary local wipe. Throws (and aborts) on server failure.
+      await invoke("delete_account", { userId });
+      try {
+        // Sweep any remaining local state (other-account remnants, data dir).
+        await invoke("wipe_local_data");
+      } catch (e) {
+        console.warn("[account] wipe_local_data after delete failed (ignored):", e);
+      }
+    },
+  });
+}

--- a/mobile/lib/autolock.tsx
+++ b/mobile/lib/autolock.tsx
@@ -1,0 +1,306 @@
+// Auto-lock after inactivity (#899) — the RN layer's own implementation.
+//
+// Desktop's idle deadline lives in Rust (`pollis-core/src/commands/autolock.rs`)
+// because a hidden WebView throttles its timers; the expiry is pushed to the
+// renderer as a Tauri event. Mobile cannot receive Tauri events, so the
+// deadline lives HERE, against the existing `lock` bridge arm only — do not
+// wire `set_auto_lock_timeout` / `report_user_activity` from mobile.
+//
+// Two clocks cover the two ways a phone goes idle:
+//   1. Backgrounded — an AppState listener records when the app left the
+//      foreground; on return it locks if the elapsed time ≥ the window.
+//      (JS timers don't run reliably in the background, so this is a
+//      timestamp comparison, not a timer.)
+//   2. Foregrounded-but-untouched — a single timer aimed at a deadline that
+//      touch activity pushes forward. Activity only moves the deadline
+//      variable (throttled); the timer re-aims itself when it fires early
+//      instead of being torn down per event.
+//
+// Locking = `invoke("lock")` (drops key material + closes the local DB) +
+// `queryClient.clear()` (decrypted message bodies survive in the query cache
+// otherwise — desktop learned this) + appStore lock state + route to the PIN
+// screen. Unlock flows back through `/(auth)/pin` → `get_unlock_state` →
+// `unlock` exactly like a cold start.
+//
+// The window choice is deliberately device-local (expo-secure-store), same
+// windows as desktop's `AUTO_LOCK_OPTIONS`: Off / 1 / 5 / 15 / 60 minutes,
+// default Off — silently locking someone out of their own app is worse than
+// not locking.
+
+import React, {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { AppState, View } from "react-native";
+import * as SecureStore from "expo-secure-store";
+import { useRouter } from "expo-router";
+import { useQueryClient } from "@tanstack/react-query";
+import { useObserver } from "mobx-react-lite";
+import { invoke } from "./native";
+import { appStore } from "../stores/appStore";
+
+/** Offered windows, mirroring desktop's `AUTO_LOCK_OPTIONS`. `null` = Off. */
+export const AUTO_LOCK_OPTIONS_MINUTES: readonly (number | null)[] = [
+  null,
+  1,
+  5,
+  15,
+  60,
+];
+
+/** Human label for a window value (Off / 1 min / …). */
+export function autoLockLabel(minutes: number | null): string {
+  if (minutes === null) {
+    return "Off";
+  }
+  return `${minutes} min`;
+}
+
+const STORE_KEY = "pollis_auto_lock_minutes";
+
+// Same rationale as desktop's ACTIVITY_REPORT_THROTTLE_MS: touch moves the
+// deadline at most once per gap. 15s is far below the shortest window (60s),
+// so a deadline can never expire inside one throttle gap.
+const ACTIVITY_THROTTLE_MS = 15_000;
+
+// ── Device-local setting ─────────────────────────────────────────────────
+
+let cachedMinutes: number | null = null;
+let cacheLoaded = false;
+const settingListeners = new Set<(m: number | null) => void>();
+
+function coerceMinutes(raw: string | null): number | null {
+  if (!raw) {
+    return null;
+  }
+  const minutes = parseInt(raw, 10);
+  // An unknown / corrupt value means "the user has not asked for this".
+  if (!AUTO_LOCK_OPTIONS_MINUTES.some((o) => o === minutes)) {
+    return null;
+  }
+  return minutes;
+}
+
+/** Read the stored window (cached after first read). `null` = Off. */
+export async function loadAutoLockMinutes(): Promise<number | null> {
+  if (cacheLoaded) {
+    return cachedMinutes;
+  }
+  try {
+    const raw = await SecureStore.getItemAsync(STORE_KEY);
+    cachedMinutes = coerceMinutes(raw);
+  } catch {
+    cachedMinutes = null;
+  }
+  cacheLoaded = true;
+  return cachedMinutes;
+}
+
+/** Persist the window and notify subscribers. `null` clears it (Off). */
+export async function persistAutoLockMinutes(
+  minutes: number | null,
+): Promise<void> {
+  cachedMinutes = minutes;
+  cacheLoaded = true;
+  for (const l of settingListeners) {
+    l(minutes);
+  }
+  try {
+    if (minutes === null) {
+      await SecureStore.deleteItemAsync(STORE_KEY);
+    } else {
+      await SecureStore.setItemAsync(STORE_KEY, String(minutes));
+    }
+  } catch (e) {
+    console.warn("[autolock] persisting setting failed:", e);
+  }
+}
+
+/** Setting hook for the Security screen — reads + live-updates the window. */
+export function useAutoLockMinutes(): {
+  minutes: number | null;
+  setMinutes: (m: number | null) => void;
+} {
+  const [minutes, setState] = useState<number | null>(cachedMinutes);
+  useEffect(() => {
+    let mounted = true;
+    void loadAutoLockMinutes().then((m) => {
+      if (mounted) {
+        setState(m);
+      }
+    });
+    const listener = (m: number | null) => setState(m);
+    settingListeners.add(listener);
+    return () => {
+      mounted = false;
+      settingListeners.delete(listener);
+    };
+  }, []);
+  const setMinutes = useCallback((m: number | null) => {
+    void persistAutoLockMinutes(m);
+  }, []);
+  return { minutes, setMinutes };
+}
+
+// ── Locking ──────────────────────────────────────────────────────────────
+
+/**
+ * The manual/automatic lock primitive. Safe to call redundantly — it no-ops
+ * when signed out or already locked.
+ */
+export function useLockNow(): () => Promise<void> {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  return useCallback(async () => {
+    if (!appStore.currentUser || appStore.isLocked) {
+      return;
+    }
+    appStore.setLocked(true);
+    try {
+      // Drops in-memory key material and closes the local DB.
+      await invoke("lock");
+    } catch (e) {
+      // Still proceed to the locked UI — a failed bridge call must not leave
+      // the app visibly unlocked when the user asked for a lock.
+      console.warn("[autolock] lock command failed:", e);
+    }
+    // Decrypted message bodies live in the query cache; drop them.
+    queryClient.clear();
+    router.replace("/(auth)/pin");
+  }, [router, queryClient]);
+}
+
+// ── Engine + touch capture ───────────────────────────────────────────────
+
+/**
+ * Mounted once around the root <Stack> (see app/_layout.tsx). Captures touch
+ * starts (without consuming them) to refresh the foreground deadline, and
+ * owns the AppState background/foreground bookkeeping.
+ */
+export function AutoLockProvider({ children }: { children: React.ReactNode }) {
+  const { minutes } = useAutoLockMinutes();
+  const lockNow = useLockNow();
+  const userId = useObserver(() => appStore.currentUser?.id ?? null);
+  const isLocked = useObserver(() => appStore.isLocked);
+
+  const minutesRef = useRef(minutes);
+  minutesRef.current = minutes;
+  const lockNowRef = useRef(lockNow);
+  lockNowRef.current = lockNow;
+
+  // Foreground idle deadline (ms epoch), moved forward by activity.
+  const deadlineRef = useRef<number | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastActivityNoteRef = useRef(0);
+  // When the app left the foreground; null while foregrounded.
+  const backgroundedAtRef = useRef<number | null>(null);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    deadlineRef.current = null;
+  }, []);
+
+  // Aim the single timer at the current deadline. When it fires early
+  // (activity moved the deadline), it re-aims at the remainder instead of
+  // locking.
+  const armTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    const deadline = deadlineRef.current;
+    if (deadline === null) {
+      return;
+    }
+    const fireIn = Math.max(0, deadline - Date.now());
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      const current = deadlineRef.current;
+      if (current === null) {
+        return;
+      }
+      if (Date.now() >= current) {
+        clearTimer();
+        void lockNowRef.current();
+      } else {
+        armTimer();
+      }
+    }, fireIn);
+  }, [clearTimer]);
+
+  // Touch activity: cheap throttle, moves the deadline without touching the
+  // timer.
+  const noteActivity = useCallback(() => {
+    const m = minutesRef.current;
+    if (m === null || deadlineRef.current === null) {
+      return;
+    }
+    const now = Date.now();
+    if (now - lastActivityNoteRef.current < ACTIVITY_THROTTLE_MS) {
+      return;
+    }
+    lastActivityNoteRef.current = now;
+    deadlineRef.current = now + m * 60_000;
+  }, []);
+
+  // (Re)start the whole engine whenever the window, the user, or the lock
+  // state changes.
+  useEffect(() => {
+    if (minutes === null || !userId || isLocked) {
+      clearTimer();
+      return;
+    }
+    deadlineRef.current = Date.now() + minutes * 60_000;
+    armTimer();
+    return clearTimer;
+  }, [minutes, userId, isLocked, armTimer, clearTimer]);
+
+  // Background/foreground transitions.
+  useEffect(() => {
+    const sub = AppState.addEventListener("change", (next) => {
+      if (next === "background" || next === "inactive") {
+        if (backgroundedAtRef.current === null) {
+          backgroundedAtRef.current = Date.now();
+        }
+        // JS timers are unreliable in the background — the timestamp above is
+        // the authority; kill the timer so it can't fire on a stale wake.
+        clearTimer();
+        return;
+      }
+      if (next !== "active") {
+        return;
+      }
+      const backgroundedAt = backgroundedAtRef.current;
+      backgroundedAtRef.current = null;
+      const m = minutesRef.current;
+      if (m === null || !appStore.currentUser || appStore.isLocked) {
+        return;
+      }
+      if (backgroundedAt !== null && Date.now() - backgroundedAt >= m * 60_000) {
+        void lockNowRef.current();
+        return;
+      }
+      // Fresh foreground session — restart the idle deadline.
+      deadlineRef.current = Date.now() + m * 60_000;
+      armTimer();
+    });
+    return () => sub.remove();
+  }, [armTimer, clearTimer]);
+
+  return (
+    <View
+      style={{ flex: 1 }}
+      onStartShouldSetResponderCapture={() => {
+        noteActivity();
+        return false;
+      }}
+    >
+      {children}
+    </View>
+  );
+}

--- a/mobile/stores/appStore.ts
+++ b/mobile/stores/appStore.ts
@@ -51,6 +51,12 @@ class AppStore implements AppState {
   // Unread message counts keyed by conversation_id or channel_id
   unreadCounts: Record<string, number> = {};
 
+  // True while the session is PIN-locked (manual "Lock now" or auto-lock,
+  // see lib/autolock.tsx). Cleared when the PIN screen unlocks or a fresh
+  // PIN is set. Guards against double-locking; NOT persisted — a cold start
+  // re-derives lock state from `get_unlock_state`.
+  isLocked = false;
+
   // Transient first-signup state. The Rust side returns `new_secret_key`
   // once on `verify_otp` — we shuttle it through the PIN setup screen to
   // the Emergency Kit display, then drop it on the floor. Stored in memory
@@ -150,6 +156,10 @@ class AppStore implements AppState {
     this.pendingSecretKey = key;
   }
 
+  setLocked(locked: boolean) {
+    this.isLocked = locked;
+  }
+
   setLoading(loading: boolean) {
     this.isLoading = loading;
   }
@@ -191,6 +201,7 @@ class AppStore implements AppState {
     this.isLoading = false;
     this.error = null;
     this.unreadCounts = {};
+    this.isLocked = false;
   }
 }
 


### PR DESCRIPTION
Base: feature/mobile-account-deletion (stacked; merge #964 first).

Implements #899 in the RN layer against the EXISTING `lock` bridge arm — core's autolock task emits a Tauri event mobile can't receive, so `set_auto_lock_timeout` / `report_user_activity` are deliberately not used.

- `mobile/lib/autolock.tsx`:
  - Device-local window in expo-secure-store, same windows as desktop's `AUTO_LOCK_OPTIONS`: Off / 1 / 5 / 15 / 60 min, default Off.
  - Backgrounded: AppState listener records a timestamp on background; on foreground locks if elapsed >= window (timestamp comparison — JS timers don't run in background).
  - Foregrounded: a single timer aimed at a deadline that touch activity moves forward (15s throttle, mirroring desktop's `ACTIVITY_REPORT_THROTTLE_MS`); the timer re-aims on early fire instead of restarting per event. Touch capture via a non-consuming `onStartShouldSetResponderCapture` wrapper around the root Stack.
  - Locking = `invoke("lock")` + `queryClient.clear()` (decrypted bodies otherwise survive in the query cache — desktop learned this) + `appStore.setLocked(true)` + `router.replace("/(auth)/pin")`.
- Self → Security: AUTO-LOCK section (window chips) + manual "Lock now" row.
- PIN screen keeps the store's lock flag honest: sets locked on an unlock-needed snapshot, clears it on successful `unlock` / `set_pin`; unlock restores through the existing `get_unlock_state` → `unlock` → initializing path.
- `appStore.isLocked` guards double-locking; reset on logout.

Gate: `pnpm typecheck` clean.