### PR TITLE
Record the ASC app-record identifiers and re-check the pre-submission blockers

### DIFF
--- a/docs/store-listing.md
+++ b/docs/store-listing.md
@@ -12,6 +12,21 @@ accounts work on both stores, and there is no way around it short of forming an 
 
 ---
 
+## 0. App record identifiers (App Store Connect → My Apps → +)
+
+Fill these once, when the app record is created. Chosen 2026-08-22.
+
+| Field | Value | Note |
+|---|---|---|
+| Platform | iOS | The universal binary covers iPad; there is no separate iPad record. |
+| Name | `Pollis` | Globally unique across the App Store — this form is where a clash surfaces. |
+| Primary language | English (U.S.) | |
+| Bundle ID | `com.pollis.mobile` | Already registered on team `9JF7WWYMU2`; pick it from the dropdown. |
+| **SKU** | `com.pollis.mobile` | **Permanent — cannot be changed after creation.** Internal only: never shown to users or reviewers, appears in sales/financial reports. Only has to be unique within the account, so it mirrors the bundle ID rather than inventing a second identifier to remember. |
+
+`ascAppId` appears under App Information once the record exists; it is what any
+later `eas submit` / Transporter automation would need.
+
 ## 1. Copy
 
 ### App name
@@ -293,15 +308,38 @@ landscape is acceptable there).
 
 ## 8. Pre-submission blockers (recap)
 
