### PR TITLE
Move the account email out of accounts.json and into the per-user keystore

### DIFF
--- a/.codesight/wiki/overview.md
+++ b/.codesight/wiki/overview.md
@@ -113,7 +113,8 @@ other; a genuinely shared home needs a crate below both, which does not exist ye
 |-------|----------|--------------|
 | **Turso** (remote) | Users, groups, channels, membership, public keys, encrypted message envelopes, MLS commit log, MLS welcomes, GroupInfo | Message plaintext, private keys |
 | **SQLite** (local, per-user, encrypted) | Decrypted messages, MLS group state (`mls_kv`), preferences cache | User profiles, groups, channels (fetched from remote) |
-| **Device keystore** | ML-DSA-44 account identity key pair (private half is its 32-byte seed, so the wrapped blob is the same size it was under Ed25519), session token, device ID, DB encryption key | Anything in plaintext — see below |
+| **Device keystore** | ML-DSA-44 account identity key pair (private half is its 32-byte seed, so the wrapped blob is the same size it was under Ed25519), session token, device ID, DB encryption key, the account's login email (`login_email_{uid}`, #997) | Anything in plaintext — see below |
+| **`accounts.json`** (local, unencrypted, guarded by file permissions alone) | Per account: opaque `user_id` ULID, `username`, `avatar_url`, `last_seen`; plus `last_active_user`. The only store readable pre-unlock | Any secret, and any PII — the login email moved to the keystore in #997 (`docs/security-whitepaper.md` §1.1.1) |
 
 ### The device keystore has two backends (#882)
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -158,7 +158,7 @@ Email OTP via Resend proves control of an email address. It is **not** the devic
 
 The unlock factor is a 4-digit PIN, local to the device. The PIN is fed through Argon2id (m=64 MiB, t=3, p=1, output 32 bytes) to derive a KEK; the KEK uses XChaCha20-Poly1305 to wrap the SQLCipher key and the account-identity Ed25519 private. 10 wrong attempts wipe the wrapped blobs and force re-enrollment via Secret Key recovery. The PIN never leaves the device.
 
-`accounts.json` records "who has signed in on this device" with crash-safe atomic writes (tempfile + fsync + rename) and loud parse-failure handling.
+`accounts.json` records "who has signed in on this device" with crash-safe atomic writes (tempfile + fsync + rename) and loud parse-failure handling. It is the only store readable pre-unlock, so it is deliberately kept to the minimum that bootstrap needs: per account an opaque `user_id` ULID, `username`, `avatar_url` and `last_seen`, plus `last_active_user`. No secret, no PII — the login address moved to the per-user keystore slot `login_email_{user_id}` in #997, which is where `local_user_id_for_email` reads it to resolve a returning user pre-unlock (`docs/security-whitepaper.md` §1.1.1). A file written by an older build still carries it; the first migrated read adopts it into the keystore and rewrites the file without it (keystore write first, erase only if every address was taken). A parse failure snapshots the file to `accounts.bad-<unix-ms>.json`; the next successful write prunes those to the newest three.
 
 ### Multi-device enrollment
 

