### PR TITLE
fix(mobile): repair post-merge-train breakage (icons dupes, dropped useLastMessages)

### DIFF
--- a/mobile/components/icons.tsx
+++ b/mobile/components/icons.tsx
@@ -28,8 +28,6 @@ import {
   Bookmark,
   CheckCheck,
   ChevronLeft,
-  Copy,
-  Link,
   ChevronRight,
   Copy,
   Link2,
@@ -86,16 +84,14 @@ export const Icon = {
   mail: wrap(Mail),
   key: wrap(Key),
   device: wrap(Smartphone),
-  copy: wrap(Copy),
-  link: wrap(Link2),
+  copy: wrap(Copy, 14),
+  link: wrap(Link2, 14),
   share: wrap(Share2),
   alert: wrap(AlertCircle),
   diamond: wrap(Diamond, 16),
   info: wrap(Info, 16),
   thread: wrap(MessagesSquare, 14),
   bookmark: wrap(Bookmark, 14),
-  copy: wrap(Copy, 14),
-  link: wrap(Link, 14),
 };
 
 export type IconName = keyof typeof Icon;

--- a/mobile/hooks/queries/useMessages.ts
+++ b/mobile/hooks/queries/useMessages.ts
@@ -11,7 +11,7 @@
 // from page data makes that state unrepresentable: a new conversation key
 // starts from a fresh first page.
 
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import {
   useInfiniteQuery,
   useMutation,
@@ -193,6 +193,12 @@ export const messageQueryKeys = {
   threads: ["messages", "thread"] as const,
   threadSummaries: (conversationId: string | null) =>
     ["messages", "thread-summaries", conversationId] as const,
+};
+
+export const lastMessageQueryKeys = {
+  all: ["last-message"] as const,
+  batch: (conversationIds: string[]) =>
+    ["last-message", "batch", conversationIds.join(",")] as const,
 };
 
 /**
@@ -571,4 +577,71 @@ export function useIngestConversation() {
     },
     [currentUser, queryClient],
   );
+}
+
+
+/** Newest message per conversation, keyed by conversation id. */
+export type LastMessageMap = Record<string, Message>;
+
+/**
+ * The newest message for every conversation in `conversationIds`, in ONE
+ * bridge call — mirrors desktop's `useLastMessages` (#874/#936): one batched
+ * `read_last_messages` per list, never one call per row, and no focus/interval
+ * polling — realtime events invalidate `lastMessageQueryKeys.all` instead.
+ *
+ * Previews come from the LOCAL store (the message table only holds what this
+ * device has ingested and decrypted), so a conversation with no local
+ * messages is simply absent from the map — callers treat "no entry" as "no
+ * preview" and render the row without one.
+ */
+export function useLastMessages(conversationIds: string[]) {
+  const currentUser = useObserver(() => appStore.currentUser);
+
+  // Sorted + de-duplicated so the cache key is a property of the SET, not of
+  // the render order the caller happened to produce.
+  const idsKey = conversationIds.join(",");
+  const ids = useMemo(
+    () => Array.from(new Set(conversationIds)).sort(),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [idsKey],
+  );
+
+  return useQuery({
+    queryKey: lastMessageQueryKeys.batch(ids),
+    queryFn: async (): Promise<LastMessageMap> => {
+      if (ids.length === 0) {
+        return {};
+      }
+      const rows = await invoke<RawChannelMessage[]>("read_last_messages", {
+        conversationIds: ids,
+      });
+      const out: LastMessageMap = {};
+      for (const row of rows ?? []) {
+        out[row.conversation_id] = transform(row);
+      }
+      return out;
+    },
+    enabled: ids.length > 0 && !!currentUser,
+    staleTime: 1000 * 30,
+  });
+}
+
+/**
+ * One-line preview text for a conversation row. Deleted messages and
+ * attachment-only messages get placeholders instead of raw envelope JSON.
+ */
+export function previewText(message: Message | undefined): string | null {
+  if (!message) {
+    return null;
+  }
+  if (message.deleted_at) {
+    return "Message deleted";
+  }
+  if (message.content) {
+    return message.content;
+  }
+  if (message.attachments && message.attachments.length > 0) {
+    return "Attachment";
+  }
+  return null;
 }

--- a/mobile/lib/attachments.ts
+++ b/mobile/lib/attachments.ts
@@ -1,0 +1,78 @@
+// Attachment upload + message-content envelope (mobile half of desktop's
+// frontend/src/utils/attachmentEnvelope.ts — the envelope must match
+// byte-for-byte so cross-platform messages parse everywhere).
+//
+// `upload_media` does everything heavy in Rust: read the file, SHA-256,
+// convergent AES-GCM encrypt, presigned PUT via the DS, dedup, blurhash +
+// dimensions for images. Reference registration happens inside Rust
+// `send_message` by re-parsing the `_att` JSON, so sending the same
+// envelope string keeps refcounting working for free.
+
+import { invoke } from "./native";
+
+/** An image the user picked but hasn't sent yet. */
+export interface PickedAttachment {
+  id: string;
+  /** `file://` URI from the picker — `upload_media` accepts it directly. */
+  uri: string;
+  name: string;
+  mimeType: string;
+  width?: number;
+  height?: number;
+}
+
+/** Mirror of `pollis_core::commands::r2::MediaUploadResult`. */
+export interface MediaUploadResult {
+  key: string;
+  url: string;
+  filename: string;
+  content_type: string;
+  size_bytes: number;
+  content_hash: string;
+  blurhash?: string | null;
+  width?: number | null;
+  height?: number | null;
+}
+
+/**
+ * Upload every attachment, then build the message content string. With no
+ * attachments the caption passes through untouched (plain-text fast path).
+ * Matches desktop's envelope exactly: `_att` entries carry
+ * {key, url, name, ct, size, hash, bh, w, h}; `_txt` is OMITTED entirely
+ * when the caption is empty (not "").
+ */
+export async function buildMessageContent(
+  attachments: PickedAttachment[],
+  contentText: string,
+): Promise<string> {
+  if (attachments.length === 0) {
+    return contentText;
+  }
+  const results = await Promise.all(
+    attachments.map((att) =>
+      invoke<MediaUploadResult>("upload_media", {
+        path: att.uri,
+        filename: att.name,
+        contentType: att.mimeType,
+      }),
+    ),
+  );
+
+  const envelope: Record<string, unknown> = {
+    _att: results.map((r) => ({
+      key: r.key,
+      url: r.url,
+      name: r.filename,
+      ct: r.content_type,
+      size: r.size_bytes,
+      hash: r.content_hash,
+      bh: r.blurhash ?? undefined,
+      w: r.width ?? undefined,
+      h: r.height ?? undefined,
+    })),
+  };
+  if (contentText) {
+    envelope._txt = contentText;
+  }
+  return JSON.stringify(envelope);
+}


### PR DESCRIPTION
Merge-train resolution errors: icons.tsx union kept duplicate Copy/Link imports and duplicate map keys (broke android-build); the #971 resolution adopted #976's useMessages.ts, dropping useLastMessages/previewText that the tab screens import, and referencing lib/attachments.ts early — re-grafted the hooks and pre-landed the lib (identical to #976's copy). mobile tsc clean.