### PR TITLE
Anchor short chat threads to the top instead of the composer

### DIFF
--- a/mobile/app/chat/[id].tsx
+++ b/mobile/app/chat/[id].tsx
@@ -462,7 +462,19 @@ function TextChat(props: ChatViewProps = {}) {
         keyExtractor={(item) => item.key}
         renderItem={renderItem}
         style={{ flex: 1 }}
-        contentContainerStyle={{ paddingVertical: 4 }}
+        // `flexGrow` + `justifyContent` anchor a SHORT thread to the visual
+        // top. Without them an inverted list pins its content to the visual
+        // bottom, so a new or nearly-empty conversation renders its handful of
+        // messages jammed against the composer with a large void under the
+        // header. Note the value looks inverted because it is: `inverted`
+        // flips the list, so `flex-end` in the flipped axis is the visual TOP.
+        // A thread taller than the viewport is unaffected — `flexGrow` only
+        // does anything while the content is shorter than the list.
+        contentContainerStyle={{
+          paddingVertical: 4,
+          flexGrow: 1,
+          justifyContent: "flex-end",
+        }}
         // With `inverted`, the "end" is the visual top — the oldest loaded
         // message. RN re-evaluates onEndReached on content-size changes as
         // well as scroll, so a prepend that leaves no scroll offset still


### PR DESCRIPTION
A new or nearly-empty conversation rendered its handful of messages jammed against the composer, with a large void between them and the header.

The timeline is an `inverted` FlatList. Inverted lists pin content to the visual bottom when it is shorter than the viewport, and the content container had no `flexGrow`, so nothing pushed it up.

```js
contentContainerStyle={{ paddingVertical: 4, flexGrow: 1, justifyContent: "flex-end" }}
```

`flex-end` looks backwards and is deliberate: `inverted` flips the layout axis, so `flex-end` in the flipped axis is the visual **top**. A thread taller than the viewport is unaffected — `flexGrow` only does anything while the content is shorter than the list.

Verified on the iPhone 16 Pro Max simulator against a real two-account conversation: messages now begin directly under the header. The screenshot set for the App Store listing was captured from this build.