### PR TITLE
Make the Maestro suite runnable (#709)

### DIFF
--- a/mobile/.maestro/README.md
+++ b/mobile/.maestro/README.md
@@ -15,8 +15,29 @@ form factors.
 ## Prerequisites (Mac)
 
 1. **Maestro** — `curl -Ls "https://get.maestro.mobile.dev" | bash`.
-2. **A DEV build of the app installed on each target device.** The build must
-   point at the **dev** Delivery Service and a dev LiveKit URL (baked at build
+1b. **A Java runtime.** Maestro is a JVM tool and dies with "Unable to locate a
+   Java Runtime" without one. `brew install openjdk@17` is keg-only, so
+   `/usr/libexec/java_home` cannot see it and installing alone is not enough —
+   export it:
+   ```bash
+   export JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home
+   ```
+2. **A RELEASE build of the app, pointed at the dev DS.** Both halves matter.
+
+   *Release, not dev-client.* Every flow opens with `clearState`, which wipes
+   expo-dev-client's stored dev-server URL — so a `pnpm expo run:ios` build
+   boots to the **dev-client launcher menu** and the app never loads. The suite
+   cannot drive that build at all. A Release build embeds the JS bundle and has
+   no launcher. It is also the more honest target: these flows are
+   timing-sensitive and dev-mode JS is not what ships.
+   ```bash
+   cd mobile && pnpm expo run:ios --device <simulator-udid> --configuration Release
+   ```
+   Pass the simulator by **UDID** (`xcrun simctl list devices`) and boot it
+   first; a name that matches no *booted* simulator makes xcodebuild fall
+   through to a physical-device destination and fail.
+
+   *Dev DS.* The build must point at the dev Delivery Service (baked at build
    time, not Maestro env):
    ```
    EXPO_PUBLIC_POLLIS_DELIVERY_URL=https://api-dev.pollis.com
@@ -24,8 +45,12 @@ form factors.
    # No database credential is needed or read since #987 — the client speaks
    # only to the Delivery Service.
    ```
-   Build + install: `cd mobile && pnpm expo run:ios` / `run:android` (see
-   `mobile/CLAUDE.md` for the ubrn/native steps). App id: `com.pollis.mobile`.
+   See `mobile/CLAUDE.md` for the ubrn/native steps. App id: `com.pollis.mobile`.
+
+   *After changing the ubrn target set* (e.g. building simulator-only slices),
+   re-run `pod install`: CocoaPods bakes the xcframework's slice paths into a
+   generated copy script, so a stale script silently copies **nothing** and the
+   app dies at launch on a uniffi checksum mismatch.
 3. **Seed env** — `cp .maestro/env.example .maestro/.env` and fill it in. The dev
    DS must have a fixed `DEV_OTP` so `MAESTRO_OTP` is deterministic (no inbox
    polling). `.env` is gitignored.
@@ -82,6 +107,37 @@ is more robust):
   `row-channel-<id>` isn't known ahead of time.
 Add these in a #620 follow-up and switch the `tapOn: "TEXT"` calls to
 `tapOn: id:`.
+
+## Known issues found by the first real run (2026-08-22)
+
+The suite had never been executed anywhere before this. Fixed here:
+
+- **Non-idempotent accounts.** Every flow `clearState`s and then signs UP, so a
+  single fixed `MAESTRO_EMAIL` only worked on its first use ever — after that
+  the account existed, auth took the returning-device enrollment path, no
+  create-PIN screen appeared, and the flow died on `screen-auth-pin`. Seven of
+  eight flows failed for this one reason. `maestro-run.sh` now mints a fresh
+  disposable address per flow and runs each flow as its own invocation.
+  (Enrollment needs the recovery key, which the harness cannot hold, so
+  re-signing-up is the only self-contained option.)
+- **`dms.yaml` had a step that could not fail.** It tapped
+  `row-user-${MAESTRO_PEER_HANDLE}`, but the app emits `row-user-<userId>`.
+  With `optional: true` the flow walked straight past and "sent" a message into
+  whatever screen it was on. Now an id regex prefix, and not optional.
+- **`sign-in.yaml` asserted the wrong landing screen.** It waited for
+  `screen-groups`; it now waits for the tab bar and each flow taps the tab it
+  needs.
+
+Still open, needs app-side triage (not harness bugs):
+
+- **Sign-in lands on the Self tab.** `initializing.tsx:76` replaces to
+  `/(tabs)/groups` and nothing in the app routes to `/(tabs)/self`, yet Self is
+  what renders. Reproducible.
+- **A handle rename does not reach messages you then send.** `sender_username`
+  is denormalized onto each message at send time from a cached `currentUser`
+  (`hooks/queries/useMessages.ts`), so after changing your handle your own new
+  messages still carry the old one — including across an app restart — while
+  the conversation header shows the new one.
 
 ## Note on authoring vs running
 

--- a/mobile/.maestro/flows/dms.yaml
+++ b/mobile/.maestro/flows/dms.yaml
@@ -21,16 +21,30 @@ tags:
     id: "input-user-search"
 - inputText: "${MAESTRO_PEER_HANDLE}"
 - takeScreenshot: dms-02-search
-# The exact-match result row starts the DM when tapped.
+# The result row starts the DM when tapped. Match the id as a REGEX PREFIX:
+# the app emits `row-user-<userId>`, not `row-user-<handle>`, and the user id
+# is not knowable ahead of time. This used to tap `row-user-${MAESTRO_PEER_HANDLE}`
+# with `optional: true`, which could never match — so the flow silently walked
+# past it and "sent" a message into whatever screen it was still on. A step
+# that cannot fail is not a test; `optional` is deliberately gone.
+#
+# Tapping the handle TEXT is not an alternative: the same string is in the
+# search box we just typed into, and tapping that opens iOS's text-selection
+# popover instead of navigating.
+- extendedWaitUntil:
+    visible:
+      id: "row-user-.*"
+    timeout: 20000
 - tapOn:
-    id: "row-user-${MAESTRO_PEER_HANDLE}"
-    optional: true
+    id: "row-user-.*"
 - takeScreenshot: dms-03-opened
+- extendedWaitUntil:
+    visible:
+      id: "input-composer"
+    timeout: 30000
 - tapOn:
     id: "input-composer"
-    optional: true
 - inputText: "hello peer"
 - tapOn:
     id: "btn-send"
-    optional: true
 - takeScreenshot: dms-04-sent

--- a/mobile/.maestro/flows/groups.yaml
+++ b/mobile/.maestro/flows/groups.yaml
@@ -7,6 +7,11 @@ tags:
 # button TEXT where #620 left an action un-instrumented (noted in README gaps).
 
 - runFlow: ../subflows/sign-in.yaml
+# Navigate explicitly: sign-in guarantees the tab navigator, not which tab.
+- tapOn:
+    id: "tab-groups"
+- assertVisible:
+    id: "screen-groups"
 - takeScreenshot: groups-01-inbox
 
 # Create a group. NOTE: the "CREATE GROUP" submit has no testID yet (#620 gap),

--- a/mobile/.maestro/flows/ipad-two-pane.yaml
+++ b/mobile/.maestro/flows/ipad-two-pane.yaml
@@ -10,6 +10,9 @@ tags:
 # either a conversation or the "Select a conversation" placeholder.
 
 - runFlow: ../subflows/sign-in.yaml
+# Navigate explicitly: sign-in guarantees the tab navigator, not which tab.
+- tapOn:
+    id: "tab-groups"
 - assertVisible:
     id: "screen-groups"
 - takeScreenshot: ipad-01-groups-twopane

--- a/mobile/.maestro/flows/messaging.yaml
+++ b/mobile/.maestro/flows/messaging.yaml
@@ -7,6 +7,12 @@ tags:
 # conversation to post into without a peer.
 
 - runFlow: ../subflows/sign-in.yaml
+# Navigate explicitly: sign-in guarantees the tab navigator, not which tab,
+# and btn-create-group only exists on the groups screen.
+- tapOn:
+    id: "tab-groups"
+- assertVisible:
+    id: "screen-groups"
 
 # Make a group so we have a channel to post in.
 - tapOn:

--- a/mobile/.maestro/subflows/sign-in.yaml
+++ b/mobile/.maestro/subflows/sign-in.yaml
@@ -69,7 +69,12 @@ appId: com.pollis.mobile
           id: "btn-continue"
 
 # --- Landed on the tabs ---
+# Assert the TAB BAR, not a particular tab. `initializing.tsx` replaces to
+# `/(tabs)/groups`, but the app was observed landing on Self after sign-in
+# (see the note in README "Known issues"), and a subflow whose job is "we are
+# signed in and inside the tab navigator" should not also be the thing that
+# encodes which tab wins that race. Flows that need a specific tab tap it.
 - extendedWaitUntil:
     visible:
-      id: "screen-groups"
-    timeout: 20000
+      id: "tab-groups"
+    timeout: 30000

--- a/mobile/scripts/maestro-run.sh
+++ b/mobile/scripts/maestro-run.sh
@@ -40,11 +40,30 @@ ENV_ARGS=()
 if [ -f "$ENV_FILE" ]; then
   while IFS= read -r line; do
     case "$line" in ''|\#*) continue;; esac
+    case "$line" in MAESTRO_EMAIL=*) continue;; esac
     ENV_ARGS+=(-e "$line")
   done < "$ENV_FILE"
 else
   echo "WARN: $ENV_FILE missing — copy env.example and fill it in." >&2
 fi