--- a/docs/security-whitepaper.md
+++ b/docs/security-whitepaper.md
@@ -19,10 +19,68 @@
 | The user-held Secret Key (printed once, expected to be stored offline) | Resend — outbound email transit for OTPs |
 | — | The Delivery Service (`pollis-delivery`) — the sole writer to the remote database, and the broker that now holds the Resend, R2 and LiveKit credentials on the client's behalf (§4, §9.3, §10.1) |
 | The user-held PIN (in the user's head) | Anyone with read access to a copy of `accounts.json` or the keystore who does not also have the PIN |
+| `accounts.json` — the local "who has signed in on this device" index (§1.1.1) | — |
 
 The application is built and shipped by the operators of the Pollis services. The trust delegation is the same as Signal Desktop or WhatsApp Desktop: the binary is trusted at install time, after which the cryptographic protocol is what defends against the *server* side of the same operator. Binary integrity now rests on two layers. The first is platform code-signing (Apple Developer ID + notarization on macOS, Azure Trusted Signing on Windows — see `.codesight/wiki/windows-signing.md`); the auto-update path verifies the same OS-native signature on every downloaded installer before launch (Gatekeeper on macOS, Authenticode on Windows), so an attacker who tampers with a release artifact in transit cannot get the running binary to install it.
 
 The second layer, **now shipped**, is **binary transparency**. Every released build's reproducible pre-signature payload *and* its signed artifact are content-hashed and appended as leaves to a third append-only, ML-DSA-44-signed Merkle tree — served alongside the commit-log and account-key trees (§6.9) at **https://verify.pollis.com/v1/binaries**, under its own domain-separated STH context so a binary head can never be replayed as a commit-log or account-key head. Anyone can confirm that every artifact published for a given release tag is provably included in that log by running `pollis-verify release <tag>`, which trusts **only** the pinned log key (ML-DSA-44, rotated to fresh material in #732) — not Pollis, not Turso, not the host serving the files. Code-signing proves only "the holder of Pollis's key produced these bytes"; the transparency log additionally makes the *set of bytes Pollis has ever published for a release* public and non-repudiable, so a compromised or compelled operator cannot quietly ship a targeted per-user build — its hash is either logged (permanently, publicly, and cross-checkable by any monitor) or conspicuously absent from the log. **Honest limits** (full design in `docs/verifiable-builds-design.md`; P0–P2 shipped, and P5 Linux reproducibility + independent rebuilder, P3 keyless SLSA/cosign provenance, and P4 in-app verify all shipped in #484): the log records a correct leaf structure — both hashes plus the pinned build recipe — and the release pipeline appends them; and the **Linux AppImage payload is now reproducible modulo a documented residual list** (`docs/reproducible-builds-residuals.md`), with the toolchain pinned to an exact version, absolute build paths remapped out of the binary, and a `SOURCE_DATE_EPOCH` derived from the tag commit. An independent, fork-runnable rebuilder (`.github/workflows/rebuild-verify.yml`) rebuilds that payload from public source at a tag and asserts the reproduced hash is the one logged, trusting **only** the pinned key. **This is demonstrated, not merely implemented:** at `v1.8.4` the rebuild matched the logged payload `1a4213a1…` exactly, and the rebuilder now runs automatically after every release, so the property is continuously checked rather than asserted. Two honest bounds on that result: it is the *Linux AppImage payload* only, and reproduction currently requires building at the same filesystem path, because `--remap-path-prefix` is a rustc flag and does not cover C/C++ compiled through `cc-rs` (`docs/reproducible-builds-residuals.md`). **macOS and Windows payload reproducibility remains best-effort** (cross-platform, not asserted by the rebuilder), and the signing/notarization outer layer is non-reproducible *by construction* — transparency-logged and cryptographically bound to the payload, not reproduced. On **macOS and Windows**, however, the logged payload digest is now **recomputable by anyone holding the public `.dmg` / `.exe`** (#750): it is defined as the shipped artifact with that platform's per-signing material normalized back out — on macOS the stapled notarization ticket, each Mach-O code signature and the `_CodeSignature` manifests; on Windows the Authenticode certificate table and the PE checksum signtool recomputes over it, stripped from every executable inside the installer — so a third party can open the release, apply the same normalization, and check the result against the log. This is the ordinary reproducible-builds treatment of signatures (exclude, don't reproduce; cf. F-Droid's "identical apart from the signature"). It replaced a scheme that hashed a separate unsigned build existing only inside CI, which no outside party could obtain and therefore could not check — and which additionally made each release conditional on the Rust compiler emitting identical bytes across two compiles of one source tree, a gate that failed a real release twice in a row for reasons unrelated to that release's soundness. It does **not** by itself establish that the macOS or Windows bytes rebuild from source — that remains best-effort, pending a matching-platform reproducer and the compiler-determinism work itemized in `docs/reproducible-builds-residuals.md`. **A second, independent transparency anchor now ships (P3, #484):** every released installer and updater bundle additionally carries a keyless **SLSA v1 build-provenance attestation** (GitHub's `actions/attest-build-provenance`) *and* a **cosign signature**, both anchored in the **public Rekor** log and cryptographically bound to Pollis's **GitHub Actions OIDC identity** — published next to the artifact on `cdn.pollis.com`, the attestation at exactly the `provenance_uri` each binaries-log leaf records. Anyone can run `cosign verify-blob` (or a SLSA verifier) and confirm the bytes were produced by the pinned Pollis release workflow, checked against Rekor, with **no Pollis-held key on that verification path** — defense in depth against a compromised or compelled Pollis signing key, and a transparency anchor Pollis does not control. This proves *build provenance* and adds a *non-Pollis* anchor; it does **not**, by itself, prove the bytes reproduce from source — that remains the reproducibility story above. Remaining gaps, itemized in the residual list: the client no longer bakes any R2 or LiveKit credentials — those moved off-client in the #506 secrets-broker cutover — so the only baked credentials left are the publishable read-only Turso token and an **optional** observability log-DB token. It is that optional log-DB token that, when a release bakes it, still prevents a *fully secretless* third party from bit-reproducing even the Linux payload (a party given the published recipe reproduces it, as before). (An optional in-app **"Verify this build"** affordance on the Security page already lets the running app confirm its own payload is published in the log — P4, #484.) For the platforms and inputs not yet reproducible, the log still proves *what* Pollis published for a tag; independent proof that those bytes *match public source* holds today for the Linux payload (given the recipe, on a matching runner) and is the remaining work elsewhere.
+
+#### 1.1.1 `accounts.json`
+
+The one client-side store that is neither encrypted nor machine-bound. It is
+called out here because until #997 it appeared in this document *only* on the
+untrusted side of the table above — as something an attacker might read, with no
+statement of what it holds or what protects it. That omission is how it came to
+hold a plaintext email address.
+
+**What it holds, per account:** the account's `user_id` (an opaque 128-bit
+ULID), the `username` and `avatar_url` the user chose — which every peer they
+talk to already sees — and a `last_seen` timestamp; plus one top-level
+`last_active_user`. That is the complete list.
+
+**What protects it:** file permissions, and nothing else. It is **not**
+encrypted, **not** machine-bound, and **not** in the keystore. Owner-only mode
+is what it should carry, and the separate client-wide file-permission hardening
+is what sets that; today it is created at the process umask, so on a default
+Linux or macOS box it is world-readable. Either way a same-UID attacker or a
+full-disk image reads it — and both of those already have the keystore, whose
+contents are worth far more.
+
+**Why that is acceptable:** the file holds no secret and no PII — an argument
+that does not lean on the mode at all, which is the point. Every field is
+either an opaque identifier or a display string the user publishes to their
+contacts anyway, so a reader learns *that this machine has accounts* and their
+opaque ids — not who owns them. Its job is bootstrap: it is the only store
+readable pre-unlock (local DB closed, no signer, no session, hence no
+credential of any kind), and `get_session` / `get_unlock_state` need a `user_id`
+before any credential exists.
+
+**The login address is not in it (#997).** It used to be: the single field that
+mapped an opaque id to a *person*, and the input to OTP sign-in and the recovery
+flow. It now lives in the per-user keystore slot `login_email_{user_id}`, under
+the same protection as the account identity key and the DB key. The pre-unlock
+email → `user_id` resolution still reaches it, because the keystore is readable
+at exactly that moment — `device_id_{user_id}` is already read there, for the
+returning-device path. Masking and hashing were both rejected for that
+resolution: it is a case-insensitive *equality* test, so every masked address at
+a shared domain collides and would resolve a returning user to an arbitrary
+account, and email is low-entropy enough that a hash buys
+confirmation-resistance rather than secrecy while still costing the login
+screen's one-click "continue as" chip.
+
+An install that predates #997 still has the address in its file. The first
+launch on the new build moves it into the keystore and then rewrites the index
+without it — keystore write first, erase second, and nothing is erased unless
+every address was taken, so an interrupted or failed migration retries on the
+next launch rather than losing the address. Until that point ordinary writes
+carry the field through untouched, for the same reason. Nothing ever *sets* the
+field, so the erase is final.
+
+Corrupt-index snapshots (`accounts.bad-<unix-ms>.json`, written when the file
+fails to parse) inherit the same contents and the same permissions, and are pruned to
+the newest three on the next successful write. A snapshot taken from a
+pre-migration file therefore still carries the old address; the prune bounds how
+many such copies can survive, where previously they accumulated forever.
 
 ### 1.2 What the server can and cannot see
 
@@ -506,7 +564,11 @@ credentials is pure attack surface.
 - **Three reads are unsigned, because no credential exists at that moment.**
   `POST /v1/auth/account-probe` runs pre-PIN at launch (local DB closed, no
   signer, no session) and answers `{ exists, has_identity, identity_version }`
-  for a 128-bit ULID the caller read out of its own `accounts.json`.
+  for a 128-bit ULID the caller read out of its own `accounts.json`. That
+  argument rests on the id being unguessable and on the file it came from being
+  non-sensitive; §1.1.1 now states both on the record, including the #997 move
+  of the login address out of that file, so an endpoint reachable with no
+  credential is answering about an opaque identifier and nothing else.
   `POST /v1/read/enrollment` is gated on possession of the enrollment
   `request_id` — a session cannot serve it, because the DS session TTL and the
   enrollment TTL are both 600s and the session is minted strictly earlier, so a

--- a/pollis-core/src/accounts.rs
+++ b/pollis-core/src/accounts.rs
@@ -4,13 +4,39 @@ use std::path::PathBuf;
 use crate::db::local::dirs_path;
 use crate::error::{Error, Result};
 
+/// One entry in the on-disk `accounts.json`.
+///
+/// Every field this code SETS is either an opaque identifier or a display string
+/// the user chose: no secret, and — since #997 moved the login address into the
+/// per-user keystore — no PII. The one exception is [`AccountInfo::legacy_email`],
+/// which is only ever read off a file an older build wrote, carried until the
+/// keystore has taken it, and then erased.
+///
+/// No new field may go in without `#[serde(default)]`. A missing field on an
+/// un-annotated type is a serde parse ERROR, and [`read_accounts_index`] treats
+/// a parse error as corruption: it would rename every existing install's index
+/// to `accounts.bad-<ts>.json`, minting exactly the permanent plaintext-email
+/// snapshot #997 exists to eliminate. Removing a field is always safe in the
+/// other direction — serde ignores unknown keys on read.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AccountInfo {
     pub user_id: String,
     pub username: String,
-    pub email: Option<String>,
     pub avatar_url: Option<String>,
     pub last_seen: String,
+    /// The pre-#997 plaintext login address, present only on a file written by
+    /// an older build. Read solely so the upgrade can move it into the keystore
+    /// (`commands::auth::read_accounts_index_migrated`) and then erase it via
+    /// [`forget_legacy_emails`].
+    ///
+    /// `default` per the rule above — current files have no such key.
+    /// `skip_serializing_if` so that erasing it is something a caller has to
+    /// DO — clear the field — rather than something any write does implicitly.
+    /// That distinction is the invariant: an ordinary `upsert_account` must not
+    /// be able to destroy an address the keystore has not taken yet, which is
+    /// precisely how it would be lost for good.
+    #[serde(default, rename = "email", skip_serializing_if = "Option::is_none")]
+    pub legacy_email: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -19,6 +45,31 @@ pub struct AccountsIndex {
     pub last_active_user: Option<String>,
 }
 
+/// One entry as the LOGIN SCREEN sees it: an [`AccountInfo`] rehydrated with the
+/// login address, which since #997 lives in the per-user keystore rather than on
+/// disk. Byte-for-byte the JSON shape `list_known_accounts` returned before that
+/// move, so the renderer's `AccountInfo` type is unchanged.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KnownAccount {
+    pub user_id: String,
+    pub username: String,
+    pub email: Option<String>,
+    pub avatar_url: Option<String>,
+    pub last_seen: String,
+}
+
+/// The wire shape of `list_known_accounts` — see [`KnownAccount`].
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct KnownAccounts {
+    pub accounts: Vec<KnownAccount>,
+    pub last_active_user: Option<String>,
+}
+
+/// How many `accounts.bad-*.json` snapshots to keep. The read path writes one
+/// per corruption and nothing ever removed them, so they accumulated for the
+/// life of the install.
+const MAX_BAD_INDEX_BACKUPS: usize = 3;
+
 fn index_path() -> PathBuf {
     dirs_path().join("accounts.json")
 }
