### PR TITLE
Stop inlining the Resend API key into the mobile bundle

### DIFF
--- a/mobile/.env.example
+++ b/mobile/.env.example
@@ -1,7 +1,12 @@
 # Mobile environment template. Copy to `mobile/.env` and fill in.
-# Expo bundles EXPO_PUBLIC_* vars into the JS bundle at build time and
-# `app/_layout.tsx` passes them to `initializeNativeBridge` at startup,
-# which forwards them to Rust's `init_pollis()`.
+# `app/_layout.tsx` passes these to `initializeNativeBridge` at startup, which
+# forwards them to Rust's `init_pollis()`.
+#
+# Expo inlines an EXPO_PUBLIC_* value into the shipped JS bundle wherever code
+# REFERENCES it — not merely because it sits in this file. So every var listed
+# here must be non-secret, and the thing to watch for is a
+# `process.env.EXPO_PUBLIC_…` read that outlives the secret it was written for
+# (see #995). Nothing secret belongs in a client env, ever.
 #
 # Required:
 
@@ -21,8 +26,13 @@ EXPO_PUBLIC_LIVEKIT_URL=
 # Store builds MUST point this at https://api.pollis.com.
 EXPO_PUBLIC_POLLIS_DELIVERY_URL="https://api-dev.pollis.com"
 
-# REMOVED in #393 — never re-add (they'd inline into the shipped JS bundle):
-# EXPO_PUBLIC_RESEND_API_KEY, EXPO_PUBLIC_LIVEKIT_API_KEY,
-# EXPO_PUBLIC_LIVEKIT_API_SECRET, EXPO_PUBLIC_R2_ACCESS_KEY_ID,
-# EXPO_PUBLIC_R2_SECRET_ACCESS_KEY. If any of these linger in your local .env,
-# delete them before a store build.
+# REMOVED — never re-add. All are held server-side now; the client reaches them
+# through the DS:
+#   EXPO_PUBLIC_LIVEKIT_API_KEY, EXPO_PUBLIC_LIVEKIT_API_SECRET,
+#   EXPO_PUBLIC_R2_ACCESS_KEY_ID, EXPO_PUBLIC_R2_SECRET_ACCESS_KEY  (#393)
+#   EXPO_PUBLIC_TURSO_URL, EXPO_PUBLIC_TURSO_TOKEN                  (#987)
+#   EXPO_PUBLIC_RESEND_API_KEY                                      (#995)
+# Delete any that linger in your local .env. Resend is called out separately
+# because #393 moved the OTP send to the DS but left the client still READING
+# the key, so it kept being inlined for two releases while this file said it was
+# gone; #995 removed the read.

--- a/mobile/CLAUDE.md
+++ b/mobile/CLAUDE.md
@@ -190,9 +190,17 @@ so before any store build check `mobile/.env`:
 - `EXPO_PUBLIC_POLLIS_DELIVERY_URL` **must** be `https://api.pollis.com` (prod
   DS), not api-dev.
 - `EXPO_PUBLIC_LIVEKIT_API_KEY` / `EXPO_PUBLIC_LIVEKIT_API_SECRET` /
-  `EXPO_PUBLIC_RESEND_API_KEY` must **not** exist in `.env` — the code stopped
-  reading them in #393, but a stale var would still be inlined into the bundle
-  as plaintext. Delete them.
+  `EXPO_PUBLIC_RESEND_API_KEY` / `EXPO_PUBLIC_R2_ACCESS_KEY_ID` /
+  `EXPO_PUBLIC_R2_SECRET_KEY` / `EXPO_PUBLIC_TURSO_TOKEN` must **not** exist in
+  `.env`. Delete them.
+  **Be precise about why, because this bullet used to get it wrong:** Expo
+  inlines an `EXPO_PUBLIC_*` value only where code *references* it. An
+  unreferenced var sits in `.env` doing nothing and never reaches a bundle. So
+  the danger is never the file on its own — it is a `process.env.EXPO_PUBLIC_…`
+  read that outlives the secret it was written for. That is exactly what #995
+  found: the Resend key had been "moved server-side" in #393, but
+  `app/_layout.tsx` still read it, so it alone kept getting inlined while the
+  others were inert. Grep for the read, not just for the var.
 
 ### iOS
 
@@ -484,15 +492,26 @@ Current state:
   navigation to `/(auth)/email`). On-device testing of realtime + push is
   still pending.
 
-## ⚠️ Secrets architecture — KNOWN CRITICAL ISSUE (do before any public release)
+## Secrets architecture — settled (#393, #987, #995)
 
-Local dev currently feeds real credentials to the Rust bridge via
-`EXPO_PUBLIC_*` env vars (`mobile/.env`, gitignored). **Expo inlines every
-`EXPO_PUBLIC_*` value into the JS bundle at build time**, so they ship inside
-the APK/IPA in plaintext — `unzip` + grep recovers them. This is fine for a dev
-build on a trusted device; it is **not shippable**. What leaks today:
+This was for a long time the mobile app's blocking release risk, and it is now
+closed. Kept because the reasoning is what stops it coming back.
 
