### PR TITLE
chore: ignore terraform state at the repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,13 @@ __pycache__/
 
 # Ad-hoc sourcemap build used for bundle attribution — never committed.
 frontend/dist-map/
+
+# Terraform state — the relay pool's state lives in R2 (`pollis-tfstate`,
+# see infra/relay-hydra/versions.tf). Nothing here should ever hold it: the
+# 2026-08-12 R2 migration left a 301K `terraform.tfstate.backup` and a
+# pre-migration snapshot sitting untracked in the tree for weeks, one
+# `git add -A` away from committing the whole infrastructure state.
+*.tfstate
+*.tfstate.*
+tfstate-*.json
+.terraform/


### PR DESCRIPTION
The relay pool's Terraform state lives in R2 (`pollis-tfstate`, see `infra/relay-hydra/versions.tf`) — that part is correct and working.

What was not: the 2026-08-12 R2 migration left three files behind on disk, and one of them sat where nothing ignored it.

- `infra/relay-hydra/terraform.tfstate` (0 B) and `terraform.tfstate.backup` (301 K) — covered by `infra/relay-hydra/.gitignore`
- `tfstate-premigration-20260812-113858.json` (297 K) at the **repo root** — covered by nothing, untracked for weeks, one `git add -A` away from committing the entire infrastructure state

Before removing them I verified R2 holds the real thing: all **116 resource instances match exactly** between the R2 state and the local backup — nothing was lost in the migration. Worth knowing that the migration did **not** preserve lineage (R2 is `serial=1, lineage=e68abde3`; the local copy was `serial=142, lineage=03883fb9`), so the local file was the only copy carrying the original history. It is now archived to `s3://pollis-tfstate/archive/relay-hydra-premigration-20260812-serial142.json` rather than deleted outright, and the local copies are gone.

Deliberately does **not** ignore `.terraform.lock.hcl` — that is meant to be committed for provider version pinning, and it is not currently tracked, which is worth a separate look.