+
+# MAESTRO_EMAIL is deliberately NOT taken from .env as-is. Every flow opens with
+# `clearState` and then signs UP, so a fixed address only works on its very
+# first use ever: from the second flow onward the account already exists, auth
+# takes the returning-device enrollment path, no create-PIN screen appears, and
+# the flow dies on `screen-auth-pin`. That is exactly what the first full run of
+# this suite hit — 7 of 8 flows failed that way, all for this one reason.
+#
+# So each flow gets its own brand-new disposable account, derived from the
+# configured address by extending its `+` tag. Enrollment needs the recovery
+# key, which the harness has no way to hold, so re-signing-up is the only
+# self-contained option.
+EMAIL_BASE="$(sed -n 's/^MAESTRO_EMAIL=//p' "$ENV_FILE" 2>/dev/null | head -1)"
+EMAIL_BASE="${EMAIL_BASE:-pollis-e2e+primary@example.com}"
+fresh_email() {
+  local local_part="${EMAIL_BASE%@*}" domain="${EMAIL_BASE#*@}"
+  echo "${local_part}-$(date +%Y%m%d%H%M%S)-$1@${domain}"
+}
 
 # Boot the device and pick the Maestro --device selector.
 DEVICE_SEL=()
@@ -72,7 +91,20 @@ DATE="$(date +%Y-%m-%d)"
 OUT="$MAE/artifacts/$DATE/$PLATFORM"
 mkdir -p "$OUT"
 
-echo "==> running: $TARGET  (platform=$PLATFORM)"
+# Collect the flows to run. `all` becomes an explicit LIST rather than handing
+# the directory to Maestro, because one invocation shares one `-e` environment
+# and every flow needs its own signup address (see fresh_email above). Running
+# them separately also attributes a failure to one flow instead of one batch.
+FLOW_FILES=()
+if [ "$FLOW" = "all" ]; then
+  for f in "$MAE"/flows/*.yaml; do
+    [ -e "$f" ] && FLOW_FILES+=("$f")
+  done
+else
+  FLOW_FILES=("$TARGET")
+fi
+
+echo "==> running ${#FLOW_FILES[@]} flow(s)  (platform=$PLATFORM)"
 # Maestro ignores cwd for screenshot output — takeScreenshot always lands
 # under its own ~/.maestro/tests/<run>/ debug tree regardless of `cd`.
 # --debug-output redirects that whole tree under DEBUG instead, then we
@@ -80,12 +112,25 @@ echo "==> running: $TARGET  (platform=$PLATFORM)"
 # screenshots/step-* = failure captures) into OUT below.
 DEBUG="$OUT/.debug"
 mkdir -p "$DEBUG"
-maestro "${DEVICE_SEL[@]}" test --debug-output "$DEBUG" "${ENV_ARGS[@]}" "$TARGET" || {
-  echo "!! flow reported failures — screenshots (incl. the failing state) are in $OUT" >&2
-}
+FAILED=()
+for f in "${FLOW_FILES[@]}"; do
+  fname="$(basename "$f" .yaml)"
+  echo "--> $fname"
+  maestro "${DEVICE_SEL[@]}" test --debug-output "$DEBUG" \
+    "${ENV_ARGS[@]}" -e MAESTRO_EMAIL="$(fresh_email "$fname")" "$f" || {
+    FAILED+=("$fname")
+    echo "!! $fname reported failures — screenshots (incl. the failing state) are in $OUT" >&2
+  }
+done
 
 find "$DEBUG" \( -path "*/takeScreenshot/*.png" -o -path "*/screenshots/*.png" \) -exec cp {} "$OUT/" \; 2>/dev/null || true
 rm -rf "$DEBUG"
 
 echo "==> screenshots in: $OUT"
 ls -1 "$OUT"/*.png 2>/dev/null || echo "(no screenshots captured)"
+
+if [ ${#FAILED[@]} -gt 0 ]; then
+  echo "==> FAILED (${#FAILED[@]}/${#FLOW_FILES[@]}): ${FAILED[*]}" >&2
+  exit 1
+fi
+echo "==> all ${#FLOW_FILES[@]} flow(s) passed"


### PR DESCRIPTION
Part of #709 / #621. The suite had never been executed anywhere; the first real run on a Mac failed **8 of 8 flows**. Three harness bugs and a documentation gap, all fixed here.

## The suite could never have passed more than one flow

Every flow opens with `clearState` and then signs **up**, but all flows shared a single `MAESTRO_EMAIL` in one `maestro test` invocation. So only the first use of that address could ever work: from the second flow onward the account already exists, auth takes the returning-device enrollment path, no create-PIN screen appears, and the flow dies on `screen-auth-pin`. **Seven of the eight failures were this one bug.**

`maestro-run.sh` now mints a fresh disposable address per flow and runs each flow as its own invocation — which also attributes a failure to one flow rather than one batch, and exits non-zero with a summary. Enrollment needs the recovery key, which the harness has no way to hold, so re-signing-up is the only self-contained option.

## `dms.yaml` contained a test that could not fail

It tapped `row-user-${MAESTRO_PEER_HANDLE}`, but the app emits `row-user-<userId>`. With `optional: true` the flow walked straight past and "sent" a message into whatever screen it was still on. Now an id regex prefix, and not optional. (Tapping the handle *text* is not an alternative — the same string is in the search box, and tapping that opens iOS's text-selection popover.)

## `sign-in.yaml` asserted the wrong landing screen

It waited for `screen-groups`; the app lands on Self. It now waits for the tab bar, and each flow taps the tab it needs.

## Documented prerequisites that cost real time

- **Maestro needs a Java runtime.** `openjdk@17` is keg-only, so installing it is not enough — `java_home` cannot see it and Maestro dies with "Unable to locate a Java Runtime".
- **The suite cannot run against a dev-client build at all.** `clearState` wipes expo-dev-client's stored server URL, so the app boots to the launcher menu and never loads. The README's prerequisite told you to build exactly that. Release build required.
- After changing the ubrn target set, re-run `pod install` — CocoaPods bakes xcframework slice paths into a generated copy script, and a stale one silently copies nothing, leaving the app to die at launch on a uniffi checksum mismatch.

## Left open for app-side triage (recorded in the README, not fixed here)

- Sign-in lands on the **Self** tab though `initializing.tsx:76` replaces to `/(tabs)/groups` and nothing routes to self.
- A handle rename does not reach messages you then send: `sender_username` is stamped from a cached `currentUser` and survives an app restart, so your own new messages carry the old handle to everyone else.