@@ -26,11 +77,16 @@ fn index_path() -> PathBuf {
 /// Read the accounts index.
 ///
 /// - Missing file → `Ok(default)`. First run.
-/// - Parse failure → rename the bad file to `accounts.bad-<unix-ts>.json`
+/// - Parse failure → rename the bad file to `accounts.bad-<unix-ms>.json`
 ///   and return `AccountsIndexCorrupt`. We refuse to silently replace a
 ///   corrupt index with an empty one because the next `upsert_account`
 ///   would then overwrite it with a single-entry file, permanently
 ///   losing the record of every other account on this device.
+///
+///   The stamp is in MILLISECONDS. It used to be seconds, so two corruptions
+///   inside the same second chose the same name and the second rename silently
+///   destroyed the first snapshot. Snapshots are pruned to the newest
+///   [`MAX_BAD_INDEX_BACKUPS`] by the next successful write.
 pub fn read_accounts_index() -> Result<AccountsIndex> {
     let path = index_path();
     let data = match std::fs::read_to_string(&path) {
@@ -48,7 +104,7 @@ pub fn read_accounts_index() -> Result<AccountsIndex> {
     match serde_json::from_str::<AccountsIndex>(&data) {
         Ok(idx) => Ok(idx),
         Err(parse_err) => {
-            let ts = chrono::Utc::now().timestamp();
+            let ts = chrono::Utc::now().timestamp_millis();
             let backup = path.with_file_name(format!("accounts.bad-{ts}.json"));
             if let Err(rename_err) = std::fs::rename(&path, &backup) {
                 eprintln!(
@@ -91,30 +147,77 @@ fn write_accounts_index(index: &AccountsIndex) -> Result<()> {
         f.sync_all()
             .map_err(|e| Error::Other(anyhow::anyhow!("fsync accounts.json.tmp: {e}")))?;
     }
-    std::fs::rename(&tmp, &path)
-        .map_err(|e| Error::Other(anyhow::anyhow!("rename accounts.json.tmp: {e}")))?;
+    if let Err(e) = std::fs::rename(&tmp, &path) {
+        // The old index survives — that is the point of the rename — but the
+        // freshly-written `.tmp` does not, and nothing else ever collected it.
+        // Remove it so a failed write leaves the directory as it found it.
+        let _ = std::fs::remove_file(&tmp);
+        return Err(Error::Other(anyhow::anyhow!("rename accounts.json.tmp: {e}")));
+    }
+
+    if let Some(parent) = path.parent() {
+        prune_bad_index_backups(parent);
+    }
     Ok(())
 }
 
+/// Keep only the newest [`MAX_BAD_INDEX_BACKUPS`] `accounts.bad-*.json`
+/// snapshots and delete the rest.
+///
+/// Best-effort throughout: this runs after a write that already succeeded, and
+/// failing to tidy an old snapshot must never turn that write into an error.
+///
+/// Newest-last is decided by file name, which orders chronologically across
+/// both stamp widths this code has written: a millisecond stamp is its own
+/// second stamp's digits plus three more, so a legacy `accounts.bad-<sec>.json`
+/// sorts exactly where its instant falls among the millisecond ones.
+fn prune_bad_index_backups(dir: &std::path::Path) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+
+    let mut backups: Vec<PathBuf> = entries
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with("accounts.bad-") && name.ends_with(".json"))
+        })
+        .collect();
+
+    if backups.len() <= MAX_BAD_INDEX_BACKUPS {
+        return;
+    }
+
+    backups.sort_by(|a, b| b.file_name().cmp(&a.file_name()));
+    for stale in backups.iter().skip(MAX_BAD_INDEX_BACKUPS) {
+        if let Err(e) = std::fs::remove_file(stale) {
+            eprintln!("[accounts] could not prune {}: {e}", stale.display());
+        }
+    }
+}
+
 /// Insert or update an account entry and set it as the last active user.
-pub fn upsert_account(user_id: &str, username: &str, email: Option<&str>, avatar_url: Option<&str>) -> Result<()> {
+///
+/// Takes no email. The login address moved to the per-user keystore in #997;
+/// callers that have one store it there via
+/// [`crate::commands::auth::store_login_email`] alongside this call.
+pub fn upsert_account(user_id: &str, username: &str, avatar_url: Option<&str>) -> Result<()> {
     let mut index = read_accounts_index()?;
 
     let now = chrono::Utc::now().to_rfc3339();
     if let Some(existing) = index.accounts.iter_mut().find(|a| a.user_id == user_id) {
         existing.username = username.to_string();
-        if let Some(e) = email {
-            existing.email = Some(e.to_string());
-        }
         existing.avatar_url = avatar_url.map(|s| s.to_string());
         existing.last_seen = now;
     } else {
         index.accounts.push(AccountInfo {
             user_id: user_id.to_string(),
             username: username.to_string(),
-            email: email.map(|s| s.to_string()),
             avatar_url: avatar_url.map(|s| s.to_string()),
             last_seen: now,
+            legacy_email: None,
         });
     }
     index.last_active_user = Some(user_id.to_string());
@@ -137,9 +240,230 @@ pub fn remove_account(user_id: &str) -> Result<()> {
     write_accounts_index(&index)
 }
 
+/// Erase every pre-#997 `email` field from the index.
+///
+/// The ONLY thing that removes the plaintext address from disk, and the reason
+/// [`AccountInfo::legacy_email`] survives an ordinary write: this runs strictly
+/// AFTER the caller has confirmed the keystore holds every one of those
+/// addresses (see `commands::auth::read_accounts_index_migrated`), so a keystore
+/// that refused the write leaves the file intact for the next attempt.
+///
+/// A no-op on a file that carries no legacy field, so a normal launch neither
+/// rewrites nor re-fsyncs anything.
+pub fn forget_legacy_emails() -> Result<()> {
+    let mut index = read_accounts_index()?;
+    if index.accounts.iter().all(|a| a.legacy_email.is_none()) {
+        return Ok(());
+    }
+    for account in index.accounts.iter_mut() {
+        account.legacy_email = None;
+    }
+    write_accounts_index(&index)
+}
+
 /// Clear the last active user (soft logout — account entry stays in the list).
 pub fn clear_last_active_user() -> Result<()> {
     let mut index = read_accounts_index().unwrap_or_default();
     index.last_active_user = None;
     write_accounts_index(&index)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The upgrade path for #997. Every install that ever logged in has an
+    /// `accounts.json` carrying the now-removed `email` key, and `AccountInfo`
+    /// annotates no field with `#[serde(default)]` — so a shape mismatch here is
+    /// not a lenient no-op, it is a parse error, which `read_accounts_index`
+    /// escalates to `AccountsIndexCorrupt` and a permanent
+    /// `accounts.bad-<ts>.json` copy of exactly the plaintext email this change
+    /// exists to remove.
+    ///
+    /// Dropping a field is safe (serde ignores unknown keys); ADDING one is not.
+    /// That asymmetry is the invariant this test pins.
+    #[test]
+    fn a_pre_997_index_still_parses() {
+        let legacy = r#"{
+          "accounts": [
+            {
+              "user_id": "01JBQ0000000000000000000AA",
+              "username": "alice",
+              "email": "alice@example.com",
+              "avatar_url": null,
+              "last_seen": "2026-08-01T10:00:00+00:00"
+            },
+            {
+              "user_id": "01JBQ0000000000000000000BB",
+              "username": "bob",
+              "email": null,
+              "avatar_url": "https://example.com/b.png",
+              "last_seen": "2026-08-02T10:00:00+00:00"
+            }
+          ],
+          "last_active_user": "01JBQ0000000000000000000AA"
+        }"#;
+
+        let index: AccountsIndex =
+            serde_json::from_str(legacy).expect("a pre-#997 accounts.json must still parse");
+
+        assert_eq!(index.accounts.len(), 2);
+        assert_eq!(index.accounts[0].username, "alice");
+        assert_eq!(index.accounts[1].avatar_url.as_deref(), Some("https://example.com/b.png"));
+        assert_eq!(
+            index.last_active_user.as_deref(),
+            Some("01JBQ0000000000000000000AA")
+        );
+
+        // The address is surfaced, once, so the upgrade can move it to the
+        // keystore instead of losing the returning-device resolution with it.
+        assert_eq!(
+            index.accounts[0].legacy_email.as_deref(),
+            Some("alice@example.com")
+        );
+        assert_eq!(index.accounts[1].legacy_email, None);
+    }
+
+    /// A file written by the CURRENT build has no `email` key at all, and must
+    /// parse just as cleanly — `#[serde(default)]` is what makes the field's
+    /// absence legal rather than corruption.
+    #[test]
+    fn a_post_997_index_parses_without_an_email_key() {
+        let current = r#"{
+          "accounts": [
+            {
+              "user_id": "01JBQ0000000000000000000AA",
+              "username": "alice",
+              "avatar_url": null,
+              "last_seen": "2026-08-01T10:00:00+00:00"
+            }
+          ],
+          "last_active_user": "01JBQ0000000000000000000AA"
+        }"#;
+
+        let index: AccountsIndex = serde_json::from_str(current).expect("current file must parse");
+        assert_eq!(index.accounts.len(), 1);
+        assert_eq!(index.accounts[0].legacy_email, None);
+    }
+
+    fn legacy_file() -> &'static str {
+        r#"{
+          "accounts": [
+            {
+              "user_id": "01JBQ0000000000000000000AA",
+              "username": "alice",
+              "email": "alice@example.com",
+              "avatar_url": null,
+              "last_seen": "2026-08-01T10:00:00+00:00"
+            }
+          ],
+          "last_active_user": "01JBQ0000000000000000000AA"
+        }"#
+    }
+
+    /// The invariant that makes the migration safe to interrupt: an ordinary
+    /// write — `upsert_account`, `remove_account`, `clear_last_active_user` —
+    /// PRESERVES a legacy address it has not been told to erase.
+    ///
+    /// If a plain write dropped it, a single login on a multi-account device
+    /// would destroy the other accounts' addresses before the keystore had ever
+    /// seen them, and nothing could recover them. Erasure has to be a deliberate
+    /// act, which is what `forget_legacy_emails` is.
+    #[test]
+    fn an_ordinary_write_preserves_an_unadopted_address() {
+        let index: AccountsIndex = serde_json::from_str(legacy_file()).expect("parse");
+
+        let rewritten = serde_json::to_string(&index).expect("serialize");
+        let reread: AccountsIndex = serde_json::from_str(&rewritten).expect("re-parse");
+
+        assert_eq!(
+            reread.accounts[0].legacy_email.as_deref(),
+            Some("alice@example.com"),
+            "a write nobody asked to erase must not erase: {rewritten}"
+        );
+    }
+
+    /// The erase step itself: clearing the field and writing leaves no `email`
+    /// key and no address behind.
+    #[test]
+    fn clearing_the_legacy_field_erases_the_address() {
+        let mut index: AccountsIndex = serde_json::from_str(legacy_file()).expect("parse");
+        for account in index.accounts.iter_mut() {
+            account.legacy_email = None;
+        }
+
+        let rewritten = serde_json::to_string(&index).expect("serialize");
+        assert!(
+            !rewritten.contains("alice@example.com") && !rewritten.contains("email"),
+            "the erase must remove the address and its key: {rewritten}"
+        );
+
+        let reread: AccountsIndex = serde_json::from_str(&rewritten).expect("re-parse");
+        assert_eq!(reread.accounts[0].legacy_email, None);
+        assert_eq!(reread.accounts[0].username, "alice");
+    }
+
+    /// The email must not come back on the way OUT either: re-serializing an
+    /// index a legacy file was read from writes no `email` key, so the first
+    /// write after upgrade is what actually erases the address from disk.
+    #[test]
+    fn writing_the_index_emits_no_email_key() {
+        let index = AccountsIndex {
+            accounts: vec![AccountInfo {
+                user_id: "01JBQ0000000000000000000AA".to_string(),
+                username: "alice".to_string(),
+                avatar_url: None,
+                last_seen: "2026-08-01T10:00:00+00:00".to_string(),
+                legacy_email: None,
+            }],
+            last_active_user: Some("01JBQ0000000000000000000AA".to_string()),
+        };
+
+        let json = serde_json::to_string(&index).expect("serialize");
+        assert!(!json.contains("email"), "accounts.json must carry no email: {json}");
+    }
+
+    #[test]
+    fn bad_index_backups_are_pruned_to_the_newest_few() {
+        let dir = tempfile::Builder::new()
+            .prefix("pollis-accounts-prune")
+            .tempdir()
+            .expect("tempdir");
+
+        // Six snapshots, oldest first, plus two files the prune must not touch.
+        let stamps = [
+            "1700000000",
+            "1755720000000",
+            "1755720000001",
+            "1755720001000",
+            "1755720002000",
+            "1755720003000",
+        ];
+        for stamp in stamps {
+            std::fs::write(dir.path().join(format!("accounts.bad-{stamp}.json")), "{}")
+                .expect("write backup");
+        }
+        std::fs::write(dir.path().join("accounts.json"), "{}").expect("write index");
+        std::fs::write(dir.path().join("pollis_u.db"), "x").expect("write db");
+
+        prune_bad_index_backups(dir.path());
+
+        let mut left: Vec<String> = std::fs::read_dir(dir.path())
+            .expect("read_dir")
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .collect();
+        left.sort();
+
+        assert_eq!(
+            left,
+            vec![
+                "accounts.bad-1755720001000.json".to_string(),
+                "accounts.bad-1755720002000.json".to_string(),
+                "accounts.bad-1755720003000.json".to_string(),
+                "accounts.json".to_string(),
+                "pollis_u.db".to_string(),
+            ]
+        );
+    }
 }

--- a/pollis-core/src/bridge.rs
+++ b/pollis-core/src/bridge.rs
@@ -274,7 +274,7 @@ async fn invoke_inner(cmd: String, args_json: String) -> Result<String, BridgeEr
             auth::logout(&state()?, delete).await?;
             ok(())
         }
