### PR TITLE
Let the recovery key be copied and saved, not just hand-selected

### DIFF
--- a/mobile/app/(auth)/emergency-kit.tsx
+++ b/mobile/app/(auth)/emergency-kit.tsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
-import { View, Text, Pressable, ScrollView } from "react-native";
+import { useEffect, useRef, useState } from "react";
+import { View, Text, Pressable, ScrollView, Share } from "react-native";
+import * as Clipboard from "expo-clipboard";
 import { useRouter } from "expo-router";
 import {
   Screen,
@@ -23,12 +24,71 @@ import { observer } from "mobx-react-lite";
  * After ACK we route to /(auth)/initializing — exactly the same path a
  * returning user takes — so the rest of the launch sequence stays the
  * same regardless of whether this was a new account or not.
+ *
+ * The key is shown exactly once and is unrecoverable afterwards, so it needs
+ * real ways OFF this screen. `selectable` text alone was not one: it is an
+ * undiscoverable long-press, it selects a 40-odd character mono string by
+ * hand, and it is the single worst string in the product to mis-transcribe.
+ * COPY and SAVE below mirror the desktop `SaveSecretKeyScreen` affordances.
  */
+
+// How long a copy outcome stays on the button before returning to idle.
+// Matches CreatedInviteLinkCard, the other once-only-secret surface.
+const COPY_FEEDBACK_MS = 2000;
+
+type CopyState = "idle" | "copied" | "failed";
+
+/**
+ * The emergency-kit document, byte-for-byte the same text desktop writes to
+ * `pollis-emergency-kit-*.txt` (`auth:emergencyKit.document`). Whatever the
+ * user saves on a phone should be the same artifact they would have saved on
+ * a laptop — a kit that reads differently per platform is a support problem
+ * the day someone compares them.
+ */
+function emergencyKitDocument(secretKey: string): string {
+  return `POLLIS — EMERGENCY KIT
+======================
+
+Your Secret Key is the only way to recover access to your account
+from a new device when you don't have any other Pollis device with
+you. Treat it like a master password.
+
+If you lose this key AND lose access to all of your devices,
+your account is unrecoverable. Pollis cannot reset it for you.
+
+  SECRET KEY:
+
+    ${secretKey}
+
+Store this file somewhere safe (a password manager, encrypted
+backup, or printed and locked away). Anyone with this key + your
+email address can sign in as you on a new device.
+
+Generated: ${new Date().toISOString()}
+`;
+}
+
 function EmergencyKit() {
   const router = useRouter();
   const pendingSecretKey = appStore.pendingSecretKey;
   const setPendingSecretKey = appStore.setPendingSecretKey;
   const [acknowledged, setAcknowledged] = useState(false);
+  const [copyState, setCopyState] = useState<CopyState>("idle");
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clear the outcome a couple of seconds after it appears, and never leave a
+  // timer behind that would set state on an unmounted screen.
+  useEffect(() => {
+    if (copyState === "idle") {
+      return;
+    }
+    timer.current = setTimeout(() => setCopyState("idle"), COPY_FEEDBACK_MS);
+    return () => {
+      if (timer.current) {
+        clearTimeout(timer.current);
+      }
+    };
+  }, [copyState]);
 
   // Defensive: if someone deep-links here without a stashed key, just
   // continue to initializing — nothing to display.
@@ -40,6 +100,35 @@ function EmergencyKit() {
   const onContinue = () => {
     setPendingSecretKey(null);
     router.replace("/(auth)/initializing");
+  };
+
+  // VERIFIED copy (#897/#958 semantics): `setStringAsync` resolves to a
+  // boolean, and a rejected or false write shows as a visible failure. A key
+  // that is shown once and silently failed to copy is the worst possible thing
+  // to report as success. We deliberately do NOT read the clipboard back —
+  // on iOS 14+ that fires the system "pasted from Pollis" banner every tap.
+  const onCopy = async () => {
+    // Back to idle first so a second tap on an already-failed button is a
+    // visible state change, and so the feedback timer restarts.
+    setCopyState("idle");
+    const copied = await Clipboard.setStringAsync(pendingSecretKey).catch(
+      () => false,
+    );
+    setCopyState(copied ? "copied" : "failed");
+  };
+
+  // Hand the whole kit to the OS share sheet — password manager, Notes, Mail,
+  // AirDrop to a laptop. Deliberately passed as `message`, NOT written to a
+  // file first: #1001 closed the plaintext-on-disk leaks and staged pasted
+  // attachments in memory rather than through a temp file, and the recovery
+  // key is the most sensitive string the app ever holds. Desktop can write a
+  // .txt because it hands it straight to the OS download flow; here a file
+  // would have to sit in the app sandbox first, so this stays in memory.
+  // Dismissing the sheet is a normal outcome, not an error state.
+  const onShare = () => {
+    Share.share({ message: emergencyKitDocument(pendingSecretKey) }).catch(
+      () => {},
+    );
   };
 
   return (
@@ -80,6 +169,42 @@ function EmergencyKit() {
               {pendingSecretKey}
             </Text>
           </Card>
+
+          <View style={{ flexDirection: "row", gap: 8 }}>
+            <View style={{ flex: 1 }}>
+              <Button
+                full
+                testID="btn-copy-recovery-key"
+                variant={copyState === "failed" ? "danger" : "primary"}
+                onPress={onCopy}
+                icon={
+                  copyState === "copied" ? (
+                    <Icon.check color="#0a0907" />
+                  ) : copyState === "failed" ? (
+                    <Icon.alert color={semantic.danger} />
+                  ) : (
+                    <Icon.copy color="#0a0907" />
+                  )
+                }
+              >
+                {copyState === "copied"
+                  ? "COPIED"
+                  : copyState === "failed"
+                    ? "COPY FAILED"
+                    : "COPY"}
+              </Button>
+            </View>
+            <View style={{ flex: 1 }}>
+              <Button
+                full
+                testID="btn-share-recovery-key"
+                onPress={onShare}
+                icon={<Icon.share color={semantic.ink} />}
+              >
+                SAVE
+              </Button>
+            </View>
+          </View>
 
           <View
             style={{


### PR DESCRIPTION
Closes #1008.

`app/(auth)/emergency-kit.tsx` shows the recovery key exactly once and then drops it from memory forever. The only way to get it off that screen was `selectable` on the `<Text>` — an undiscoverable long-press that makes the user hand-select a ~40-character mono string. It is the single worst string in the product to mis-transcribe, and losing it means the account is unrecoverable.

Desktop already solves this (`frontend/src/components/Auth/SaveSecretKeyScreen.tsx`: copy + a formatted `.txt` download). Mobile now has:

- **COPY** with verified clipboard semantics (#897/#958) — `setStringAsync` resolves to a boolean and a failed write shows `COPY FAILED` in the danger variant. Silently reporting a failed copy of a once-only secret as success is the worst available outcome. It deliberately does not read the clipboard back: on iOS 14+ that fires the "pasted from Pollis" banner every tap. Same treatment `CreatedInviteLinkCard` already gives the other once-only secret.
- **SAVE** handing the full emergency-kit document to the OS share sheet — password manager, Notes, Mail, AirDrop to a laptop.

The document text is byte-for-byte desktop's `auth:emergencyKit.document`, so a kit saved on a phone is the same artifact as one saved on a laptop.

## Why no file

Desktop writes a real `.txt` because it hands it straight to the OS download flow. On mobile a file has to be staged in the app sandbox first, which is exactly the class #1001 closed (it moved pasted attachments to in-memory staging rather than a temp file). The recovery key is the most sensitive string the app holds, so the share sheet gets it in memory and nothing touches disk.

Trade-off, stated plainly: iOS's share sheet will not offer "Save to Files" for plain text, only apps. If true parity with desktop's `.txt` is wanted, that is a follow-up decision, not a silent one.

## Verification

Built Release and driven on the iPhone 16 Pro simulator through a real signup — both buttons render and the screen reaches the key with a live account. Typecheck clean.