-- ✅ **Resend key** — DONE, moved server-side (OTP runs on the DS).
+The hazard: **Expo inlines an `EXPO_PUBLIC_*` value into the JS bundle wherever
+code references it**, so anything referenced ships inside the APK/IPA in
+plaintext and `unzip` + grep recovers it. Note the precise rule — *referenced*,
+not merely *present in `.env`*. A var nothing reads is inert; a read that
+outlives its secret is the actual leak. The client now holds **no secret of any
+kind**, and every credential below moved server-side rather than being scoped
+down:
+
+- ✅ **Resend key** — server half moved in #393 (OTP runs on the DS); the client
+  half was missed until **#995**, which deleted `resendApiKey` from `InitConfig`,
+  the init-JSON mapping and `app/_layout.tsx`. Until then it was the one secret
+  still being inlined, because it was the one still being read — `pollis-core`'s
+  `InitConfig` has no `resend_api_key` field, so serde parsed and discarded it.
+  This section claimed "✅ DONE" for the whole of that window, which is the real
+  lesson: mark a bullet done against the code, not against the intent.
 - ✅ **R2 keys** — DONE (#393). `r2_access_key_id` / `r2_secret_access_key` are
   gone from the bundle; `commands/r2.rs` presigns every get/put/delete via the DS
   (`POST /v1/r2/presign`) and only the non-secret `EXPO_PUBLIC_R2_ENDPOINT` /
@@ -511,12 +530,12 @@ build on a trusted device; it is **not shippable**. What leaks today:
   "true per-user row scoping needs per-user DBs (#261)" line this bullet used to
   end on is moot — there is no client token left to scope.
 
-The fix is an **authorized-secrets broker** — a thin server-side endpoint (a
-Cloudflare Worker fits; CF is already in the stack) that holds the real secrets
-and never ships them to the client:
+The fix was an **authorized-secrets broker** — a server-side endpoint (the DS)
+that holds the real secrets and never ships them to the client:
 
-1. **Bootstrap (pre-auth):** `POST /otp/request` + `/otp/verify` run server-side
-   (server calls Resend). The phone never holds the Resend key.
+1. **Bootstrap (pre-auth):** ✅ DONE — `POST /otp/request` + `/otp/verify` run
+   server-side (the DS calls Resend). The phone never holds the Resend key; the
+   last client-side remnant of one went in #995.
 2. **Post-auth, scoped + short-lived creds:**
    - **Turso:** ✅ DONE — and then deleted (#987). The client reads through the
      DS and holds no token; the mint endpoint is gone with it.

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -47,7 +47,6 @@ export default function RootLayout() {
       r2Endpoint: process.env.EXPO_PUBLIC_R2_ENDPOINT,
       r2PublicUrl: process.env.EXPO_PUBLIC_R2_PUBLIC_URL,
       livekitUrl: process.env.EXPO_PUBLIC_LIVEKIT_URL,
-      resendApiKey: process.env.EXPO_PUBLIC_RESEND_API_KEY,
       pollisDeliveryUrl: process.env.EXPO_PUBLIC_POLLIS_DELIVERY_URL,
     })
       .then(() => setBridgeReady(true))

--- a/mobile/lib/native/bridge.ts
+++ b/mobile/lib/native/bridge.ts
@@ -102,7 +102,11 @@ export interface InitConfig {
   // no longer carries them. Only the non-secret ws URL remains (the SFU dial URL,
   // also returned by the DS token endpoint).
   livekitUrl?: string;
-  resendApiKey?: string;
+  // No Resend key (#995). The DS sends the OTP mail; the core has no
+  // `resend_api_key` field to receive one and never did. Reading the env var
+  // here was the one thing that made Expo inline it into the bundle — the other
+  // stale `EXPO_PUBLIC_*` secrets are unreferenced and so never reach a build.
+  // Never re-add it.
   // Delivery Service base URL (api-dev.pollis.com / api.pollis.com). Since #987
   // this is the ONLY backend: OTP bootstrap, every remote read and every remote
   // write go through it. Optional in the type only because the Rust side
@@ -138,7 +142,6 @@ export async function initializeNativeBridge(config: InitConfig): Promise<void> 
     r2_endpoint: config.r2Endpoint ?? "",
     r2_public_url: config.r2PublicUrl ?? "",
     livekit_url: config.livekitUrl ?? "",
-    resend_api_key: config.resendApiKey ?? "",
     pollis_delivery_url: config.pollisDeliveryUrl ?? "",
   });
   await pollisNative.initPollis(configJson);


### PR DESCRIPTION
Closes #995.

`mobile/CLAUDE.md` has recorded the Resend key as "✅ DONE, moved server-side"
since #393. The server half was done — the DS sends the OTP mail. The client half
was not: `app/_layout.tsx` still read `EXPO_PUBLIC_RESEND_API_KEY` and
`bridge.ts` still mapped it to `resend_api_key` in the init JSON.

It bought nothing. `InitConfig` in `pollis-core/src/bridge.rs` has no
`resend_api_key` field and serde ignores unknown keys, so the value was parsed
and discarded — while Expo, seeing a `process.env` reference, inlined it into
every locally-built bundle.

- Dropped `resendApiKey` from `InitConfig`, the init-JSON mapping and
  `_layout.tsx`. Purely subtractive: the Rust side never had the field.
- Corrected `.env.example` and the `mobile/CLAUDE.md` secrets section, which is
  now titled as settled rather than as a standing critical issue — #393, #987 and
  this change close it out.

**One correction worth keeping, since it is what hid the bug.** Both documents
claimed a stale var in `.env` "would still be inlined into the bundle". That is
not how it works: Expo inlines an `EXPO_PUBLIC_*` value only where code
*references* it. `TURSO_TOKEN`, `LIVEKIT_API_SECRET` and `R2_SECRET_KEY` sat in
`.env.development` unreferenced and never reached a bundle at all. Resend was
the only one still being read, and so the only one that actually leaked — but the
inaccurate rule filed all four under the same harmless-looking advice. The docs
now say: grep for the read, not for the var.

**Exposure:** local dev bundles only. CI has no `.env.development` (gitignored),
so the `pollis-android-apk` artifact carries `undefined` here, and no store build
has ever shipped.

**Verified:** `tsc --noEmit` · `expo-doctor` 20/20 · no `resendApiKey` /
`resend_api_key` reference left outside an explanatory comment.