### PR TITLE
Correct the stale test-harness justification in CI that cited the deleted RemoteDb

### DIFF
--- a/.github/workflows/mls-tests.yml
+++ b/.github/workflows/mls-tests.yml
@@ -249,13 +249,20 @@ jobs:
 
       # openmls-level MLS state-machine tests (mls/tests.rs, reconcile, etc.).
       #
-      # `--features test-harness` (#914): the feature exists so integration tests
-      # can build a real `RemoteDb` over a local file (`RemoteDb::connect_local`,
-      # gated `#[cfg(any(test, feature = "test-harness"))]`). Without it every
-      # pollis-core integration test that needs one silently could not exist —
-      # `tests/remote_with_retry.rs` compiled to nothing here while passing
-      # locally. The feature only ADDS test-only constructors; it changes no
-      # production behaviour, and the flows step below already runs with it.
+      # `--features test-harness` (#914): the feature exists so integration
+      # tests can reach constructors and overrides that are `#[cfg(any(test,
+      # feature = "test-harness"))]` — the in-memory MLS storage
+      # (`signal/mls_storage.rs`), the config overrides (`config.rs`), the R2
+      # stubs (`commands/r2.rs`) and the message test helpers. Without it those
+      # tests do not fail, they silently compile to nothing here while passing
+      # locally, which is the failure mode worth guarding against. The feature
+      # only ADDS test-only items; it changes no production behaviour, and the
+      # flows step below already runs with it.
+      #
+      # It used to be justified here by `RemoteDb::connect_local` and
+      # `tests/remote_with_retry.rs`. #987/#988 deleted `RemoteDb` and the
+      # client's database handle outright, so both are gone — the feature is
+      # still load-bearing for the reasons above.
       - name: MLS unit tests (pollis-core)
         if: ${{ !cancelled() }}
         run: cargo test -p pollis-core --features test-harness


### PR DESCRIPTION
Closes #914.

The helper the issue was about is gone: #981 first wired `with_retry` into real call sites, then #987/#988 deleted `RemoteDb` and the client's database handle outright. Every remaining citation in `.rs` and in `docs/` correctly describes it as deleted — except one, in CI, which still reads as if the type exists:

> the feature exists so integration tests can build a real `RemoteDb` over a local file (`RemoteDb::connect_local` …) … `tests/remote_with_retry.rs` compiled to nothing here

`RemoteDb`, `RemoteDb::connect_local` and `tests/remote_with_retry.rs` are all gone. That was the last dangling citation, and it sat on the one line explaining why the flag is passed — so the next person to touch it had no true reason for it.

`--features test-harness` is still load-bearing, just for different reasons, so the flag stays and the comment now names them: the in-memory MLS storage (`signal/mls_storage.rs`), config overrides (`config.rs`), R2 stubs (`commands/r2.rs`) and the message test helpers, all `#[cfg(any(test, feature = "test-harness"))]`. The failure mode worth keeping in the comment is that without the flag those tests do not fail — they silently compile to nothing in CI while passing locally.

Comment-only; no behaviour change. YAML re-validated.