-1. **Mobile in-app account deletion UI** — required by both stores; core command exists, mobile
-   UI does not (§3).
-2. **`ITSAppUsesNonExemptEncryption` in `app.json`** — set to `true` when the owner adopts the
-   export position (§5).
-3. **BIS annual report + ANSSI France declaration** — file (or restrict France) before release
-   (§5).
-4. **SystemBootTime / `@livekit/react-native-webrtc` linkage check** at EAS build time — see
-   `docs/mobile-compliance-answers.md` §1; an undeclared required-reason API is an automatic
-   rejection (ITMS-91053).
-5. **Play closed-testing gate** — 12 testers / 14 days before production (§6).
-6. **EAS credentials** (`eas init`, APNs key, FCM service account) — push is content-free but
-   still needs real credentials (#344).
+Re-checked 2026-08-22 against the actual signed build. Four of the six are done;
+do not re-litigate them from this list's old wording.
+
+1. ~~**Mobile in-app account deletion UI**~~ — **DONE.** Self → Security carries the
+   typed-DELETE full-screen confirm → `delete_account` + best-effort `wipe_local_data`
+   → sign-out (App Store 5.1.1(v)).
+2. ~~**`ITSAppUsesNonExemptEncryption`**~~ — **DONE.** `app.json` sets it `true`, and the
+   signed IPA's `Info.plist` carries it. See §5 for why `true` is the honest answer.
+3. **BIS annual report + ANSSI France declaration** — still outstanding. File (or restrict
+   France) before release (§5). Operational, not code.
+4. ~~**SystemBootTime / required-reason APIs**~~ — **DONE, and verified in the binary**
+   rather than assumed. CocoaPods' privacy-manifest aggregation merges every pod's
+   manifest into the app's at build time; the shipped `Pollis.app/PrivacyInfo.xcprivacy`
+   declares:
+
+   | API category | Reasons |
+   |---|---|
+   | FileTimestamp | `C617.1`, `0A2A.1`, `3B52.1` |
+   | UserDefaults | `CA92.1` |
+   | DiskSpace | `E174.1`, `85F4.1` |
+   | SystemBootTime | `35F9.1` |
+
+   plus `NSPrivacyTracking: false` and 3 collected-data types. Re-verify after any
+   dependency change with:
+   ```bash
+   unzip -q build/export/Pollis.ipa -d /tmp/ipa
+   plutil -p /tmp/ipa/Payload/Pollis.app/PrivacyInfo.xcprivacy
+   ```
+   ITMS-91053 is an automatic rejection, so check the binary, never the intent.
+5. **Play closed-testing gate** — 12 testers / 14 days before production (§6). Android only.
+6. ~~**EAS credentials**~~ — **DONE (#707).** EAS holds the APNs key (`DZB37YSPU7`) and the
+   FCM v1 service account; `projectId` + `owner` are in `app.json`.
+
+So the iOS-side remainder is **§3 (export paperwork)** and **screenshots (§7)** — everything
+else on this list is satisfied.

--- a/mobile/CLAUDE.md
+++ b/mobile/CLAUDE.md
@@ -57,6 +57,15 @@ Smoke-tested on macOS Tahoe (26.4.1) + Xcode 26.4.1 + iOS 26.4 simulator. `versi
 
 **Expo SDK 55 requires Xcode 26 / macOS 26.** Earlier Xcode/macOS hits `@MainActor` parse errors in `expo-modules-core` (see [expo/expo#42525](https://github.com/expo/expo/issues/42525) — closed, won't fix). SDK 54 is the last line that supports Xcode 16.x if a downgrade is ever needed.
 
+**An Xcode update silently breaks every simulator build until you download the matching runtime.** Xcode auto-updated 26.4.1 → 26.6 mid-session on 2026-08-22; the new SDK is iOS 26.5, no iOS 26.5 *simulator runtime* was installed, and `xcodebuild` then enumerates **zero** simulator destinations. Every build fails with `Unable to find a destination matching the provided destination specifier`, and the only "ineligible" entry it prints is the physical-device placeholder — which reads like a code-signing problem and is not one. Booting an older-runtime simulator does **not** help. The fix is one command and an 8.5 GB download:
+
+```bash
+xcodebuild -downloadPlatform iOS
+xcodebuild -workspace ios/Pollis.xcworkspace -scheme Pollis -showdestinations   # sanity: should list simulators, not just the placeholder
+```
+
+Two related traps while you are in there: pass simulators to `expo run:ios` by **UDID** (`xcrun simctl list devices`) and boot them first — a name matching no booted simulator makes xcodebuild fall through to a device destination; and the store `.ipa` currently in `build/export` was produced under Xcode **26.4.1**, so a rebuild under 26.6 is not byte-identical.
+
 ### Dev loop — iOS
 
 ```bash


### PR DESCRIPTION
Documentation only.

- **`docs/store-listing.md` §0 (new)** — the App Store Connect app-record fields, so the permanent ones are not decided twice. Notably **SKU = `com.pollis.mobile`**: internal-only, never shown to users, appears in financial reports, and **cannot be changed after creation** — mirroring the bundle ID avoids inventing a second identifier to remember.
- **§8 pre-submission blockers re-checked against the actual signed build.** Four of six were already done and the list was telling the reader otherwise:
  - in-app account deletion UI — shipped (Self → Security, typed-DELETE confirm)
  - `ITSAppUsesNonExemptEncryption` — set, and present in the signed IPA
  - required-reason APIs — **verified in the binary, not assumed.** ITMS-91053 is an automatic rejection, so this was checked by unzipping the IPA: CocoaPods' privacy-manifest aggregation merges each pod's manifest into the app's, and the shipped `PrivacyInfo.xcprivacy` declares FileTimestamp, UserDefaults, DiskSpace and **SystemBootTime** (`35F9.1`), with `NSPrivacyTracking: false`. The re-verification command is recorded alongside it.
  - EAS credentials — done in #707

  Remaining for iOS: the BIS/ANSSI export paperwork, and screenshots.
- **`mobile/CLAUDE.md`** — records the Xcode-update trap that cost a chunk of a session: Xcode auto-updating 26.4.1 → 26.6 leaves the SDK at iOS 26.5 with no matching *simulator runtime*, after which `xcodebuild` enumerates **zero** simulator destinations and every build fails with "Unable to find a destination…", printing only the physical-device placeholder as ineligible. It reads like a signing problem and is not one; booting an older-runtime simulator does not help. Fix is `xcodebuild -downloadPlatform iOS`.