-        "list_known_accounts" => ok(auth::list_known_accounts()?),
+        "list_known_accounts" => ok(auth::list_known_accounts(&state()?).await?),
         "request_email_change_otp" => {
             let user_id: String = arg(&args, "userId")?;
             let new_email: String = arg(&args, "newEmail")?;

--- a/pollis-core/src/commands/auth.rs
+++ b/pollis-core/src/commands/auth.rs
@@ -8,6 +8,16 @@ use ulid::Ulid;
 
 const DEVICE_ID_KEY: &str = "device_id";
 
+/// Per-user keystore slot holding this account's login address (#997).
+///
+/// It used to sit in plaintext in `accounts.json` — the one field on the device
+/// that maps an opaque account id to a person, and the only one outside every
+/// protection the product has. The keystore is the right home and costs nothing:
+/// every reader of the address already runs at a moment where the keystore is
+/// reachable, including [`stable_device_id_for_reenrollment`], which reads
+/// [`DEVICE_ID_KEY`] from it at exactly this pre-unlock point.
+const LOGIN_EMAIL_KEY: &str = "login_email";
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct UserProfile {
     pub id: String,
@@ -337,7 +347,8 @@ async fn verify_otp_ds(
         enrollment_required,
     };
 
-    crate::accounts::upsert_account(&profile.id, &profile.username, Some(&profile.email), None)?;
+    crate::accounts::upsert_account(&profile.id, &profile.username, None)?;
+    store_login_email(state, &profile.id, &profile.email).await;
 
     Ok(profile)
 }
@@ -404,7 +415,135 @@ async fn ensure_device_id(
     Ok(device_id)
 }
 
-/// Resolve an email address to a `user_id` from the LOCAL accounts index.
+/// Read a user's login address out of the per-user keystore (#997).
+///
+/// `None` on ANY failure, deliberately. The whitepaper §4 records that transient
+/// keychain / secret-service errors used to bounce returning users back to OTP,
+/// so a hiccup here must degrade — to "type your email", which is the screen a
+/// brand-new device sees anyway — and never propagate as an error out of a call
+/// whose other results are perfectly good.
+async fn login_email_for_user(state: &Arc<AppState>, user_id: &str) -> Option<String> {
+    let bytes = state
+        .keystore
+        .load_for_user(LOGIN_EMAIL_KEY, user_id)
+        .await
+        .unwrap_or(None)?;
+    String::from_utf8(bytes).ok()
+}
+
+/// Persist a user's login address in the per-user keystore, next to every other
+/// per-user secret. Called by each site that also calls `upsert_account`.
+///
+/// Best-effort for the same reason [`login_email_for_user`] is: a keystore
+/// hiccup must not fail a login that has otherwise fully succeeded. A miss costs
+/// the login screen's one-click chip and the returning-device `device_id` reuse,
+/// and both re-establish on the next successful login.
+///
+/// Returns whether the address actually landed, which only the upgrade path
+/// below cares about — it must not erase the plaintext copy on disk until the
+/// keystore has taken one.
+async fn store_login_email(state: &Arc<AppState>, user_id: &str, email: &str) -> bool {
+    match state
+        .keystore
+        .store_for_user(LOGIN_EMAIL_KEY, user_id, email.as_bytes())
+        .await
+    {
+        Ok(()) => true,
+        Err(e) => {
+            eprintln!("[auth] could not persist the login address for {user_id}: {e}");
+            false
+        }
+    }
+}
+
+/// Read the accounts index, first moving any pre-#997 plaintext login address it
+/// still carries into the per-user keystore and erasing it from the file.
+///
+/// This is the upgrade path, and it is load-bearing rather than cosmetic. Every
+/// install that predates #997 has the address in `accounts.json` and nowhere
+/// else; without this it would lose the pre-unlock email → `user_id` resolution
+/// — #419's returning-device path — and the login screen's "continue as" chip
+/// until the user signed in by OTP again. It runs at the three places that need
+/// the address, all of which are already async with `state` in hand.
+///
+/// Ordering is deliberate: keystore write first, disk erase second. An address
+/// already in the keystore wins over the file's copy, because every writer since
+/// the upgrade has kept the keystore current. If ANY account's keystore write
+/// fails, nothing is erased and the next launch simply tries again — a failed
+/// migration must never be a lost address.
+async fn read_accounts_index_migrated(
+    state: &Arc<AppState>,
+) -> Result<crate::accounts::AccountsIndex> {
+    let index = crate::accounts::read_accounts_index()?;
+
+    if adopt_legacy_login_emails(state, &index.accounts).await {
+        if let Err(e) = crate::accounts::forget_legacy_emails() {
+            eprintln!("[auth] could not erase legacy login addresses from accounts.json: {e}");
+        }
+    }
+
+    Ok(index)
+}
+
+/// Move every pre-#997 address these accounts still carry into the keystore.
+///
+/// Returns whether the file is now safe to rewrite without them: true only when
+/// at least one legacy address was seen AND every one of them is now in the
+/// keystore. Split from [`read_accounts_index_migrated`] at the index read, for
+/// the same reason [`user_id_for_email_among`] is — the keystore is hermetic per
+/// `AppState`, the on-disk index is process-global.
+async fn adopt_legacy_login_emails(
+    state: &Arc<AppState>,
+    accounts: &[crate::accounts::AccountInfo],
+) -> bool {
+    let mut saw_legacy = false;
+    let mut adopted_all = true;
+
+    for account in accounts {
+        let Some(legacy) = account.legacy_email.as_deref() else {
+            continue;
+        };
+        saw_legacy = true;
+        // A keystore entry wins over the file's copy: every writer since the
+        // upgrade has kept the keystore current, and the file's is frozen at
+        // whatever the last pre-upgrade login wrote.
+        if login_email_for_user(state, &account.user_id).await.is_some() {
+            continue;
+        }
+        if !store_login_email(state, &account.user_id, legacy).await {
+            adopted_all = false;
+        }
+    }
+
+    saw_legacy && adopted_all
+}
+
+/// Match an email against the login addresses the keystore holds for `accounts`.
+///
+/// Split off from [`local_user_id_for_email`] at the index read so the matching
+/// rule itself is testable: the index lives at the process-global data dir,
+/// which unit tests in this crate cannot claim without fighting each other over
+/// it, while the keystore is per-`AppState` and therefore hermetic.
+///
+/// N is the number of accounts that have signed in on this device — three or so
+/// at the outside — so the linear scan of keystore reads is not worth indexing.
+async fn user_id_for_email_among(
+    state: &Arc<AppState>,
+    accounts: &[crate::accounts::AccountInfo],
+    email: &str,
+) -> Option<String> {
+    for account in accounts {
+        let Some(stored) = login_email_for_user(state, &account.user_id).await else {
+            continue;
+        };
+        if stored.eq_ignore_ascii_case(email) {
+            return Some(account.user_id.clone());
+        }
+    }
+    None
+}
+
+/// Resolve an email address to a `user_id` using only local state.
 ///
 /// The only such lookup available pre-unlock: the local DB is closed (so there
 /// is no device signer) and no OTP has run (so there is no session), which
@@ -412,17 +551,14 @@ async fn ensure_device_id(
 /// `SELECT id FROM users WHERE email = ?` that used to serve these call sites.
 /// `None` means "this machine has not signed into that address before", which is
 /// exactly the condition under which both callers want the fresh-device path.
-fn local_user_id_for_email(email: &str) -> Option<String> {
-    let index = crate::accounts::read_accounts_index().ok()?;
-    index
-        .accounts
-        .iter()
-        .find(|a| {
-            a.email
-                .as_deref()
-                .is_some_and(|e| e.eq_ignore_ascii_case(email))
-        })
-        .map(|a| a.user_id.clone())
+///
+/// The candidate `user_id`s come from `accounts.json`; the addresses they are
+/// matched against come from the keystore (#997), which is readable at this
+/// moment for exactly the reason [`stable_device_id_for_reenrollment`] — the
+/// caller below — can already read [`DEVICE_ID_KEY`] out of it here.
+async fn local_user_id_for_email(state: &Arc<AppState>, email: &str) -> Option<String> {
+    let index = read_accounts_index_migrated(state).await.ok()?;
+    user_id_for_email_among(state, &index.accounts, email).await
 }
 
 /// For a RETURNING, not-yet-enrolled device, return its existing stable
@@ -438,7 +574,7 @@ fn local_user_id_for_email(email: &str) -> Option<String> {
 /// enrollment check reads the keystore, not the still-locked DB, so it is valid
 /// here pre-unlock (same call site semantics as the `enrollment_required` calc).
 async fn stable_device_id_for_reenrollment(state: &Arc<AppState>, email: &str) -> Option<String> {
-    let user_id = local_user_id_for_email(email)?;
+    let user_id = local_user_id_for_email(state, email).await?;
 
     let enrolled = crate::commands::account_identity::has_local_account_identity(state, &user_id)
         .await
@@ -553,12 +689,16 @@ pub async fn verify_email_change(
         }
     };
 
-    // Mirror the new email into the local accounts index so the login screen's
-    // "continue as" picker shows the new address. Runs after the swap succeeds.
+    // Mirror the new email into the keystore so the login screen's "continue as"
+    // picker offers the new address, and so the pre-unlock
+    // `local_user_id_for_email` resolution follows the account. Runs after the
+    // swap succeeds. Touch the accounts index too — it carries the `last_seen`
+    // and username this flow can also have changed.
     if let Some(username) = username {
-        if let Err(e) = crate::accounts::upsert_account(&user_id, &username, Some(&trimmed), None) {
+        if let Err(e) = crate::accounts::upsert_account(&user_id, &username, None) {
             eprintln!("[auth] email-change accounts.json mirror failed: {e}");
         }
+        store_login_email(state, &user_id, &trimmed).await;
     }
 
     Ok(())
@@ -614,7 +754,7 @@ pub async fn get_session(state: &Arc<AppState>) -> Result<Option<UserProfile>> {
     }
 
     // Identify the last active user from the local accounts index.
-    let index = crate::accounts::read_accounts_index()?;
+    let index = read_accounts_index_migrated(state).await?;
     let account = match index
         .last_active_user
         .and_then(|uid| index.accounts.iter().find(|a| a.user_id == uid).cloned())
@@ -626,9 +766,16 @@ pub async fn get_session(state: &Arc<AppState>) -> Result<Option<UserProfile>> {
         }
     };
 
+    // The address is a keystore read now (#997), not a field of the index. Empty
+    // on a keystore miss, exactly as an absent `email` field used to be — the
+    // downstream `UserProfile.email` contract is unchanged.
+    let email = login_email_for_user(state, &account.user_id)
+        .await
+        .unwrap_or_default();
+
     let mut profile = UserProfile {
         id: account.user_id.clone(),
-        email: account.email.clone().unwrap_or_default(),
+        email,
         username: account.username.clone(),
         new_secret_key: None,
         enrollment_required: false,
@@ -793,7 +940,7 @@ async fn dev_login_ds(state: &Arc<AppState>, email: String) -> Result<UserProfil
     // below would degenerate into a fresh candidate anyway, and the standard
     // first-device DS bootstrap (verify_otp_ds via verify_otp) is the correct
     // path. That covers both a brand-new dev account and a clean dev machine.
-    let user_id = match local_user_id_for_email(&email) {
+    let user_id = match local_user_id_for_email(state, &email).await {
         Some(uid) => uid,
         None => {
             eprintln!(
@@ -872,7 +1019,8 @@ async fn dev_login_ds(state: &Arc<AppState>, email: String) -> Result<UserProfil
             .await
             .unwrap_or(false);
 
-    crate::accounts::upsert_account(&user_id, &username, Some(&email), None)?;
+    crate::accounts::upsert_account(&user_id, &username, None)?;
+    store_login_email(state, &user_id, &email).await;
 
     eprintln!("[auth] DEV_EMAIL: DS-enrolled device {device_id} for {user_id}");
     Ok(UserProfile {
@@ -988,6 +1136,7 @@ pub async fn logout(state: &Arc<AppState>, delete_data: bool) -> Result<()> {
             let _ = state.keystore.delete_for_user("account_id_key_wrapped", uid).await;
             let _ = state.keystore.delete_for_user("pin_meta", uid).await;
             let _ = state.keystore.delete_for_user(DEVICE_ID_KEY, uid).await;
+            let _ = state.keystore.delete_for_user(LOGIN_EMAIL_KEY, uid).await;
             let data_dir = crate::db::local::dirs_path();
             let db_path = data_dir.join(format!("pollis_{uid}.db"));
             if db_path.exists() {
@@ -1090,6 +1239,7 @@ pub async fn delete_account(
     let _ = state.keystore.delete_for_user("account_id_key_wrapped", &user_id).await;
     let _ = state.keystore.delete_for_user("pin_meta", &user_id).await;
     let _ = state.keystore.delete_for_user(DEVICE_ID_KEY, &user_id).await;
+    let _ = state.keystore.delete_for_user(LOGIN_EMAIL_KEY, &user_id).await;
     *state.device_id.lock().await = None;
     *state.unlock.lock().await = None;
 
@@ -1102,8 +1252,34 @@ pub async fn delete_account(
 
 /// Return the list of accounts that have previously signed in on this device.
 /// Used by the login screen to show a "continue as" picker.
-pub fn list_known_accounts() -> Result<crate::accounts::AccountsIndex> {
-    crate::accounts::read_accounts_index()
+///
+/// The index supplies the identity and display fields; the login address is
+/// rehydrated per account from the keystore (#997), which is why this is async
+/// and takes `state`. The JSON it produces is identical to what the raw index
+/// serialized to before that move, so the renderer is untouched.
+///
+/// A per-account keystore read that fails yields `email: None` for that account
+/// and nothing more — see [`login_email_for_user`]. The picker then renders that
+/// chip disabled and the user types their address, which is strictly better than
+/// failing the whole call and hiding every OTHER account's chip too.
+pub async fn list_known_accounts(state: &Arc<AppState>) -> Result<crate::accounts::KnownAccounts> {
+    let index = read_accounts_index_migrated(state).await?;
+
+    let mut accounts = Vec::with_capacity(index.accounts.len());
+    for account in &index.accounts {
+        accounts.push(crate::accounts::KnownAccount {
+            user_id: account.user_id.clone(),
+            username: account.username.clone(),
+            email: login_email_for_user(state, &account.user_id).await,
+            avatar_url: account.avatar_url.clone(),
+            last_seen: account.last_seen.clone(),
+        });
+    }
+
+    Ok(crate::accounts::KnownAccounts {
+        accounts,
+        last_active_user: index.last_active_user,
+    })
 }
 
 /// Delete all local data on this computer: per-user databases, keystore
@@ -1131,6 +1307,7 @@ pub async fn wipe_local_data(state: &Arc<AppState>) -> Result<()> {
         "account_id_key",
         "account_id_key_wrapped",
         "pin_meta",
+        LOGIN_EMAIL_KEY,
     ];
     for account in &index.accounts {
         for key in &per_user_keys {
@@ -1328,6 +1505,234 @@ pub async fn is_current_device_registered(
     )
     .await?;
     Ok(rows.iter().any(|d| d.device_id == device_id))
+}
+
+/// The pre-unlock email → `user_id` resolution, after #997 moved the address
+/// out of `accounts.json` and into the per-user keystore.
+///
+/// Everything here runs against a bare `AppState`: `local_db` is `None`,
+/// `unlock` is `None`, `device_id` is `None`. That is not incidental — it is the
+/// exact state the callers run in (no signer, no session, no DS credential), and
+/// it is the whole reason a locally-resolvable address has to exist at all.
+#[cfg(test)]
+mod prelock_email_resolution {
+    use super::*;
+    use crate::accounts::AccountInfo;
+    use crate::config::Config;
+    use crate::keystore::{InMemoryKeystore, Keystore};
+
+    fn locked_state() -> Arc<AppState> {
+        let keystore: Arc<dyn Keystore> = Arc::new(InMemoryKeystore::new());
+        Arc::new(AppState::new_with_parts(
+            Config::for_test().expect("test config"),
+            keystore,
+        ))
+    }
+
+    fn account(user_id: &str, username: &str) -> AccountInfo {
+        AccountInfo {
+            user_id: user_id.to_string(),
+            username: username.to_string(),
+            avatar_url: None,
+            last_seen: "2026-08-01T10:00:00+00:00".to_string(),
+            legacy_email: None,
+        }
+    }
+
+    /// An entry as a pre-#997 `accounts.json` deserializes to it.
+    fn legacy_account(user_id: &str, username: &str, email: &str) -> AccountInfo {
+        AccountInfo {
+            legacy_email: Some(email.to_string()),
+            ..account(user_id, username)
+        }
+    }
+
+    async fn assert_fully_locked(state: &Arc<AppState>) {
+        assert!(state.local_db.lock().await.is_none(), "local DB must be closed");
+        assert!(state.unlock.lock().await.is_none(), "no unlocked session");
+        assert!(state.device_id.lock().await.is_none(), "no device id yet");
+    }
+
+    /// The returning-device path (#419): a machine that has signed into this
+    /// address before resolves its `user_id` with nothing open.
+    #[tokio::test]
+    async fn a_returning_address_resolves_with_the_database_closed() {
+        let state = locked_state();
+        let accounts = vec![account("01USER_A", "alice"), account("01USER_B", "bob")];
+        store_login_email(&state, "01USER_A", "alice@example.com").await;
+        store_login_email(&state, "01USER_B", "bob@example.com").await;
+
+        assert_fully_locked(&state).await;
+
+        assert_eq!(
+            user_id_for_email_among(&state, &accounts, "bob@example.com").await,
+            Some("01USER_B".to_string())
+        );
+        assert_eq!(
+            user_id_for_email_among(&state, &accounts, "alice@example.com").await,
+            Some("01USER_A".to_string())
+        );
+    }
+
+    /// Case-insensitivity is the property that made a masked address unusable
+    /// here: `***@example.com` would compare equal for BOTH accounts below and
+    /// resolve to an arbitrary one. Real addresses cannot collide, so the
+    /// resolution stays exact even when two accounts share a domain.
+    #[tokio::test]
+    async fn matching_is_case_insensitive_and_never_collides_on_the_domain() {
+        let state = locked_state();
+        let accounts = vec![account("01USER_A", "alice"), account("01USER_B", "bob")];
+        store_login_email(&state, "01USER_A", "Alice@Example.com").await;
+        store_login_email(&state, "01USER_B", "bob@example.com").await;
+
+        assert_eq!(
+            user_id_for_email_among(&state, &accounts, "ALICE@EXAMPLE.COM").await,
+            Some("01USER_A".to_string())
+        );
+        assert_eq!(
+            user_id_for_email_among(&state, &accounts, "BOB@example.com").await,
+            Some("01USER_B".to_string())
+        );
+    }
+
+    /// An address this machine has never signed into resolves to `None` — the
+    /// signal both callers read as "fresh device, take the first-device path".
+    #[tokio::test]
+    async fn an_unknown_address_does_not_resolve() {
+        let state = locked_state();
+        let accounts = vec![account("01USER_A", "alice")];
+        store_login_email(&state, "01USER_A", "alice@example.com").await;
+
+        assert_eq!(
+            user_id_for_email_among(&state, &accounts, "stranger@example.com").await,
+            None
+        );
+    }
+
+    /// An account present in the index but with no keystore entry — a legacy
+    /// install whose address is only in the pre-#997 `accounts.json`, or a
+    /// keystore that failed to answer — must not stall the scan or resolve to
+    /// the wrong account. It is skipped, and the account behind it still wins.
+    #[tokio::test]
+    async fn an_account_without_a_stored_address_is_skipped_not_matched() {
+        let state = locked_state();
+        let accounts = vec![account("01LEGACY", "legacy"), account("01USER_B", "bob")];
+        store_login_email(&state, "01USER_B", "bob@example.com").await;
+
+        assert_eq!(
+            user_id_for_email_among(&state, &accounts, "legacy@example.com").await,
+            None
+        );
+        assert_eq!(
+            user_id_for_email_among(&state, &accounts, "bob@example.com").await,
+            Some("01USER_B".to_string())
+        );
+    }
+
+    /// The whole point of the move: the address lives in the keystore, and
+    /// `AccountInfo` — everything `accounts.json` serializes — has no field that
+    /// can hold it. This is the invalid state the change makes unrepresentable.
+    #[tokio::test]
+    async fn the_address_is_readable_from_the_keystore_and_absent_from_the_index() {
+        let state = locked_state();
+        let entry = account("01USER_A", "alice");
+        store_login_email(&state, "01USER_A", "alice@example.com").await;
+
+        assert_eq!(
+            login_email_for_user(&state, "01USER_A").await,
+            Some("alice@example.com".to_string())
+        );
+
+        let serialized = serde_json::to_string(&entry).expect("serialize");
+        assert!(
+            !serialized.contains("alice@example.com") && !serialized.contains("email"),
+            "the index entry must not be able to carry an address: {serialized}"
+        );
+    }
+
+    /// The upgrade path. An install that predates #997 has the address on disk
+    /// and nowhere else; after one migrated read it is in the keystore and the
+    /// returning-device resolution works from there — which is the whole reason
+    /// the move could not simply DROP the field.
+    #[tokio::test]
+    async fn a_legacy_address_is_adopted_into_the_keystore_and_then_resolves() {
+        let state = locked_state();
+        let accounts = vec![
+            legacy_account("01USER_A", "alice", "alice@example.com"),
+            legacy_account("01USER_B", "bob", "bob@example.com"),
+        ];
+
+        // Before the migration the keystore knows nothing, so nothing resolves.
+        assert_eq!(login_email_for_user(&state, "01USER_A").await, None);
+        assert_eq!(
+            user_id_for_email_among(&state, &accounts, "alice@example.com").await,
+            None
+        );
+
+        assert!(
+            adopt_legacy_login_emails(&state, &accounts).await,
+            "every legacy address was adopted, so the file may be rewritten"
+        );
+
+        assert_fully_locked(&state).await;
+        assert_eq!(
+            user_id_for_email_among(&state, &accounts, "alice@example.com").await,
+            Some("01USER_A".to_string())
+        );
+        assert_eq!(
+            user_id_for_email_among(&state, &accounts, "bob@example.com").await,
+            Some("01USER_B".to_string())
+        );
+    }
+
+    /// An index with nothing legacy in it must not authorize a rewrite — the
+    /// erase step is for files that actually carry an address, and a launch that
+    /// finds none should leave the file untouched.
+    #[tokio::test]
+    async fn an_index_with_no_legacy_address_authorizes_no_rewrite() {
+        let state = locked_state();
+        let accounts = vec![account("01USER_A", "alice")];
+
+        assert!(!adopt_legacy_login_emails(&state, &accounts).await);
+    }
+
+    /// The keystore is the newer copy once the upgrade has run: a stale address
+    /// still sitting in the file must not overwrite the one a later email change
+    /// wrote to the keystore.
+    #[tokio::test]
+    async fn a_stale_file_address_never_overwrites_the_keystore() {
+        let state = locked_state();
+        let accounts = vec![legacy_account("01USER_A", "alice", "old@example.com")];
+        store_login_email(&state, "01USER_A", "new@example.com").await;
+
+        assert!(adopt_legacy_login_emails(&state, &accounts).await);
+
+        assert_eq!(
+            login_email_for_user(&state, "01USER_A").await,
+            Some("new@example.com".to_string())
+        );
+    }
+
+    /// Deleting the account clears the address with everything else, so a wiped
+    /// account leaves nothing behind to resolve.
+    #[tokio::test]
+    async fn deleting_the_stored_address_unresolves_the_account() {
+        let state = locked_state();
+        let accounts = vec![account("01USER_A", "alice")];
+        store_login_email(&state, "01USER_A", "alice@example.com").await;
+
+        state
+            .keystore
+            .delete_for_user(LOGIN_EMAIL_KEY, "01USER_A")
+            .await
+            .expect("delete");
+
+        assert_eq!(login_email_for_user(&state, "01USER_A").await, None);
+        assert_eq!(
+            user_id_for_email_among(&state, &accounts, "alice@example.com").await,
+            None
+        );
+    }
 }
 
 #[cfg(test)]

--- a/pollis-tui/tests/common/mod.rs
+++ b/pollis-tui/tests/common/mod.rs
@@ -481,7 +481,7 @@ impl TestClient {
         // every subsequent DB/keystore touch) lands in THIS device's dir.
         self.use_dir();
         if let Some(p) = &self.profile {
-            let _ = accounts::upsert_account(&p.id, &p.username, None, None);
+            let _ = accounts::upsert_account(&p.id, &p.username, None);
         }
     }
 

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -59,8 +59,8 @@ pub async fn delete_account(state: State<'_, Arc<AppState>>, user_id: String) ->
 }
 
 #[tauri::command]
-pub fn list_known_accounts() -> Result<crate::accounts::AccountsIndex> {
-    pollis_core::commands::auth::list_known_accounts()
+pub async fn list_known_accounts(state: State<'_, Arc<AppState>>) -> Result<crate::accounts::KnownAccounts> {
+    pollis_core::commands::auth::list_known_accounts(&state).await
 }
 
 #[tauri::command]

--- a/src-tauri/tests/flows/harness.rs
+++ b/src-tauri/tests/flows/harness.rs
@@ -1091,7 +1091,7 @@ impl TestClient {
     /// so flipping the active user immediately before dispatch is race-free.
     fn activate(&self) {
         if let Some(p) = &self.profile {
-            let _ = pollis_lib::accounts::upsert_account(&p.id, &p.username, None, None);
+            let _ = pollis_lib::accounts::upsert_account(&p.id, &p.username, None);
         }
     }
 


### PR DESCRIPTION
Closes #997. The decision on that ticket was the keystore, not masking, hashing, or dropping.

`accounts.json` now holds only opaque `user_id`, `username`, `avatar_url`, `last_seen` and `last_active_user`. The login address lives in the per-user keystore slot `login_email_{user_id}`, alongside `device_id_{user_id}` and the wrapped keys.

**Why not the cheaper options.** `local_user_id_for_email` resolves an address to a `user_id` *pre-unlock* — local DB closed, no signer, no session — by case-insensitive equality. Masked values collide for every account at a shared domain, so masking would resolve a returning user to an arbitrary account. Dropping the field loses the resolution entirely and regresses #419's returning-device path. A hash preserves it but kills the one-click "continue as" chip and, against low-entropy email, buys confirmation-resistance rather than secrecy. The keystore costs no UX and no frontend change.

**How the pre-unlock resolution works now.** `accounts.json` still supplies the candidate `user_id`s; each is matched against its keystore `login_email` (N ≤ 3 in practice). The keystore is readable at exactly that moment — `stable_device_id_for_reenrollment` already reads `DEVICE_ID_KEY` from it there.

**Migration.** A file written by an older build still carries `email`, read through `AccountInfo::legacy_email` (`#[serde(default, rename = "email", skip_serializing_if)]`). The first migrated read adopts it into the keystore and only then rewrites the file without it; if any keystore write fails nothing is erased and the next launch retries. Ordinary writes carry the field through untouched, so a login on a multi-account device cannot destroy an address the keystore has not taken yet. Without this, every existing install would silently lose the returning-device path.

`serde(default)` is load-bearing throughout: `AccountInfo` annotates no other field, and a missing field on an un-annotated type is a parse error, which the read path escalates to `AccountsIndexCorrupt` — minting exactly the permanent plaintext-email `accounts.bad-*.json` snapshot this change exists to eliminate.

**No frontend change.** `list_known_accounts` returns a DTO whose JSON is identical to the old raw index; `frontend/src/types/index.ts` and `LoginScreen.tsx` are untouched. A keystore hiccup degrades one account's chip to `email: null` rather than failing the call (whitepaper §4: transient keychain failures used to bounce returning users to OTP).

**Also here, same file.** `accounts.bad-*.json` snapshots are pruned to the newest three (nothing removed them before) and their stamp moved from seconds to milliseconds, so two corruptions in one second no longer overwrite each other. `accounts.json.tmp` is removed on the rename-error path.

**Docs.** `accounts.json` joins the whitepaper trust table with a new §1.1.1 stating what it holds, what protects it, and why that is acceptable; §8.2's unauthenticated account-probe argument now cross-references it instead of assuming it. `ARCHITECTURE.md` and the wiki storage model updated.

**Tests.** A pre-#997 file with the `email` key parses cleanly; an ordinary write preserves an unadopted address while an explicit clear erases it; and the pre-unlock resolution is exercised against an `AppState` with the local DB closed, no unlock and no device id — including adoption, case-insensitivity, unknown addresses, missing entries, and stale-file-vs-keystore precedence.

**Out of scope, worth a ticket.** `EnrollmentGateScreen` passes `placeholder={expectedEmail}`, displaying the answer to its own confirmation prompt. Unaffected by this change (`UserProfile.email` stays populated) and deliberately not fixed here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbrzJCaXpibaviYetQWGNF)_