### PR TITLE
fix(mobile): photo-library usage string; drop unused mic permission

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -106,13 +106,23 @@
       [
         "expo-camera",
         {
-          "cameraPermission": "Pollis needs your camera to scan the pairing QR code from your desktop."
+          "cameraPermission": "Pollis needs your camera to scan the pairing QR code from your desktop.",
+          "microphonePermission": false,
+          "recordAudioAndroid": false
         }
       ],
       [
         "expo-notifications",
         {
           "color": "#e6b65a"
+        }
+      ],
+      [
+        "expo-image-picker",
+        {
+          "photosPermission": "Pollis needs access to your photo library so you can attach images to messages and upload custom group emoji.",
+          "cameraPermission": false,
+          "microphonePermission": false
         }
       ]
     ]


### PR DESCRIPTION
expo-image-picker landed (#970/#976) without its config plugin — the binary references photo APIs, so upload validation fails with ITMS-90683 without NSPhotoLibraryUsageDescription. Also sets expo-camera microphonePermission:false / recordAudioAndroid:false (QR-only camera; the app never records — matches mobile/CLAUDE.md's no-mic rule).